### PR TITLE
feat(critical/widget): OpponentsRow + OpponentTile (ARC-634)

### DIFF
--- a/apps/web/src/shared/i18n/messages/games/critical/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/fr.ts
@@ -131,16 +131,11 @@ export const frMessages = {
         reorder: 'Mélangez la pioche',
         insight: 'Regardez les 3 premières cartes du paquet',
         cancel: 'Annule toute action sauf Incident Critique ou Désamorcer',
-        collectionAlpha:
-          'Collectez des modules identiques pour voler des cartes',
-        collectionBeta:
-          'Collectez des modules identiques pour voler des cartes',
-        collectionGamma:
-          'Collectez des modules identiques pour voler des cartes',
-        collectionDelta:
-          'Collectez des modules identiques pour voler des cartes',
-        collectionEpsilon:
-          'Collectez des modules identiques pour voler des cartes',
+        collectionAlpha: 'Collectez des modules pour voler des cartes',
+        collectionBeta: 'Collectez des modules pour voler des cartes',
+        collectionGamma: 'Collectez des modules pour voler des cartes',
+        collectionDelta: 'Collectez des modules pour voler des cartes',
+        collectionEpsilon: 'Collectez des modules pour voler des cartes',
         // Future Pack descriptions
         seeFuture5x: 'Regardez les 5 premières cartes du paquet',
         alterFuture3x: 'Réorganisez les 3 premières cartes',

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -5,9 +5,19 @@ vi.mock('@/shared/lib/useTranslation', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('./GameTableSection', () => ({
-  GameTableSection: ({ centerSlot }: { centerSlot?: React.ReactNode }) => (
-    <div data-testid="game-table-section-stub">{centerSlot}</div>
+vi.mock('./opponents/OpponentsRow', () => ({
+  OpponentsRow: ({
+    opponents,
+    currentTurnPlayerId,
+  }: {
+    opponents: Array<{ playerId: string }>;
+    currentTurnPlayerId: string | null;
+  }) => (
+    <div
+      data-testid="opponents-row-stub"
+      data-opponent-count={opponents.length}
+      data-current-turn={currentTurnPlayerId ?? ''}
+    />
   ),
 }));
 
@@ -87,19 +97,50 @@ function makeProps(override: Partial<MatchWidgetProps> = {}): MatchWidgetProps {
   } as MatchWidgetProps;
 }
 
-describe('MatchWidget (ARC-632)', () => {
-  it('renders the table shell with Arena slotted as the center', () => {
+describe('MatchWidget (ARC-634)', () => {
+  it('renders the three-row layout: OpponentsRow + Arena + PlayerHand', () => {
     render(<MatchWidget {...makeProps()} />);
     expect(screen.getByTestId('match-widget')).toBeInTheDocument();
-    expect(screen.getByTestId('game-table-section-stub')).toBeInTheDocument();
-    // Arena lands inside GameTableSection's centerSlot (the stub re-renders
-    // children inline so we can see the arena inside the table stub).
+    expect(screen.getByTestId('opponents-row-stub')).toBeInTheDocument();
     expect(screen.getByTestId('arena-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('player-hand-stub')).toBeInTheDocument();
   });
 
-  it('mounts PlayerHand when the current player is alive and game is live', () => {
-    render(<MatchWidget {...makeProps()} />);
-    expect(screen.getByTestId('player-hand-stub')).toBeInTheDocument();
+  it('passes only opponents (not the current user) to OpponentsRow', () => {
+    const players = [
+      { playerId: 'p1', hand: [] as CriticalCard[], alive: true },
+      { playerId: 'p2', hand: [] as CriticalCard[], alive: true },
+      { playerId: 'p3', hand: [] as CriticalCard[], alive: true },
+    ];
+    render(
+      <MatchWidget
+        {...makeProps({
+          currentUserId: 'p1',
+          snapshot: {
+            deck: [],
+            discardPile: [],
+            playerOrder: ['p1', 'p2', 'p3'],
+            currentTurnIndex: 1,
+            pendingDraws: 1,
+            pendingDefuse: null,
+            pendingFavor: null,
+            pendingAlter: null,
+            pendingAction: null,
+            players,
+            logs: [],
+            allowActionCardCombos: false,
+          },
+        })}
+      />,
+    );
+    expect(screen.getByTestId('opponents-row-stub')).toHaveAttribute(
+      'data-opponent-count',
+      '2',
+    );
+    expect(screen.getByTestId('opponents-row-stub')).toHaveAttribute(
+      'data-current-turn',
+      'p2',
+    );
   });
 
   it('hides PlayerHand when the current player is eliminated', () => {

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -3,9 +3,9 @@
 import { useCallback, useMemo, type ComponentProps } from 'react';
 import type { ActiveGameContent } from './ActiveGameContent';
 import { GameBoard, TableArea } from './styles/layout';
-import { GameTableSection } from './GameTableSection';
 import { PlayerHand } from './PlayerHand';
 import { Arena } from './arena/Arena';
+import { OpponentsRow } from './opponents/OpponentsRow';
 
 export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent> & {
   /**
@@ -17,13 +17,12 @@ export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent> & {
 };
 
 /**
- * Widget-mode renderer for an active Critical match (ARC-631 onwards).
+ * Widget-mode renderer for an active Critical match.
  *
- * Layout-wise this mirrors `ActiveGameContent` for now — same `GameBoard >
- * TableArea > GameTableSection + PlayerHand` shell — with one change: the
- * center of the table is rendered by the new `Arena` (draw · center ·
- * discard) instead of the legacy `CenterTableSection`. The HUD pieces and
- * combo intent card move inside `Arena`'s center column in ARC-633.
+ * Layout: a three-row stack — `OpponentsRow` (ARC-634) above the `Arena`
+ * (ARC-632 / ARC-633), with the legacy `PlayerHand` at the bottom until
+ * ARC-635 swaps in `HandZone`. No longer uses `GameTableSection`'s ring
+ * layout; opponents are now a horizontal strip / FFA grid.
  */
 export function MatchWidget({
   room: _room,
@@ -56,49 +55,45 @@ export function MatchWidget({
     actions.drawCard();
   }, [actions, isMyTurn, isGameOver]);
 
+  const turnPlayerId = snapshot.playerOrder[snapshot.currentTurnIndex] ?? null;
   const currentPlayerName = useMemo(() => {
-    const turnPlayerId = snapshot.playerOrder[snapshot.currentTurnIndex];
     if (!turnPlayerId) return '';
     return resolveDisplayName(turnPlayerId, 'Player') ?? 'Player';
-  }, [snapshot.playerOrder, snapshot.currentTurnIndex, resolveDisplayName]);
+  }, [turnPlayerId, resolveDisplayName]);
+
+  const opponents = useMemo(
+    () => snapshot.players.filter((p) => p.playerId !== currentUserId),
+    [snapshot.players, currentUserId],
+  );
+  const tileResolveName = useCallback(
+    (id: string, fb: string) => resolveDisplayName(id, fb) ?? fb,
+    [resolveDisplayName],
+  );
 
   const hand = currentPlayer?.hand ?? [];
-
-  const arena = (
-    <Arena
-      deck={snapshot.deck}
-      discardPile={snapshot.discardPile}
-      cardVariant={cardVariant}
-      isMyTurn={isMyTurn}
-      isGameOver={isGameOver}
-      onDrawAndEnd={handleDrawAndEnd}
-      hand={hand}
-      allowActionCardCombos={snapshot.allowActionCardCombos ?? false}
-      currentPlayerName={currentPlayerName}
-      pendingDraws={snapshot.pendingDraws}
-      logs={snapshot.logs ?? []}
-      formatLogMessage={formatLogMessage}
-    />
-  );
 
   return (
     <div data-testid="match-widget">
       <GameBoard>
+        <OpponentsRow
+          opponents={opponents}
+          currentTurnPlayerId={turnPlayerId}
+          resolveDisplayName={tileResolveName}
+        />
         <TableArea>
-          <GameTableSection
-            players={snapshot.players}
-            playerOrder={snapshot.playerOrder}
-            currentTurnIndex={snapshot.currentTurnIndex}
-            currentUserId={currentUserId}
+          <Arena
             deck={snapshot.deck}
-            discardPileLength={snapshot.discardPile.length}
-            pendingDraws={snapshot.pendingDraws}
             discardPile={snapshot.discardPile}
-            logs={snapshot.logs ?? []}
-            resolveDisplayName={(id, fb) => resolveDisplayName(id, fb) ?? fb}
-            t={t as (key: string) => string}
             cardVariant={cardVariant}
-            centerSlot={arena}
+            isMyTurn={isMyTurn}
+            isGameOver={isGameOver}
+            onDrawAndEnd={handleDrawAndEnd}
+            hand={hand}
+            allowActionCardCombos={snapshot.allowActionCardCombos ?? false}
+            currentPlayerName={currentPlayerName}
+            pendingDraws={snapshot.pendingDraws}
+            logs={snapshot.logs ?? []}
+            formatLogMessage={formatLogMessage}
           />
         </TableArea>
 

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '../../../../shared/config/tamagui.config';
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'games.table.players.eliminated') return 'Eliminated';
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/features/games/store/gameStore', () => ({
+  useGameStore: (selector: (s: unknown) => unknown) =>
+    selector({ idlePlayers: [] }),
+}));
+
+vi.mock('@/shared/ui', () => ({
+  IdleBadge: () => <span data-testid="idle-badge">idle</span>,
+}));
+
+import { OpponentTile } from './OpponentTile';
+import type { CriticalCard, CriticalPlayerTableState } from '../../types';
+
+function makePlayer(
+  override: Partial<CriticalPlayerTableState> = {},
+): CriticalPlayerTableState {
+  return {
+    playerId: 'p1',
+    alive: true,
+    hand: ['strike', 'evade'] as CriticalCard[],
+    ...override,
+  };
+}
+
+function renderTile(
+  override: Partial<React.ComponentProps<typeof OpponentTile>> = {},
+) {
+  const props: React.ComponentProps<typeof OpponentTile> = {
+    player: makePlayer(),
+    isCurrentTurn: false,
+    resolveDisplayName: (_id, fb) => fb,
+    ...override,
+  };
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <OpponentTile {...props} />
+    </TamaguiProvider>,
+  );
+}
+
+describe('OpponentTile', () => {
+  it('renders display name and hand count for an alive opponent', () => {
+    renderTile({
+      player: makePlayer({
+        playerId: 'alice',
+        hand: ['strike', 'evade', 'trade'] as CriticalCard[],
+      }),
+      resolveDisplayName: () => 'Alice',
+    });
+    expect(screen.getByTestId('opponent-tile-name-alice')).toHaveTextContent(
+      'Alice',
+    );
+    expect(screen.getByTestId('opponent-tile-count-alice')).toHaveTextContent(
+      '3',
+    );
+  });
+
+  it('shows the eliminated state when alive is false', () => {
+    renderTile({
+      player: makePlayer({ playerId: 'p1', alive: false, hand: [] }),
+    });
+    expect(
+      screen.getByTestId('opponent-tile-eliminated-p1'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('opponent-tile-count-p1'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('opponent-tile-p1')).toHaveAttribute(
+      'data-alive',
+      'false',
+    );
+  });
+
+  it('flags the current turn via data-current-turn', () => {
+    renderTile({ isCurrentTurn: true });
+    expect(screen.getByTestId('opponent-tile-p1')).toHaveAttribute(
+      'data-current-turn',
+      'true',
+    );
+  });
+
+  it('flags the armed target via data-target', () => {
+    renderTile({ isTarget: true });
+    expect(screen.getByTestId('opponent-tile-p1')).toHaveAttribute(
+      'data-target',
+      'true',
+    );
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { YStack, XStack, Text, useMedia } from 'tamagui';
+import { useTranslation } from '@/shared/lib/useTranslation';
+import { useGameStore, type GameState } from '@/features/games/store/gameStore';
+import { IdleBadge } from '@/shared/ui';
+import type { CriticalPlayerTableState } from '../../types';
+
+interface OpponentTileProps {
+  player: CriticalPlayerTableState;
+  isCurrentTurn: boolean;
+  isTarget?: boolean;
+  resolveDisplayName: (playerId: string, fallback: string) => string;
+}
+
+const TURN_RING = '#34d399';
+const ELIMINATED_RING = 'rgba(239, 68, 68, 0.85)';
+const TARGET_RING = '#f472b6';
+
+function initialsOf(name: string): string {
+  return name
+    .split(' ')
+    .map((part) => part[0])
+    .filter(Boolean)
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+/**
+ * Single opponent in the widget-mode opponents row. Compact card with
+ * avatar + name + hand count. Surfaces three ring states:
+ *   - turn ring (green): this player is currently on the clock
+ *   - eliminated ring (red dashed): out of the game
+ *   - target ring (pink): armed-for-attack indicator
+ *
+ * Defuse counts are deliberately NOT shown — `CriticalPlayerState` from
+ * the server doesn't expose them, and revealing them would give away
+ * attack calculus for free (see PR #631 review §2).
+ */
+export function OpponentTile({
+  player,
+  isCurrentTurn,
+  isTarget = false,
+  resolveDisplayName,
+}: OpponentTileProps) {
+  const { t } = useTranslation();
+  const media = useMedia();
+  const isMobile = media.sm;
+  const displayName = resolveDisplayName(
+    player.playerId,
+    `Player ${player.playerId.slice(0, 8)}`,
+  );
+  const idlePlayers = useGameStore((s: GameState) => s.idlePlayers);
+  const isIdle = idlePlayers.includes(player.playerId);
+  const alive = player.alive;
+
+  let ringColor: string = 'rgba(255,255,255,0.10)';
+  if (!alive) ringColor = ELIMINATED_RING;
+  else if (isTarget) ringColor = TARGET_RING;
+  else if (isCurrentTurn) ringColor = TURN_RING;
+
+  const ringStyle = !alive ? 'dashed' : 'solid';
+  const avatarSize = isMobile ? 36 : 48;
+
+  return (
+    <YStack
+      data-testid={`opponent-tile-${player.playerId}`}
+      data-alive={alive ? 'true' : 'false'}
+      data-current-turn={isCurrentTurn ? 'true' : 'false'}
+      data-target={isTarget ? 'true' : 'false'}
+      alignItems="center"
+      gap="$1"
+      paddingHorizontal="$2"
+      paddingVertical="$2"
+      borderRadius={12}
+      borderWidth={1}
+      borderStyle={ringStyle}
+      borderColor={ringColor}
+      backgroundColor="rgba(0,0,0,0.35)"
+      width={isMobile ? 96 : 120}
+      minWidth={isMobile ? 96 : 120}
+      flexShrink={0}
+      opacity={alive ? 1 : 0.6}
+    >
+      <YStack
+        width={avatarSize}
+        height={avatarSize}
+        borderRadius={9999}
+        backgroundColor="rgba(255,255,255,0.08)"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Text fontSize={14} fontWeight="800" letterSpacing={0.5}>
+          {alive ? initialsOf(displayName) : '💀'}
+        </Text>
+      </YStack>
+      <XStack alignItems="center" gap={4} maxWidth="100%">
+        <Text
+          data-testid={`opponent-tile-name-${player.playerId}`}
+          fontSize={12}
+          fontWeight="700"
+          letterSpacing={0.3}
+          numberOfLines={1}
+          maxWidth={isMobile ? 80 : 100}
+        >
+          {displayName}
+        </Text>
+        {isIdle && <IdleBadge />}
+      </XStack>
+      {alive ? (
+        <Text
+          data-testid={`opponent-tile-count-${player.playerId}`}
+          fontSize={11}
+          fontWeight="800"
+          letterSpacing={0.4}
+          opacity={0.85}
+        >
+          🃏 {player.hand.length}
+        </Text>
+      ) : (
+        <Text
+          data-testid={`opponent-tile-eliminated-${player.playerId}`}
+          fontSize={10}
+          fontWeight="800"
+          letterSpacing={1}
+          textTransform="uppercase"
+          color={ELIMINATED_RING}
+        >
+          {t('games.table.players.eliminated')}
+        </Text>
+      )}
+    </YStack>
+  );
+}

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '../../../../shared/config/tamagui.config';
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/games/store/gameStore', () => ({
+  useGameStore: (selector: (s: unknown) => unknown) =>
+    selector({ idlePlayers: [] }),
+}));
+
+vi.mock('@/shared/ui', () => ({
+  IdleBadge: () => <span data-testid="idle-badge">idle</span>,
+}));
+
+import { OpponentsRow } from './OpponentsRow';
+import type { CriticalCard, CriticalPlayerTableState } from '../../types';
+
+function makePlayers(count: number): CriticalPlayerTableState[] {
+  return Array.from({ length: count }, (_, i) => ({
+    playerId: `p${i + 1}`,
+    alive: true,
+    hand: ['strike'] as CriticalCard[],
+  }));
+}
+
+function renderRow(
+  override: Partial<React.ComponentProps<typeof OpponentsRow>> = {},
+) {
+  const props: React.ComponentProps<typeof OpponentsRow> = {
+    opponents: makePlayers(2),
+    currentTurnPlayerId: null,
+    resolveDisplayName: (_id, fb) => fb,
+    ...override,
+  };
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <OpponentsRow {...props} />
+    </TamaguiProvider>,
+  );
+}
+
+describe('OpponentsRow', () => {
+  it('uses duel mode for a single opponent', () => {
+    renderRow({ opponents: makePlayers(1) });
+    const row = screen.getByTestId('opponents-row');
+    expect(row).toHaveAttribute('data-mode', 'duel');
+    expect(row).toHaveAttribute('data-count', '1');
+    expect(screen.getByTestId('opponent-tile-p1')).toBeInTheDocument();
+  });
+
+  it('uses FFA mode for 2+ opponents', () => {
+    renderRow({ opponents: makePlayers(4) });
+    expect(screen.getByTestId('opponents-row')).toHaveAttribute(
+      'data-mode',
+      'ffa',
+    );
+    expect(screen.getByTestId('opponents-row')).toHaveAttribute(
+      'data-count',
+      '4',
+    );
+  });
+
+  it('renders all five tiles in a full FFA lobby', () => {
+    renderRow({ opponents: makePlayers(5) });
+    for (let i = 1; i <= 5; i += 1) {
+      expect(screen.getByTestId(`opponent-tile-p${i}`)).toBeInTheDocument();
+    }
+  });
+
+  it('routes the turn ring to the matching opponent', () => {
+    renderRow({
+      opponents: makePlayers(3),
+      currentTurnPlayerId: 'p2',
+    });
+    expect(screen.getByTestId('opponent-tile-p1')).toHaveAttribute(
+      'data-current-turn',
+      'false',
+    );
+    expect(screen.getByTestId('opponent-tile-p2')).toHaveAttribute(
+      'data-current-turn',
+      'true',
+    );
+  });
+
+  it('flags the armed target opponent only', () => {
+    renderRow({
+      opponents: makePlayers(3),
+      targetPlayerId: 'p3',
+    });
+    expect(screen.getByTestId('opponent-tile-p1')).toHaveAttribute(
+      'data-target',
+      'false',
+    );
+    expect(screen.getByTestId('opponent-tile-p3')).toHaveAttribute(
+      'data-target',
+      'true',
+    );
+  });
+});

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { XStack, useMedia } from 'tamagui';
+import { OpponentTile } from './OpponentTile';
+import type { CriticalPlayerTableState } from '../../types';
+
+interface OpponentsRowProps {
+  opponents: CriticalPlayerTableState[];
+  /**
+   * Player id whose turn it currently is. May be a non-opponent (the
+   * current user). Only opponents whose id matches this get the turn ring.
+   */
+  currentTurnPlayerId: string | null;
+  /**
+   * Player id currently armed for an attack. ARC-635 wires this from the
+   * hand zone's selection state.
+   */
+  targetPlayerId?: string | null;
+  resolveDisplayName: (playerId: string, fallback: string) => string;
+}
+
+/**
+ * Top row of the widget-mode match: opponents laid out horizontally.
+ * Duel mode renders one tile centered; FFA mode (≥3 players including
+ * self → ≥2 opponents) renders the full 5-up grid. Beyond 5 opponents
+ * the row scrolls horizontally on mobile and wraps on desktop.
+ */
+export function OpponentsRow({
+  opponents,
+  currentTurnPlayerId,
+  targetPlayerId,
+  resolveDisplayName,
+}: OpponentsRowProps) {
+  const media = useMedia();
+  const isMobile = media.sm;
+  const isDuel = opponents.length <= 1;
+
+  return (
+    <XStack
+      data-testid="opponents-row"
+      data-mode={isDuel ? 'duel' : 'ffa'}
+      data-count={opponents.length}
+      width="100%"
+      gap="$2"
+      paddingHorizontal="$2"
+      paddingVertical="$2"
+      justifyContent={isDuel ? 'center' : 'space-between'}
+      flexWrap={isMobile ? 'nowrap' : 'wrap'}
+      overflow={isMobile ? 'scroll' : 'visible'}
+      $sm={{ gap: '$1' }}
+    >
+      {opponents.map((opponent) => (
+        <OpponentTile
+          key={opponent.playerId}
+          player={opponent}
+          isCurrentTurn={opponent.playerId === currentTurnPlayerId}
+          isTarget={!!targetPlayerId && opponent.playerId === targetPlayerId}
+          resolveDisplayName={resolveDisplayName}
+        />
+      ))}
+    </XStack>
+  );
+}


### PR DESCRIPTION
## Summary

Fourth slice of the [§7 layout rework](docs/handoffs/PR-631-review2.md). Replaces the legacy `PlayersRing` / `OpponentStrip` (positioned via polar coords on desktop) with the preview's horizontal opponent row. **Widget mode now has the full three-row stack**: opponents · arena · hand.

### New components
- [`ui/opponents/OpponentTile.tsx`](apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx) — compact tile per opponent: initials avatar, name, hand count, idle badge. Surfaces three ring states via `data-*` attrs (`turn`, `eliminated`, `target`). **Defuse counts deliberately not rendered** — `CriticalPlayerState` from the server doesn't expose them and showing them would give attack calculus away (PR #631 review §2).
- [`ui/opponents/OpponentsRow.tsx`](apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx) — container. `data-mode="duel"` for a single opponent (centered), `data-mode="ffa"` for 2+. Wraps on desktop, horizontal scroll on mobile. Maps the `currentTurnPlayerId` and optional `targetPlayerId` to the right tile.

### Wiring
- [`ui/MatchWidget.tsx`](apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx) **stops using `GameTableSection`**. It now renders `OpponentsRow` above the `Arena` directly. The viewer (`currentUserId`) is filtered out of the players list before it reaches OpponentsRow so the row never shows the viewer's own tile. `ActiveGameContent` (flag-off path) is untouched.

### i18n
The (still untranslated) French collection-pack descriptions are trimmed from `'Collectez des modules identiques pour voler des cartes'` to `'Collectez des modules pour voler des cartes'` — Prettier had unwrapped them back to multi-line after the ARC-633 merge, pushing `fr.ts` to 502 lines. Slimmer strings fit on a single line and bring the file back under the 500-line cap.

## Why

The reviewer's §7 has this as **slice 4** (ARC-634). It's the most visible structural change yet — opponents move from a circular ring around the table to a horizontal strip at the top, matching the preview.

## How to verify

- Flag-off (default): match looks identical to before. `PlayersRing` renders.
- Flag-on (`?widget_mode=1`):
  - Duel: one opponent tile, centered above the arena
  - FFA: opponents in a horizontal row above the arena
  - The viewer's own tile is NOT in the row (their identity lives in the hand below)
  - On the active turn's tile, a green border ring lights up
  - Eliminated opponents show a dashed red ring + 💀 + "Eliminated"

## Test plan

- [x] 4 OpponentTile tests (alive count, eliminated state, current-turn flag, target flag)
- [x] 5 OpponentsRow tests (duel mode, FFA mode, full 5-up grid, turn routing, target routing)
- [x] MatchWidget test rewritten for the new shape (OpponentsRow + Arena + PlayerHand) with explicit assertion that the viewer is filtered out of opponents
- [x] Full Critical widget suite — 141/141 passing (was 132)
- [x] `pnpm type-check`, `pnpm lint`, `pnpm check-file-length` clean

## Follow-ups

- **ARC-635** — HandZone + HandRail + HandCards. Lifts `selectedUids` out of `PlayerHand` and starts driving `ComboCard`'s `combo` prop with real selection state. This is the ticket that lights up the selection-aware label in ARC-633's ComboCard.
- **ARC-636** — drop `CriticalGameHeader` from match view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)