### PR TITLE
fix(web): persist sea battle lobby variant changes to backend (ARC-578)

### DIFF
--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -15,6 +15,9 @@ import { SeaBattleThemePreview } from './SeaBattleThemePreview';
 import { SeaBattleThemeProvider } from '../lib/SeaBattleThemeContext';
 import { SeaBattleTeamPanel } from './SeaBattleTeamPanel';
 import type { SeaBattleGameOptions } from '@/features/games/sea-battle/lobby';
+import { gamesApi } from '@/features/games/api';
+import { useMutation } from '@/shared/hooks/useMutation';
+import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 
 const getSeaBattleTheme = (variantId?: string): GameLobbyTheme => {
   const variant = SEA_BATTLE_VARIANTS.find((v) => v.id === variantId);
@@ -69,6 +72,29 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
   const roomVariant = (room.gameOptions?.variant as string) || 'classic';
   const [selectedVariant, setSelectedVariant] = React.useState(roomVariant);
   const [showAllVariants, setShowAllVariants] = React.useState(false);
+  const { snapshot } = useSessionTokens();
+
+  const { mutate: persistVariant } = useMutation({
+    mutationFn: async (newVariant: string) => {
+      await gamesApi.updateRoomOptions(
+        room.id,
+        { variant: newVariant },
+        { token: snapshot.accessToken ?? undefined },
+      );
+    },
+    onError: () => {
+      setSelectedVariant(roomVariant);
+    },
+  });
+
+  const handleVariantSelect = React.useCallback(
+    (variantId: string) => {
+      if (variantId === selectedVariant) return;
+      setSelectedVariant(variantId);
+      persistVariant(variantId);
+    },
+    [persistVariant, selectedVariant],
+  );
 
   // Team mode state derived from room game options
   const teamOpts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
@@ -148,7 +174,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
                 borderRadius={20}
                 borderWidth={1.5}
                 cursor="pointer"
-                onClick={() => setSelectedVariant(variant.id)}
+                onClick={() => handleVariantSelect(variant.id)}
                 borderColor={
                   selectedVariant === variant.id
                     ? 'rgba(96,165,250,0.6)'


### PR DESCRIPTION
## Summary

- Variant chip clicks in the Sea Battle lobby only updated local React state, so the host's selection was never sent to the server, never broadcast over `games.room.update`, and reverted on refresh.
- Wire the chip click into `gamesApi.updateRoomOptions` (mirroring the existing `GameVariantSelector` pattern) with an optimistic update that reverts on error.
- Other clients now receive the change via the existing `games.room.update` socket event + the room-variant sync effect already in `SeaBattleLobby`.

## Changes

- `apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx` — added `useMutation` + `useSessionTokens` + `gamesApi` imports, a `persistVariant` mutation, and `handleVariantSelect` handler; chip `onClick` now calls the handler instead of setting local state directly.

## Test plan

- [ ] Host opens Sea Battle lobby, picks a non-default theme chip → other clients in the same room see the variant change without refresh
- [ ] Refresh the page → selected variant persists (was reverting before)
- [ ] Simulate API failure on `/games/rooms/:roomId/options` → chip selection reverts to server-confirmed variant
- [ ] Non-host (or unauthenticated viewer) cannot trigger variant change (host-only UI gating preserved)

> Note: pushed with `--no-verify` at user request; CI will run the full hook suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)