### PR TITLE
feat(critical/widget): scaffold MatchWidget behind widget_mode flag (ARC-631)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/hooks/useWidgetMode.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/hooks/useWidgetMode.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockSearchParams = vi.fn();
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams(),
+}));
+
+import { useWidgetMode } from './useWidgetMode';
+import { WIDGET_MODE_STORAGE_KEY } from '../lib/widgetMode';
+
+function fakeParams(value: string | null) {
+  return { get: (_key: string) => value };
+}
+
+describe('useWidgetMode', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = originalEnv;
+    window.localStorage.clear();
+    mockSearchParams.mockReset();
+  });
+
+  it('returns env-default when no URL param or storage is set', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'true';
+    mockSearchParams.mockReturnValue(fakeParams(null));
+    const { result } = renderHook(() => useWidgetMode());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false by default when nothing configured', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = undefined;
+    mockSearchParams.mockReturnValue(fakeParams(null));
+    const { result } = renderHook(() => useWidgetMode());
+    expect(result.current).toBe(false);
+  });
+
+  it('URL param overrides env', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'false';
+    mockSearchParams.mockReturnValue(fakeParams('1'));
+    const { result } = renderHook(() => useWidgetMode());
+    expect(result.current).toBe(true);
+  });
+
+  it('persists URL param into localStorage', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = undefined;
+    mockSearchParams.mockReturnValue(fakeParams('1'));
+    renderHook(() => useWidgetMode());
+    expect(window.localStorage.getItem(WIDGET_MODE_STORAGE_KEY)).toBe('1');
+  });
+
+  it('reads from localStorage when no URL param is present', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'false';
+    window.localStorage.setItem(WIDGET_MODE_STORAGE_KEY, '1');
+    mockSearchParams.mockReturnValue(fakeParams(null));
+    const { result } = renderHook(() => useWidgetMode());
+    // useSyncExternalStore reads the client snapshot on the first render,
+    // so storage takes effect immediately after the env fallback.
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/hooks/useWidgetMode.ts
+++ b/apps/web/src/widgets/CriticalGame/hooks/useWidgetMode.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { useSearchParams } from 'next/navigation';
+import {
+  WIDGET_MODE_PARAM,
+  WIDGET_MODE_STORAGE_KEY,
+  resolveWidgetMode,
+} from '../lib/widgetMode';
+
+function subscribeToStorage(notify: () => void) {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener('storage', notify);
+  return () => window.removeEventListener('storage', notify);
+}
+
+function getStorageSnapshot(): string | null {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem(WIDGET_MODE_STORAGE_KEY);
+}
+
+// Server renders pre-storage; the client re-renders with the real value
+// once hydration completes.
+function getServerSnapshot(): string | null {
+  return null;
+}
+
+/**
+ * Returns whether the Critical widget rework should render in place of the
+ * legacy `ActiveGameContent` layout. Resolution order: URL search param,
+ * then localStorage, then env var. See `lib/widgetMode.ts` for details.
+ *
+ * The URL param is also persisted into localStorage on change so a QA can
+ * flip the flag once via URL and have it stick across in-app navigation.
+ */
+export function useWidgetMode(): boolean {
+  const searchParams = useSearchParams();
+  const paramValue = searchParams?.get(WIDGET_MODE_PARAM) ?? null;
+  const storageValue = useSyncExternalStore(
+    subscribeToStorage,
+    getStorageSnapshot,
+    getServerSnapshot,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (paramValue === null) return;
+    if (window.localStorage.getItem(WIDGET_MODE_STORAGE_KEY) === paramValue) {
+      return;
+    }
+    window.localStorage.setItem(WIDGET_MODE_STORAGE_KEY, paramValue);
+    // localStorage `storage` events don't fire in the same tab that wrote
+    // the value, so we nudge our own subscriber to re-read.
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: WIDGET_MODE_STORAGE_KEY,
+        newValue: paramValue,
+      }),
+    );
+  }, [paramValue]);
+
+  return resolveWidgetMode({ paramValue, storageValue });
+}

--- a/apps/web/src/widgets/CriticalGame/lib/widgetMode.test.ts
+++ b/apps/web/src/widgets/CriticalGame/lib/widgetMode.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveWidgetMode, isWidgetModeEnabledFromEnv } from './widgetMode';
+
+describe('resolveWidgetMode', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE;
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = originalEnv;
+  });
+
+  it('URL param wins over storage and env', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'false';
+    expect(resolveWidgetMode({ paramValue: '1', storageValue: '0' })).toBe(
+      true,
+    );
+    expect(resolveWidgetMode({ paramValue: '0', storageValue: '1' })).toBe(
+      false,
+    );
+  });
+
+  it('storage wins over env when no URL param', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'false';
+    expect(resolveWidgetMode({ storageValue: '1' })).toBe(true);
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'true';
+    expect(resolveWidgetMode({ storageValue: '0' })).toBe(false);
+  });
+
+  it('falls back to env when neither URL nor storage is set', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'true';
+    expect(resolveWidgetMode({})).toBe(true);
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'false';
+    expect(resolveWidgetMode({})).toBe(false);
+  });
+
+  it('accepts both `1` and `true` as truthy', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = undefined;
+    expect(resolveWidgetMode({ paramValue: '1' })).toBe(true);
+    expect(resolveWidgetMode({ paramValue: 'true' })).toBe(true);
+  });
+
+  it('ignores garbage values and falls through to next layer', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'true';
+    expect(resolveWidgetMode({ paramValue: 'banana' })).toBe(true);
+    expect(resolveWidgetMode({ paramValue: 'banana', storageValue: '0' })).toBe(
+      false,
+    );
+  });
+
+  it('defaults to false when nothing is configured', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = undefined;
+    expect(resolveWidgetMode({})).toBe(false);
+  });
+});
+
+describe('isWidgetModeEnabledFromEnv', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = originalEnv;
+  });
+
+  it('returns true when env is "true" or "1"', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'true';
+    expect(isWidgetModeEnabledFromEnv()).toBe(true);
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = '1';
+    expect(isWidgetModeEnabledFromEnv()).toBe(true);
+  });
+
+  it('returns false when env is unset or anything else', () => {
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = undefined;
+    expect(isWidgetModeEnabledFromEnv()).toBe(false);
+    process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE = 'maybe';
+    expect(isWidgetModeEnabledFromEnv()).toBe(false);
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/lib/widgetMode.ts
+++ b/apps/web/src/widgets/CriticalGame/lib/widgetMode.ts
@@ -1,0 +1,41 @@
+/**
+ * Feature flag for the Critical game widget rework (ARC-631 onwards).
+ *
+ * Default is OFF — `ActiveGameView` keeps rendering the existing
+ * `ActiveGameContent` layout. When enabled, the same render slot is taken
+ * over by `MatchWidget`, which is where the §7 layout restructure (Arena,
+ * OpponentsRow, HandZone, ComboCard, etc.) will land in follow-up tickets.
+ *
+ * Three resolution paths, in priority order:
+ *  1. URL search param `?widget_mode=1` (or `0`) — for ad-hoc QA / demos
+ *  2. localStorage key `arcadeum.widget_mode` (`1` / `0`) — sticks across reloads
+ *  3. env var `NEXT_PUBLIC_CRITICAL_WIDGET_MODE` (`true` / `1`) — production default
+ *
+ * The URL form always wins so a QA can flip the flag without env access.
+ * The localStorage form persists the URL choice across navigation.
+ */
+
+export const WIDGET_MODE_PARAM = 'widget_mode';
+export const WIDGET_MODE_STORAGE_KEY = 'arcadeum.widget_mode';
+
+function parseFlag(value: string | null | undefined): boolean | null {
+  if (value == null) return null;
+  if (value === '1' || value === 'true') return true;
+  if (value === '0' || value === 'false') return false;
+  return null;
+}
+
+export function isWidgetModeEnabledFromEnv(): boolean {
+  return parseFlag(process.env.NEXT_PUBLIC_CRITICAL_WIDGET_MODE) === true;
+}
+
+export function resolveWidgetMode(opts: {
+  paramValue?: string | null;
+  storageValue?: string | null;
+}): boolean {
+  const fromParam = parseFlag(opts.paramValue);
+  if (fromParam !== null) return fromParam;
+  const fromStorage = parseFlag(opts.storageValue);
+  if (fromStorage !== null) return fromStorage;
+  return isWidgetModeEnabledFromEnv();
+}

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -25,6 +25,7 @@ import { GameModals } from './GameModals';
 import { GameResultModal } from '@/features/games/ui/GameResultModal';
 import { GameStatusMessage } from './GameStatusMessage';
 import { ActiveGameContent } from './ActiveGameContent';
+import { MatchWidget } from './MatchWidget';
 import { CriticalGameHeader } from './CriticalGameHeader';
 import { MobileActionSheet } from './MobileActionSheet';
 import { getVariantStyles } from './styles/variants';
@@ -32,6 +33,7 @@ import { ScenePaletteProvider } from './ScenePaletteContext';
 import { SceneBackdrop } from './SceneBackdrop';
 import { TurnBanner } from './TurnBanner';
 import { MatchHud } from './MatchHud';
+import { useWidgetMode } from '../hooks/useWidgetMode';
 import type { UseGameActionsReturn } from '@/features/games/hooks/useGameActions';
 import type { RematchInvitation } from '../hooks/useRematch';
 
@@ -97,6 +99,7 @@ export function ActiveGameView({
   const { t } = useTranslation();
   const media = useMedia();
   const isMobile = media.sm;
+  const widgetMode = useWidgetMode();
 
   // Layout State
   const [handLayout, setHandLayout] = useState<HandLayoutMode>('grid');
@@ -304,36 +307,43 @@ export function ActiveGameView({
           formatLogMessage={formatLogMessage}
         />
 
-        <ActiveGameContent
-          room={room}
-          snapshot={snapshot}
-          currentUserId={currentUserId}
-          currentPlayer={currentPlayer}
-          cardVariant={cardVariant}
-          isGameOver={!!isGameOver}
-          isMyTurn={!!isMyTurn}
-          canAct={!!canAct}
-          canPlayNope={canPlayNope}
-          actionBusy={actionBusy}
-          aliveOpponents={aliveOpponents}
-          handLayout={handLayout}
-          setHandLayout={setHandLayout}
-          resolveDisplayName={resolveDisplayName}
-          t={
-            t as unknown as (
-              key: string,
-              params?: Record<string, string | number>,
-            ) => string
-          }
-          actions={actions}
-          idleTimerTriggered={idleTimerTriggered}
-          autoplayState={autoplayState}
-          handleUnstash={handleUnstash}
-          handlePlayActionCard={handlePlayActionCard}
-          handleOpenFavorModal={handleOpenFavorModal}
-          handleOpenEventCombo={handleOpenEventCombo}
-          handleOpenFiverCombo={handleOpenFiverCombo}
-        />
+        {/* Flag-gated render. MatchWidget is currently a pass-through to */}
+        {/* ActiveGameContent; the §7 rework lands inside MatchWidget. */}
+        {(() => {
+          const ContentImpl = widgetMode ? MatchWidget : ActiveGameContent;
+          return (
+            <ContentImpl
+              room={room}
+              snapshot={snapshot}
+              currentUserId={currentUserId}
+              currentPlayer={currentPlayer}
+              cardVariant={cardVariant}
+              isGameOver={!!isGameOver}
+              isMyTurn={!!isMyTurn}
+              canAct={!!canAct}
+              canPlayNope={canPlayNope}
+              actionBusy={actionBusy}
+              aliveOpponents={aliveOpponents}
+              handLayout={handLayout}
+              setHandLayout={setHandLayout}
+              resolveDisplayName={resolveDisplayName}
+              t={
+                t as unknown as (
+                  key: string,
+                  params?: Record<string, string | number>,
+                ) => string
+              }
+              actions={actions}
+              idleTimerTriggered={idleTimerTriggered}
+              autoplayState={autoplayState}
+              handleUnstash={handleUnstash}
+              handlePlayActionCard={handlePlayActionCard}
+              handleOpenFavorModal={handleOpenFavorModal}
+              handleOpenEventCombo={handleOpenEventCombo}
+              handleOpenFiverCombo={handleOpenFiverCombo}
+            />
+          );
+        })()}
       </YStack>
 
       {currentPlayer && (

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('./ActiveGameContent', () => ({
+  ActiveGameContent: () => (
+    <div data-testid="active-game-content-stub">stub</div>
+  ),
+}));
+
+import { MatchWidget, type MatchWidgetProps } from './MatchWidget';
+
+describe('MatchWidget (ARC-631 scaffold)', () => {
+  it('passes through to ActiveGameContent', () => {
+    // For ARC-631 the widget is a transparent wrapper. Follow-up tickets
+    // replace the inside with the §7 layout (Arena, OpponentsRow, HandZone).
+    // The test asserts the pass-through stays in place for now — the inner
+    // is mocked, so the actual prop values don't matter.
+    const stubProps = {} as unknown as MatchWidgetProps;
+    render(<MatchWidget {...stubProps} />);
+    expect(screen.getByTestId('match-widget')).toBeInTheDocument();
+    expect(screen.getByTestId('active-game-content-stub')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { ActiveGameContent } from './ActiveGameContent';
+import type { ComponentProps } from 'react';
+
+export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent>;
+
+/**
+ * Entry point for the Critical game widget rework (ARC-631).
+ *
+ * For this ticket the widget is a transparent pass-through to the legacy
+ * `ActiveGameContent`, mounted only when the `widget_mode` feature flag
+ * is on. No behavior change vs. flag-off.
+ *
+ * Follow-up tickets restructure the inside of this component into the
+ * three-row preview layout (opponents / arena / hand) — see
+ * `docs/handoffs/PR-631-review2.md` §7 (ARC-632 — ARC-636).
+ */
+export function MatchWidget(props: MatchWidgetProps) {
+  return (
+    <div data-testid="match-widget">
+      <ActiveGameContent {...props} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

First slice of the [§7 layout rework](docs/handoffs/PR-631-review2.md) (ARC-631 → ARC-636). Adds the feature flag and the render slot for the new widget. **No behavior change** vs. flag-off — `ActiveGameContent` still drives every active match by default.

- [lib/widgetMode.ts](apps/web/src/widgets/CriticalGame/lib/widgetMode.ts) — pure resolver: URL param `?widget_mode=1` → `localStorage` → env `NEXT_PUBLIC_CRITICAL_WIDGET_MODE`. Default off. Garbage values fall through to the next layer.
- [hooks/useWidgetMode.ts](apps/web/src/widgets/CriticalGame/hooks/useWidgetMode.ts) — exposes the flag as a hook. Storage reads go through `useSyncExternalStore` so the SSR snapshot is the env default and the client hydrates to the resolved value without a sync setState in effect. URL → storage persistence is handled in a side-effect-only `useEffect` (no React state writes).
- [ui/MatchWidget.tsx](apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx) — transparent pass-through to `ActiveGameContent`. Follow-up tickets restructure its innards into the three-row preview layout (opponents / arena / hand).
- [ui/ActiveGameView.tsx](apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx) — picks `MatchWidget` vs. `ActiveGameContent` from the hook. Same prop type on both → the swap is a one-liner alias.

## Why

The reviewer's recommended migration in `PR-631-review2.md` §7 explicitly wants the rework to ship as 6 independent, mergeable slices each behind this flag. This PR is **slice 1**: zero-risk surface that the next 5 PRs can land into.

## Toggling the flag

- **Per-tab, no env change**: visit any game page with `?widget_mode=1` (or `0` to disable). The value is also written to `localStorage` so it sticks across navigation.
- **Stickier**: set `localStorage.setItem('arcadeum.widget_mode', '1')` in devtools.
- **Production default**: set `NEXT_PUBLIC_CRITICAL_WIDGET_MODE=true` in `.env.local` / deployment env.

## Test plan

- [x] 14 new unit tests across the resolver, hook, and the MatchWidget smoke test
- [x] Full Critical widget suite — 113/113 passing (was 99)
- [x] `pnpm type-check`, `pnpm lint`, `pnpm check-file-length` clean
- [ ] Manual QA flag-off: existing match UX unchanged
- [ ] Manual QA flag-on (`?widget_mode=1`): same UX (MatchWidget pass-through verified by a `data-testid="match-widget"` wrapper)

## Follow-ups

ARC-632 (Arena), ARC-633 (ArenaCenter + ComboCard), ARC-634 (OpponentsRow), ARC-635 (HandZone), ARC-636 (drop CriticalGameHeader from match view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)