### PR TITLE
feat(critical/widget): Arena row inside MatchWidget (ARC-632)

### DIFF
--- a/apps/web/src/shared/i18n/messages/games/critical/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/by.ts
@@ -224,6 +224,10 @@ export const byMessages = {
       cards: 'карт',
       card: 'карта',
     },
+    arena: {
+      drawHint: 'Націсніце, каб узяць карту і скончыць ход',
+      drawAria: 'Узяць карту і скончыць ход',
+    },
     hud: {
       threat: {
         label: 'Пагроза',

--- a/apps/web/src/shared/i18n/messages/games/critical/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/en.ts
@@ -220,6 +220,10 @@ export const enMessages = {
       cards: 'cards',
       card: 'card',
     },
+    arena: {
+      drawHint: 'Tap to draw + end turn',
+      drawAria: 'Draw a card and end your turn',
+    },
     hud: {
       threat: {
         label: 'Threat',

--- a/apps/web/src/shared/i18n/messages/games/critical/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/es.ts
@@ -223,6 +223,10 @@ export const esMessages = {
       cards: 'cartas',
       card: 'carta',
     },
+    arena: {
+      drawHint: 'Tócalo para robar y terminar el turno',
+      drawAria: 'Robar una carta y terminar el turno',
+    },
     hud: {
       threat: {
         label: 'Amenaza',

--- a/apps/web/src/shared/i18n/messages/games/critical/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/fr.ts
@@ -227,11 +227,15 @@ export const frMessages = {
       cards: 'cartes',
       card: 'carte',
     },
+    arena: {
+      drawHint: 'Toucher pour piocher et terminer le tour',
+      drawAria: 'Piocher une carte et terminer le tour',
+    },
     hud: {
       threat: {
         label: 'Menace',
         oddsTitle:
-          'Probabilité minimale de piocher une carte Critique (cartes visibles uniquement — les cartes cachées peuvent l’augmenter)',
+          'Probabilité minimale de piocher une Critique (cartes visibles uniquement — les cachées peuvent l’augmenter)',
         defusesTitle: 'Cartes de Défuse en main',
       },
       combo: {

--- a/apps/web/src/shared/i18n/messages/games/critical/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/ru.ts
@@ -226,6 +226,10 @@ export const ruMessages = {
       cards: 'карт',
       card: 'карта',
     },
+    arena: {
+      drawHint: 'Нажмите, чтобы взять карту и закончить ход',
+      drawAria: 'Взять карту и закончить ход',
+    },
     hud: {
       threat: {
         label: 'Угроза',

--- a/apps/web/src/widgets/CriticalGame/ui/GameTableSection.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/GameTableSection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import { useMedia } from 'tamagui';
 import { TableStats } from './TableStats';
 import {
@@ -32,6 +32,12 @@ interface GameTableSectionProps {
   resolveDisplayName: (playerId: string, fallback: string) => string;
   t: (key: string) => string;
   cardVariant?: string;
+  /**
+   * Optional render override for the center of the table. When provided,
+   * replaces the legacy `CenterTableSection` on both desktop and mobile.
+   * Used by the new `MatchWidget` (widget_mode flag) to inject the Arena.
+   */
+  centerSlot?: ReactNode;
 }
 
 export function GameTableSection({
@@ -47,9 +53,18 @@ export function GameTableSection({
   resolveDisplayName,
   t,
   cardVariant,
+  centerSlot,
 }: GameTableSectionProps) {
   const media = useMedia();
   const isMobile = media.sm;
+  const center = centerSlot ?? (
+    <CenterTableSection
+      discardPile={discardPile}
+      deck={deck}
+      cardVariant={cardVariant}
+      t={t}
+    />
+  );
   const myIndex = playerOrder.findIndex((id) => id === currentUserId);
   const viewerIndex = myIndex >= 0 ? myIndex : 0; // Default to 0 if spectating
 
@@ -94,22 +109,10 @@ export function GameTableSection({
       ) : (
         <PlayersRing>
           {playerNodes}
-          <CenterTableSection
-            discardPile={discardPile}
-            deck={deck}
-            cardVariant={cardVariant}
-            t={t}
-          />
+          {center}
         </PlayersRing>
       )}
-      {isMobile && (
-        <CenterTableSection
-          discardPile={discardPile}
-          deck={deck}
-          cardVariant={cardVariant}
-          t={t}
-        />
-      )}
+      {isMobile && center}
       <TableStats
         deckCount={deck.length}
         discardPileCount={discardPileLength}

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -5,23 +5,119 @@ vi.mock('@/shared/lib/useTranslation', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('./ActiveGameContent', () => ({
-  ActiveGameContent: () => (
-    <div data-testid="active-game-content-stub">stub</div>
+vi.mock('./GameTableSection', () => ({
+  GameTableSection: ({ centerSlot }: { centerSlot?: React.ReactNode }) => (
+    <div data-testid="game-table-section-stub">{centerSlot}</div>
+  ),
+}));
+
+vi.mock('./PlayerHand', () => ({
+  PlayerHand: () => <div data-testid="player-hand-stub" />,
+}));
+
+vi.mock('./arena/Arena', () => ({
+  Arena: () => <div data-testid="arena-stub" />,
+}));
+
+vi.mock('./styles/layout', () => ({
+  GameBoard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="game-board-stub">{children}</div>
+  ),
+  TableArea: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="table-area-stub">{children}</div>
   ),
 }));
 
 import { MatchWidget, type MatchWidgetProps } from './MatchWidget';
+import type { CriticalCard, CriticalPlayerState } from '../types';
 
-describe('MatchWidget (ARC-631 scaffold)', () => {
-  it('passes through to ActiveGameContent', () => {
-    // For ARC-631 the widget is a transparent wrapper. Follow-up tickets
-    // replace the inside with the §7 layout (Arena, OpponentsRow, HandZone).
-    // The test asserts the pass-through stays in place for now — the inner
-    // is mocked, so the actual prop values don't matter.
-    const stubProps = {} as unknown as MatchWidgetProps;
-    render(<MatchWidget {...stubProps} />);
+function makeProps(override: Partial<MatchWidgetProps> = {}): MatchWidgetProps {
+  const currentPlayer: CriticalPlayerState = {
+    playerId: 'p1',
+    hand: ['strike'] as CriticalCard[],
+    alive: true,
+  };
+  const baseSnapshot = {
+    deck: [] as CriticalCard[],
+    discardPile: [] as CriticalCard[],
+    playerOrder: ['p1'],
+    currentTurnIndex: 0,
+    pendingDraws: 1,
+    pendingDefuse: null,
+    pendingFavor: null,
+    pendingAlter: null,
+    pendingAction: null,
+    players: [currentPlayer],
+    logs: [],
+    allowActionCardCombos: false,
+  };
+  return {
+    room: { id: 'room' } as never,
+    snapshot: baseSnapshot,
+    currentUserId: 'p1',
+    currentPlayer,
+    cardVariant: 'cyberpunk',
+    isGameOver: false,
+    isMyTurn: true,
+    canAct: true,
+    canPlayNope: false,
+    actionBusy: null,
+    aliveOpponents: [],
+    handLayout: 'grid',
+    setHandLayout: vi.fn(),
+    resolveDisplayName: (_id?: string, fb?: string) => fb,
+    t: ((k: string) => k) as never,
+    actions: {
+      drawCard: vi.fn(),
+      playNope: vi.fn(),
+      playSeeTheFuture: vi.fn(),
+      playFavor: vi.fn(),
+      giveFavorCard: vi.fn(),
+      playDefuse: vi.fn(),
+    } as never,
+    idleTimerTriggered: false,
+    autoplayState: { setAllEnabled: vi.fn() },
+    handleUnstash: vi.fn(),
+    handlePlayActionCard: vi.fn(),
+    handleOpenFavorModal: vi.fn(),
+    handleOpenEventCombo: vi.fn(),
+    handleOpenFiverCombo: vi.fn(),
+    ...override,
+  } as MatchWidgetProps;
+}
+
+describe('MatchWidget (ARC-632)', () => {
+  it('renders the table shell with Arena slotted as the center', () => {
+    render(<MatchWidget {...makeProps()} />);
     expect(screen.getByTestId('match-widget')).toBeInTheDocument();
-    expect(screen.getByTestId('active-game-content-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('game-table-section-stub')).toBeInTheDocument();
+    // Arena lands inside GameTableSection's centerSlot (the stub re-renders
+    // children inline so we can see the arena inside the table stub).
+    expect(screen.getByTestId('arena-stub')).toBeInTheDocument();
+  });
+
+  it('mounts PlayerHand when the current player is alive and game is live', () => {
+    render(<MatchWidget {...makeProps()} />);
+    expect(screen.getByTestId('player-hand-stub')).toBeInTheDocument();
+  });
+
+  it('hides PlayerHand when the current player is eliminated', () => {
+    render(
+      <MatchWidget
+        {...makeProps({
+          currentPlayer: {
+            playerId: 'p1',
+            hand: [],
+            alive: false,
+          },
+        })}
+      />,
+    );
+    expect(screen.queryByTestId('player-hand-stub')).not.toBeInTheDocument();
+  });
+
+  it('hides PlayerHand when the game is over', () => {
+    render(<MatchWidget {...makeProps({ isGameOver: true })} />);
+    expect(screen.queryByTestId('player-hand-stub')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -1,25 +1,122 @@
 'use client';
 
-import { ActiveGameContent } from './ActiveGameContent';
-import type { ComponentProps } from 'react';
+import { useCallback, type ComponentProps } from 'react';
+import type { ActiveGameContent } from './ActiveGameContent';
+import { GameBoard, TableArea } from './styles/layout';
+import { GameTableSection } from './GameTableSection';
+import { PlayerHand } from './PlayerHand';
+import { Arena } from './arena/Arena';
 
 export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent>;
 
 /**
- * Entry point for the Critical game widget rework (ARC-631).
+ * Widget-mode renderer for an active Critical match (ARC-631 onwards).
  *
- * For this ticket the widget is a transparent pass-through to the legacy
- * `ActiveGameContent`, mounted only when the `widget_mode` feature flag
- * is on. No behavior change vs. flag-off.
- *
- * Follow-up tickets restructure the inside of this component into the
- * three-row preview layout (opponents / arena / hand) — see
- * `docs/handoffs/PR-631-review2.md` §7 (ARC-632 — ARC-636).
+ * Layout-wise this mirrors `ActiveGameContent` for now — same `GameBoard >
+ * TableArea > GameTableSection + PlayerHand` shell — with one change: the
+ * center of the table is rendered by the new `Arena` (draw · center ·
+ * discard) instead of the legacy `CenterTableSection`. The HUD pieces and
+ * combo intent card move inside `Arena`'s center column in ARC-633.
  */
-export function MatchWidget(props: MatchWidgetProps) {
+export function MatchWidget({
+  room: _room,
+  snapshot,
+  currentUserId,
+  currentPlayer,
+  cardVariant,
+  isGameOver,
+  isMyTurn,
+  canAct,
+  canPlayNope,
+  actionBusy,
+  aliveOpponents,
+  handLayout,
+  setHandLayout,
+  resolveDisplayName,
+  t,
+  actions,
+  idleTimerTriggered,
+  autoplayState,
+  handleUnstash,
+  handlePlayActionCard,
+  handleOpenFavorModal,
+  handleOpenEventCombo,
+  handleOpenFiverCombo,
+}: MatchWidgetProps) {
+  const handleDrawAndEnd = useCallback(() => {
+    if (!isMyTurn || isGameOver) return;
+    actions.drawCard();
+  }, [actions, isMyTurn, isGameOver]);
+
+  const arena = (
+    <Arena
+      deck={snapshot.deck}
+      discardPile={snapshot.discardPile}
+      cardVariant={cardVariant}
+      isMyTurn={isMyTurn}
+      isGameOver={isGameOver}
+      onDrawAndEnd={handleDrawAndEnd}
+    />
+  );
+
   return (
     <div data-testid="match-widget">
-      <ActiveGameContent {...props} />
+      <GameBoard>
+        <TableArea>
+          <GameTableSection
+            players={snapshot.players}
+            playerOrder={snapshot.playerOrder}
+            currentTurnIndex={snapshot.currentTurnIndex}
+            currentUserId={currentUserId}
+            deck={snapshot.deck}
+            discardPileLength={snapshot.discardPile.length}
+            pendingDraws={snapshot.pendingDraws}
+            discardPile={snapshot.discardPile}
+            logs={snapshot.logs ?? []}
+            resolveDisplayName={(id, fb) => resolveDisplayName(id, fb) ?? fb}
+            t={t as (key: string) => string}
+            cardVariant={cardVariant}
+            centerSlot={arena}
+          />
+        </TableArea>
+
+        {currentPlayer && currentPlayer.alive && !isGameOver && (
+          <PlayerHand
+            currentPlayer={currentPlayer}
+            onUnstashCard={handleUnstash}
+            isMyTurn={isMyTurn}
+            isGameOver={isGameOver}
+            canAct={canAct}
+            canPlayNope={canPlayNope}
+            actionBusy={actionBusy}
+            aliveOpponents={aliveOpponents}
+            discardPileLength={snapshot?.discardPile?.length ?? 0}
+            logs={snapshot?.logs ?? []}
+            pendingAction={snapshot?.pendingAction ?? null}
+            pendingFavor={snapshot?.pendingFavor ?? null}
+            pendingDefuse={snapshot?.pendingDefuse ?? null}
+            deckSize={snapshot?.deck?.length ?? 0}
+            playerOrder={snapshot?.playerOrder ?? []}
+            currentUserId={currentUserId}
+            allowActionCardCombos={snapshot?.allowActionCardCombos ?? false}
+            t={t as (key: string) => string}
+            onDraw={actions.drawCard}
+            onPlayActionCard={handlePlayActionCard}
+            onPlayNope={actions.playNope}
+            onPlaySeeTheFuture={actions.playSeeTheFuture}
+            onOpenFavorModal={handleOpenFavorModal}
+            onGiveFavorCard={actions.giveFavorCard}
+            onPlayDefuse={actions.playDefuse}
+            onOpenEventCombo={handleOpenEventCombo}
+            onOpenFiverCombo={handleOpenFiverCombo}
+            forceEnableAutoplay={idleTimerTriggered}
+            onAutoplayEnabledChange={autoplayState.setAllEnabled}
+            cardVariant={cardVariant}
+            handLayout={handLayout}
+            setHandLayout={setHandLayout}
+          />
+        )}
+      </GameBoard>
     </div>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '../../../../shared/config/tamagui.config';
+import { ScenePaletteProvider } from '../ScenePaletteContext';
+import { getVariantStyles } from '../styles/variants';
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// DeckDisplay and LastPlayedCardDisplay pull in the cards sprite pipeline
+// which isn't worth booting just to assert the Arena composition.
+vi.mock('../DeckDisplay', () => ({
+  DeckDisplay: () => <div data-testid="deck-display-stub" />,
+}));
+vi.mock('../LastPlayedCardDisplay', () => ({
+  LastPlayedCardDisplay: () => <div data-testid="last-played-stub" />,
+}));
+
+import { Arena } from './Arena';
+import type { CriticalCard } from '../../types';
+
+const palette = getVariantStyles('cyberpunk').scene;
+
+function renderArena(
+  override: Partial<React.ComponentProps<typeof Arena>> = {},
+) {
+  const props: React.ComponentProps<typeof Arena> = {
+    deck: ['strike', 'evade', 'trade'] as CriticalCard[],
+    discardPile: ['strike'] as CriticalCard[],
+    cardVariant: 'cyberpunk',
+    isMyTurn: true,
+    isGameOver: false,
+    onDrawAndEnd: vi.fn(),
+    ...override,
+  };
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <ScenePaletteProvider palette={palette}>
+        <Arena {...props} />
+      </ScenePaletteProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('Arena', () => {
+  it('renders draw pile, center placeholder, and discard pile', () => {
+    renderArena();
+    expect(screen.getByTestId('arena')).toBeInTheDocument();
+    expect(screen.getByTestId('arena-draw-pile')).toBeInTheDocument();
+    expect(screen.getByTestId('arena-center')).toBeInTheDocument();
+    expect(screen.getByTestId('arena-discard-pile')).toBeInTheDocument();
+  });
+
+  it('shows the deck count', () => {
+    renderArena({ deck: ['strike', 'evade'] as CriticalCard[] });
+    expect(screen.getByTestId('arena-draw-pile-count')).toHaveTextContent('2');
+  });
+
+  it('shows the discard count', () => {
+    renderArena({
+      discardPile: ['strike', 'evade', 'trade'] as CriticalCard[],
+    });
+    expect(screen.getByTestId('arena-discard-pile-count')).toHaveTextContent(
+      '3',
+    );
+  });
+
+  it('fires onDrawAndEnd when the draw pile is clicked on your turn', () => {
+    const onDrawAndEnd = vi.fn();
+    renderArena({ isMyTurn: true, onDrawAndEnd });
+    fireEvent.click(screen.getByTestId('arena-draw-pile'));
+    expect(onDrawAndEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire onDrawAndEnd when it is not your turn', () => {
+    const onDrawAndEnd = vi.fn();
+    renderArena({ isMyTurn: false, onDrawAndEnd });
+    fireEvent.click(screen.getByTestId('arena-draw-pile'));
+    expect(onDrawAndEnd).not.toHaveBeenCalled();
+  });
+
+  it('disables the draw pile when the game is over', () => {
+    const onDrawAndEnd = vi.fn();
+    renderArena({ isMyTurn: true, isGameOver: true, onDrawAndEnd });
+    fireEvent.click(screen.getByTestId('arena-draw-pile'));
+    expect(onDrawAndEnd).not.toHaveBeenCalled();
+    expect(screen.getByTestId('arena-draw-pile')).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { XStack } from 'tamagui';
+import type { CriticalCard } from '../../types';
+import { DrawPile } from './DrawPile';
+import { DiscardPile } from './DiscardPile';
+import { ArenaCenter } from './ArenaCenter';
+
+interface ArenaProps {
+  deck: CriticalCard[];
+  discardPile: CriticalCard[];
+  cardVariant?: string;
+  isMyTurn: boolean;
+  isGameOver: boolean;
+  onDrawAndEnd: () => void;
+}
+
+/**
+ * Three-column arena row (draw · center · discard) — Row 2 of the §7
+ * widget layout. The center column is currently a placeholder slot for
+ * the HUD pieces that ARC-633 will move inside it.
+ */
+export function Arena({
+  deck,
+  discardPile,
+  cardVariant,
+  isMyTurn,
+  isGameOver,
+  onDrawAndEnd,
+}: ArenaProps) {
+  return (
+    <XStack
+      data-testid="arena"
+      width="100%"
+      alignItems="center"
+      justifyContent="space-between"
+      gap="$4"
+      paddingHorizontal="$3"
+      $sm={{ gap: '$2', paddingHorizontal: '$2' }}
+    >
+      <DrawPile
+        deck={deck}
+        count={deck.length}
+        disabled={!isMyTurn || isGameOver}
+        onDraw={onDrawAndEnd}
+        cardVariant={cardVariant}
+      />
+      <ArenaCenter />
+      <DiscardPile pile={discardPile} cardVariant={cardVariant} />
+    </XStack>
+  );
+}

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { YStack } from 'tamagui';
+
+/**
+ * Center column of the Arena. ARC-633 fills this with the turn pill, combo
+ * intent card, threat strip, and absolutely-positioned flash banner.
+ * For ARC-632 it's a sized placeholder so the three-column grid keeps its
+ * shape when the strip is empty.
+ */
+export function ArenaCenter() {
+  return (
+    <YStack
+      data-testid="arena-center"
+      flex={1}
+      minHeight={120}
+      alignItems="center"
+      justifyContent="center"
+    />
+  );
+}

--- a/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { YStack, Text } from 'tamagui';
+import { useTranslation } from '@/shared/lib/useTranslation';
+import type { CriticalCard } from '../../types';
+import { LastPlayedCardDisplay } from '../LastPlayedCardDisplay';
+
+interface DiscardPileProps {
+  pile: CriticalCard[];
+  cardVariant?: string;
+}
+
+export function DiscardPile({ pile, cardVariant }: DiscardPileProps) {
+  const { t } = useTranslation();
+  const count = pile.length;
+  const tCompat = t as unknown as (key: string) => string;
+
+  return (
+    <YStack data-testid="arena-discard-pile" alignItems="center" gap="$1">
+      <LastPlayedCardDisplay
+        discardPile={pile}
+        t={tCompat}
+        cardVariant={cardVariant}
+      />
+      <Text
+        data-testid="arena-discard-pile-count"
+        fontSize={12}
+        fontWeight="800"
+        letterSpacing={0.4}
+        opacity={0.85}
+      >
+        {t('games.table.state.discard')} · {count}
+      </Text>
+    </YStack>
+  );
+}

--- a/apps/web/src/widgets/CriticalGame/ui/arena/DrawPile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/DrawPile.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { YStack, Text } from 'tamagui';
+import { useTranslation } from '@/shared/lib/useTranslation';
+import type { CriticalCard } from '../../types';
+import { DeckDisplay } from '../DeckDisplay';
+
+interface DrawPileProps {
+  deck: CriticalCard[];
+  count: number;
+  disabled: boolean;
+  onDraw: () => void;
+  cardVariant?: string;
+}
+
+export function DrawPile({
+  deck,
+  count,
+  disabled,
+  onDraw,
+  cardVariant,
+}: DrawPileProps) {
+  const { t } = useTranslation();
+  // DeckDisplay's `t` prop accepts the unparameterised string form used by
+  // the existing layout — cast through to keep the typed namespace inside
+  // the new components without forking DeckDisplay just for ARC-632.
+  const tCompat = t as unknown as (key: string) => string;
+
+  return (
+    <YStack
+      data-testid="arena-draw-pile"
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
+      aria-label={t('games.table.arena.drawAria')}
+      onPress={disabled ? undefined : onDraw}
+      onKeyDown={
+        disabled
+          ? undefined
+          : (e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onDraw();
+              }
+            }
+      }
+      alignItems="center"
+      gap="$1"
+      opacity={disabled ? 0.55 : 1}
+      cursor={disabled ? 'default' : 'pointer'}
+      hoverStyle={disabled ? undefined : { scale: 1.02 }}
+      pressStyle={disabled ? undefined : { scale: 0.98 }}
+    >
+      <DeckDisplay deck={deck} t={tCompat} cardVariant={cardVariant} />
+      <Text
+        data-testid="arena-draw-pile-count"
+        fontSize={12}
+        fontWeight="800"
+        letterSpacing={0.4}
+        opacity={0.85}
+      >
+        {t('games.table.state.deck')} · {count}
+      </Text>
+      <Text
+        data-testid="arena-draw-pile-hint"
+        fontSize={10}
+        fontWeight="600"
+        letterSpacing={0.4}
+        textTransform="uppercase"
+        opacity={0.6}
+      >
+        {t('games.table.arena.drawHint')}
+      </Text>
+    </YStack>
+  );
+}


### PR DESCRIPTION
## Summary

Second slice of the [§7 layout rework](docs/handoffs/PR-631-review2.md). Builds the three-column arena row (**draw · center · discard**) and slots it into the widget-mode render path. **No behavior change vs. flag-off** — `ActiveGameContent` + `CenterTableSection` still drive the legacy layout.

### New components
- [`ui/arena/Arena.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx) — XStack laying out the three columns.
- [`ui/arena/DrawPile.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/DrawPile.tsx) — `DeckDisplay` wrapped in a keyboard-accessible button. Disabled (`aria-disabled`, no click handler) when it's not your turn or the game is over. Shows count + a `tap to draw + end turn` hint.
- [`ui/arena/DiscardPile.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx) — `LastPlayedCardDisplay` + count label.
- [`ui/arena/ArenaCenter.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx) — sized placeholder; ARC-633 fills it with the turn pill, combo intent card, threat strip, and an absolutely-positioned flash banner.

### Wiring
- [`ui/GameTableSection.tsx`](apps/web/src/widgets/CriticalGame/ui/GameTableSection.tsx) gains an optional `centerSlot?: ReactNode` prop. Backward-compatible — every existing caller (and the flag-off path) keeps using `CenterTableSection` by default.
- [`ui/MatchWidget.tsx`](apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx) stops being a transparent pass-through. It now owns the same `GameBoard > TableArea > GameTableSection + PlayerHand` shell as `ActiveGameContent`, but injects `<Arena>` as the `centerSlot`. `ActiveGameContent` itself is untouched.

### i18n
New `games.table.arena.{drawHint, drawAria}` keys added across en/ru/es/fr/by.

## Why

The reviewer's migration in `PR-631-review2.md` §7 has this as **slice 2** (ARC-632). It's the smallest demonstrable visual change behind the flag — players in widget mode see the new draw / discard layout while the rest of the table (opponents, hand) stays on the legacy path until ARC-634 / ARC-635 land.

## How to verify

- Flag-off (default): match looks identical to before this PR. CenterTableSection still renders the deck + last-played in the ring.
- Flag-on (`?widget_mode=1`): the center of the table is now the new Arena row. `data-testid=\"arena\"`, `data-testid=\"arena-draw-pile\"`, `data-testid=\"arena-discard-pile\"` visible in DevTools.
- Click the draw pile on your turn → draws a card and ends turn.
- Off-turn / game-over: draw pile shows `aria-disabled=\"true\"` and clicks are no-ops.

## Test plan

- [x] 6 new Arena unit tests (composition, counts, click guards on turn / game-over)
- [x] MatchWidget tests rewritten for the new composition (4 tests covering shell, Arena slotting, PlayerHand alive/eliminated/game-over guards)
- [x] Full Critical widget suite — 122/122 passing (was 113)
- [x] `pnpm type-check`, `pnpm lint`, `pnpm check-file-length` clean
- [ ] Manual QA flag-on: visit any active match with `?widget_mode=1`; confirm Arena renders and Draw click works
- [ ] Manual QA flag-off: existing CenterTableSection layout still renders unchanged

## Follow-ups

ARC-633 (ArenaCenter + ComboCard + relocate Hud pieces), ARC-634 (OpponentsRow), ARC-635 (HandZone), ARC-636 (drop CriticalGameHeader from match view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)