### PR TITLE
feat(critical/widget): ArenaCenter + ComboCard inside Arena (ARC-633)

### DIFF
--- a/apps/web/src/shared/i18n/messages/games/critical/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/by.ts
@@ -240,6 +240,7 @@ export const byMessages = {
         pair: '2× пара',
         triple: '3× тройка',
         fiver: '5 розных',
+        placeholder: 'Абярыце карты для камбо',
       },
       extraTurns: '+{{count}} ход',
       extraTurnsPlural: '+{{count}} хадоў',

--- a/apps/web/src/shared/i18n/messages/games/critical/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/en.ts
@@ -236,6 +236,7 @@ export const enMessages = {
         pair: '2× pair',
         triple: '3× triple',
         fiver: '5 different',
+        placeholder: 'Select cards to combo',
       },
       extraTurns: '+{{count}} turn',
       extraTurnsPlural: '+{{count}} turns',

--- a/apps/web/src/shared/i18n/messages/games/critical/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/es.ts
@@ -239,6 +239,7 @@ export const esMessages = {
         pair: '2× par',
         triple: '3× trío',
         fiver: '5 diferentes',
+        placeholder: 'Selecciona cartas para un combo',
       },
       extraTurns: '+{{count}} turno',
       extraTurnsPlural: '+{{count}} turnos',

--- a/apps/web/src/shared/i18n/messages/games/critical/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/fr.ts
@@ -243,6 +243,7 @@ export const frMessages = {
         pair: '2× paire',
         triple: '3× triple',
         fiver: '5 différentes',
+        placeholder: 'Sélectionnez des cartes pour un combo',
       },
       extraTurns: '+{{count}} tour',
       extraTurnsPlural: '+{{count}} tours',

--- a/apps/web/src/shared/i18n/messages/games/critical/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/ru.ts
@@ -242,6 +242,7 @@ export const ruMessages = {
         pair: '2× пара',
         triple: '3× тройка',
         fiver: '5 разных',
+        placeholder: 'Выберите карты для комбо',
       },
       extraTurns: '+{{count}} ход',
       extraTurnsPlural: '+{{count}} ходов',

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -288,60 +288,64 @@ export function ActiveGameView({
           isFullscreen={isFullscreen}
           toggleFullscreen={toggleFullscreen}
         />
-        <XStack justifyContent="center">
-          <TurnBanner
-            isMyTurn={!!isMyTurn}
-            currentPlayerName={
-              currentTurnPlayer
-                ? resolveDisplayName(currentTurnPlayer.playerId, 'Player')
-                : ''
-            }
-            secondsRemaining={null}
-            pendingDraws={snapshot.pendingDraws}
-          />
-        </XStack>
-        <MatchHud
-          snapshot={snapshot}
-          currentPlayer={currentPlayer}
-          isGameOver={!!isGameOver}
-          formatLogMessage={formatLogMessage}
-        />
-
-        {/* Flag-gated render. MatchWidget is currently a pass-through to */}
-        {/* ActiveGameContent; the §7 rework lands inside MatchWidget. */}
-        {(() => {
-          const ContentImpl = widgetMode ? MatchWidget : ActiveGameContent;
-          return (
-            <ContentImpl
-              room={room}
+        {/* Flag-off: legacy top-of-page TurnBanner + MatchHud. In widget */}
+        {/* mode these move inside the Arena's center column (ARC-633). */}
+        {!widgetMode && (
+          <>
+            <XStack justifyContent="center">
+              <TurnBanner
+                isMyTurn={!!isMyTurn}
+                currentPlayerName={
+                  currentTurnPlayer
+                    ? resolveDisplayName(currentTurnPlayer.playerId, 'Player')
+                    : ''
+                }
+                secondsRemaining={null}
+                pendingDraws={snapshot.pendingDraws}
+              />
+            </XStack>
+            <MatchHud
               snapshot={snapshot}
-              currentUserId={currentUserId}
               currentPlayer={currentPlayer}
-              cardVariant={cardVariant}
               isGameOver={!!isGameOver}
-              isMyTurn={!!isMyTurn}
-              canAct={!!canAct}
-              canPlayNope={canPlayNope}
-              actionBusy={actionBusy}
-              aliveOpponents={aliveOpponents}
-              handLayout={handLayout}
-              setHandLayout={setHandLayout}
-              resolveDisplayName={resolveDisplayName}
-              t={
-                t as unknown as (
-                  key: string,
-                  params?: Record<string, string | number>,
-                ) => string
-              }
-              actions={actions}
-              idleTimerTriggered={idleTimerTriggered}
-              autoplayState={autoplayState}
-              handleUnstash={handleUnstash}
-              handlePlayActionCard={handlePlayActionCard}
-              handleOpenFavorModal={handleOpenFavorModal}
-              handleOpenEventCombo={handleOpenEventCombo}
-              handleOpenFiverCombo={handleOpenFiverCombo}
+              formatLogMessage={formatLogMessage}
             />
+          </>
+        )}
+
+        {(() => {
+          const sharedProps = {
+            room,
+            snapshot,
+            currentUserId,
+            currentPlayer,
+            cardVariant,
+            isGameOver: !!isGameOver,
+            isMyTurn: !!isMyTurn,
+            canAct: !!canAct,
+            canPlayNope,
+            actionBusy,
+            aliveOpponents,
+            handLayout,
+            setHandLayout,
+            resolveDisplayName,
+            t: t as unknown as (
+              key: string,
+              params?: Record<string, string | number>,
+            ) => string,
+            actions,
+            idleTimerTriggered,
+            autoplayState,
+            handleUnstash,
+            handlePlayActionCard,
+            handleOpenFavorModal,
+            handleOpenEventCombo,
+            handleOpenFiverCombo,
+          };
+          return widgetMode ? (
+            <MatchWidget {...sharedProps} formatLogMessage={formatLogMessage} />
+          ) : (
+            <ActiveGameContent {...sharedProps} />
           );
         })()}
       </YStack>

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -82,6 +82,7 @@ function makeProps(override: Partial<MatchWidgetProps> = {}): MatchWidgetProps {
     handleOpenFavorModal: vi.fn(),
     handleOpenEventCombo: vi.fn(),
     handleOpenFiverCombo: vi.fn(),
+    formatLogMessage: (m?: string | null) => m ?? '',
     ...override,
   } as MatchWidgetProps;
 }

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import { useCallback, type ComponentProps } from 'react';
+import { useCallback, useMemo, type ComponentProps } from 'react';
 import type { ActiveGameContent } from './ActiveGameContent';
 import { GameBoard, TableArea } from './styles/layout';
 import { GameTableSection } from './GameTableSection';
 import { PlayerHand } from './PlayerHand';
 import { Arena } from './arena/Arena';
 
-export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent>;
+export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent> & {
+  /**
+   * Format a raw `CriticalLogEntry.message` for display. Comes from
+   * `useDisplayNames` in `ActiveGameView` — passed down so the FlashBanner
+   * inside the new ArenaCenter can surface formatted log entries.
+   */
+  formatLogMessage: (message?: string | null) => string;
+};
 
 /**
  * Widget-mode renderer for an active Critical match (ARC-631 onwards).
@@ -42,11 +49,20 @@ export function MatchWidget({
   handleOpenFavorModal,
   handleOpenEventCombo,
   handleOpenFiverCombo,
+  formatLogMessage,
 }: MatchWidgetProps) {
   const handleDrawAndEnd = useCallback(() => {
     if (!isMyTurn || isGameOver) return;
     actions.drawCard();
   }, [actions, isMyTurn, isGameOver]);
+
+  const currentPlayerName = useMemo(() => {
+    const turnPlayerId = snapshot.playerOrder[snapshot.currentTurnIndex];
+    if (!turnPlayerId) return '';
+    return resolveDisplayName(turnPlayerId, 'Player') ?? 'Player';
+  }, [snapshot.playerOrder, snapshot.currentTurnIndex, resolveDisplayName]);
+
+  const hand = currentPlayer?.hand ?? [];
 
   const arena = (
     <Arena
@@ -56,6 +72,12 @@ export function MatchWidget({
       isMyTurn={isMyTurn}
       isGameOver={isGameOver}
       onDrawAndEnd={handleDrawAndEnd}
+      hand={hand}
+      allowActionCardCombos={snapshot.allowActionCardCombos ?? false}
+      currentPlayerName={currentPlayerName}
+      pendingDraws={snapshot.pendingDraws}
+      logs={snapshot.logs ?? []}
+      formatLogMessage={formatLogMessage}
     />
   );
 

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
@@ -35,6 +35,12 @@ function renderArena(
     isMyTurn: true,
     isGameOver: false,
     onDrawAndEnd: vi.fn(),
+    hand: ['strike'] as CriticalCard[],
+    allowActionCardCombos: false,
+    currentPlayerName: 'Alice',
+    pendingDraws: 1,
+    logs: [],
+    formatLogMessage: (m?: string | null) => m ?? '',
     ...override,
   };
   return render(

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { XStack } from 'tamagui';
-import type { CriticalCard } from '../../types';
+import type { CriticalCard, CriticalLogEntry } from '../../types';
 import { DrawPile } from './DrawPile';
 import { DiscardPile } from './DiscardPile';
 import { ArenaCenter } from './ArenaCenter';
+import type { ComboKind } from './ComboCard';
 
 interface ArenaProps {
   deck: CriticalCard[];
@@ -13,12 +14,20 @@ interface ArenaProps {
   isMyTurn: boolean;
   isGameOver: boolean;
   onDrawAndEnd: () => void;
+  // ArenaCenter passthrough
+  hand: CriticalCard[];
+  allowActionCardCombos: boolean;
+  combo?: { kind: ComboKind; label: string };
+  currentPlayerName: string;
+  pendingDraws: number;
+  logs: CriticalLogEntry[];
+  formatLogMessage: (message?: string | null) => string;
 }
 
 /**
  * Three-column arena row (draw · center · discard) — Row 2 of the §7
- * widget layout. The center column is currently a placeholder slot for
- * the HUD pieces that ARC-633 will move inside it.
+ * widget layout. The center column hosts the turn pill, combo intent
+ * card, threat strip, and an absolutely-positioned flash banner.
  */
 export function Arena({
   deck,
@@ -27,6 +36,13 @@ export function Arena({
   isMyTurn,
   isGameOver,
   onDrawAndEnd,
+  hand,
+  allowActionCardCombos,
+  combo,
+  currentPlayerName,
+  pendingDraws,
+  logs,
+  formatLogMessage,
 }: ArenaProps) {
   return (
     <XStack
@@ -45,7 +61,17 @@ export function Arena({
         onDraw={onDrawAndEnd}
         cardVariant={cardVariant}
       />
-      <ArenaCenter />
+      <ArenaCenter
+        isMyTurn={isMyTurn}
+        currentPlayerName={currentPlayerName}
+        pendingDraws={pendingDraws}
+        hand={hand}
+        allowActionCardCombos={allowActionCardCombos}
+        combo={combo}
+        deck={deck}
+        logs={logs}
+        formatLogMessage={formatLogMessage}
+      />
       <DiscardPile pile={discardPile} cardVariant={cardVariant} />
     </XStack>
   );

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '../../../../shared/config/tamagui.config';
+import { ScenePaletteProvider } from '../ScenePaletteContext';
+import { getVariantStyles } from '../styles/variants';
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      if (key === 'games.table.players.yourMove') return 'Your move';
+      if (key === 'games.table.players.playerTurn') {
+        return `${params?.name ?? ''}'s turn`;
+      }
+      return key;
+    },
+  }),
+}));
+
+import { ArenaCenter } from './ArenaCenter';
+import type { CriticalCard } from '../../types';
+
+const palette = getVariantStyles('cyberpunk').scene;
+
+function renderCenter(
+  override: Partial<React.ComponentProps<typeof ArenaCenter>> = {},
+) {
+  const props: React.ComponentProps<typeof ArenaCenter> = {
+    isMyTurn: true,
+    currentPlayerName: 'Alice',
+    pendingDraws: 1,
+    hand: ['strike', 'evade'] as CriticalCard[],
+    allowActionCardCombos: false,
+    deck: ['strike'] as CriticalCard[],
+    logs: [],
+    formatLogMessage: (m?: string | null) => m ?? '',
+    ...override,
+  };
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <ScenePaletteProvider palette={palette}>
+        <ArenaCenter {...props} />
+      </ScenePaletteProvider>
+    </TamaguiProvider>,
+  );
+}
+
+describe('ArenaCenter', () => {
+  it('renders turn banner, combo card, threat strip, and flash slot', () => {
+    renderCenter();
+    expect(screen.getByTestId('arena-center')).toBeInTheDocument();
+    expect(screen.getByTestId('turn-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('combo-card')).toBeInTheDocument();
+    expect(screen.getByTestId('threat-strip')).toBeInTheDocument();
+    expect(screen.getByTestId('arena-flash-slot')).toBeInTheDocument();
+  });
+
+  it('renders the flash slot as a child of arena-center so the overlay can position relative to it', () => {
+    const { container } = renderCenter();
+    const center = container.querySelector('[data-testid="arena-center"]');
+    expect(center).not.toBeNull();
+    expect(
+      center?.querySelector('[data-testid="arena-flash-slot"]'),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
@@ -1,14 +1,48 @@
 'use client';
 
 import { YStack } from 'tamagui';
+import { TurnBanner } from '../TurnBanner';
+import { ThreatStrip } from '../ThreatStrip';
+import { FlashBanner } from '../FlashBanner';
+import { HudStyles } from '../hudStyles';
+import { ComboCard, type ComboKind } from './ComboCard';
+import type { CriticalCard, CriticalLogEntry } from '../../types';
+
+interface ArenaCenterProps {
+  // Turn banner
+  isMyTurn: boolean;
+  currentPlayerName: string;
+  pendingDraws: number;
+  // Combo card
+  hand: CriticalCard[];
+  allowActionCardCombos: boolean;
+  combo?: { kind: ComboKind; label: string };
+  // Threat strip
+  deck: CriticalCard[];
+  // Flash banner
+  logs: CriticalLogEntry[];
+  formatLogMessage: (message?: string | null) => string;
+}
 
 /**
- * Center column of the Arena. ARC-633 fills this with the turn pill, combo
- * intent card, threat strip, and absolutely-positioned flash banner.
- * For ARC-632 it's a sized placeholder so the three-column grid keeps its
- * shape when the strip is empty.
+ * Center column of the Arena. Stacks the turn pill, combo intent card, and
+ * threat strip vertically; the flash banner is absolutely positioned at the
+ * top so it overlays without pushing the stack down.
+ *
+ * Selection-aware combo intent (the `combo` prop) lands when HandZone
+ * lifts `selectedUids` in ARC-635. ARC-633 ships the shell.
  */
-export function ArenaCenter() {
+export function ArenaCenter({
+  isMyTurn,
+  currentPlayerName,
+  pendingDraws,
+  hand,
+  allowActionCardCombos,
+  combo,
+  deck,
+  logs,
+  formatLogMessage,
+}: ArenaCenterProps) {
   return (
     <YStack
       data-testid="arena-center"
@@ -16,6 +50,34 @@ export function ArenaCenter() {
       minHeight={120}
       alignItems="center"
       justifyContent="center"
-    />
+      gap="$2"
+      position="relative"
+    >
+      <HudStyles />
+      <YStack
+        data-testid="arena-flash-slot"
+        position="absolute"
+        top={-8}
+        left={0}
+        right={0}
+        alignItems="center"
+        pointerEvents="none"
+        zIndex={5}
+      >
+        <FlashBanner logs={logs} formatMessage={formatLogMessage} />
+      </YStack>
+      <TurnBanner
+        isMyTurn={isMyTurn}
+        currentPlayerName={currentPlayerName}
+        secondsRemaining={null}
+        pendingDraws={pendingDraws}
+      />
+      <ComboCard
+        hand={hand}
+        allowActionCardCombos={allowActionCardCombos}
+        combo={combo}
+      />
+      <ThreatStrip hand={hand} deck={deck} />
+    </YStack>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '../../../../shared/config/tamagui.config';
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ComboCard, type ComboKind } from './ComboCard';
+import type { CriticalCard } from '../../types';
+
+function renderCard(
+  props: React.ComponentProps<typeof ComboCard>,
+): ReturnType<typeof render> {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <ComboCard {...props} />
+    </TamaguiProvider>,
+  );
+}
+
+describe('ComboCard', () => {
+  it('falls back to the placeholder label and `none` kind when no combo is provided', () => {
+    renderCard({
+      hand: ['strike'] as CriticalCard[],
+      allowActionCardCombos: false,
+    });
+    const card = screen.getByTestId('combo-card');
+    expect(card).toHaveAttribute('data-kind', 'none');
+    expect(screen.getByTestId('combo-card-label')).toHaveTextContent(
+      'games.table.hud.combo.placeholder',
+    );
+  });
+
+  it('renders the contextual label when a combo is detected', () => {
+    renderCard({
+      hand: [] as CriticalCard[],
+      allowActionCardCombos: false,
+      combo: { kind: 'pair', label: 'Play 2× Strike · steal' },
+    });
+    expect(screen.getByTestId('combo-card-label')).toHaveTextContent(
+      'Play 2× Strike · steal',
+    );
+    expect(screen.getByTestId('combo-card')).toHaveAttribute(
+      'data-kind',
+      'pair',
+    );
+  });
+
+  it.each<ComboKind>(['single', 'pair', 'triple', 'five', 'invalid'])(
+    'exposes data-kind="%s" on the wrapper for downstream tints',
+    (kind) => {
+      renderCard({
+        hand: [] as CriticalCard[],
+        allowActionCardCombos: false,
+        combo: { kind, label: kind },
+      });
+      expect(screen.getByTestId('combo-card')).toHaveAttribute(
+        'data-kind',
+        kind,
+      );
+    },
+  );
+
+  it('embeds ComboHints inside the card', () => {
+    renderCard({
+      hand: ['strike'] as CriticalCard[],
+      allowActionCardCombos: false,
+    });
+    expect(screen.getByTestId('combo-hints')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { YStack, Text } from 'tamagui';
+import { useTranslation } from '@/shared/lib/useTranslation';
+import { ComboHints } from '../ComboHints';
+import type { CriticalCard } from '../../types';
+
+export type ComboKind =
+  | 'none'
+  | 'single'
+  | 'pair'
+  | 'triple'
+  | 'five'
+  | 'invalid';
+
+interface ComboCardProps {
+  hand: CriticalCard[];
+  allowActionCardCombos: boolean;
+  /**
+   * Detected combo for the current selection. ARC-633 wires only the
+   * default `none` state through — ARC-635 (HandZone) lifts the actual
+   * selection state and starts driving this value.
+   */
+  combo?: { kind: ComboKind; label: string };
+}
+
+const KIND_BORDER: Record<ComboKind, string> = {
+  none: 'rgba(255,255,255,0.12)',
+  single: '#22d3ee',
+  pair: '#f59e0b',
+  triple: '#a78bfa',
+  five: '#f472b6',
+  invalid: '#ef4444',
+};
+
+const KIND_GLOW: Record<ComboKind, string> = {
+  none: 'transparent',
+  single: 'rgba(34, 211, 238, 0.25)',
+  pair: 'rgba(245, 158, 11, 0.28)',
+  triple: 'rgba(167, 139, 250, 0.28)',
+  five: 'rgba(244, 114, 182, 0.28)',
+  invalid: 'rgba(239, 68, 68, 0.18)',
+};
+
+export function ComboCard({
+  hand,
+  allowActionCardCombos,
+  combo,
+}: ComboCardProps) {
+  const { t } = useTranslation();
+  const kind: ComboKind = combo?.kind ?? 'none';
+  const label = combo?.label ?? t('games.table.hud.combo.placeholder');
+
+  return (
+    <YStack
+      data-testid="combo-card"
+      data-kind={kind}
+      alignItems="center"
+      gap="$2"
+      paddingHorizontal="$3"
+      paddingVertical="$2"
+      borderRadius={14}
+      borderWidth={1}
+      borderColor={KIND_BORDER[kind]}
+      backgroundColor="rgba(0,0,0,0.45)"
+      opacity={kind === 'invalid' ? 0.65 : 1}
+      shadowColor={KIND_GLOW[kind]}
+      shadowOpacity={kind === 'none' ? 0 : 1}
+      shadowRadius={12}
+    >
+      <Text
+        data-testid="combo-card-label"
+        fontSize={11}
+        fontWeight="800"
+        letterSpacing={0.6}
+        textTransform="uppercase"
+        color="#e2e8f0"
+      >
+        {label}
+      </Text>
+      <ComboHints hand={hand} allowActionCardCombos={allowActionCardCombos} />
+    </YStack>
+  );
+}


### PR DESCRIPTION
## Summary

Third slice of the [§7 rework](docs/handoffs/PR-631-review2.md). Fills the `ArenaCenter` placeholder from ARC-632 with the actual HUD pieces (TurnBanner, ComboCard, ThreatStrip) and an absolutely-positioned FlashBanner overlay. Adds the new `ComboCard` wrapper around the existing combo hint chips.

**Selection-aware combo intent is plumbed but not yet driven.** The `combo` prop on `ComboCard` and `ArenaCenter` is in place and renders the right tint/label when given a value — but ARC-635 (HandZone) is the one that lifts `selectedUids` out of `PlayerHand` and starts feeding a real value through. Until then, ComboCard sits in the `none` state with a placeholder label.

### New components
- [`ui/arena/ComboCard.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx) — wrapper that tints by `data-kind` (`none` / `single` / `pair` / `triple` / `five` / `invalid`) and embeds `ComboHints`. Placeholder label `Select cards to combo` until selection lifts.

### Updated components
- [`ui/arena/ArenaCenter.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx) — was an empty placeholder; now stacks `TurnBanner` + `ComboCard` + `ThreatStrip` vertically with `FlashBanner` absolutely positioned at the top so feedback overlays without shifting the stack.
- [`ui/arena/Arena.tsx`](apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx) — forwards hand / logs / current turn player name / pending draws / `formatLogMessage` through to `ArenaCenter`.
- [`ui/MatchWidget.tsx`](apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx) — gains a `formatLogMessage` prop and derives the current turn player's display name. `ActiveGameView` passes it through.
- [`ui/ActiveGameView.tsx`](apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx) — **top-of-page TurnBanner + MatchHud now render only when `!widgetMode`**, since the same pieces live inside `ArenaCenter` in widget mode. Avoids duplicate HUDs. Legacy (flag-off) path is unchanged.

### i18n
`games.table.hud.combo.placeholder` added across en/ru/es/fr/by.

## Why

The reviewer's §7 has this as **slice 3** (ARC-633). It's the most visible widget-mode change so far: the entire HUD stack is now anchored to the arena center column rather than free-floating above the table.

## How to verify

- Flag-off (default): everything looks identical to before. Top-of-page TurnBanner + MatchHud still render.
- Flag-on (`?widget_mode=1`): top-of-page TurnBanner + MatchHud disappear. The same pieces re-appear inside the Arena's center column, with the FlashBanner overlaying transient feedback at the top. `data-testid` markers: `combo-card`, `arena-center`, `arena-flash-slot`.
- ComboCard currently shows the placeholder label. Try selecting cards — the label won't change yet (that's ARC-635).

## Test plan

- [x] 6 new ComboCard tests (placeholder/contextual label, all 5 tint kinds, ComboHints embedding)
- [x] 2 new ArenaCenter tests (4-piece composition, flash slot as child)
- [x] Existing tests updated for the new prop shape
- [x] Full Critical widget suite — 132/132 passing (was 122)
- [x] `pnpm type-check`, `pnpm lint`, `pnpm check-file-length` clean
- [ ] Manual QA flag-on: HUD shows up inside arena, flash banner overlays correctly, no duplicate HUDs
- [ ] Manual QA flag-off: existing layout unchanged

## Follow-ups

- **ARC-634** — OpponentsRow + OpponentTile (FFA 5-up grid)
- **ARC-635** — HandZone + HandRail + HandCards; lifts `selectedUids` from PlayerHand and starts driving ComboCard's `combo` prop with real selection state
- **ARC-636** — drop CriticalGameHeader from match view

🤖 Generated with [Claude Code](https://claude.com/claude-code)