### PR TITLE
feat(critical/be): emit log.kind for HUD classification (ARC-637)

### DIFF
--- a/apps/be/src/games/critical/critical.state.ts
+++ b/apps/be/src/games/critical/critical.state.ts
@@ -22,9 +22,24 @@ export interface CriticalPlayerState {
   [key: string]: unknown;
 }
 
+/**
+ * Structured event kind for HUD feedback (FlashBanner classifier). Mirrors
+ * the same union on the web client (`CriticalLogKind`). Optional for
+ * backward compatibility — clients fall back to message string-matching
+ * when absent.
+ */
+export type CriticalLogKind =
+  | 'play'
+  | 'draw'
+  | 'defuse'
+  | 'eliminated'
+  | 'critical'
+  | 'system';
+
 export interface CriticalLogEntry {
   id: string;
   type: 'system' | 'action' | 'message';
+  kind?: CriticalLogKind;
   message: string;
   createdAt: string;
   scope?: ChatScope;

--- a/apps/be/src/games/engines/base/base-game-engine.abstract.ts
+++ b/apps/be/src/games/engines/base/base-game-engine.abstract.ts
@@ -81,6 +81,7 @@ export abstract class BaseGameEngine<
     type: 'system' | 'action' | 'message',
     message: string,
     options?: {
+      kind?: string;
       scope?: ChatScope;
       senderId?: string;
       senderName?: string;
@@ -89,6 +90,7 @@ export abstract class BaseGameEngine<
     return {
       id: randomUUID(),
       type,
+      kind: options?.kind,
       message,
       createdAt: new Date().toISOString(),
       scope: options?.scope || 'all',

--- a/apps/be/src/games/engines/base/game-engine.interface.ts
+++ b/apps/be/src/games/engines/base/game-engine.interface.ts
@@ -23,6 +23,12 @@ export type ChatScope = 'all' | 'players' | 'private' | 'team';
 export interface GameLogEntry {
   id: string;
   type: 'system' | 'action' | 'message';
+  /**
+   * Game-specific structured event kind for client HUD classification
+   * (e.g. Critical's FlashBanner). Optional and untyped at this layer so
+   * each game can define its own union (see `CriticalLogKind`).
+   */
+  kind?: string;
   message: string;
   createdAt: string;
   scope?: ChatScope;

--- a/apps/be/src/games/engines/critical/critical-chaos.utils.ts
+++ b/apps/be/src/games/engines/critical/critical-chaos.utils.ts
@@ -10,6 +10,7 @@ import {
 } from '../base/game-engine.interface';
 
 export interface LogEntryOptions {
+  kind?: string;
   scope?: ChatScope;
   senderId?: string | null;
   senderName?: string | null;

--- a/apps/be/src/games/engines/critical/critical-combo.utils.ts
+++ b/apps/be/src/games/engines/critical/critical-combo.utils.ts
@@ -11,6 +11,7 @@ import {
 import { FIVER_COMBO_SIZE } from './critical-validation.utils';
 
 export interface LogEntryOptions {
+  kind?: string;
   scope?: ChatScope;
   senderId?: string | null;
   senderName?: string | null;

--- a/apps/be/src/games/engines/critical/critical-defuse.utils.ts
+++ b/apps/be/src/games/engines/critical/critical-defuse.utils.ts
@@ -42,6 +42,7 @@ export function executeDefuse(
   helpers.addLog(
     state,
     helpers.createLogEntry('action', `Defused an Exploding Cat!`, {
+      kind: 'defuse',
       scope: 'all',
       senderId: playerId,
     }),

--- a/apps/be/src/games/engines/critical/critical-future.utils.ts
+++ b/apps/be/src/games/engines/critical/critical-future.utils.ts
@@ -11,6 +11,7 @@ import {
 import { CriticalLogic } from './critical-logic.utils';
 
 export interface LogEntryOptions {
+  kind?: string;
   scope?: ChatScope;
   senderId?: string | null;
   senderName?: string | null;
@@ -329,6 +330,7 @@ export function executeDrawBottom(
       helpers.addLog(
         state,
         helpers.createLogEntry('system', `Player exploded from bottom draw!`, {
+          kind: 'eliminated',
           scope: 'all',
           senderId: playerId,
         }),

--- a/apps/be/src/games/engines/critical/critical-logic.utils.ts
+++ b/apps/be/src/games/engines/critical/critical-logic.utils.ts
@@ -21,6 +21,7 @@ export { executeCancel };
 import { executeDefuse as executeDefuseHelper } from './critical-defuse.utils';
 
 export interface LogEntryOptions {
+  kind?: string;
   scope?: ChatScope;
   senderId?: string | null;
   senderName?: string | null;
@@ -79,6 +80,7 @@ export class CriticalLogic {
             'action',
             `Drew an Exploding Cat but safely held it using Containment Field! 📦`,
             {
+              kind: 'critical',
               scope: 'all',
               senderId: playerId,
             },
@@ -94,6 +96,7 @@ export class CriticalLogic {
             'action',
             `Drew an Exploding Cat! Must play Defuse!`,
             {
+              kind: 'critical',
               scope: 'all',
               senderId: playerId,
             },
@@ -109,6 +112,7 @@ export class CriticalLogic {
         helpers.addLog(
           state,
           helpers.createLogEntry('system', `Player exploded!`, {
+            kind: 'eliminated',
             scope: 'all',
             senderId: playerId,
           }),
@@ -132,6 +136,7 @@ export class CriticalLogic {
             'system',
             `Drew Critical Implosion (Open)! IMPLOSION! Player eliminated! 🤯`,
             {
+              kind: 'eliminated',
               scope: 'all',
               senderId: playerId,
             },
@@ -156,6 +161,7 @@ export class CriticalLogic {
             'action',
             `Drew Critical Implosion (First time). It goes back in the deck FACE UP! 😰`,
             {
+              kind: 'critical',
               scope: 'all',
               senderId: playerId,
             },
@@ -174,6 +180,7 @@ export class CriticalLogic {
     helpers.addLog(
       state,
       helpers.createLogEntry('action', `Drew a card`, {
+        kind: 'draw',
         scope: 'all',
         senderId: playerId,
       }),

--- a/apps/be/src/games/engines/critical/critical-theft.utils.ts
+++ b/apps/be/src/games/engines/critical/critical-theft.utils.ts
@@ -13,6 +13,7 @@ import {
 } from '../base/game-engine.interface';
 
 export interface LogEntryOptions {
+  kind?: string;
   scope?: ChatScope;
   senderId?: string | null;
   senderName?: string | null;

--- a/apps/be/src/games/engines/critical/critical.engine.spec.ts
+++ b/apps/be/src/games/engines/critical/critical.engine.spec.ts
@@ -370,4 +370,108 @@ describe('CriticalEngine', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  // ARC-637: structured `kind` on log entries lets the web FlashBanner
+  // classify events without string-matching the message text.
+  describe('log.kind for HUD classification', () => {
+    it("tags a routine draw with kind: 'draw'", () => {
+      const state = engine.initializeState(['p1', 'p2']);
+      state.deck = ['evade', 'evade', 'evade'] as CriticalCard[];
+
+      const result = engine.executeAction(
+        state,
+        'draw_card',
+        createMockContext('p1'),
+      );
+      expect(result.success).toBe(true);
+      const drawLog = result.state!.logs.find((l) => l.kind === 'draw');
+      expect(drawLog).toBeDefined();
+    });
+
+    it("tags an elimination with kind: 'eliminated'", () => {
+      const state = engine.initializeState(['p1', 'p2']);
+      // Force a Critical card on top, and strip p1's defuse so they explode.
+      state.deck = ['critical_event'] as CriticalCard[];
+      state.players[0].hand = state.players[0].hand.filter(
+        (c) => c !== 'neutralizer' && c !== 'containment_field',
+      );
+
+      const result = engine.executeAction(
+        state,
+        'draw_card',
+        createMockContext('p1'),
+      );
+      expect(result.success).toBe(true);
+      const explodeLog = result.state!.logs.find(
+        (l) => l.kind === 'eliminated',
+      );
+      expect(explodeLog).toBeDefined();
+    });
+
+    it("tags a Critical draw that's safely defused with kind: 'critical'", () => {
+      const state = engine.initializeState(['p1', 'p2']);
+      // Force the Critical on top; p1 keeps a neutralizer so it triggers
+      // the "must play Defuse" branch, which is a `critical` kind log.
+      state.deck = ['critical_event'] as CriticalCard[];
+      if (!state.players[0].hand.includes('neutralizer')) {
+        state.players[0].hand.push('neutralizer');
+      }
+
+      const result = engine.executeAction(
+        state,
+        'draw_card',
+        createMockContext('p1'),
+      );
+      expect(result.success).toBe(true);
+      const criticalLog = result.state!.logs.find((l) => l.kind === 'critical');
+      expect(criticalLog).toBeDefined();
+    });
+
+    it("tags playing Defuse with kind: 'defuse'", () => {
+      const state = engine.initializeState(['p1', 'p2']);
+      state.deck = ['critical_event', 'evade'] as CriticalCard[];
+      if (!state.players[0].hand.includes('neutralizer')) {
+        state.players[0].hand.push('neutralizer');
+      }
+
+      // Step 1: draw the Critical → enters pendingDefuse state.
+      const drawResult = engine.executeAction(
+        state,
+        'draw_card',
+        createMockContext('p1'),
+      );
+      expect(drawResult.success).toBe(true);
+      expect(drawResult.state!.pendingDefuse).toBe('p1');
+
+      // Step 2: play the defuse with a reinsert position.
+      const defuseResult = engine.executeAction(
+        drawResult.state!,
+        'neutralizer',
+        createMockContext('p1'),
+        { position: 0 },
+      );
+      expect(defuseResult.success).toBe(true);
+      const defuseLog = defuseResult.state!.logs.find(
+        (l) => l.kind === 'defuse',
+      );
+      expect(defuseLog).toBeDefined();
+    });
+
+    it('preserves kind through sanitizeStateForPlayer', () => {
+      const state = engine.initializeState(['p1', 'p2']);
+      state.logs = [
+        {
+          id: 'l1',
+          type: 'system',
+          kind: 'eliminated',
+          message: 'something happened',
+          scope: 'all',
+          createdAt: '',
+        },
+      ];
+
+      const sanitized = engine.sanitizeStateForPlayer(state, 'p1');
+      expect(sanitized.logs?.[0]?.kind).toBe('eliminated');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds an optional structured `kind` field to game log entries so the web FlashBanner can classify events without string-matching the message text. The client side already prefers `entry.kind` when present (landed in PR #631's review-2 fix); **this PR is the server side of that contract**.

### Type changes
- [`GameLogEntry`](apps/be/src/games/engines/base/game-engine.interface.ts) gains `kind?: string` on the generic base interface, so any game can populate it with its own union without pulling Critical types into the base layer.
- [`CriticalLogEntry`](apps/be/src/games/critical/critical.state.ts) narrows the field to the typed `CriticalLogKind = 'play' | 'draw' | 'defuse' | 'eliminated' | 'critical' | 'system'` union that mirrors the FE.
- [`createLogEntry`](apps/be/src/games/engines/base/base-game-engine.abstract.ts) on the base abstract engine + all five local `LogEntryOptions` interfaces in the Critical utils accept `kind`.

### Tagged emission sites (high-signal only)
Only the sites that drive distinct FlashBanner colors are tagged. Everything else (action card plays, system messages, chat) keeps the existing untagged shape — the FE falls back to string-matching for those, which is fine because they all classify as `info` anyway.

- [`critical-logic.utils.ts`](apps/be/src/games/engines/critical/critical-logic.utils.ts):
  - normal draw → `kind: 'draw'`
  - drawing Critical Cat with Containment Field / forced Defuse → `'critical'`
  - first Implosion draw → `'critical'`
  - explosion (no defuse, no containment) → `'eliminated'`
  - face-up Implosion explosion → `'eliminated'`
- [`critical-defuse.utils.ts`](apps/be/src/games/engines/critical/critical-defuse.utils.ts): playing the defuse → `'defuse'`
- [`critical-future.utils.ts`](apps/be/src/games/engines/critical/critical-future.utils.ts): bottom-draw explosion → `'eliminated'`

Snapshot sanitization (`sanitizeCriticalStateForPlayer`) doesn't strip fields, so `kind` flows to the client unchanged.

### Drive-by
[`ActiveGameView.tsx`](apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx): collapsed a 4-line `t` cast in `buildSharedProps` to keep the file under the 500-line cap (it grew past 500 after recent merges, unrelated to this PR's BE changes).

## Why

The reviewer flagged FlashBanner's `classifyMessage` string-matching as fragile across i18n and refactors back in PR-631 review §5. The FE was already prepared (consuming `entry.kind` opportunistically since the review-2 fix). This PR closes the loop: the server now emits the field on the events the FE colors specially.

The fallback in FlashBanner stays — it's the last resort for any untagged event and degrades gracefully.

## Test plan

- [x] 5 new BE engine cases asserting `kind` flows out on the four tagged events + a sanitization passthrough check
- [x] 73/73 existing BE Critical tests still pass
- [x] 171/171 FE Critical widget tests still pass (no behavior change on FE)
- [x] `tsc --noEmit` clean on both apps
- [x] FE `pnpm lint`, `pnpm check-file-length` clean
- [ ] Manual QA: trigger each of the 5 tagged events with the widget on (`?widget_mode=1`) and confirm the FlashBanner shows the right color (defuse: green, danger/critical: amber, eliminated: red, info: default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)