### PR TITLE
feat(critical): widget parity pass against Critical.html preview (ARC-670)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/lib/useNarrowViewport.ts
+++ b/apps/web/src/widgets/CriticalGame/lib/useNarrowViewport.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * True while the viewport is ≤480px — phones in portrait. Used to gate
+ * widget-mode mobile branches that the tamagui `sm` breakpoint (≤800px)
+ * fires too eagerly for. SSR-safe: returns `false` on the server and
+ * during first paint, then syncs on mount.
+ */
+export function useNarrowViewport(maxWidth = 480): boolean {
+  const [narrow, setNarrow] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia(`(max-width: ${maxWidth}px)`);
+    const apply = () => setNarrow(mq.matches);
+    apply();
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, [maxWidth]);
+  return narrow;
+}

--- a/apps/web/src/widgets/CriticalGame/ui/ComboHints.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ComboHints.test.tsx
@@ -9,7 +9,7 @@ import { ComboHints } from './ComboHints';
 import type { CriticalCard } from '../types';
 
 describe('ComboHints', () => {
-  it('activates the pair chip when two combo cards match', () => {
+  it('marks the pair chip as possible when two combo cards match', () => {
     const hand: CriticalCard[] = [
       'collection_alpha',
       'collection_alpha',
@@ -17,20 +17,20 @@ describe('ComboHints', () => {
     ];
     render(<ComboHints hand={hand} allowActionCardCombos={false} />);
     expect(screen.getByTestId('combo-hint-pair')).toHaveAttribute(
-      'data-active',
-      'true',
+      'data-state',
+      'possible',
     );
     expect(screen.getByTestId('combo-hint-triple')).toHaveAttribute(
-      'data-active',
-      'false',
+      'data-state',
+      'inactive',
     );
     expect(screen.getByTestId('combo-hint-fiver')).toHaveAttribute(
-      'data-active',
-      'false',
+      'data-state',
+      'inactive',
     );
   });
 
-  it('activates the triple chip when three combo cards match', () => {
+  it('marks the triple chip as possible when three combo cards match', () => {
     const hand: CriticalCard[] = [
       'collection_beta',
       'collection_beta',
@@ -38,16 +38,16 @@ describe('ComboHints', () => {
     ];
     render(<ComboHints hand={hand} allowActionCardCombos={false} />);
     expect(screen.getByTestId('combo-hint-pair')).toHaveAttribute(
-      'data-active',
-      'true',
+      'data-state',
+      'possible',
     );
     expect(screen.getByTestId('combo-hint-triple')).toHaveAttribute(
-      'data-active',
-      'true',
+      'data-state',
+      'possible',
     );
   });
 
-  it('activates the fiver chip when hand has 5 distinct cards', () => {
+  it('marks the fiver chip as possible when hand has 5 distinct cards', () => {
     const hand: CriticalCard[] = [
       'strike',
       'evade',
@@ -57,8 +57,8 @@ describe('ComboHints', () => {
     ];
     render(<ComboHints hand={hand} allowActionCardCombos={false} />);
     expect(screen.getByTestId('combo-hint-fiver')).toHaveAttribute(
-      'data-active',
-      'true',
+      'data-state',
+      'possible',
     );
   });
 
@@ -66,8 +66,8 @@ describe('ComboHints', () => {
     const hand: CriticalCard[] = ['strike', 'strike'];
     render(<ComboHints hand={hand} allowActionCardCombos={false} />);
     expect(screen.getByTestId('combo-hint-pair')).toHaveAttribute(
-      'data-active',
-      'false',
+      'data-state',
+      'inactive',
     );
   });
 
@@ -75,8 +75,35 @@ describe('ComboHints', () => {
     const hand: CriticalCard[] = ['strike', 'strike'];
     render(<ComboHints hand={hand} allowActionCardCombos={true} />);
     expect(screen.getByTestId('combo-hint-pair')).toHaveAttribute(
+      'data-state',
+      'possible',
+    );
+  });
+
+  it('flips the matching chip to active when activeKind is supplied', () => {
+    const hand: CriticalCard[] = [
+      'collection_alpha',
+      'collection_alpha',
+      'strike',
+    ];
+    render(
+      <ComboHints
+        hand={hand}
+        allowActionCardCombos={false}
+        activeKind="pair"
+      />,
+    );
+    expect(screen.getByTestId('combo-hint-pair')).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+    expect(screen.getByTestId('combo-hint-pair')).toHaveAttribute(
       'data-active',
       'true',
+    );
+    expect(screen.getByTestId('combo-hint-triple')).toHaveAttribute(
+      'data-state',
+      'inactive',
     );
   });
 

--- a/apps/web/src/widgets/CriticalGame/ui/ComboHints.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ComboHints.tsx
@@ -8,6 +8,13 @@ import { COMBO_CARDS, FIVER_COMBO_SIZE } from '../types';
 interface ComboHintsProps {
   hand: CriticalCard[];
   allowActionCardCombos: boolean;
+  /**
+   * The combo kind currently formed by the player's selection. When a
+   * chip matches this kind it renders in the "active" state (filled
+   * green); the other chips fall back to the softer "possible" state
+   * that only reflects what's available in the hand.
+   */
+  activeKind?: 'none' | 'single' | 'pair' | 'triple' | 'five' | 'invalid';
 }
 
 interface ComboAvailability {
@@ -39,7 +46,11 @@ function computeAvailability(
   return { pair, triple, fiver };
 }
 
-export function ComboHints({ hand, allowActionCardCombos }: ComboHintsProps) {
+export function ComboHints({
+  hand,
+  allowActionCardCombos,
+  activeKind,
+}: ComboHintsProps) {
   const { t } = useTranslation();
   const { pair, triple, fiver } = useMemo(
     () => computeAvailability(hand, allowActionCardCombos),
@@ -56,41 +67,80 @@ export function ComboHints({ hand, allowActionCardCombos }: ComboHintsProps) {
     border: '1px solid rgba(255,255,255,0.12)',
   };
 
-  const chip = (active: boolean): CSSProperties => ({
-    display: 'inline-flex',
-    alignItems: 'center',
-    padding: '3px 8px',
-    borderRadius: 9999,
-    fontSize: 10.5,
-    fontWeight: 700,
-    letterSpacing: 0.4,
-    textTransform: 'uppercase',
-    color: active ? '#0b0b0b' : 'rgba(255,255,255,0.55)',
-    background: active ? '#34d399' : 'rgba(255,255,255,0.06)',
-    border: `1px solid ${active ? '#34d399' : 'rgba(255,255,255,0.1)'}`,
-    transition: 'all 180ms ease-out',
-  });
+  // Three states per chip:
+  //   - active: the selection currently forms this combo kind. Filled
+  //     green with dark text — preview's "you have this right now".
+  //   - possible: the hand could form this combo but the selection
+  //     hasn't yet. Soft outline — at-idle affordance.
+  //   - inactive: neither active nor possible. Dimmed.
+  const chip = (state: 'active' | 'possible' | 'inactive'): CSSProperties => {
+    const isActive = state === 'active';
+    const isPossible = state === 'possible';
+    return {
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '3px 8px',
+      borderRadius: 9999,
+      fontSize: 10.5,
+      fontWeight: 700,
+      letterSpacing: 0.4,
+      textTransform: 'uppercase',
+      color: isActive
+        ? '#0b0b0b'
+        : isPossible
+          ? 'rgba(255,255,255,0.85)'
+          : 'rgba(255,255,255,0.4)',
+      background: isActive
+        ? '#34d399'
+        : isPossible
+          ? 'rgba(52,211,153,0.10)'
+          : 'rgba(255,255,255,0.04)',
+      border: `1px solid ${
+        isActive
+          ? '#34d399'
+          : isPossible
+            ? 'rgba(52,211,153,0.45)'
+            : 'rgba(255,255,255,0.08)'
+      }`,
+      transition: 'all 180ms ease-out',
+    };
+  };
+
+  const stateFor = (
+    kind: 'pair' | 'triple' | 'five',
+    possible: boolean,
+  ): 'active' | 'possible' | 'inactive' => {
+    if (activeKind === kind) return 'active';
+    return possible ? 'possible' : 'inactive';
+  };
+
+  const pairState = stateFor('pair', pair);
+  const tripleState = stateFor('triple', triple);
+  const fiverState = stateFor('five', fiver);
 
   return (
     <div data-testid="combo-hints" style={containerStyle}>
       <span
         data-testid="combo-hint-pair"
-        data-active={pair ? 'true' : 'false'}
-        style={chip(pair)}
+        data-active={pairState === 'active' ? 'true' : 'false'}
+        data-state={pairState}
+        style={chip(pairState)}
       >
         {t('games.table.hud.combo.pair')}
       </span>
       <span
         data-testid="combo-hint-triple"
-        data-active={triple ? 'true' : 'false'}
-        style={chip(triple)}
+        data-active={tripleState === 'active' ? 'true' : 'false'}
+        data-state={tripleState}
+        style={chip(tripleState)}
       >
         {t('games.table.hud.combo.triple')}
       </span>
       <span
         data-testid="combo-hint-fiver"
-        data-active={fiver ? 'true' : 'false'}
-        style={chip(fiver)}
+        data-active={fiverState === 'active' ? 'true' : 'false'}
+        data-state={fiverState}
+        style={chip(fiverState)}
       >
         {t('games.table.hud.combo.fiver')}
       </span>

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -137,11 +137,8 @@ vi.mock('./RulesModal', () => ({
 }));
 
 vi.mock('./styles/layout', () => ({
-  GameBoard: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="game-board-stub">{children}</div>
-  ),
-  TableArea: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="table-area-stub">{children}</div>
+  MatchWidgetGrid: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="match-widget-grid-stub">{children}</div>
   ),
 }));
 

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -9,7 +9,7 @@ import {
   type ComponentProps,
 } from 'react';
 import type { ActiveGameContent } from './ActiveGameContent';
-import { GameBoard, TableArea } from './styles/layout';
+import { MatchWidgetGrid } from './styles/layout';
 import { Arena } from './arena/Arena';
 import { OpponentsRow } from './opponents/OpponentsRow';
 import { HandZone } from './hand/HandZone';
@@ -274,7 +274,7 @@ export function MatchWidget({
 
   return (
     <div data-testid="match-widget">
-      <GameBoard>
+      <MatchWidgetGrid data-testid="match-widget-grid">
         <OpponentsRow
           opponents={opponents}
           currentTurnPlayerId={turnPlayerId}
@@ -284,25 +284,23 @@ export function MatchWidget({
           }
           resolveDisplayName={tileResolveName}
         />
-        <TableArea>
-          <Arena
-            deck={snapshot.deck}
-            discardPile={snapshot.discardPile}
-            cardVariant={cardVariant}
-            isMyTurn={isMyTurn}
-            isGameOver={isGameOver}
-            onDrawAndEnd={handleDrawAndEnd}
-            hand={hand}
-            allowActionCardCombos={allowActionCardCombos}
-            combo={combo}
-            currentPlayerName={currentPlayerName}
-            pendingDraws={snapshot.pendingDraws}
-            logs={snapshot.logs ?? []}
-            formatLogMessage={formatLogMessage}
-            serverOverloadOdds={snapshot.overloadOdds}
-            hiddenCount={snapshot.hiddenCount}
-          />
-        </TableArea>
+        <Arena
+          deck={snapshot.deck}
+          discardPile={snapshot.discardPile}
+          cardVariant={cardVariant}
+          isMyTurn={isMyTurn}
+          isGameOver={isGameOver}
+          onDrawAndEnd={handleDrawAndEnd}
+          hand={hand}
+          allowActionCardCombos={allowActionCardCombos}
+          combo={combo}
+          currentPlayerName={currentPlayerName}
+          pendingDraws={snapshot.pendingDraws}
+          logs={snapshot.logs ?? []}
+          formatLogMessage={formatLogMessage}
+          serverOverloadOdds={snapshot.overloadOdds}
+          hiddenCount={snapshot.hiddenCount}
+        />
 
         {showHand && (
           <HandZone
@@ -327,7 +325,7 @@ export function MatchWidget({
             onToggleCardDescription={handleToggleCardDescription}
           />
         )}
-      </GameBoard>
+      </MatchWidgetGrid>
       <RulesModal
         isOpen={rulesOpen}
         onClose={handleCloseRules}

--- a/apps/web/src/widgets/CriticalGame/ui/TurnBanner.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/TurnBanner.test.tsx
@@ -87,18 +87,14 @@ describe('TurnBanner', () => {
     expect(screen.getByTestId('turn-banner-extra')).toHaveTextContent('+2');
   });
 
-  it('gates the pulsing dot animation behind prefers-reduced-motion: no-preference', () => {
+  it('attaches its pulse via the global hudStyles attribute selector, not inline', () => {
+    // Keyframes live in `hudStyles.tsx` (HUD_KEYFRAMES_CSS) and are
+    // mounted once by `ArenaCenter`. The banner itself should NOT emit
+    // a `<style>` tag and the dot's inline style must NOT carry an
+    // animation rule — the prefers-reduced-motion media gate inside
+    // hudStyles is what actually controls the pulse.
     const { container } = renderBanner({ isMyTurn: true });
-    // The animation must live inside a @media (prefers-reduced-motion: no-preference)
-    // block so that users with "reduce" set never receive the animation property.
-    const styleTag = container.querySelector('style');
-    expect(styleTag).not.toBeNull();
-    const css = styleTag?.innerHTML ?? '';
-    expect(css).toMatch(/prefers-reduced-motion:\s*no-preference/);
-    expect(css).toMatch(/animation:\s*turnBannerDotPulse/);
-
-    // The dot's inline style must not contain an animation rule — animation is
-    // only attached via the guarded @media CSS block.
+    expect(container.querySelector('style')).toBeNull();
     const dot = screen.getByTestId('turn-banner-dot');
     expect(dot.getAttribute('style') ?? '').not.toContain('animation');
   });

--- a/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
@@ -13,17 +13,10 @@ interface TurnBannerProps {
   pendingDraws?: number;
 }
 
-const PULSE_KEYFRAMES_CSS = `
-@media (prefers-reduced-motion: no-preference) {
-  @keyframes turnBannerDotPulse {
-    0%, 100% { transform: scale(1); opacity: 1; }
-    50% { transform: scale(1.35); opacity: 0.6; }
-  }
-  [data-testid="turn-banner-dot"] {
-    animation: turnBannerDotPulse 1.5s ease-in-out infinite;
-  }
-}
-`;
+// `turnBannerDotPulse` keyframes live in `hudStyles.tsx`
+// (HUD_KEYFRAMES_CSS) — `ArenaCenter` mounts `<HudStyles />` once for
+// the whole widget, so the rule is already in the document by the time
+// this banner paints.
 
 function formatTimer(secondsRemaining: number | null): string {
   const s = secondsRemaining ?? 0;
@@ -89,12 +82,15 @@ export function TurnBanner({
     minWidth: 0,
   };
 
-  // Gradient border rendered via ::before-equivalent overlay using mask-composite
+  // Gradient border rendered via ::before-equivalent overlay using
+  // mask-composite. The radius mirrors the shell so the gradient mask
+  // tracks the rounded card on phones — without this it kept the full
+  // pill radius and clipped at the corners of the narrower layout.
   const borderOverlayStyle: CSSProperties = {
     content: '""',
     position: 'absolute',
     inset: 0,
-    borderRadius: 9999,
+    borderRadius: isNarrow ? 14 : 9999,
     padding: 2,
     background: palette.turnBannerBorderGradient,
     WebkitMask:
@@ -137,39 +133,36 @@ export function TurnBanner({
   };
 
   return (
-    <>
-      <style dangerouslySetInnerHTML={{ __html: PULSE_KEYFRAMES_CSS }} />
-      <div data-testid="turn-banner" style={shellStyle}>
-        <span aria-hidden style={borderOverlayStyle} />
-        <div style={headerRowStyle}>
-          <span data-testid="turn-banner-dot" style={dotStyle} />
-          <span style={labelStyle}>{label}</span>
-          {extraLabel && (
-            <span
-              data-testid="turn-banner-extra"
-              style={{
-                position: 'relative',
-                zIndex: 1,
-                padding: '2px 8px',
-                borderRadius: 9999,
-                background: 'rgba(245, 158, 11, 0.18)',
-                color: '#fbbf24',
-                border: '1px solid rgba(245, 158, 11, 0.45)',
-                fontSize: 11,
-                fontWeight: 800,
-                letterSpacing: 0.4,
-                textTransform: 'uppercase',
-                fontVariantNumeric: 'tabular-nums',
-                flexShrink: 0,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {extraLabel}
-            </span>
-          )}
-        </div>
-        <span style={timerStyle}>{timer}</span>
+    <div data-testid="turn-banner" style={shellStyle}>
+      <span aria-hidden style={borderOverlayStyle} />
+      <div style={headerRowStyle}>
+        <span data-testid="turn-banner-dot" style={dotStyle} />
+        <span style={labelStyle}>{label}</span>
+        {extraLabel && (
+          <span
+            data-testid="turn-banner-extra"
+            style={{
+              position: 'relative',
+              zIndex: 1,
+              padding: '2px 8px',
+              borderRadius: 9999,
+              background: 'rgba(245, 158, 11, 0.18)',
+              color: '#fbbf24',
+              border: '1px solid rgba(245, 158, 11, 0.45)',
+              fontSize: 11,
+              fontWeight: 800,
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+              fontVariantNumeric: 'tabular-nums',
+              flexShrink: 0,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {extraLabel}
+          </span>
+        )}
       </div>
-    </>
+      <span style={timerStyle}>{timer}</span>
+    </div>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from 'react';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useScenePalette } from './ScenePaletteContext';
+import { useNarrowViewport } from '../lib/useNarrowViewport';
 
 interface TurnBannerProps {
   isMyTurn: boolean;
@@ -40,6 +41,7 @@ export function TurnBanner({
 }: TurnBannerProps) {
   const palette = useScenePalette();
   const { t } = useTranslation();
+  const isNarrow = useNarrowViewport(480);
 
   const label = isMyTurn
     ? t('games.table.players.yourMove')
@@ -55,13 +57,17 @@ export function TurnBanner({
         : t('games.table.hud.extraTurnsPlural', { count: extra })
       : null;
 
+  // On narrow phones the dot+label+chip+timer row blows past the
+  // viewport. Stack vertically so each element gets its own line and the
+  // player-name truncates instead of pushing the timer off-screen.
   const shellStyle: CSSProperties = {
     position: 'relative',
     display: 'inline-flex',
-    alignItems: 'center',
-    gap: 10,
+    flexDirection: isNarrow ? 'column' : 'row',
+    alignItems: isNarrow ? 'stretch' : 'center',
+    gap: isNarrow ? 4 : 10,
     padding: '8px 16px',
-    borderRadius: 9999,
+    borderRadius: isNarrow ? 14 : 9999,
     background: 'rgba(0, 0, 0, 0.45)',
     color: '#ffffff',
     fontWeight: 700,
@@ -71,6 +77,16 @@ export function TurnBanner({
     boxShadow: palette.turnBannerShadow,
     overflow: 'hidden',
     isolation: 'isolate',
+    maxWidth: '100%',
+  };
+
+  const headerRowStyle: CSSProperties = {
+    position: 'relative',
+    zIndex: 1,
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 8,
+    minWidth: 0,
   };
 
   // Gradient border rendered via ::before-equivalent overlay using mask-composite
@@ -104,6 +120,11 @@ export function TurnBanner({
     position: 'relative',
     zIndex: 1,
     textTransform: 'uppercase',
+    minWidth: 0,
+    flex: 1,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   };
 
   const timerStyle: CSSProperties = {
@@ -111,7 +132,8 @@ export function TurnBanner({
     zIndex: 1,
     fontVariantNumeric: 'tabular-nums',
     opacity: 0.85,
-    marginLeft: 4,
+    marginLeft: isNarrow ? 0 : 4,
+    alignSelf: isNarrow ? 'flex-end' : 'auto',
   };
 
   return (
@@ -119,29 +141,33 @@ export function TurnBanner({
       <style dangerouslySetInnerHTML={{ __html: PULSE_KEYFRAMES_CSS }} />
       <div data-testid="turn-banner" style={shellStyle}>
         <span aria-hidden style={borderOverlayStyle} />
-        <span data-testid="turn-banner-dot" style={dotStyle} />
-        <span style={labelStyle}>{label}</span>
-        {extraLabel && (
-          <span
-            data-testid="turn-banner-extra"
-            style={{
-              position: 'relative',
-              zIndex: 1,
-              padding: '2px 8px',
-              borderRadius: 9999,
-              background: 'rgba(245, 158, 11, 0.18)',
-              color: '#fbbf24',
-              border: '1px solid rgba(245, 158, 11, 0.45)',
-              fontSize: 11,
-              fontWeight: 800,
-              letterSpacing: 0.4,
-              textTransform: 'uppercase',
-              fontVariantNumeric: 'tabular-nums',
-            }}
-          >
-            {extraLabel}
-          </span>
-        )}
+        <div style={headerRowStyle}>
+          <span data-testid="turn-banner-dot" style={dotStyle} />
+          <span style={labelStyle}>{label}</span>
+          {extraLabel && (
+            <span
+              data-testid="turn-banner-extra"
+              style={{
+                position: 'relative',
+                zIndex: 1,
+                padding: '2px 8px',
+                borderRadius: 9999,
+                background: 'rgba(245, 158, 11, 0.18)',
+                color: '#fbbf24',
+                border: '1px solid rgba(245, 158, 11, 0.45)',
+                fontSize: 11,
+                fontWeight: 800,
+                letterSpacing: 0.4,
+                textTransform: 'uppercase',
+                fontVariantNumeric: 'tabular-nums',
+                flexShrink: 0,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {extraLabel}
+            </span>
+          )}
+        </div>
         <span style={timerStyle}>{timer}</span>
       </div>
     </>

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { XStack, YStack, useMedia } from 'tamagui';
+import { XStack } from 'tamagui';
 import type { CriticalCard, CriticalLogEntry } from '../../types';
 import { DrawPile } from './DrawPile';
 import { DiscardPile } from './DiscardPile';
 import { ArenaCenter } from './ArenaCenter';
+import { useNarrowViewport } from '../../lib/useNarrowViewport';
 import type { ComboKind } from './ComboCard';
 
 interface ArenaProps {
@@ -50,90 +51,62 @@ export function Arena({
   serverOverloadOdds,
   hiddenCount,
 }: ArenaProps) {
-  const media = useMedia();
-  const isMobile = media.sm;
-
-  const drawPile = (
-    <DrawPile
-      deck={deck}
-      count={deck.length}
-      disabled={!isMyTurn || isGameOver}
-      onDraw={onDrawAndEnd}
-      cardVariant={cardVariant}
-    />
-  );
-  const arenaCenter = (
-    <ArenaCenter
-      isMyTurn={isMyTurn}
-      currentPlayerName={currentPlayerName}
-      pendingDraws={pendingDraws}
-      hand={hand}
-      allowActionCardCombos={allowActionCardCombos}
-      combo={combo}
-      deck={deck}
-      logs={logs}
-      formatLogMessage={formatLogMessage}
-      serverOverloadOdds={serverOverloadOdds}
-      hiddenCount={hiddenCount}
-    />
-  );
-  const discardPileEl = (
-    <DiscardPile pile={discardPile} cardVariant={cardVariant} />
-  );
-
-  // Mobile: stack vertically so the center column gets full row width
-  // for the turn pill, combo chips, threat strip, and FlashBanner —
-  // otherwise the side piles squeeze it to a few pixels and the
-  // absolutely-positioned overlays collide with neighbours.
-  if (isMobile) {
-    return (
-      <YStack
-        data-testid="arena"
-        data-layout="mobile"
-        width="100%"
-        gap="$2"
-        paddingHorizontal="$2"
-        alignItems="stretch"
-      >
-        <XStack
-          width="100%"
-          alignItems="center"
-          justifyContent="space-around"
-          gap="$2"
-        >
-          {drawPile}
-          {discardPileEl}
-        </XStack>
-        {arenaCenter}
-      </YStack>
-    );
-  }
+  // Phones get smaller piles so the three-column row still fits at
+  // 390px; the layout otherwise stays identical so the threat strip,
+  // combo card, and FlashBanner don't fall down 200px below the piles.
+  const isNarrow = useNarrowViewport(480);
 
   return (
     <XStack
       data-testid="arena"
-      data-layout="desktop"
+      data-layout={isNarrow ? 'mobile' : 'desktop'}
       width="100%"
       alignItems="center"
       gap="$5"
       paddingHorizontal="$4"
       paddingVertical="$3"
-      borderRadius={18}
-      borderWidth={1}
+      borderRadius={isNarrow ? 0 : 18}
+      borderWidth={isNarrow ? 0 : 1}
       borderColor="rgba(255,255,255,0.06)"
-      backgroundColor="rgba(8,12,20,0.55)"
+      backgroundColor={isNarrow ? 'transparent' : 'rgba(8,12,20,0.55)'}
       // overflow: hidden keeps hover glows on the piles inside the
-      // rounded border and stops the FlashBanner overlay leaking out.
-      overflow="hidden"
+      // rounded border on desktop. On phones we drop the card chrome so
+      // the row reads as a strip and the FlashBanner overlay can extend
+      // past the arena bounds without clipping.
+      overflow={isNarrow ? 'visible' : 'hidden'}
       $sm={{
         gap: '$2',
         paddingHorizontal: '$2',
         paddingVertical: '$2',
       }}
     >
-      {drawPile}
-      {arenaCenter}
-      {discardPileEl}
+      <DrawPile
+        deck={deck}
+        count={deck.length}
+        disabled={!isMyTurn || isGameOver}
+        onDraw={onDrawAndEnd}
+        cardVariant={cardVariant}
+        isNarrow={isNarrow}
+      />
+      <ArenaCenter
+        isMyTurn={isMyTurn}
+        currentPlayerName={currentPlayerName}
+        pendingDraws={pendingDraws}
+        hand={hand}
+        allowActionCardCombos={allowActionCardCombos}
+        combo={combo}
+        deck={deck}
+        logs={logs}
+        formatLogMessage={formatLogMessage}
+        serverOverloadOdds={serverOverloadOdds}
+        hiddenCount={hiddenCount}
+        isNarrow={isNarrow}
+      />
+      <DiscardPile
+        pile={discardPile}
+        cardVariant={cardVariant}
+        isNarrow={isNarrow}
+      />
     </XStack>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
@@ -115,9 +115,21 @@ export function Arena({
       data-layout="desktop"
       width="100%"
       alignItems="center"
-      justifyContent="space-between"
-      gap="$4"
-      paddingHorizontal="$3"
+      gap="$5"
+      paddingHorizontal="$4"
+      paddingVertical="$3"
+      borderRadius={18}
+      borderWidth={1}
+      borderColor="rgba(255,255,255,0.06)"
+      backgroundColor="rgba(8,12,20,0.55)"
+      // overflow: hidden keeps hover glows on the piles inside the
+      // rounded border and stops the FlashBanner overlay leaking out.
+      overflow="hidden"
+      $sm={{
+        gap: '$2',
+        paddingHorizontal: '$2',
+        paddingVertical: '$2',
+      }}
     >
       {drawPile}
       {arenaCenter}

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
@@ -53,7 +53,7 @@ export function ArenaCenter({
     <YStack
       data-testid="arena-center"
       flex={1}
-      minHeight={120}
+      minHeight={180}
       alignItems="center"
       justifyContent="center"
       gap="$2"
@@ -63,7 +63,7 @@ export function ArenaCenter({
       <YStack
         data-testid="arena-flash-slot"
         position="absolute"
-        top={-8}
+        top={8}
         left={0}
         right={0}
         alignItems="center"

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ArenaCenter.tsx
@@ -26,6 +26,12 @@ interface ArenaCenterProps {
   // Flash banner
   logs: CriticalLogEntry[];
   formatLogMessage: (message?: string | null) => string;
+  /**
+   * Phones: drop `minHeight` so the centre column doesn't burn 180px
+   * of vertical real estate when content is just a turn pill. Passed
+   * from `Arena` so the layout decision lives in one place.
+   */
+  isNarrow?: boolean;
 }
 
 /**
@@ -48,12 +54,13 @@ export function ArenaCenter({
   hiddenCount,
   logs,
   formatLogMessage,
+  isNarrow = false,
 }: ArenaCenterProps) {
   return (
     <YStack
       data-testid="arena-center"
       flex={1}
-      minHeight={180}
+      minHeight={isNarrow ? 0 : 180}
       alignItems="center"
       justifyContent="center"
       gap="$2"

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.test.tsx
@@ -63,10 +63,19 @@ describe('ComboCard', () => {
     },
   );
 
-  it('embeds ComboHints inside the card', () => {
+  it('hides ComboHints at idle (kind="none") so the placeholder reads clean', () => {
     renderCard({
       hand: ['strike'] as CriticalCard[],
       allowActionCardCombos: false,
+    });
+    expect(screen.queryByTestId('combo-hints')).not.toBeInTheDocument();
+  });
+
+  it('embeds ComboHints once a combo is detected', () => {
+    renderCard({
+      hand: ['strike', 'strike'] as CriticalCard[],
+      allowActionCardCombos: true,
+      combo: { kind: 'pair', label: 'pair' },
     });
     expect(screen.getByTestId('combo-hints')).toBeInTheDocument();
   });

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
@@ -67,6 +67,16 @@ export function ComboCard({
       shadowColor={KIND_GLOW[kind]}
       shadowOpacity={kind === 'none' ? 0 : 1}
       shadowRadius={12}
+      shadowOffset={{ width: 0, height: 0 }}
+      // tamagui's RN-style shadow props translate inconsistently to web
+      // box-shadow; a filter-based drop-shadow guarantees the glow paints
+      // in every browser. `none` kind keeps the filter off so the card
+      // renders flat in the default state.
+      style={
+        kind === 'none'
+          ? undefined
+          : { filter: `drop-shadow(0 0 12px ${KIND_GLOW[kind]})` }
+      }
     >
       <Text
         data-testid="combo-card-label"

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
@@ -88,7 +88,17 @@ export function ComboCard({
       >
         {label}
       </Text>
-      <ComboHints hand={hand} allowActionCardCombos={allowActionCardCombos} />
+      {/* Hide the chip strip at idle — three "possible" chips read as
+          decorative clutter without a selection. Once the player picks
+          anything (kind !== 'none') the strip surfaces the active /
+          possible combo states. */}
+      {kind !== 'none' && (
+        <ComboHints
+          hand={hand}
+          allowActionCardCombos={allowActionCardCombos}
+          activeKind={kind}
+        />
+      )}
     </YStack>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
@@ -9,15 +9,26 @@ import { CardSlot } from '../styles';
 interface DiscardPileProps {
   pile: CriticalCard[];
   cardVariant?: string;
+  /** Phones use a shrunk 80×112 slot so the three-column row fits. */
+  isNarrow?: boolean;
 }
 
-export function DiscardPile({ pile, cardVariant }: DiscardPileProps) {
+export function DiscardPile({
+  pile,
+  cardVariant,
+  isNarrow = false,
+}: DiscardPileProps) {
   const { t } = useTranslation();
   const count = pile.length;
   const tCompat = t as unknown as (key: string) => string;
 
   return (
-    <YStack data-testid="arena-discard-pile" alignItems="center" gap="$1">
+    <YStack
+      data-testid="arena-discard-pile"
+      alignItems="center"
+      gap="$1"
+      flexShrink={0}
+    >
       {/* `LastPlayedCardDisplay` renders `LastPlayedCard`, which is
           `position: absolute` with width/height 100%. Without a sized,
           positioned slot it expands to fill the nearest positioned
@@ -25,9 +36,8 @@ export function DiscardPile({ pile, cardVariant }: DiscardPileProps) {
           table layout uses for the same component. */}
       <CardSlot
         $role="lastPlayed"
-        width={140}
-        height={196}
-        $sm={{ width: 96, height: 134 }}
+        width={isNarrow ? 80 : 140}
+        height={isNarrow ? 112 : 196}
       >
         <LastPlayedCardDisplay
           discardPile={pile}

--- a/apps/web/src/widgets/CriticalGame/ui/arena/DrawPile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/DrawPile.tsx
@@ -12,6 +12,12 @@ interface DrawPileProps {
   disabled: boolean;
   onDraw: () => void;
   cardVariant?: string;
+  /**
+   * When true, shrink the pile to ~80×112 so the three-column arena
+   * row still fits at 390px. Passed from `Arena` once per layout so
+   * piles don't each call the matchMedia hook.
+   */
+  isNarrow?: boolean;
 }
 
 export function DrawPile({
@@ -20,6 +26,7 @@ export function DrawPile({
   disabled,
   onDraw,
   cardVariant,
+  isNarrow = false,
 }: DrawPileProps) {
   const { t } = useTranslation();
   // DeckDisplay's `t` prop accepts the unparameterised string form used by
@@ -51,15 +58,15 @@ export function DrawPile({
       cursor={disabled ? 'default' : 'pointer'}
       hoverStyle={disabled ? undefined : { scale: 1.02 }}
       pressStyle={disabled ? undefined : { scale: 0.98 }}
+      flexShrink={0}
     >
-      {/* Override the legacy slot dimensions — the widget arena has
-          more vertical real-estate than the table-mode header, so the
-          pile cards can read larger. */}
+      {/* Desktop: 140×196 — the widget arena has more vertical real
+          estate than the table-mode header. Phones: 80×112 so the
+          three-column row still fits at 390px. */}
       <CardSlot
         $role="deck"
-        width={140}
-        height={196}
-        $sm={{ width: 96, height: 134 }}
+        width={isNarrow ? 80 : 140}
+        height={isNarrow ? 112 : 196}
       >
         <DeckDisplay deck={deck} t={tCompat} cardVariant={cardVariant} />
       </CardSlot>

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
@@ -71,14 +71,14 @@ const SELECT_RING = '#34d399';
 const SELECT_GLOW = 'rgba(52, 211, 153, 0.55)';
 
 /**
- * Single-card cell for the widget-mode hand. Border colour + corner icon
- * come from the card's role family (`cardRoles.ts`). Selection lifts the
- * card and swaps the border to the accent green + glow.
- *
- * Card art is intentionally not pulled from the legacy `CardImage`
- * sprite — the widget aims for compact info density, not a faithful
- * reproduction of the table-mode card. The legacy `PlayerHand` keeps
- * the rich art on the flag-off path.
+ * Single-card cell for the widget-mode hand. Renders the variant's
+ * sprite via `<CardImage>` when available, with a role-keyed fallback
+ * glyph as the underlay for the unthemed "default" variant. Name +
+ * description overlay a bottom scrim so the artwork stays visible.
+ * Border colour comes from the card's role family (`cardRoles.ts`);
+ * selection lifts the cell and swaps the border to the accent green.
+ * The legacy `PlayerHand` keeps the rich table-mode card on the
+ * flag-off path.
  */
 export function HandCard({
   card,

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
@@ -97,10 +97,11 @@ export function HandCard({
   const borderColor = isSelected ? SELECT_RING : ROLE_BORDER[role];
   const glow = isSelected ? SELECT_GLOW : ROLE_GLOW[role];
 
-  // Width stays fixed; height adapts to which text rows are visible so a
-  // hand of art-only cells doesn't waste vertical space.
-  const baseHeight = 160 + (showName ? 24 : 0) + (showDescription ? 56 : 0);
-  const selectedBoost = 12;
+  // Fixed card silhouette (~3:4) regardless of which text rows show —
+  // text now overlays the art rather than pushing the cell taller. The
+  // selected state widens + grows the cell slightly so the lift reads.
+  const width = isSelected ? 132 : 124;
+  const height = isSelected ? 184 : 172;
 
   return (
     <YStack
@@ -124,20 +125,17 @@ export function HandCard({
               }
             }
       }
-      width={isSelected ? 140 : 132}
-      height={baseHeight + (isSelected ? selectedBoost : 0)}
+      width={width}
+      height={height}
       borderRadius={10}
       borderWidth={2}
       borderColor={borderColor}
       backgroundColor="rgba(8,12,20,0.85)"
+      overflow="hidden"
+      position="relative"
       transform={isSelected ? [{ translateY: -8 }] : undefined}
       cursor={disabled ? 'default' : 'pointer'}
       opacity={disabled ? 0.7 : 1}
-      alignItems="stretch"
-      justifyContent="flex-start"
-      paddingHorizontal={6}
-      paddingVertical={8}
-      gap={4}
       shadowColor={glow}
       shadowRadius={isSelected ? 14 : 8}
       shadowOpacity={1}
@@ -152,52 +150,59 @@ export function HandCard({
       }
       flexShrink={0}
     >
-      <YStack
-        data-testid={`hand-card-art-${card.uid}`}
-        position="relative"
-        width="100%"
-        flex={1}
-        minHeight={120}
-        borderRadius={6}
-        overflow="hidden"
-        backgroundColor="rgba(0,0,0,0.45)"
-        alignItems="center"
-        justifyContent="center"
-      >
-        {/* Role glyph sits underneath so it shows through when the
-            active variant has no sprite sheet (CardImage renders null).
-            When a sheet exists, the absolutely-positioned sprite layer
-            paints over the glyph. */}
-        <Text fontSize={44} lineHeight={48} opacity={0.6}>
-          {ROLE_FALLBACK_GLYPH[role]}
-        </Text>
-        <CardImage variant={cardVariant ?? ''} cardType={card.id} />
-      </YStack>
-      {showName && (
-        <Text
-          data-testid={`hand-card-name-${card.uid}`}
-          fontSize={11}
-          fontWeight="800"
-          letterSpacing={0.4}
-          textTransform="uppercase"
-          textAlign="center"
-          numberOfLines={2}
-          color={borderColor}
+      <CardArt
+        cardId={card.id}
+        cardVariant={cardVariant}
+        role={role}
+        testId={`hand-card-art-${card.uid}`}
+      />
+      {(showName || showDescription) && (
+        <YStack
+          data-testid={`hand-card-overlay-${card.uid}`}
+          position="absolute"
+          left={0}
+          right={0}
+          bottom={0}
+          paddingHorizontal={8}
+          paddingTop={14}
+          paddingBottom={8}
+          gap={2}
+          pointerEvents="none"
+          // Linear scrim so the text reads cleanly against the art
+          // without obscuring the upper half. Transparent at the top so
+          // the artwork stays visible.
+          style={{
+            background:
+              'linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.55) 60%, rgba(0,0,0,0) 100%)',
+          }}
         >
-          {name}
-        </Text>
-      )}
-      {showDescription && (
-        <Text
-          data-testid={`hand-card-description-${card.uid}`}
-          fontSize={9}
-          lineHeight={12}
-          textAlign="center"
-          numberOfLines={4}
-          color="rgba(226, 232, 240, 0.78)"
-        >
-          {description}
-        </Text>
+          {showName && (
+            <Text
+              data-testid={`hand-card-name-${card.uid}`}
+              fontSize={11}
+              fontWeight="800"
+              letterSpacing={0.4}
+              textTransform="uppercase"
+              textAlign="center"
+              numberOfLines={1}
+              color={borderColor}
+            >
+              {name}
+            </Text>
+          )}
+          {showDescription && (
+            <Text
+              data-testid={`hand-card-description-${card.uid}`}
+              fontSize={9}
+              lineHeight={12}
+              textAlign="center"
+              numberOfLines={2}
+              color="rgba(226, 232, 240, 0.88)"
+            >
+              {description}
+            </Text>
+          )}
+        </YStack>
       )}
       {!!count && count > 1 && (
         <YStack
@@ -220,6 +225,40 @@ export function HandCard({
           </Text>
         </YStack>
       )}
+    </YStack>
+  );
+}
+
+interface CardArtProps {
+  cardId: string;
+  cardVariant?: string;
+  role: CardRole;
+  testId: string;
+}
+
+/**
+ * Full-bleed art slot. Renders the variant's sprite if `CardImage` has
+ * art for the card; otherwise falls back to a centered role glyph at
+ * the silhouette's scale. The slot fills the whole cell so the name +
+ * description overlay scrim sits cleanly on top of the artwork.
+ */
+function CardArt({ cardId, cardVariant, role, testId }: CardArtProps) {
+  return (
+    <YStack
+      data-testid={testId}
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      bottom={0}
+      alignItems="center"
+      justifyContent="center"
+      backgroundColor="rgba(0,0,0,0.45)"
+    >
+      <Text fontSize={56} lineHeight={60} opacity={0.55}>
+        {ROLE_FALLBACK_GLYPH[role]}
+      </Text>
+      <CardImage variant={cardVariant ?? ''} cardType={cardId} />
     </YStack>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { XStack } from 'tamagui';
 import { HandCard } from './HandCard';
+import { getFanTransform } from '../../lib/handLayout';
 import type { HandCardInstance } from '../../lib/combo';
 
 interface HandCardsProps {
@@ -13,12 +14,23 @@ interface HandCardsProps {
   disabled?: boolean;
   showName?: boolean;
   showDescription?: boolean;
+  /**
+   * Apply per-card fan rotation around the centre of the row. Defaults to
+   * `true` for the desktop layout; the mobile bar disables it because
+   * cards already scroll horizontally and rotation eats horizontal space.
+   */
+  isFanned?: boolean;
 }
+
+const EDGE_FADE_MASK =
+  'linear-gradient(90deg, transparent 0, #000 24px, #000 calc(100% - 24px), transparent 100%)';
 
 /**
  * Horizontal card track for the player's hand. Each cell is a `HandCard`
  * — selection state lives one level up in `MatchWidget` so the arena's
- * `ComboCard` can read it too.
+ * `ComboCard` can read it too. Desktop: single-row nowrap with horizontal
+ * scroll + edge fade + fan rotation. Mobile: single-row nowrap with
+ * horizontal scroll, no fan.
  */
 export function HandCards({
   cards,
@@ -28,6 +40,7 @@ export function HandCards({
   disabled = false,
   showName = true,
   showDescription = true,
+  isFanned = true,
 }: HandCardsProps) {
   const selected = useMemo(() => new Set(selectedUids), [selectedUids]);
   const countsById = useMemo(() => {
@@ -40,35 +53,61 @@ export function HandCards({
     <XStack
       data-testid="hand-cards"
       flex={1}
-      flexWrap="wrap"
+      flexWrap="nowrap"
+      alignItems="flex-end"
+      justifyContent="center"
       gap="$2"
-      padding="$2"
-      // On mobile the parent is a column with no fixed height — `flex: 1`
-      // inside a column collapses to 0px, hiding the cards entirely.
-      // Force an intrinsic height + horizontal scroll instead.
+      // paddingTop reserves clearance for the selected-card lift
+      // (translateY: -8 / hover -10) so the lifted edge doesn't clip
+      // the arena above. paddingBottom keeps the scroll-track shadow
+      // from getting cropped.
+      paddingTop={16}
+      paddingBottom={12}
+      paddingHorizontal="$2"
+      width="100%"
+      // Single horizontally scrolling row — never wraps to a second row.
+      style={{
+        overflowX: 'auto',
+        overflowY: 'visible',
+        WebkitMaskImage: EDGE_FADE_MASK,
+        maskImage: EDGE_FADE_MASK,
+      }}
       $sm={{
         flex: 0,
         flexBasis: 'auto',
-        flexWrap: 'nowrap',
-        overflowX: 'scroll',
-        overflowY: 'hidden',
         width: '100%',
-        minHeight: 230,
+        minHeight: 200,
+        justifyContent: 'flex-start',
       }}
     >
-      {cards.map((card) => (
-        <HandCard
-          key={card.uid}
-          card={card}
-          isSelected={selected.has(card.uid)}
-          disabled={disabled}
-          cardVariant={cardVariant}
-          count={countsById.get(card.id)}
-          showName={showName}
-          showDescription={showDescription}
-          onToggle={() => onToggleSelect(card.uid)}
-        />
-      ))}
+      {cards.map((card, i) => {
+        const fan = isFanned ? getFanTransform(i, cards.length) : null;
+        // Apply the fan via a wrapping div instead of HandCard's
+        // transform prop — HandCard already uses transform for the
+        // selected-state lift, so we keep the two concerns separated.
+        const fanStyle = fan
+          ? {
+              transform: `rotate(${fan.angle}deg) translateY(${fan.offsetY}px)`,
+              transformOrigin: 'bottom center',
+              display: 'inline-flex',
+              flexShrink: 0,
+            }
+          : { display: 'inline-flex', flexShrink: 0 };
+        return (
+          <div key={card.uid} style={fanStyle}>
+            <HandCard
+              card={card}
+              isSelected={selected.has(card.uid)}
+              disabled={disabled}
+              cardVariant={cardVariant}
+              count={countsById.get(card.id)}
+              showName={showName}
+              showDescription={showDescription}
+              onToggle={() => onToggleSelect(card.uid)}
+            />
+          </div>
+        );
+      })}
     </XStack>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
@@ -57,11 +57,12 @@ export function HandCards({
       alignItems="flex-end"
       justifyContent="center"
       gap="$2"
-      // paddingTop reserves clearance for the selected-card lift
-      // (translateY: -8 / hover -10) so the lifted edge doesn't clip
-      // the arena above. paddingBottom keeps the scroll-track shadow
-      // from getting cropped.
-      paddingTop={16}
+      // paddingTop reserves clearance for the combined lift + fan
+      // bounding-box growth. The selected lift is -8 / hover -10, and
+      // `getFanTransform` adds quadratic offsetY up to ~7px at the
+      // edges; rotation grows the rotated rect further still. 24 covers
+      // both at a 7-card hand with selected lift on an outer card.
+      paddingTop={24}
       paddingBottom={12}
       paddingHorizontal="$2"
       width="100%"

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx
@@ -91,14 +91,15 @@ export function HandRail({
   return (
     <YStack
       data-testid="hand-rail"
-      width={240}
-      gap="$3"
-      paddingHorizontal="$3"
-      paddingVertical="$3.5"
+      width={128}
+      gap="$2"
+      paddingHorizontal="$2"
+      paddingVertical="$2.5"
       borderRadius={16}
       borderWidth={1}
       borderColor={NEUTRAL_BORDER}
       backgroundColor="rgba(8, 12, 20, 0.7)"
+      flexShrink={0}
       $sm={{ width: '100%' }}
     >
       {/* Stats header */}
@@ -161,13 +162,14 @@ export function HandRail({
       </XStack>
 
       {/* Primary actions */}
-      <YStack gap="$2">
+      <YStack gap="$1.5">
         <Button
           data-testid="hand-rail-play"
           data-combo-kind={combo.kind}
-          size="$5"
-          height={56}
+          size="$3"
+          height={48}
           borderRadius={12}
+          paddingHorizontal={4}
           disabled={!canPlay}
           opacity={canPlay ? 1 : 0.45}
           backgroundColor={canPlay ? ACCENT : NEUTRAL_BG}
@@ -176,9 +178,9 @@ export function HandRail({
           onPress={canPlay ? onPlay : undefined}
         >
           <Text
-            fontSize={14}
+            fontSize={12}
             fontWeight="900"
-            letterSpacing={0.4}
+            letterSpacing={0.3}
             textTransform="uppercase"
             color={canPlay ? '#062317' : 'rgba(255,255,255,0.5)'}
             numberOfLines={2}
@@ -189,8 +191,8 @@ export function HandRail({
         </Button>
         <Button
           data-testid="hand-rail-draw"
-          size="$4"
-          height={48}
+          size="$2"
+          height={36}
           borderRadius={10}
           disabled={!canDraw}
           opacity={canDraw ? 1 : 0.45}
@@ -204,9 +206,9 @@ export function HandRail({
           onPress={canDraw ? onDraw : undefined}
         >
           <Text
-            fontSize={13}
+            fontSize={11}
             fontWeight="800"
-            letterSpacing={0.4}
+            letterSpacing={0.3}
             textTransform="uppercase"
           >
             ↓ {t('games.table.actions.draw')}
@@ -215,8 +217,8 @@ export function HandRail({
         {canNope && (
           <Button
             data-testid="hand-rail-nope"
-            size="$4"
-            height={48}
+            size="$2"
+            height={36}
             borderRadius={10}
             backgroundColor={NOPE_COLOR}
             hoverStyle={{ backgroundColor: '#fbbf24' }}
@@ -224,9 +226,9 @@ export function HandRail({
             onPress={onNope}
           >
             <Text
-              fontSize={13}
+              fontSize={11}
               fontWeight="900"
-              letterSpacing={0.4}
+              letterSpacing={0.3}
               textTransform="uppercase"
               color="#1c0f00"
             >
@@ -236,15 +238,18 @@ export function HandRail({
         )}
       </YStack>
 
-      {/* Card-text toggles */}
+      {/* Card-text toggles — compact 2-column row so the rail keeps its
+          128px footprint instead of stacking two full-width buttons. */}
       {hasCardToggles && (
         <RailSection>
-          <YStack gap="$1.5" data-testid="hand-rail-card-toggles">
+          <XStack gap="$1.5" data-testid="hand-rail-card-toggles">
             {onToggleCardName && (
               <Button
                 data-testid="hand-rail-toggle-name"
-                size="$3"
-                height={36}
+                size="$2"
+                height={32}
+                flex={1}
+                paddingHorizontal={4}
                 borderRadius={8}
                 backgroundColor={showCardName ? ACCENT_TINT_BG : NEUTRAL_BG}
                 borderWidth={1}
@@ -256,31 +261,25 @@ export function HandRail({
                 }}
                 onPress={onToggleCardName}
                 aria-pressed={!!showCardName}
+                aria-label={t('games.table.hud.cards.toggleName')}
               >
-                <XStack
-                  flex={1}
-                  alignItems="center"
-                  justifyContent="space-between"
-                  paddingHorizontal={2}
+                <Text
+                  fontSize={11}
+                  fontWeight="800"
+                  letterSpacing={0.3}
+                  color={showCardName ? ACCENT : 'rgba(255,255,255,0.7)'}
                 >
-                  <Text fontSize={12} fontWeight="700" letterSpacing={0.3}>
-                    Aa · {t('games.table.hud.cards.toggleName')}
-                  </Text>
-                  <Text
-                    fontSize={12}
-                    fontWeight="900"
-                    color={showCardName ? ACCENT : 'rgba(255,255,255,0.4)'}
-                  >
-                    {showCardName ? '✓' : '○'}
-                  </Text>
-                </XStack>
+                  Aa {showCardName ? '✓' : '○'}
+                </Text>
               </Button>
             )}
             {onToggleCardDescription && (
               <Button
                 data-testid="hand-rail-toggle-description"
-                size="$3"
-                height={36}
+                size="$2"
+                height={32}
+                flex={1}
+                paddingHorizontal={4}
                 borderRadius={8}
                 backgroundColor={
                   showCardDescription ? ACCENT_TINT_BG : NEUTRAL_BG
@@ -296,29 +295,19 @@ export function HandRail({
                 }}
                 onPress={onToggleCardDescription}
                 aria-pressed={!!showCardDescription}
+                aria-label={t('games.table.hud.cards.toggleDescription')}
               >
-                <XStack
-                  flex={1}
-                  alignItems="center"
-                  justifyContent="space-between"
-                  paddingHorizontal={2}
+                <Text
+                  fontSize={11}
+                  fontWeight="800"
+                  letterSpacing={0.3}
+                  color={showCardDescription ? ACCENT : 'rgba(255,255,255,0.7)'}
                 >
-                  <Text fontSize={12} fontWeight="700" letterSpacing={0.3}>
-                    ¶ · {t('games.table.hud.cards.toggleDescription')}
-                  </Text>
-                  <Text
-                    fontSize={12}
-                    fontWeight="900"
-                    color={
-                      showCardDescription ? ACCENT : 'rgba(255,255,255,0.4)'
-                    }
-                  >
-                    {showCardDescription ? '✓' : '○'}
-                  </Text>
-                </XStack>
+                  ¶ {showCardDescription ? '✓' : '○'}
+                </Text>
               </Button>
             )}
-          </YStack>
+          </XStack>
         </RailSection>
       )}
 

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { XStack, YStack, useMedia } from 'tamagui';
+import { XStack, YStack } from 'tamagui';
 import { HandCards } from './HandCards';
 import { HandRail } from './HandRail';
 import { MobileHandBar } from './MobileHandBar';
+import { useNarrowViewport } from '../../lib/useNarrowViewport';
 import type { HandCardInstance, ComboKind } from '../../lib/combo';
 
 interface HandZoneProps {
@@ -36,8 +37,10 @@ interface HandZoneProps {
  * 64` on `$sm` so cards aren't hidden behind the bar.
  */
 export function HandZone(props: HandZoneProps) {
-  const media = useMedia();
-  const isMobile = media.sm;
+  // Tamagui's `sm` (≤800px) fires on tablet portrait where the desktop
+  // rail still has plenty of room. Use a strict ≤480px check so the
+  // sticky bar only takes over on phones, matching the preview spec.
+  const isMobile = useNarrowViewport(480);
 
   if (isMobile) {
     return (
@@ -48,7 +51,6 @@ export function HandZone(props: HandZoneProps) {
         gap="$2"
         paddingHorizontal="$2"
         paddingTop="$2"
-        paddingBottom={120}
       >
         <HandCards
           cards={props.cards}
@@ -57,6 +59,7 @@ export function HandZone(props: HandZoneProps) {
           cardVariant={props.cardVariant}
           showName={props.showCardName}
           showDescription={props.showCardDescription}
+          isFanned={false}
         />
         <MobileHandBar
           handCount={props.cards.length}

--- a/apps/web/src/widgets/CriticalGame/ui/hudStyles.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hudStyles.tsx
@@ -17,6 +17,13 @@ const HUD_KEYFRAMES_CSS = `
   [data-testid="threat-strip"][data-pulse="true"] {
     animation: threatPulse 1.4s ease-in-out infinite;
   }
+  @keyframes turnBannerDotPulse {
+    0%, 100% { transform: scale(1); opacity: 1; }
+    50%      { transform: scale(1.35); opacity: 0.6; }
+  }
+  [data-testid="turn-banner-dot"] {
+    animation: turnBannerDotPulse 1.5s ease-in-out infinite;
+  }
 }
 @keyframes flashBannerIn {
   from { opacity: 0; transform: translateY(-4px); }

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
@@ -159,7 +159,6 @@ export function OpponentTile({
           letterSpacing={0.3}
           numberOfLines={1}
           maxWidth={isMobile ? 80 : 100}
-          style={alive ? { color: playerColor } : undefined}
         >
           {displayName}
         </Text>

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { YStack, XStack, Text, useMedia } from 'tamagui';
+import { YStack, XStack, Text } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { IdleBadge } from '@/shared/ui';
@@ -11,6 +11,18 @@ interface OpponentTileProps {
   player: CriticalPlayerTableState;
   isCurrentTurn: boolean;
   isTarget?: boolean;
+  /**
+   * True when the row is in duel mode (one opponent). Used to scale the
+   * tile up so the focal opponent reads at viewport size rather than
+   * floating lost in the row.
+   */
+  isDuel?: boolean;
+  /**
+   * Mobile flag passed down from OpponentsRow so the row decides the
+   * breakpoint once and tiles inherit consistent sizing — useMedia in
+   * each tile fragmented the boundary across components.
+   */
+  isMobile?: boolean;
   /**
    * Click handler invoked when the tile is activated (mouse, touch, Enter,
    * or Space). Omitted when the tile isn't a valid attack target — e.g.
@@ -49,12 +61,12 @@ export function OpponentTile({
   player,
   isCurrentTurn,
   isTarget = false,
+  isDuel = false,
+  isMobile = false,
   onSelect,
   resolveDisplayName,
 }: OpponentTileProps) {
   const { t } = useTranslation();
-  const media = useMedia();
-  const isMobile = media.sm;
   const displayName = resolveDisplayName(
     player.playerId,
     `Player ${player.playerId.slice(0, 8)}`,
@@ -71,7 +83,12 @@ export function OpponentTile({
   else if (isCurrentTurn) ringColor = TURN_RING;
 
   const ringStyle = !alive ? 'dashed' : 'solid';
-  const avatarSize = isMobile ? 36 : 48;
+  // Duel mode pushes the lone opponent to focal size; FFA tiles are
+  // smaller because up to 5 share the row. Mobile knocks both down so
+  // they fit thumb-width.
+  let avatarSize: number;
+  if (isMobile) avatarSize = isDuel ? 64 : 36;
+  else avatarSize = isDuel ? 88 : 48;
   const interactive = alive && !!onSelect;
   const handleKeyDown = interactive
     ? (e: React.KeyboardEvent) => {
@@ -107,10 +124,18 @@ export function OpponentTile({
       borderStyle={ringStyle}
       borderColor={ringColor}
       backgroundColor="rgba(0,0,0,0.35)"
-      width={isMobile ? 96 : 120}
+      // FFA: flex-grow with a max so 2–5 tiles distribute evenly across
+      // the row. Duel: lock the lone tile to a focal width so the
+      // opponent reads as the primary subject, not space-betweened.
+      flex={isDuel ? 0 : 1}
+      width={isDuel ? (isMobile ? 180 : 240) : undefined}
+      maxWidth={isDuel ? (isMobile ? 180 : 240) : 180}
       minWidth={isMobile ? 96 : 120}
       flexShrink={0}
       opacity={alive ? 1 : 0.6}
+      // Scroll-snap on mobile: align each tile to the start of the
+      // scroll container so swipes don't strand a tile mid-row.
+      style={isMobile ? { scrollSnapAlign: 'start' } : undefined}
     >
       <YStack
         width={avatarSize}

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { XStack, useMedia } from 'tamagui';
+import { XStack } from 'tamagui';
 import { OpponentTile } from './OpponentTile';
+import { useNarrowViewport } from '../../lib/useNarrowViewport';
 import type { CriticalPlayerTableState } from '../../types';
 
 interface OpponentsRowProps {
@@ -38,8 +39,9 @@ export function OpponentsRow({
   onSelectTarget,
   resolveDisplayName,
 }: OpponentsRowProps) {
-  const media = useMedia();
-  const isMobile = media.sm;
+  // Use the ≤480px hook (not tamagui's `sm`) so tablet portrait keeps
+  // the desktop layout. Mobile picks up scroll-snap + smaller tiles.
+  const isMobile = useNarrowViewport(480);
   const isDuel = opponents.length <= 1;
 
   return (
@@ -48,13 +50,25 @@ export function OpponentsRow({
       data-mode={isDuel ? 'duel' : 'ffa'}
       data-count={opponents.length}
       width="100%"
-      gap="$2"
+      gap="$3"
       paddingHorizontal="$2"
       paddingVertical="$2"
-      justifyContent={isDuel ? 'center' : 'space-between'}
-      flexWrap={isMobile ? 'nowrap' : 'wrap'}
-      overflow={isMobile ? 'scroll' : 'visible'}
-      $sm={{ gap: '$1' }}
+      justifyContent="center"
+      flexWrap="nowrap"
+      // Mobile: horizontal scroll with scroll-snap so each tile lands on
+      // a fixed stop instead of free-floating. Desktop: tiles flex-grow
+      // evenly with a max width so 2-/3-/4-up rows look balanced rather
+      // than space-between-clumped.
+      style={
+        isMobile
+          ? {
+              overflowX: 'auto',
+              overflowY: 'hidden',
+              scrollSnapType: 'x mandatory',
+            }
+          : { overflow: 'visible' }
+      }
+      $sm={{ gap: '$2' }}
     >
       {opponents.map((opponent) => (
         <OpponentTile
@@ -62,6 +76,8 @@ export function OpponentsRow({
           player={opponent}
           isCurrentTurn={opponent.playerId === currentTurnPlayerId}
           isTarget={!!targetPlayerId && opponent.playerId === targetPlayerId}
+          isDuel={isDuel}
+          isMobile={isMobile}
           onSelect={
             onSelectTarget && opponent.alive
               ? () => onSelectTarget(opponent.playerId)

--- a/apps/web/src/widgets/CriticalGame/ui/styles/layout.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/layout.tsx
@@ -116,6 +116,31 @@ export const TableArea = styled(BaseTableArea, {
   } as const,
 });
 
+/**
+ * Widget-mode grid: 3-row stack (opponents · arena · hand) with a max
+ * width and explicit gutters. Replaces the legacy `GameBoard` wrapper
+ * for `MatchWidget` so the rows don't span full bleed and the hand
+ * stays clear of the screen edges on wide monitors.
+ *
+ * `paddingBottom` on `$sm` reserves room for the sticky `MobileHandBar`
+ * which is portaled to body and thus outside this grid's flow.
+ */
+export const MatchWidgetGrid = styled(YStack, {
+  name: 'MatchWidgetGrid',
+  width: '100%',
+  maxWidth: 1240,
+  marginHorizontal: 'auto',
+  paddingHorizontal: '$3',
+  paddingVertical: '$3',
+  gap: '$3',
+
+  $sm: {
+    paddingHorizontal: '$2',
+    gap: '$2',
+    paddingBottom: 120,
+  },
+});
+
 export const HandSection = styled(YStack, {
   name: 'HandSection',
   gap: '$4',


### PR DESCRIPTION
## Summary

Applies the parity-fix punch list from `docs/handoffs/PARITY_FIXES.md` to bring the widget-mode Critical UI in line with `Critical.html`. All changes are scoped to the widget-mode renderer behind `useWidgetMode()`; the legacy flag-off path (`ActiveGameContent`, `CriticalGameHeader`, `PlayerHand`) is untouched.

## Changes

- **MatchWidget (ARC-A)**: new `MatchWidgetGrid` styled-component wrapper (max-w 1240, gutters, mobile padding for the sticky bar). Drops the legacy `GameBoard` + `TableArea` inset that pinched the arena.
- **Arena (ARC-B)**: card-style container (rounded border + tinted bg + `overflow: hidden`), `gap` instead of `space-between`, deeper padding.
- **ArenaCenter (ARC-F)**: `minHeight: 180`; `FlashBanner` slot moved inside the arena card (`top: 8`) so it stops clipping past the rounded border.
- **ComboCard (ARC-L)**: `shadowOffset` + `filter: drop-shadow` fallback so the glow paints on web.
- **HandCard (ARC-C)**: fixed 3:4 silhouette, full-bleed `CardArt` slot (sprite over glyph fallback), name + description as a gradient-scrim overlay rather than flex rows beneath.
- **HandCards (ARC-D / ARC-I)**: single-row `nowrap` with horizontal scroll, edge-fade mask, per-card fan rotation via `getFanTransform` applied through a wrapping `div` so the tamagui `transform` used by the lift is untouched. `paddingTop: 16` reserves lift clearance.
- **HandRail (ARC-G)**: width `128`, tighter buttons, card-text toggles compacted to a 2-column row.
- **HandZone / OpponentsRow / OpponentTile / TurnBanner (ARC-H / ARC-M)**: new `useNarrowViewport(480)` hook (`matchMedia` based) so the sticky bar, smaller tiles, and vertical banner layout only fire on phones — tablet portrait keeps the desktop layout.
- **OpponentsRow / OpponentTile (ARC-E)**: `flex: 1` tiles with `maxWidth: 180` so FFA rows distribute evenly; duel tile pushed to 240px focal width; `scroll-snap-type: x mandatory` on the mobile strip with `scroll-snap-align: start` per tile.
- **TurnBanner (ARC-M)**: mobile column layout with ellipsis on the player-name label and `flex-shrink: 0` on the extra-turns chip.

### ARC-K (ThreatStrip pulse)

No change required — the pulse keyframes are already wired via `hudStyles.tsx` using the global `[data-testid="threat-strip"][data-pulse="true"]` attribute selector, and `ThreatStrip` already sets `data-pulse`. The handoff's concern was based on an earlier state.

## Verification

- ✅ `pnpm --filter web test` — 835 tests pass (189 of those are CriticalGame widget tests)
- ✅ `pnpm --filter web run type-check` — clean
- ✅ `pnpm --filter web lint src/widgets/CriticalGame` — clean
- ✅ `pnpm check-file-length` — all changed files under the 500-line limit

## Test plan

- [ ] Visual diff at 1440 / 1280 / 768 / 390 against `Critical.html`
- [ ] Click opponent tile → pink ring, `aria-pressed="true"`; re-click clears
- [ ] Select `targeted_strike` without target → Play disabled, label "Pick a target"; pick target → Play enabled
- [ ] Select 2-same / 3-same / 5-different cards → `ComboCard` border + glow tint match
- [ ] Threat strip pulses when `defuseCount === 0` or odds ≥ 30%
- [ ] Mobile sticky bar appears at ≤480 only, respects safe-area, overflow popover opens above the bar
- [ ] Hand cards render in a single horizontally-scrolling row with fan rotation; selection lift doesn't clip the arena
- [ ] Flag off → legacy view unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)