### PR TITLE
ARC-650 feat: equipped avatar in header + buy UX fixes

### DIFF
--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -478,6 +478,8 @@ export class AuthService {
       username: user.username,
       displayName: this.resolveDisplayName(user),
       role: user.role ?? 'free',
+      equippedAvatarId: user.equippedAvatarId ?? null,
+      equippedBadgeId: user.equippedBadgeId ?? null,
     };
 
     const createdAt = (user as Partial<{ createdAt: Date }>).createdAt;

--- a/apps/be/src/auth/lib/types.ts
+++ b/apps/be/src/auth/lib/types.ts
@@ -47,6 +47,10 @@ export interface AuthUserProfile {
   displayName: string;
   createdAt?: Date;
   role: UserRole;
+  /** Currently-equipped avatar item id, or null. */
+  equippedAvatarId?: string | null;
+  /** Currently-equipped badge item id, or null. */
+  equippedBadgeId?: string | null;
 }
 
 /**

--- a/apps/web/src/entities/session/api/authApi.ts
+++ b/apps/web/src/entities/session/api/authApi.ts
@@ -8,6 +8,8 @@ export type AuthUserProfile = {
   username: string;
   displayName: string;
   role: UserRole;
+  equippedAvatarId?: string | null;
+  equippedBadgeId?: string | null;
 };
 
 export type LoginResponse = {

--- a/apps/web/src/entities/session/model/types.ts
+++ b/apps/web/src/entities/session/model/types.ts
@@ -27,6 +27,8 @@ export type SessionTokensSnapshot = {
   username: string | null;
   displayName: string | null;
   role: UserRole | null;
+  equippedAvatarId: string | null;
+  equippedBadgeId: string | null;
 };
 
 export type SetSessionTokensInput = {
@@ -41,6 +43,8 @@ export type SetSessionTokensInput = {
   username?: string | null;
   displayName?: string | null;
   role?: UserRole | null;
+  equippedAvatarId?: string | null;
+  equippedBadgeId?: string | null;
 };
 
 export type LocalAuthMode = 'login' | 'register';

--- a/apps/web/src/entities/session/store/sessionStore.ts
+++ b/apps/web/src/entities/session/store/sessionStore.ts
@@ -23,6 +23,8 @@ const defaultSnapshot: SessionTokensSnapshot = {
   username: null,
   displayName: null,
   role: null,
+  equippedAvatarId: null,
+  equippedBadgeId: null,
 };
 
 interface SessionState {
@@ -67,6 +69,14 @@ function buildSnapshot(
     username: input.username ?? current.username ?? null,
     displayName: input.displayName ?? current.displayName ?? null,
     role: input.role ?? current.role ?? null,
+    equippedAvatarId:
+      input.equippedAvatarId === undefined
+        ? (current.equippedAvatarId ?? null)
+        : input.equippedAvatarId,
+    equippedBadgeId:
+      input.equippedBadgeId === undefined
+        ? (current.equippedBadgeId ?? null)
+        : input.equippedBadgeId,
   };
 }
 
@@ -91,6 +101,10 @@ function enrichWithResponse(
       snapshot.displayName ??
       null,
     role: response.user?.role ?? snapshot.role ?? null,
+    equippedAvatarId:
+      response.user?.equippedAvatarId ?? snapshot.equippedAvatarId ?? null,
+    equippedBadgeId:
+      response.user?.equippedBadgeId ?? snapshot.equippedBadgeId ?? null,
   });
 }
 

--- a/apps/web/src/features/shop/hooks/useEquippedCosmetics.ts
+++ b/apps/web/src/features/shop/hooks/useEquippedCosmetics.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { loadCatalog } from '../lib/catalogCache';
+import type { EffectiveShopItem } from '../server/shop.types';
+
+export interface EquippedCosmetics {
+  avatarUrl: string | null;
+  avatarItem: EffectiveShopItem | null;
+  badgeUrl: string | null;
+  badgeItem: EffectiveShopItem | null;
+}
+
+const EMPTY_MAP: ReadonlyMap<string, EffectiveShopItem> = new Map();
+
+/**
+ * Resolve a user's equipped item ids (from the session snapshot or any
+ * user-view payload) to their asset URLs via the public shop catalog.
+ *
+ * Returns nulls until the catalog has loaded, then derives the resolved
+ * values at render time. Catalog is module-level cached (see
+ * `catalogCache.ts`) so this hook does at most one fetch per page
+ * session even with many consumers.
+ */
+export function useEquippedCosmetics(args: {
+  equippedAvatarId: string | null | undefined;
+  equippedBadgeId: string | null | undefined;
+}): EquippedCosmetics {
+  const { equippedAvatarId, equippedBadgeId } = args;
+  const [catalogMap, setCatalogMap] =
+    useState<ReadonlyMap<string, EffectiveShopItem>>(EMPTY_MAP);
+
+  useEffect(() => {
+    let mounted = true;
+    void loadCatalog().then((catalog) => {
+      if (!mounted) return;
+      setCatalogMap(new Map(catalog.map((item) => [item.id, item])));
+    });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return useMemo<EquippedCosmetics>(() => {
+    const avatar = equippedAvatarId
+      ? (catalogMap.get(equippedAvatarId) ?? null)
+      : null;
+    const badge = equippedBadgeId
+      ? (catalogMap.get(equippedBadgeId) ?? null)
+      : null;
+    return {
+      avatarItem: avatar,
+      avatarUrl: avatar?.assetUrl ?? null,
+      badgeItem: badge,
+      badgeUrl: badge?.assetUrl ?? null,
+    };
+  }, [equippedAvatarId, equippedBadgeId, catalogMap]);
+}

--- a/apps/web/src/features/shop/lib/catalogCache.ts
+++ b/apps/web/src/features/shop/lib/catalogCache.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { resolveApiUrl } from '@/shared/lib/api-base';
+import type { EffectiveShopItem } from '../server/shop.types';
+
+/**
+ * Client-side cache for the public /shop/catalog response. Used to resolve
+ * an equipped item id to its asset URL + display name without forcing
+ * every consumer to re-fetch. One in-flight promise per page session;
+ * subsequent callers reuse the same promise.
+ */
+
+let catalogPromise: Promise<EffectiveShopItem[]> | null = null;
+let catalogResult: EffectiveShopItem[] | null = null;
+
+async function fetchCatalog(): Promise<EffectiveShopItem[]> {
+  const res = await fetch(resolveApiUrl('/shop/catalog'), {
+    cache: 'no-store',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) return [];
+  return (await res.json()) as EffectiveShopItem[];
+}
+
+export function loadCatalog(): Promise<EffectiveShopItem[]> {
+  if (catalogResult) return Promise.resolve(catalogResult);
+  if (catalogPromise) return catalogPromise;
+  catalogPromise = fetchCatalog()
+    .then((rows) => {
+      catalogResult = rows;
+      return rows;
+    })
+    .catch(() => {
+      catalogPromise = null;
+      return [];
+    });
+  return catalogPromise;
+}
+
+/** Forget the cache; primarily for tests. */
+export function resetCatalogCache(): void {
+  catalogPromise = null;
+  catalogResult = null;
+}

--- a/apps/web/src/features/shop/ui/PurchaseConfirmDialog.tsx
+++ b/apps/web/src/features/shop/ui/PurchaseConfirmDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, useTransition } from 'react';
+import { useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button, YStack, XStack } from '@arcadeum/ui';
 import { Text } from 'tamagui';
@@ -20,8 +20,11 @@ export interface PurchaseConfirmLabels {
   title: string;
   buy: string;
   cancel: string;
+  close?: string;
   yourBalance: string;
   free: string;
+  successTitle?: string;
+  successBody?: string;
   errors: {
     insufficientFunds: string;
     unavailable: string;
@@ -40,7 +43,18 @@ export interface PurchaseConfirmDialogProps {
   labels: PurchaseConfirmLabels;
 }
 
-export function PurchaseConfirmDialog({
+export function PurchaseConfirmDialog(
+  props: PurchaseConfirmDialogProps,
+): React.JSX.Element | null {
+  if (!props.open || !props.item) return null;
+  // Parent gates `open`; we render a fresh inner component per open cycle so
+  // local state (UUID nonce, succeeded flag, error) resets without
+  // setState-in-effect. The inner key is the item id so opening a *different*
+  // item also remounts.
+  return <PurchaseConfirmDialogInner key={props.item.id} {...props} />;
+}
+
+function PurchaseConfirmDialogInner({
   item,
   itemName,
   itemDesc,
@@ -51,20 +65,16 @@ export function PurchaseConfirmDialog({
   labels,
 }: PurchaseConfirmDialogProps) {
   const router = useRouter();
-  // Stable per-dialog UUID: regenerated whenever the dialog opens for a new
-  // item, kept constant for the lifetime of that open state so React's
-  // strict-mode double-render and any in-flight retries reuse the same id.
-  const purchaseIdRef = useRef<string>('');
-  useEffect(() => {
-    if (open && item) {
-      purchaseIdRef.current = uuid();
-    }
-  }, [open, item]);
+  // Stable per-mount UUID — regenerated only when the outer key changes (new
+  // open / new item), so React's strict-mode double-render and any retries
+  // reuse the same id.
+  const purchaseIdRef = useRef<string>(uuid());
 
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [succeeded, setSucceeded] = useState(false);
   const [isPending, startTransition] = useTransition();
 
-  if (!open || !item) return null;
+  if (!item) return null;
 
   // Destructure to avoid the no-restricted-syntax wallet-balance member-access
   // guardrail (only direct property reads are restricted).
@@ -82,9 +92,9 @@ export function PurchaseConfirmDialog({
     startTransition(async () => {
       const result = await purchaseItemAction(item.id, purchaseIdRef.current);
       if (result.ok) {
+        setSucceeded(true);
         router.refresh();
         onSuccess();
-        onClose();
         return;
       }
       if (result.error === 'insufficient_funds') {
@@ -96,6 +106,32 @@ export function PurchaseConfirmDialog({
       }
     });
   };
+
+  if (succeeded) {
+    return (
+      <DialogShell
+        open={open}
+        onClose={onClose}
+        testId="purchase-confirm-dialog"
+      >
+        <YStack gap="$3" alignItems="center">
+          <Text fontSize={48}>✓</Text>
+          <Text fontSize="$6" fontWeight="700">
+            {labels.successTitle ?? 'Equipped'}
+          </Text>
+          <Text fontSize="$3" color="$colorPress" textAlign="center">
+            {(labels.successBody ?? '{name} is now equipped.').replace(
+              '{name}',
+              itemName,
+            )}
+          </Text>
+          <Button onPress={onClose} data-testid="purchase-success-close">
+            {labels.close ?? labels.cancel}
+          </Button>
+        </YStack>
+      </DialogShell>
+    );
+  }
 
   return (
     <DialogShell open={open} onClose={onClose} testId="purchase-confirm-dialog">

--- a/apps/web/src/features/shop/ui/ShopGrid.tsx
+++ b/apps/web/src/features/shop/ui/ShopGrid.tsx
@@ -41,6 +41,7 @@ export function ShopGrid({
 }: ShopGridProps) {
   const category = useShopFiltersStore((s) => s.category);
   const rarities = useShopFiltersStore((s) => s.rarities);
+  const setTab = useShopFiltersStore((s) => s.setTab);
   const { t } = useTranslation();
   const [selectedItem, setSelectedItem] = useState<EffectiveShopItem | null>(
     null,
@@ -96,7 +97,17 @@ export function ShopGrid({
               priceCurrency={item.priceCurrency}
               owned={ownedIds.has(item.id)}
               equipped={equipped[item.category] === item.id}
-              onClick={() => setSelectedItem(item)}
+              onClick={() => {
+                // Already-owned items: route to Inventory instead of opening
+                // a purchase dialog. The spec allows re-buying after a sell-
+                // back, but a fresh duplicate buy of a still-owned item is
+                // almost always an accidental click.
+                if (ownedIds.has(item.id)) {
+                  setTab('inventory');
+                  return;
+                }
+                setSelectedItem(item);
+              }}
             />
           </YStack>
         ))}

--- a/apps/web/src/features/shop/ui/ShopPageView.tsx
+++ b/apps/web/src/features/shop/ui/ShopPageView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import Image from 'next/image';
 import { YStack, XStack } from '@arcadeum/ui';
 import { Text, YStack as Stack, styled } from 'tamagui';
 import { useShopFiltersStore } from '../store/shopFiltersStore';
@@ -16,6 +17,7 @@ import type {
 export interface ShopPageLabels {
   title: string;
   subtitle: string;
+  equipped?: string;
   sidebar: ShopSidebarLabels;
   grid: ShopGridLabels;
   inventory: InventoryTabLabels;
@@ -77,6 +79,17 @@ export function ShopPageView({
     [catalog],
   );
 
+  const catalogById = useMemo(
+    () => new Map(catalog.map((item) => [item.id, item])),
+    [catalog],
+  );
+  const equippedAvatar = inventory.equipped.avatar
+    ? (catalogById.get(inventory.equipped.avatar) ?? null)
+    : null;
+  const equippedBadge = inventory.equipped.badge
+    ? (catalogById.get(inventory.equipped.badge) ?? null)
+    : null;
+
   // Destructure to avoid the wallet-balance no-restricted-syntax guardrail.
   const { coins, gems } = balance;
 
@@ -103,7 +116,47 @@ export function ShopPageView({
             {labels.subtitle}
           </Text>
         </YStack>
-        <XStack gap="$2">
+        <XStack gap="$2" alignItems="center">
+          {equippedAvatar || equippedBadge ? (
+            <Stack
+              flexDirection="row"
+              alignItems="center"
+              gap={6}
+              paddingHorizontal="$3"
+              paddingVertical="$2"
+              borderRadius="$3"
+              borderWidth={1}
+              borderColor="rgba(16,185,129,0.35)"
+              backgroundColor="rgba(16,185,129,0.08)"
+              data-testid="shop-equipped-preview"
+            >
+              <Text fontSize="$1" letterSpacing={0.5} color="$green11">
+                {(labels.equipped ?? 'Equipped').toUpperCase()}
+              </Text>
+              {equippedAvatar ? (
+                <Image
+                  src={equippedAvatar.assetUrl}
+                  alt=""
+                  width={28}
+                  height={28}
+                  data-testid="shop-equipped-avatar"
+                  style={{ objectFit: 'contain' }}
+                  unoptimized
+                />
+              ) : null}
+              {equippedBadge ? (
+                <Image
+                  src={equippedBadge.assetUrl}
+                  alt=""
+                  width={24}
+                  height={24}
+                  data-testid="shop-equipped-badge"
+                  style={{ objectFit: 'contain' }}
+                  unoptimized
+                />
+              ) : null}
+            </Stack>
+          ) : null}
           <BalanceChip currency="coins" data-testid="shop-balance-coins">
             <Text fontSize={18}>🪙</Text>
             <Text fontSize="$4" fontWeight="700" color="#fbbf24">

--- a/apps/web/src/shared/i18n/messages/pages/shop/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/shop/by.ts
@@ -30,14 +30,18 @@ export const shopBy = {
       title: 'Пацвердзіць пакупку',
       buy: 'Купіць',
       cancel: 'Адмена',
+      close: 'Закрыць',
       yourBalance: 'У вас {amount} {currency}.',
       free: 'Бясплатна',
+      successTitle: 'Экіпіравана',
+      successBody: '{name} цяпер экіпіравана.',
       errors: {
         insufficientFunds: 'Не хапае сродкаў на пакупку.',
         unavailable: 'Гэты прадмет цяпер недаступны.',
         generic: 'Не атрымалася завяршыць пакупку. Паспрабуйце зноў.',
       },
     },
+    equipped: 'Экіпіравана',
   },
   inventory: {
     emptyInventory: 'Інвентар пусты. Завітайце ў краму, каб пачаць.',

--- a/apps/web/src/shared/i18n/messages/pages/shop/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/shop/en.ts
@@ -30,14 +30,18 @@ export const shopEn = {
       title: 'Confirm purchase',
       buy: 'Buy',
       cancel: 'Cancel',
+      close: 'Close',
       yourBalance: 'You have {amount} {currency}.',
       free: 'Free',
+      successTitle: 'Equipped',
+      successBody: '{name} is now equipped.',
       errors: {
         insufficientFunds: "You don't have enough to buy this.",
         unavailable: "This item isn't available right now.",
         generic: "Couldn't complete the purchase. Try again.",
       },
     },
+    equipped: 'Equipped',
   },
   inventory: {
     emptyInventory: 'Your inventory is empty. Browse the shop to get started.',

--- a/apps/web/src/shared/i18n/messages/pages/shop/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/shop/es.ts
@@ -30,14 +30,18 @@ export const shopEs = {
       title: 'Confirmar compra',
       buy: 'Comprar',
       cancel: 'Cancelar',
+      close: 'Cerrar',
       yourBalance: 'Tienes {amount} {currency}.',
       free: 'Gratis',
+      successTitle: 'Equipado',
+      successBody: '{name} ahora está equipado.',
       errors: {
         insufficientFunds: 'No tienes suficiente para comprar esto.',
         unavailable: 'Este artículo no está disponible ahora.',
         generic: 'No se pudo completar la compra. Inténtalo de nuevo.',
       },
     },
+    equipped: 'Equipado',
   },
   inventory: {
     emptyInventory: 'Tu inventario está vacío. Visita la tienda para empezar.',

--- a/apps/web/src/shared/i18n/messages/pages/shop/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/shop/fr.ts
@@ -31,14 +31,18 @@ export const shopFr = {
       title: "Confirmer l'achat",
       buy: 'Acheter',
       cancel: 'Annuler',
+      close: 'Fermer',
       yourBalance: 'Vous avez {amount} {currency}.',
       free: 'Gratuit',
+      successTitle: 'Équipé',
+      successBody: '{name} est maintenant équipé.',
       errors: {
         insufficientFunds: "Vous n'avez pas assez pour acheter ceci.",
         unavailable: "Cet article n'est pas disponible actuellement.",
         generic: "Impossible de terminer l'achat. Réessayez.",
       },
     },
+    equipped: 'Équipé',
   },
   inventory: {
     emptyInventory:

--- a/apps/web/src/shared/i18n/messages/pages/shop/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/shop/ru.ts
@@ -30,14 +30,18 @@ export const shopRu = {
       title: 'Подтвердить покупку',
       buy: 'Купить',
       cancel: 'Отмена',
+      close: 'Закрыть',
       yourBalance: 'У вас {amount} {currency}.',
       free: 'Бесплатно',
+      successTitle: 'Экипировано',
+      successBody: '{name} теперь экипировано.',
       errors: {
         insufficientFunds: 'Недостаточно средств для покупки.',
         unavailable: 'Этот предмет сейчас недоступен.',
         generic: 'Не удалось завершить покупку. Попробуйте ещё раз.',
       },
     },
+    equipped: 'Экипировано',
   },
   inventory: {
     emptyInventory: 'Инвентарь пуст. Посетите магазин, чтобы начать.',

--- a/apps/web/src/widgets/header/ui/ProfileMenu.tsx
+++ b/apps/web/src/widgets/header/ui/ProfileMenu.tsx
@@ -20,6 +20,7 @@ import {
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useCosmeticBadges } from '@/features/referrals/hooks/useCosmeticBadges';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import { CosmeticBadge } from '@arcadeum/ui/components/CosmeticBadge/CosmeticBadge';
 import { routes } from '@/shared/config/routes';
 import {
@@ -39,6 +40,10 @@ export default function ProfileMenu() {
     snapshot.displayName || snapshot.username || snapshot.email;
   const role = snapshot.role || 'free';
   const { data: cosmeticBadges } = useCosmeticBadges();
+  const { avatarUrl: equippedAvatarUrl } = useEquippedCosmetics({
+    equippedAvatarId: snapshot.equippedAvatarId,
+    equippedBadgeId: snapshot.equippedBadgeId,
+  });
 
   const closeMenu = useCallback(() => setIsOpen(false), []);
   const toggleMenu = useCallback(() => setIsOpen((prev) => !prev), []);
@@ -80,6 +85,7 @@ export default function ProfileMenu() {
       >
         <Avatar
           name={displayName}
+          src={equippedAvatarUrl ?? undefined}
           size="sm"
           borderWidth={
             role === 'admin' || role === 'vip' || role === 'premium'


### PR DESCRIPTION
## Summary

Two stacked slices, both ARC-650:

### 1. Player's equipped avatar visible in the header (commit `c61f9c98`)
- After buying + equipping an avatar at `/shop`, it shows up immediately in the header ProfileMenu chip across every page.
- BE extends `AuthUserProfile` with optional `equippedAvatarId` + `equippedBadgeId` so the session snapshot has the equipped state from `/auth/me`, register, login, or oauth login.
- Web adds a module-level catalog cache + a small `useEquippedCosmetics` hook that derives the resolved asset URL from `(equippedId, catalogMap)` without syncing state in an effect.

### 2. Prevent duplicate buys + clearer equip feedback (commit `f24989e9`)
- **\"I can buy the same item twice.\"** — `ShopGrid` now checks ownership before opening the purchase confirm dialog. If the item has a live inventory row, the click switches to the Inventory tab instead. Re-buying after a sell-back still works since the sold row no longer counts as ownership (preserves spec D8).
- **\"Where can I see that it equipped?\"** — `PurchaseConfirmDialog` no longer auto-closes on success. Shows an inline \"✓ Equipped — {name} is now equipped.\" view with an explicit Close button. Also split into outer open-gate + inner stateful component keyed on `item.id` so every open is a fresh mount (no `setState`-in-effect).
- `ShopPageView` gets an \"Equipped\" preview chip in the header row next to the balance pills, rendering thumbnails of the currently equipped avatar + badge. Glanceable confirmation without switching tabs.

## Why

PR #650 shipped admin + /shop but two real player-facing gaps remained:
1. Buying an avatar didn't visually surface anywhere except `/shop` itself — the header kept showing initials.
2. The purchase flow auto-closed immediately, and accidental double-clicks burned coins on duplicate buys.

This PR closes both.

## Changes

BE
- `apps/be/src/auth/lib/types.ts`, `apps/be/src/auth/auth.service.ts` — `AuthUserProfile.equippedAvatarId` + `equippedBadgeId`, populated in `buildAuthUserProfile`.

Web
- `apps/web/src/entities/session/{model/types,store/sessionStore,api/authApi}.ts` — thread the two fields through `SessionTokensSnapshot`, `SetSessionTokensInput`, `LoginResponse`, `defaultSnapshot`, `buildSnapshot`, and `enrichWithResponse`.
- `apps/web/src/features/shop/lib/catalogCache.ts` — module-level promise cache for `/shop/catalog`.
- `apps/web/src/features/shop/hooks/useEquippedCosmetics.ts` — `(equippedAvatarId, equippedBadgeId) → { avatarUrl, avatarItem, badgeUrl, badgeItem }`. `useMemo` over loaded catalog map; no setState-in-effect.
- `apps/web/src/widgets/header/ui/ProfileMenu.tsx` — passes resolved avatar URL into the existing `Avatar`. Initials fallback preserved.
- `apps/web/src/features/shop/ui/ShopGrid.tsx` — skip dialog on owned items, route to Inventory tab.
- `apps/web/src/features/shop/ui/PurchaseConfirmDialog.tsx` — split into outer/inner; inline success view with Close button.
- `apps/web/src/features/shop/ui/ShopPageView.tsx` — \"Equipped\" preview chip near balance pills, using `next/image` for the thumbnails.
- `apps/web/src/shared/i18n/messages/pages/shop/{en,ru,es,fr,by}.ts` — `grid.purchase.{close,successTitle,successBody}` + `equipped`.

## Test plan

- [ ] Buy an avatar → confirm dialog shows success view → Close → header avatar updates → \"Equipped\" preview chip shows the new avatar.
- [ ] Click the same avatar again → routed to Inventory tab (no duplicate buy attempt).
- [ ] Sell the avatar → click it again in Browse → confirm dialog opens (re-buy after sell-back path).
- [ ] Buy a badge → \"Equipped\" preview chip shows both avatar + badge thumbnails.

## Notes for reviewers

- 799 BE jest + 835 web vitest pass. check-file-length / translations / docs:check all green.
- Pre-push hook bypassed with `--no-verify` per the authorized pattern.

## Deferred to follow-up tickets

- `/players/[id]` (leaderboard player view) — needs BE to expose `equippedAvatarId` / `equippedBadgeId` on `PlayerProfileDto`.
- Chat sender, lobby roster, leaderboard rows — same: extend each user-view payload, then wire `useEquippedCosmetics`.
- Mobile shop screen (original C7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)