### PR TITLE
fix(sea-battle): advance turn when active player leaves (ARC-600)

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.removePlayer.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.removePlayer.spec.ts
@@ -1,0 +1,128 @@
+import { SeaBattleEngine } from './sea-battle.engine';
+import { GAME_PHASE } from './sea-battle.constants';
+
+describe('SeaBattleEngine — removePlayer', () => {
+  const engine = new SeaBattleEngine();
+
+  describe('team mode', () => {
+    function battleTeamState(
+      playerIds: string[],
+      teams: { id: string; playerIds: string[] }[],
+    ) {
+      const s = engine.initializeState(playerIds, {
+        teams: teams.map((t) => ({
+          id: t.id,
+          name: t.id,
+          color: '#000',
+          playerIds: t.playerIds,
+        })),
+      });
+      s.phase = GAME_PHASE.BATTLE;
+      return s;
+    }
+
+    it("active shooter leaving passes the turn to the next team and advances their team's shooter", () => {
+      const s = battleTeamState(
+        ['a', 'b', 'c', 'd'],
+        [
+          { id: 't1', playerIds: ['a', 'b'] },
+          { id: 't2', playerIds: ['c', 'd'] },
+        ],
+      );
+      const result = engine.removePlayer(s, 'a');
+      const ns = result.state!;
+
+      expect(ns.players.find((p) => p.playerId === 'a')!.alive).toBe(false);
+      expect(ns.currentTeamIndex).toBe(1);
+      expect(ns.teams!.find((t) => t.id === 't1')!.currentShooterIndex).toBe(1);
+      expect(ns.playerOrder[ns.currentTurnIndex]).toBe('c');
+    });
+
+    it("non-active teammate leaving does not change turn or active team's shooter", () => {
+      const s = battleTeamState(
+        ['a', 'b', 'c', 'd'],
+        [
+          { id: 't1', playerIds: ['a', 'b'] },
+          { id: 't2', playerIds: ['c', 'd'] },
+        ],
+      );
+      const result = engine.removePlayer(s, 'b');
+      const ns = result.state!;
+
+      expect(ns.players.find((p) => p.playerId === 'b')!.alive).toBe(false);
+      expect(ns.currentTeamIndex).toBe(0);
+      expect(ns.teams!.find((t) => t.id === 't1')!.currentShooterIndex).toBe(0);
+      expect(ns.playerOrder[ns.currentTurnIndex]).toBe('a');
+    });
+
+    it("inactive team's current shooter leaving rotates only that team's shooter", () => {
+      const s = battleTeamState(
+        ['a', 'b', 'c', 'd'],
+        [
+          { id: 't1', playerIds: ['a', 'b'] },
+          { id: 't2', playerIds: ['c', 'd'] },
+        ],
+      );
+      const result = engine.removePlayer(s, 'c');
+      const ns = result.state!;
+
+      expect(ns.currentTeamIndex).toBe(0);
+      expect(ns.teams!.find((t) => t.id === 't2')!.currentShooterIndex).toBe(1);
+      expect(ns.playerOrder[ns.currentTurnIndex]).toBe('a');
+    });
+
+    it('skips a fully dead team when the active shooter leaves', () => {
+      const s = battleTeamState(
+        ['a', 'b', 'c', 'd', 'e'],
+        [
+          { id: 't1', playerIds: ['a', 'b'] },
+          { id: 't2', playerIds: ['c'] },
+          { id: 't3', playerIds: ['d', 'e'] },
+        ],
+      );
+      s.players.find((p) => p.playerId === 'c')!.alive = false;
+
+      const result = engine.removePlayer(s, 'a');
+      const ns = result.state!;
+
+      expect(ns.currentTeamIndex).toBe(2);
+      expect(ns.playerOrder[ns.currentTurnIndex]).toBe('d');
+    });
+
+    it('ends the game when the active shooter leaving wipes their team and only one survives', () => {
+      const s = battleTeamState(
+        ['a', 'b'],
+        [
+          { id: 't1', playerIds: ['a'] },
+          { id: 't2', playerIds: ['b'] },
+        ],
+      );
+      const result = engine.removePlayer(s, 'a');
+      const ns = result.state!;
+
+      expect(ns.winnerId).toBe('t2');
+      expect(engine.isGameOver(ns)).toBe(true);
+    });
+  });
+
+  describe('FFA mode', () => {
+    it('advances currentTurnIndex when the active player leaves', () => {
+      const s = engine.initializeState(['a', 'b', 'c']);
+      s.phase = GAME_PHASE.BATTLE;
+      const result = engine.removePlayer(s, 'a');
+      const ns = result.state!;
+
+      expect(ns.players.find((p) => p.playerId === 'a')!.alive).toBe(false);
+      expect(ns.playerOrder[ns.currentTurnIndex]).toBe('b');
+    });
+
+    it('does not change currentTurnIndex when a non-active player leaves', () => {
+      const s = engine.initializeState(['a', 'b', 'c']);
+      s.phase = GAME_PHASE.BATTLE;
+      const result = engine.removePlayer(s, 'b');
+      const ns = result.state!;
+
+      expect(ns.playerOrder[ns.currentTurnIndex]).toBe('a');
+    });
+  });
+});

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -38,6 +38,7 @@ import {
   advanceTeamRotationOnMiss,
   countAliveTeams,
   getActiveShooterId,
+  getActiveTeam,
   isTeamAlive,
 } from './team-rotation.utils';
 import {
@@ -380,12 +381,25 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
   ): GameActionResult<SeaBattleState> {
     const newState = this.cloneState(state);
     const player = newState.players.find((p) => p.playerId === playerId);
-    if (player) {
-      player.alive = false;
-      newState.logs.push(
-        this.createLogEntry('system', 'A player has left the game'),
-      );
-      if (newState.teams) {
+    if (!player) {
+      return this.successResult(newState);
+    }
+
+    player.alive = false;
+    newState.logs.push(
+      this.createLogEntry('system', 'A player has left the game'),
+    );
+
+    if (newState.teams) {
+      const wasActiveShooter = getActiveShooterId(newState) === playerId;
+
+      if (wasActiveShooter) {
+        // Active shooter forfeits the turn — advance like a miss so the
+        // next team plays and the leaver's team rotates to the next teammate.
+        advanceTeamRotationOnMiss(newState);
+      } else {
+        // Otherwise, only patch up the leaver's own team shooter pointer so
+        // a live teammate is queued up when their team plays again.
         const team = newState.teams.find((t) => t.playerIds.includes(playerId));
         if (team && team.playerIds[team.currentShooterIndex] === playerId) {
           const n = team.playerIds.length;
@@ -402,8 +416,22 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
           }
         }
       }
-      this.checkAndSetWinner(newState);
+
+      // Keep currentTurnIndex in sync with the active shooter so consumers
+      // that read playerOrder[currentTurnIndex] (e.g. the bot service) match.
+      const activeTeam = getActiveTeam(newState);
+      if (activeTeam) {
+        const shooter = getActiveShooterId(newState);
+        if (shooter) {
+          const idx = newState.playerOrder.indexOf(shooter);
+          if (idx >= 0) newState.currentTurnIndex = idx;
+        }
+      }
+    } else if (newState.playerOrder[newState.currentTurnIndex] === playerId) {
+      this.advanceToNextPlayer(newState);
     }
+
+    this.checkAndSetWinner(newState);
     return this.successResult(newState);
   }
 


### PR DESCRIPTION
## What
Fixes the turn-order break that happens after a player leaves a Sea Battle game (team mode and FFA).

## Why
`SeaBattleEngine.removePlayer` only patched the leaver's team `currentShooterIndex`. It never updated `state.currentTurnIndex` and never advanced `state.currentTeamIndex`, which caused two real symptoms:

- **Bot/UI deadlock**: `sea-battle-bot.service` reads `state.playerOrder[state.currentTurnIndex]` to decide whose turn it is. When the active shooter left, that index still pointed at the dead player, so bots never triggered and clients couldn't progress.
- **Unfair team turn**: when the active team's active shooter left, the leaver's team kept the turn and rotated to a teammate (a free shot), instead of yielding to the next team like a normal miss.

Texas Hold'em and Critical engines already advance the turn on `removePlayer`; Sea Battle now matches that pattern.

## Changes
- `apps/be/src/games/engines/sea-battle/sea-battle.engine.ts`: rewrite `removePlayer`:
  - Team mode, leaver is active shooter → call `advanceTeamRotationOnMiss` (forfeit-as-miss): rotates active team's shooter and advances `currentTeamIndex` past dead teams.
  - Team mode, leaver is not active shooter → keep the prior shooter-pointer cleanup so a live teammate is queued for next round.
  - Team mode, always → sync `currentTurnIndex` to the new active shooter.
  - FFA mode → call `advanceToNextPlayer` when leaver held the turn.
- `apps/be/src/games/engines/sea-battle/sea-battle.engine.removePlayer.spec.ts` *(new)*: 7 cases covering active-shooter leave, non-active leaver, inactive-team's-shooter leave, dead-team skipping, last-team-standing winner, and FFA active/non-active leave.

## Test plan
- [x] `pnpm --filter be jest` — 22 suites / 180 tests pass
- [x] `pnpm --filter be lint` — clean
- [x] `pnpm check-file-length` — clean
- [ ] Manual verification: in a 2v2 team room, have the active shooter leave; turn should pass to the opposing team and bots should keep playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)