### PR TITLE
feat(critical/widget): drop header in widget mode; Rules + Fullscreen on HandRail (ARC-636)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -263,31 +263,64 @@ export function ActiveGameView({
     [snapshot.players, resolveDisplayName],
   );
 
+  const buildSharedProps = () => ({
+    room,
+    snapshot,
+    currentUserId,
+    currentPlayer,
+    cardVariant,
+    isGameOver: !!isGameOver,
+    isMyTurn: !!isMyTurn,
+    canAct: !!canAct,
+    canPlayNope,
+    actionBusy,
+    aliveOpponents,
+    handLayout,
+    setHandLayout,
+    resolveDisplayName,
+    t: t as unknown as (
+      k: string,
+      p?: Record<string, string | number>,
+    ) => string,
+    actions,
+    idleTimerTriggered,
+    autoplayState,
+    handleUnstash,
+    handlePlayActionCard,
+    handleOpenFavorModal,
+    handleOpenEventCombo,
+    handleOpenFiverCombo,
+  });
+
   return (
     <ScenePaletteProvider palette={scenePalette}>
       <SceneBackdrop />
       <YStack flex={1} className="animate-entrance">
-        <CriticalGameHeader
-          room={room}
-          t={
-            t as unknown as (
-              key: string,
-              params?: Record<string, string | number>,
-            ) => string
-          }
-          idleTimerEnabled={idleTimerEnabled}
-          actionBusy={actionBusy}
-          isGameOver={!!isGameOver}
-          currentPlayer={currentPlayer ?? undefined}
-          canAct={!!canAct}
-          isMyTurn={!!isMyTurn}
-          handleIdleTimeout={handleIdleTimeout}
-          autoplayState={autoplayState}
-          idleTimerTriggered={idleTimerTriggered}
-          handleStopAutoplay={handleStopAutoplay}
-          isFullscreen={isFullscreen}
-          toggleFullscreen={toggleFullscreen}
-        />
+        {/* Flag-off: legacy header sits above the match. Widget mode hoists */}
+        {/* Rules / Fullscreen into a small menu inside HandRail (ARC-636). */}
+        {!widgetMode && (
+          <CriticalGameHeader
+            room={room}
+            t={
+              t as unknown as (
+                key: string,
+                params?: Record<string, string | number>,
+              ) => string
+            }
+            idleTimerEnabled={idleTimerEnabled}
+            actionBusy={actionBusy}
+            isGameOver={!!isGameOver}
+            currentPlayer={currentPlayer ?? undefined}
+            canAct={!!canAct}
+            isMyTurn={!!isMyTurn}
+            handleIdleTimeout={handleIdleTimeout}
+            autoplayState={autoplayState}
+            idleTimerTriggered={idleTimerTriggered}
+            handleStopAutoplay={handleStopAutoplay}
+            isFullscreen={isFullscreen}
+            toggleFullscreen={toggleFullscreen}
+          />
+        )}
         {/* Flag-off: legacy top-of-page TurnBanner + MatchHud. In widget */}
         {/* mode these move inside the Arena's center column (ARC-633). */}
         {!widgetMode && (
@@ -313,41 +346,16 @@ export function ActiveGameView({
           </>
         )}
 
-        {(() => {
-          const sharedProps = {
-            room,
-            snapshot,
-            currentUserId,
-            currentPlayer,
-            cardVariant,
-            isGameOver: !!isGameOver,
-            isMyTurn: !!isMyTurn,
-            canAct: !!canAct,
-            canPlayNope,
-            actionBusy,
-            aliveOpponents,
-            handLayout,
-            setHandLayout,
-            resolveDisplayName,
-            t: t as unknown as (
-              key: string,
-              params?: Record<string, string | number>,
-            ) => string,
-            actions,
-            idleTimerTriggered,
-            autoplayState,
-            handleUnstash,
-            handlePlayActionCard,
-            handleOpenFavorModal,
-            handleOpenEventCombo,
-            handleOpenFiverCombo,
-          };
-          return widgetMode ? (
-            <MatchWidget {...sharedProps} formatLogMessage={formatLogMessage} />
-          ) : (
-            <ActiveGameContent {...sharedProps} />
-          );
-        })()}
+        {widgetMode ? (
+          <MatchWidget
+            {...buildSharedProps()}
+            formatLogMessage={formatLogMessage}
+            isFullscreen={isFullscreen}
+            toggleFullscreen={toggleFullscreen}
+          />
+        ) : (
+          <ActiveGameContent {...buildSharedProps()} />
+        )}
       </YStack>
 
       {currentPlayer && (

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -43,18 +43,25 @@ vi.mock('./hand/HandZone', () => ({
     cards,
     onPlay,
     onToggleSelect,
+    onOpenRules,
+    onToggleFullscreen,
+    isFullscreen,
   }: {
     combo: { kind: string; label: string };
     canPlay: boolean;
     cards: Array<{ uid: string }>;
     onPlay: () => void;
     onToggleSelect: (uid: string) => void;
+    onOpenRules?: () => void;
+    onToggleFullscreen?: () => void;
+    isFullscreen?: boolean;
   }) => (
     <div
       data-testid="hand-zone-stub"
       data-combo-kind={combo.kind}
       data-can-play={canPlay ? 'true' : 'false'}
       data-card-uids={cards.map((c) => c.uid).join(',')}
+      data-is-fullscreen={isFullscreen ? 'true' : 'false'}
     >
       <button
         type="button"
@@ -71,8 +78,41 @@ vi.mock('./hand/HandZone', () => ({
         data-testid="hand-zone-stub-select-strike-1"
         onClick={() => onToggleSelect('strike-1')}
       />
+      {onOpenRules && (
+        <button
+          type="button"
+          data-testid="hand-zone-stub-rules"
+          onClick={onOpenRules}
+        />
+      )}
+      {onToggleFullscreen && (
+        <button
+          type="button"
+          data-testid="hand-zone-stub-fullscreen"
+          onClick={onToggleFullscreen}
+        />
+      )}
     </div>
   ),
+}));
+
+vi.mock('./RulesModal', () => ({
+  RulesModal: ({
+    isOpen,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="rules-modal-stub">
+        <button
+          type="button"
+          data-testid="rules-modal-close"
+          onClick={onClose}
+        />
+      </div>
+    ) : null,
 }));
 
 vi.mock('./styles/layout', () => ({
@@ -139,6 +179,8 @@ function makeProps(override: Partial<MatchWidgetProps> = {}): MatchWidgetProps {
     handleOpenEventCombo: vi.fn(),
     handleOpenFiverCombo: vi.fn(),
     formatLogMessage: (m?: string | null) => m ?? '',
+    isFullscreen: false,
+    toggleFullscreen: vi.fn(),
     ...override,
   } as MatchWidgetProps;
 }
@@ -225,5 +267,27 @@ describe('MatchWidget (ARC-635)', () => {
       'data-can-play',
       'false',
     );
+  });
+
+  it('forwards fullscreen state + toggle to HandZone for the chrome menu', () => {
+    const toggleFullscreen = vi.fn();
+    render(
+      <MatchWidget {...makeProps({ isFullscreen: true, toggleFullscreen })} />,
+    );
+    expect(screen.getByTestId('hand-zone-stub')).toHaveAttribute(
+      'data-is-fullscreen',
+      'true',
+    );
+    fireEvent.click(screen.getByTestId('hand-zone-stub-fullscreen'));
+    expect(toggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('mounts RulesModal in-place and toggles it via HandRail menu', () => {
+    render(<MatchWidget {...makeProps()} />);
+    expect(screen.queryByTestId('rules-modal-stub')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('hand-zone-stub-rules'));
+    expect(screen.getByTestId('rules-modal-stub')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('rules-modal-close'));
+    expect(screen.queryByTestId('rules-modal-stub')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -6,6 +6,7 @@ import { GameBoard, TableArea } from './styles/layout';
 import { Arena } from './arena/Arena';
 import { OpponentsRow } from './opponents/OpponentsRow';
 import { HandZone } from './hand/HandZone';
+import { RulesModal } from './RulesModal';
 import {
   detectCombo,
   handWithUids,
@@ -27,6 +28,13 @@ export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent> & {
    * inside the new ArenaCenter can surface formatted log entries.
    */
   formatLogMessage: (message?: string | null) => string;
+  /**
+   * Fullscreen state + toggle, sourced from `useFullscreen` in the
+   * parent. The HandRail menu (ARC-636) exposes the toggle so widget
+   * mode doesn't need the legacy `CriticalGameHeader` to access it.
+   */
+  isFullscreen: boolean;
+  toggleFullscreen: () => void;
 };
 
 /**
@@ -36,7 +44,7 @@ export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent> & {
  * arena's `ComboCard` (label + tint) and the rail's `Play` button.
  */
 export function MatchWidget({
-  room: _room,
+  room,
   snapshot,
   currentUserId,
   currentPlayer,
@@ -60,8 +68,13 @@ export function MatchWidget({
   handleOpenEventCombo,
   handleOpenFiverCombo,
   formatLogMessage,
+  isFullscreen,
+  toggleFullscreen,
 }: MatchWidgetProps) {
   const [selectedUids, setSelectedUids] = useState<string[]>([]);
+  const [rulesOpen, setRulesOpen] = useState(false);
+  const handleOpenRules = useCallback(() => setRulesOpen(true), []);
+  const handleCloseRules = useCallback(() => setRulesOpen(false), []);
 
   // Memoize hand so downstream useCallback / useMemo deps are stable when
   // the parent re-renders without `currentPlayer.hand` actually changing.
@@ -201,12 +214,22 @@ export function MatchWidget({
             canDraw={isMyTurn && !isGameOver}
             canNope={canPlayNope}
             cardVariant={cardVariant}
+            isFullscreen={isFullscreen}
             onPlay={handlePlay}
             onDraw={handleDrawAndEnd}
             onNope={actions.playNope}
+            onOpenRules={handleOpenRules}
+            onToggleFullscreen={toggleFullscreen}
           />
         )}
       </GameBoard>
+      <RulesModal
+        isOpen={rulesOpen}
+        onClose={handleCloseRules}
+        currentVariant={cardVariant || 'default'}
+        isPrivate={room?.visibility === 'private'}
+        t={t}
+      />
     </div>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.test.tsx
@@ -86,4 +86,59 @@ describe('HandRail', () => {
     fireEvent.click(screen.getByTestId('hand-rail-nope'));
     expect(onNope).toHaveBeenCalledTimes(1);
   });
+
+  it('hides the chrome menu by default (no callbacks provided)', () => {
+    renderRail();
+    expect(screen.queryByTestId('hand-rail-menu')).not.toBeInTheDocument();
+  });
+
+  it('renders Rules + Fullscreen buttons when both callbacks are provided', () => {
+    const onOpenRules = vi.fn();
+    const onToggleFullscreen = vi.fn();
+    renderRail({ onOpenRules, onToggleFullscreen });
+    fireEvent.click(screen.getByTestId('hand-rail-rules'));
+    expect(onOpenRules).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('hand-rail-fullscreen'));
+    expect(onToggleFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders only the Rules button when fullscreen callback is omitted', () => {
+    renderRail({ onOpenRules: vi.fn() });
+    expect(screen.getByTestId('hand-rail-rules')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('hand-rail-fullscreen'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('exposes the right aria-label on the fullscreen button by state', () => {
+    const { rerender } = renderRail({
+      onToggleFullscreen: vi.fn(),
+      isFullscreen: false,
+    });
+    expect(screen.getByTestId('hand-rail-fullscreen')).toHaveAttribute(
+      'aria-label',
+      'games.table.controlPanel.enterFullscreen',
+    );
+    rerender(
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+        <HandRail
+          handCount={5}
+          defuseCount={1}
+          combo={{ kind: 'none', label: 'Select cards' }}
+          canPlay={false}
+          canDraw={true}
+          canNope={false}
+          onPlay={vi.fn()}
+          onDraw={vi.fn()}
+          onNope={vi.fn()}
+          onToggleFullscreen={vi.fn()}
+          isFullscreen={true}
+        />
+      </TamaguiProvider>,
+    );
+    expect(screen.getByTestId('hand-rail-fullscreen')).toHaveAttribute(
+      'aria-label',
+      'games.table.controlPanel.exitFullscreen',
+    );
+  });
 });

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx
@@ -16,17 +16,19 @@ interface HandRailProps {
   canDraw: boolean;
   canNope: boolean;
   cardVariant?: string;
+  /**
+   * Widget-mode replacement for the legacy CriticalGameHeader buttons.
+   * When omitted, the menu row is hidden (e.g. for tests that don't care
+   * about the chrome).
+   */
+  isFullscreen?: boolean;
   onPlay: () => void;
   onDraw: () => void;
   onNope: () => void;
+  onOpenRules?: () => void;
+  onToggleFullscreen?: () => void;
 }
 
-/**
- * Side rail next to the hand: shows the player's hand count, defuse
- * count, and the two primary action buttons (contextual Play + Draw +
- * end). A Nope button appears reactively when a nope-eligible pending
- * action is on the table.
- */
 export function HandRail({
   handCount,
   defuseCount,
@@ -35,12 +37,16 @@ export function HandRail({
   canDraw,
   canNope,
   cardVariant: _cardVariant,
+  isFullscreen,
   onPlay,
   onDraw,
   onNope,
+  onOpenRules,
+  onToggleFullscreen,
 }: HandRailProps) {
   const { t } = useTranslation();
   const playLabel = combo.label;
+  const hasMenu = !!(onOpenRules || onToggleFullscreen);
 
   return (
     <YStack
@@ -123,6 +129,47 @@ export function HandRail({
             {t('games.table.actions.playNope')}
           </Text>
         </Button>
+      )}
+      {hasMenu && (
+        <XStack
+          data-testid="hand-rail-menu"
+          gap="$1"
+          paddingTop="$1"
+          borderTopWidth={1}
+          borderTopColor="rgba(255,255,255,0.08)"
+        >
+          {onOpenRules && (
+            <Button
+              data-testid="hand-rail-rules"
+              size="$2"
+              flex={1}
+              backgroundColor="rgba(255,255,255,0.05)"
+              onPress={onOpenRules}
+            >
+              <Text fontSize={10} fontWeight="700" letterSpacing={0.4}>
+                {t('games.table.controlPanel.rules')}
+              </Text>
+            </Button>
+          )}
+          {onToggleFullscreen && (
+            <Button
+              data-testid="hand-rail-fullscreen"
+              size="$2"
+              flex={1}
+              backgroundColor="rgba(255,255,255,0.05)"
+              onPress={onToggleFullscreen}
+              aria-label={t(
+                isFullscreen
+                  ? 'games.table.controlPanel.exitFullscreen'
+                  : 'games.table.controlPanel.enterFullscreen',
+              )}
+            >
+              <Text fontSize={12} fontWeight="700">
+                {isFullscreen ? '⤡' : '⛶'}
+              </Text>
+            </Button>
+          )}
+        </XStack>
       )}
     </YStack>
   );

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
@@ -15,9 +15,12 @@ interface HandZoneProps {
   canDraw: boolean;
   canNope: boolean;
   cardVariant?: string;
+  isFullscreen?: boolean;
   onPlay: () => void;
   onDraw: () => void;
   onNope: () => void;
+  onOpenRules?: () => void;
+  onToggleFullscreen?: () => void;
 }
 
 /**
@@ -49,9 +52,12 @@ export function HandZone(props: HandZoneProps) {
         canDraw={props.canDraw}
         canNope={props.canNope}
         cardVariant={props.cardVariant}
+        isFullscreen={props.isFullscreen}
         onPlay={props.onPlay}
         onDraw={props.onDraw}
         onNope={props.onNope}
+        onOpenRules={props.onOpenRules}
+        onToggleFullscreen={props.onToggleFullscreen}
       />
       <HandCards
         cards={props.cards}


### PR DESCRIPTION
## Summary

**Final slice of the [§7 layout rework](docs/handoffs/PR-631-review2.md).** In widget mode the legacy `CriticalGameHeader` no longer renders — its essential controls (Rules + Fullscreen) move into a small menu row at the bottom of the hand rail, matching the preview's "widget owns its chrome" intent.

### Changes
- [`ui/ActiveGameView.tsx`](apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx) — `CriticalGameHeader` is now wrapped in a `!widgetMode` guard. Threads `isFullscreen` + `toggleFullscreen` to MatchWidget so the rail menu can drive the toggle without going through the legacy header. Folded the inline IIFE into a small `buildSharedProps()` helper to stay under the 500-line cap.
- [`ui/MatchWidget.tsx`](apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx) — owns local `rulesOpen` state and mounts `RulesModal` directly so widget mode doesn't depend on the host page reaching in. Accepts new props: `isFullscreen`, `toggleFullscreen`.
- [`ui/hand/HandRail.tsx`](apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx) — gains an optional menu row at the bottom with a `Rules` button and a `⛶ / ⤡` fullscreen toggle. The fullscreen button's `aria-label` flips with state. The row only renders when at least one callback is wired, so existing callers without these props see no change.
- [`ui/hand/HandZone.tsx`](apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx) — forwards the new optional props through to the rail.

### i18n
**No new keys.** `games.table.controlPanel.{rules, enterFullscreen, exitFullscreen}` already existed for the legacy header.

## Why

The reviewer's §7 has this as **slice 6** — the last step. After this PR merges, the §7 widget rework is feature-complete behind the `widget_mode` flag and ready for staged rollout.

## How to verify

- Flag-off (default): `CriticalGameHeader` still renders. Match looks identical to before.
- Flag-on (`?widget_mode=1`): no top-of-page header. At the bottom of the hand rail you'll see a small Rules button and a ⛶ fullscreen toggle. Click Rules → modal opens. Click fullscreen → page goes fullscreen, button flips to ⤡ and aria-label updates.

## Test plan

- [x] 5 new HandRail cases (menu hidden by default, both buttons fire, Rules-only mode, fullscreen aria-label flip on state change)
- [x] 2 new MatchWidget cases (forwards fullscreen to HandZone; mounts RulesModal and closes it via the modal's onClose)
- [x] Full Critical widget suite — **171/171** passing (was 165)
- [x] `pnpm type-check`, `pnpm lint`, `pnpm check-file-length` clean
- [ ] Manual QA flag-on: verify the menu row appears, Rules modal opens/closes, fullscreen toggle works on both desktop and mobile
- [ ] Manual QA flag-off: confirm `CriticalGameHeader` still renders unchanged

## §7 wrap-up

This is the last ticket in the migration plan. After it merges, every preview-parity row is in place behind the flag:

- **ARC-631** — scaffold + `widget_mode` flag
- **ARC-632** — Arena (draw · center · discard)
- **ARC-633** — ArenaCenter + ComboCard with selection-aware tinting
- **ARC-634** — OpponentsRow (horizontal strip / FFA grid)
- **ARC-635** — HandZone (rail + cards) with lifted `selectedUids`
- **ARC-636** — drop legacy header in widget mode (this PR)

Next steps for the widget itself are operational: dogfood with `?widget_mode=1`, then flip the env-var default per environment, then eventually delete the legacy `ActiveGameContent` / `CriticalGameHeader` / `PlayerHand` paths in a cleanup PR once the new code has lived in production for a release or two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)