### PR TITLE
ARC-650 feat: equipped cosmetics in game chat + dropped-commit CI guard

### DIFF
--- a/.github/workflows/no-dropped-commits.yml
+++ b/.github/workflows/no-dropped-commits.yml
@@ -1,0 +1,75 @@
+name: No dropped commits
+
+# Detects force-pushes on feature branches that *remove* commits — the failure
+# mode behind PR #651, where a force-push rewrote history and the subsequent
+# merge silently dropped 5 of 7 commits from develop. A non-force-push (push
+# with new commits on top) is always safe: the previous tip remains reachable
+# from the new tip. A force-push that drops commits leaves the previous tip
+# unreachable from the new tip — `git merge-base --is-ancestor` catches that.
+#
+# Skipped on main/develop (those are protected and shouldn't see force-pushes
+# at all), and on the initial-push case where `before` is all zeros.
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  detect-dropped-commits:
+    name: Verify push preserves history
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether the previous tip is still reachable
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+            echo "Initial push of $REF — nothing to compare. OK."
+            exit 0
+          fi
+          if [[ "$AFTER"  == "0000000000000000000000000000000000000000" ]]; then
+            echo "Branch deletion of $REF — nothing to compare. OK."
+            exit 0
+          fi
+
+      - name: Checkout enough history to walk both tips
+        uses: actions/checkout@v4
+        if: ${{ github.event.before != '0000000000000000000000000000000000000000' && github.event.after != '0000000000000000000000000000000000000000' }}
+        with:
+          fetch-depth: 0
+
+      - name: Fail if the force-push removed commits
+        if: ${{ github.event.before != '0000000000000000000000000000000000000000' && github.event.after != '0000000000000000000000000000000000000000' }}
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          REF: ${{ github.ref }}
+        run: |
+          # Make sure both tips are actually fetched. checkout@v4 with
+          # fetch-depth: 0 normally covers this, but be explicit.
+          git fetch --no-tags --quiet origin "$BEFORE" || true
+          git fetch --no-tags --quiet origin "$AFTER"  || true
+
+          if git merge-base --is-ancestor "$BEFORE" "$AFTER"; then
+            echo "Push to $REF is a fast-forward — all previous commits preserved. OK."
+            exit 0
+          fi
+
+          echo "::error::Push to $REF dropped commits."
+          echo "Previous tip $BEFORE is no longer reachable from new tip $AFTER."
+          echo ""
+          echo "Commits that existed on $REF before this push and are now gone:"
+          git log --oneline "$AFTER..$BEFORE" || true
+          echo ""
+          echo "If this was intentional (e.g. rebase, squash), open a PR from"
+          echo "the new branch instead of force-pushing over an existing branch"
+          echo "with an open PR — the merge will otherwise silently drop the"
+          echo "missing commits when GitHub merges."
+          exit 1

--- a/apps/be/src/shop/services/inventory.service.ts
+++ b/apps/be/src/shop/services/inventory.service.ts
@@ -147,6 +147,18 @@ export class InventoryService {
     }
   }
 
+  // Equip / unequip freshness contract:
+  //  - /chat (player-to-player): live — equipped IDs are read on every page
+  //    of messages via the chat helper's batched User lookup.
+  //  - Lobby roster (room.members): next room emit picks it up. We don't push
+  //    a refresh on equip because in-lobby equipping is rare and the join /
+  //    leave / options-change traffic already produces a fresh summary within
+  //    seconds. Adding a cross-module socket emit from Shop → Games would
+  //    invert a dependency for marginal UX gain.
+  //  - Leaderboards: stale up to 30s (LeaderboardsCacheService TTL). Same
+  //    trade-off — capture and the 30s timer refresh equipped state.
+  //  - Header / ProfileMenu / /shop / /players/[id]: live — these read the
+  //    session snapshot or refetch on every render.
   async equip(userId: string, itemId: string): Promise<EquippedView> {
     const def = getCatalogItem(itemId);
     if (!def) throw new BadRequestException('shop.unknownItem');

--- a/apps/web/src/app/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/games/rooms/[id]/components/GamePageLayout.tsx
@@ -99,6 +99,22 @@ export function GamePageLayout(props: GamePageLayoutProps) {
     [registeredResolver, fallbackResolver],
   );
 
+  const resolveEquipped = useCallback(
+    (id?: string | null) => {
+      if (!id) return null;
+      const member = room.members?.find((m) => m.id === id);
+      if (!member) return null;
+      return {
+        equippedAvatarId: member.equippedAvatarId ?? null,
+        equippedBadgeId: member.equippedBadgeId ?? null,
+      };
+    },
+    [room.members],
+  );
+
+  const popupSender = latestMessage
+    ? resolveEquipped(latestMessage.senderId ?? null)
+    : null;
   const popupSenderName = latestMessage
     ? (resolveDisplayName(latestMessage.senderId, latestMessage.senderName) ??
       latestMessage.senderName)
@@ -150,6 +166,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
               onClose={() => setShowChat(false)}
               teamMode={teamMode}
               resolveDisplayName={resolveDisplayName}
+              resolveEquipped={resolveEquipped}
               currentUserId={userId}
             />
           </ChatPanel>
@@ -158,7 +175,10 @@ export function GamePageLayout(props: GamePageLayoutProps) {
         {latestMessage && (
           <ChatMessagePopup
             key={latestMessage.id}
+            senderId={latestMessage.senderId ?? null}
             senderName={popupSenderName}
+            senderEquippedAvatarId={popupSender?.equippedAvatarId ?? null}
+            senderEquippedBadgeId={popupSender?.equippedBadgeId ?? null}
             message={latestMessage.message}
             visible={!!latestMessage}
             onDismiss={dismissPopup}

--- a/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
@@ -3,7 +3,10 @@
 import { ChatMessageBubble } from './ChatMessageBubble';
 
 interface ChatMessagePopupProps {
+  senderId?: string | null;
   senderName: string;
+  senderEquippedAvatarId?: string | null;
+  senderEquippedBadgeId?: string | null;
   message: string;
   visible: boolean;
   onDismiss: () => void;
@@ -11,7 +14,10 @@ interface ChatMessagePopupProps {
 }
 
 export function ChatMessagePopup({
+  senderId,
   senderName,
+  senderEquippedAvatarId,
+  senderEquippedBadgeId,
   message,
   visible,
   onDismiss,
@@ -42,7 +48,10 @@ export function ChatMessagePopup({
       }}
     >
       <ChatMessageBubble
+        senderId={senderId ?? null}
         senderName={senderName}
+        senderEquippedAvatarId={senderEquippedAvatarId ?? null}
+        senderEquippedBadgeId={senderEquippedBadgeId ?? null}
         message={message}
         type="message"
         isOwn={isOwn}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -13,11 +13,26 @@ import {
 import type { ScrollView as TamaguiScrollView } from 'tamagui';
 import { scrollbarStyles } from '@/shared/lib/styles';
 import { getPlayerColor } from '@/shared/lib/playerColors';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import { useGameChatStore } from '../store/gameChatStore';
 import type { ChatScope } from '../store/gameChatStore';
 
+export interface ResolvedEquipped {
+  equippedAvatarId: string | null;
+  equippedBadgeId: string | null;
+}
+
+export type EquippedResolver = (id?: string | null) => ResolvedEquipped | null;
+
 interface GameChatProps {
   resolveDisplayName?: (id?: string, fallback?: string) => string | undefined;
+  /**
+   * Maps a senderId to that user's currently-equipped shop cosmetics, used
+   * to render avatars and inline badges in chat rows. Caller is expected to
+   * derive this from the lobby's room.members payload (which now carries
+   * equippedAvatarId / equippedBadgeId per member).
+   */
+  resolveEquipped?: EquippedResolver;
   currentUserId?: string | null;
   onClose?: () => void;
   teamMode?: boolean;
@@ -64,6 +79,7 @@ function renderResultHighlights(message: string): ReactNode {
 
 export function GameChat({
   resolveDisplayName,
+  resolveEquipped,
   currentUserId,
   onClose,
   teamMode,
@@ -187,8 +203,9 @@ export function GameChat({
                   ? renderResultHighlights(log.message)
                   : undefined;
               return (
-                <ChatMessage
+                <GameChatRow
                   key={log.id}
+                  senderId={log.senderId ?? null}
                   senderName={log.senderId ? senderName : undefined}
                   senderColor={senderColor}
                   targetName={targetId ? targetName : undefined}
@@ -197,6 +214,7 @@ export function GameChat({
                   contentNode={contentNode}
                   type={log.type}
                   isOwn={isOwn}
+                  resolveEquipped={resolveEquipped}
                 />
               );
             })}
@@ -220,5 +238,49 @@ export function GameChat({
         }
       />
     </GlassCard>
+  );
+}
+
+function GameChatRow({
+  senderId,
+  senderName,
+  senderColor,
+  targetName,
+  targetColor,
+  content,
+  contentNode,
+  type,
+  isOwn,
+  resolveEquipped,
+}: {
+  senderId: string | null;
+  senderName?: string;
+  senderColor?: string;
+  targetName?: string;
+  targetColor?: string;
+  content: string;
+  contentNode?: ReactNode;
+  type: 'system' | 'action' | 'message';
+  isOwn: boolean;
+  resolveEquipped?: EquippedResolver;
+}) {
+  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
+  const { avatarUrl, badgeUrl } = useEquippedCosmetics({
+    equippedAvatarId: resolved?.equippedAvatarId,
+    equippedBadgeId: resolved?.equippedBadgeId,
+  });
+  return (
+    <ChatMessage
+      senderName={senderName}
+      senderColor={senderColor}
+      targetName={targetName}
+      targetColor={targetColor}
+      content={content}
+      contentNode={contentNode}
+      type={type}
+      isOwn={isOwn}
+      avatarUrl={avatarUrl ?? undefined}
+      badgeUrl={badgeUrl ?? undefined}
+    />
   );
 }

--- a/packages/ui/src/components/Chat/ChatMessage.tsx
+++ b/packages/ui/src/components/Chat/ChatMessage.tsx
@@ -16,6 +16,8 @@ export type ChatMessageProps = {
   timestamp?: string;
   isOwn?: boolean;
   avatarUrl?: string;
+  /** Sender's equipped shop badge URL — rendered inline next to the name. */
+  badgeUrl?: string;
   isEncrypted?: boolean;
   type?: 'system' | 'action' | 'message';
 };
@@ -124,6 +126,7 @@ export const ChatMessage = memo(function ChatMessage({
   timestamp,
   isOwn = false,
   avatarUrl,
+  badgeUrl,
   isEncrypted,
   type = 'message',
 }: ChatMessageProps) {
@@ -147,10 +150,30 @@ export const ChatMessage = memo(function ChatMessage({
           >
             {senderName}
           </Typography>
+          {badgeUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={badgeUrl}
+              alt=""
+              width={16}
+              height={16}
+              style={{ objectFit: 'contain' }}
+            />
+          ) : null}
         </XStack>
       )}
       {isOwn && !isSystem && senderName && (
         <XStack ai="center" gap="$2" mb="$1" px="$2" alignSelf="flex-end">
+          {badgeUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={badgeUrl}
+              alt=""
+              width={16}
+              height={16}
+              style={{ objectFit: 'contain' }}
+            />
+          ) : null}
           <Typography
             uiSize="xs"
             weight="600"


### PR DESCRIPTION
## Summary

Closes out the remaining ARC-650 follow-ups for in-match social surfaces, plus a CI guard against the exact failure mode behind PR #651.

- **In-game chat**: sender's equipped avatar + inline badge in both the side-panel chat and the toast popup, across every game (Sea Battle, Critical, Texas Hold'em, Glimworm).
- **Equip freshness contract**: documented in code where equipped state is live vs cached, and why.
- **CI guard**: workflow that fails any feature-branch force-push that drops commits — the silent merge-drop that lost 5 of 7 commits from PR #651.

## Changes

**In-game chat**
- `packages/ui/src/components/Chat/ChatMessage.tsx` — new optional `badgeUrl` prop, rendered inline next to the sender name on both own and other rows.
- `apps/web/src/widgets/GameChat/ui/GameChat.tsx` — new `resolveEquipped` callback prop; extracted `GameChatRow` sub-component because the `useEquippedCosmetics` hook can't run inside `.map`. Falls back to initials when no resolver is supplied.
- `apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx` — forwards `senderId` + equipped IDs to the already equipped-aware `ChatMessageBubble`.
- `apps/web/src/app/games/rooms/[id]/components/GamePageLayout.tsx` — builds the resolver from `room.members` (which has carried equipped IDs since the previous PR) and feeds it to both `GameChat` and `ChatMessagePopup`. No BE work needed — every senderId during a game is in the room snapshot.

**Equip freshness contract**
- `apps/be/src/shop/services/inventory.service.ts` — comment block on `equip()` documenting which surfaces are live (chat, header, profile, /shop, /players/[id]) vs cached (lobby roster next-emit; leaderboards 30s TTL). Captures the deliberate choice not to push a cross-module refresh signal from Shop → Games/Leaderboards.

**CI guard**
- `.github/workflows/no-dropped-commits.yml` — runs on push to any feature branch. Fails if the previous tip is no longer reachable from the new tip (`git merge-base --is-ancestor`), which is the signature of a force-push that removed commits. Skips main/develop and initial-push/branch-deletion events.

## Test plan

- [x] `pnpm --filter web test` → 835 vitest pass
- [x] `pnpm --filter be test` → 799 jest pass
- [x] `pnpm --filter web exec tsc --noEmit` clean
- [x] `pnpm --filter be exec tsc --noEmit` clean
- [ ] Manual: equip avatar+badge as user A; user B joins A's Sea Battle room and the in-game chat shows A's avatar/badge next to messages and in the toast popup.
- [ ] Manual: force-push a feature branch (drop a commit) — workflow run shows the dropped-commit error in CI logs and fails the job. (After this PR merges, future force-pushes get caught.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)