### PR TITLE
fix(critical): widget parity follow-ups §1.1–1.8 + §2.1, 2.3–2.6 (ARC-671)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/lib/useNarrowViewport.ts
+++ b/apps/web/src/widgets/CriticalGame/lib/useNarrowViewport.ts
@@ -1,15 +1,29 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import {
+  createContext,
+  createElement,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
 
 /**
- * True while the viewport is ≤480px — phones in portrait. Used to gate
- * widget-mode mobile branches that the tamagui `sm` breakpoint (≤800px)
- * fires too eagerly for. SSR-safe: returns `false` on the server and
- * during first paint, then syncs on mount.
+ * True while the viewport is ≤maxWidth — phones in portrait at 480. Used
+ * to gate widget-mode mobile branches that the tamagui `sm` breakpoint
+ * (≤800px) fires too eagerly for.
+ *
+ * Synchronous initializer reads `matchMedia` on first paint so phone
+ * users don't get a desktop-layout flash before the effect runs. The
+ * server pass falls back to `false`; the client first paint is already
+ * correct.
  */
 export function useNarrowViewport(maxWidth = 480): boolean {
-  const [narrow, setNarrow] = useState(false);
+  const [narrow, setNarrow] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(`(max-width: ${maxWidth}px)`).matches;
+  });
   useEffect(() => {
     if (typeof window === 'undefined' || !window.matchMedia) return;
     const mq = window.matchMedia(`(max-width: ${maxWidth}px)`);
@@ -19,4 +33,47 @@ export function useNarrowViewport(maxWidth = 480): boolean {
     return () => mq.removeEventListener('change', apply);
   }, [maxWidth]);
   return narrow;
+}
+
+// Sentinel marks "no provider" so consumers can fall back to subscribing
+// directly. We can't default the context value to `false` because that
+// reads as "definitely desktop" — undefined means "ask the hook yourself".
+const NarrowViewportContext = createContext<boolean | undefined>(undefined);
+
+interface NarrowViewportProviderProps {
+  maxWidth?: number;
+  children: ReactNode;
+}
+
+/**
+ * Computes `isNarrow` once at the widget root and broadcasts to all
+ * children, so the 5 components that previously subscribed to
+ * `matchMedia(max-width: 480px)` independently (Arena, HandZone,
+ * OpponentsRow, TurnBanner, and indirectly the piles via Arena) commit
+ * the same value on the same React frame. Without this, viewport flips
+ * could split the layout state across the tree for a frame at the
+ * boundary, flashing mismatched border radii on resize.
+ */
+export function NarrowViewportProvider({
+  maxWidth = 480,
+  children,
+}: NarrowViewportProviderProps) {
+  const isNarrow = useNarrowViewport(maxWidth);
+  return createElement(
+    NarrowViewportContext.Provider,
+    { value: isNarrow },
+    children,
+  );
+}
+
+/**
+ * Reads the broadcast `isNarrow` value when wrapped in a
+ * `NarrowViewportProvider`; falls back to subscribing directly via
+ * `useNarrowViewport` so consumers rendered in isolation (tests,
+ * Storybook) still get the right value.
+ */
+export function useIsNarrow(maxWidth = 480): boolean {
+  const ctx = useContext(NarrowViewportContext);
+  const fallback = useNarrowViewport(maxWidth);
+  return ctx ?? fallback;
 }

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -22,6 +22,7 @@ import {
   type ComboKind,
 } from '../lib/combo';
 import { getCardTranslationKey } from '../lib/cardUtils';
+import { NarrowViewportProvider } from '../lib/useNarrowViewport';
 import type { CriticalCard } from '../types';
 
 const DEFUSE_CARDS: readonly CriticalCard[] = [
@@ -129,9 +130,14 @@ export function MatchWidget({
    * cascading-renders pattern the rule guards against.
    */
   useEffect(() => {
-    if (validSelectedUids.length !== selectedUids.length) {
-      setSelectedUids(validSelectedUids);
-    }
+    // Length-only check missed the same-length-different-uids case: when
+    // Nope clears the played card but a fresh draw lands on the same
+    // index and reuses the uid, the array length stays the same but the
+    // identities shift. Element-wise comparison catches that.
+    const drifted =
+      validSelectedUids.length !== selectedUids.length ||
+      validSelectedUids.some((uid, i) => uid !== selectedUids[i]);
+    if (drifted) setSelectedUids(validSelectedUids);
   }, [validSelectedUids, selectedUids]);
 
   const prevIsMyTurn = useRef(isMyTurn);
@@ -274,58 +280,60 @@ export function MatchWidget({
 
   return (
     <div data-testid="match-widget">
-      <MatchWidgetGrid data-testid="match-widget-grid">
-        <OpponentsRow
-          opponents={opponents}
-          currentTurnPlayerId={turnPlayerId}
-          targetPlayerId={targetPlayerId}
-          onSelectTarget={
-            isMyTurn && !isGameOver && canAct ? handleSelectTarget : undefined
-          }
-          resolveDisplayName={tileResolveName}
-        />
-        <Arena
-          deck={snapshot.deck}
-          discardPile={snapshot.discardPile}
-          cardVariant={cardVariant}
-          isMyTurn={isMyTurn}
-          isGameOver={isGameOver}
-          onDrawAndEnd={handleDrawAndEnd}
-          hand={hand}
-          allowActionCardCombos={allowActionCardCombos}
-          combo={combo}
-          currentPlayerName={currentPlayerName}
-          pendingDraws={snapshot.pendingDraws}
-          logs={snapshot.logs ?? []}
-          formatLogMessage={formatLogMessage}
-          serverOverloadOdds={snapshot.overloadOdds}
-          hiddenCount={snapshot.hiddenCount}
-        />
-
-        {showHand && (
-          <HandZone
-            cards={handCards}
-            selectedUids={validSelectedUids}
-            onToggleSelect={handleToggleSelect}
-            combo={combo}
-            defuseCount={defuseCount}
-            canPlay={canPlay}
-            canDraw={isMyTurn && !isGameOver}
-            canNope={canPlayNope}
-            cardVariant={cardVariant}
-            isFullscreen={isFullscreen}
-            showCardName={showCardName}
-            showCardDescription={showCardDescription}
-            onPlay={handlePlay}
-            onDraw={handleDrawAndEnd}
-            onNope={actions.playNope}
-            onOpenRules={handleOpenRules}
-            onToggleFullscreen={toggleFullscreen}
-            onToggleCardName={handleToggleCardName}
-            onToggleCardDescription={handleToggleCardDescription}
+      <NarrowViewportProvider maxWidth={480}>
+        <MatchWidgetGrid data-testid="match-widget-grid">
+          <OpponentsRow
+            opponents={opponents}
+            currentTurnPlayerId={turnPlayerId}
+            targetPlayerId={targetPlayerId}
+            onSelectTarget={
+              isMyTurn && !isGameOver && canAct ? handleSelectTarget : undefined
+            }
+            resolveDisplayName={tileResolveName}
           />
-        )}
-      </MatchWidgetGrid>
+          <Arena
+            deck={snapshot.deck}
+            discardPile={snapshot.discardPile}
+            cardVariant={cardVariant}
+            isMyTurn={isMyTurn}
+            isGameOver={isGameOver}
+            onDrawAndEnd={handleDrawAndEnd}
+            hand={hand}
+            allowActionCardCombos={allowActionCardCombos}
+            combo={combo}
+            currentPlayerName={currentPlayerName}
+            pendingDraws={snapshot.pendingDraws}
+            logs={snapshot.logs ?? []}
+            formatLogMessage={formatLogMessage}
+            serverOverloadOdds={snapshot.overloadOdds}
+            hiddenCount={snapshot.hiddenCount}
+          />
+
+          {showHand && (
+            <HandZone
+              cards={handCards}
+              selectedUids={validSelectedUids}
+              onToggleSelect={handleToggleSelect}
+              combo={combo}
+              defuseCount={defuseCount}
+              canPlay={canPlay}
+              canDraw={isMyTurn && !isGameOver}
+              canNope={canPlayNope}
+              cardVariant={cardVariant}
+              isFullscreen={isFullscreen}
+              showCardName={showCardName}
+              showCardDescription={showCardDescription}
+              onPlay={handlePlay}
+              onDraw={handleDrawAndEnd}
+              onNope={actions.playNope}
+              onOpenRules={handleOpenRules}
+              onToggleFullscreen={toggleFullscreen}
+              onToggleCardName={handleToggleCardName}
+              onToggleCardDescription={handleToggleCardDescription}
+            />
+          )}
+        </MatchWidgetGrid>
+      </NarrowViewportProvider>
       <RulesModal
         isOpen={rulesOpen}
         onClose={handleCloseRules}

--- a/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from 'react';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useScenePalette } from './ScenePaletteContext';
-import { useNarrowViewport } from '../lib/useNarrowViewport';
+import { useIsNarrow } from '../lib/useNarrowViewport';
 
 interface TurnBannerProps {
   isMyTurn: boolean;
@@ -34,7 +34,7 @@ export function TurnBanner({
 }: TurnBannerProps) {
   const palette = useScenePalette();
   const { t } = useTranslation();
-  const isNarrow = useNarrowViewport(480);
+  const isNarrow = useIsNarrow(480);
 
   const label = isMyTurn
     ? t('games.table.players.yourMove')

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
@@ -5,7 +5,7 @@ import type { CriticalCard, CriticalLogEntry } from '../../types';
 import { DrawPile } from './DrawPile';
 import { DiscardPile } from './DiscardPile';
 import { ArenaCenter } from './ArenaCenter';
-import { useNarrowViewport } from '../../lib/useNarrowViewport';
+import { useIsNarrow } from '../../lib/useNarrowViewport';
 import type { ComboKind } from './ComboCard';
 
 interface ArenaProps {
@@ -54,7 +54,10 @@ export function Arena({
   // Phones get smaller piles so the three-column row still fits at
   // 390px; the layout otherwise stays identical so the threat strip,
   // combo card, and FlashBanner don't fall down 200px below the piles.
-  const isNarrow = useNarrowViewport(480);
+  // `useIsNarrow` reads the value broadcast by `NarrowViewportProvider`
+  // at the widget root so Arena / HandZone / OpponentsRow / TurnBanner
+  // all commit the same viewport flip on the same React frame.
+  const isNarrow = useIsNarrow(480);
 
   return (
     <XStack

--- a/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/ComboCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { CSSProperties } from 'react';
 import { YStack, Text } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { ComboHints } from '../ComboHints';
@@ -33,13 +34,19 @@ const KIND_BORDER: Record<ComboKind, string> = {
   invalid: '#ef4444',
 };
 
-const KIND_GLOW: Record<ComboKind, string> = {
-  none: 'transparent',
-  single: 'rgba(34, 211, 238, 0.25)',
-  pair: 'rgba(245, 158, 11, 0.28)',
-  triple: 'rgba(167, 139, 250, 0.28)',
-  five: 'rgba(244, 114, 182, 0.28)',
-  invalid: 'rgba(239, 68, 68, 0.18)',
+// Pre-built filter strings keyed by kind so we don't rebuild the template
+// literal on every render. tamagui's RN-style `shadow*` props translate to
+// `box-shadow` on web; emitting both there and via `filter: drop-shadow`
+// painted the glow twice — we now drop the shadow props entirely and rely
+// on `filter` only, which is also the only path that paints consistently
+// across browsers for non-rectangular cards.
+const KIND_FILTER: Record<ComboKind, CSSProperties['filter']> = {
+  none: undefined,
+  single: 'drop-shadow(0 0 12px rgba(34,211,238,0.25))',
+  pair: 'drop-shadow(0 0 12px rgba(245,158,11,0.28))',
+  triple: 'drop-shadow(0 0 12px rgba(167,139,250,0.28))',
+  five: 'drop-shadow(0 0 12px rgba(244,114,182,0.28))',
+  invalid: 'drop-shadow(0 0 12px rgba(239,68,68,0.18))',
 };
 
 export function ComboCard({
@@ -64,19 +71,7 @@ export function ComboCard({
       borderColor={KIND_BORDER[kind]}
       backgroundColor="rgba(0,0,0,0.45)"
       opacity={kind === 'invalid' ? 0.65 : 1}
-      shadowColor={KIND_GLOW[kind]}
-      shadowOpacity={kind === 'none' ? 0 : 1}
-      shadowRadius={12}
-      shadowOffset={{ width: 0, height: 0 }}
-      // tamagui's RN-style shadow props translate inconsistently to web
-      // box-shadow; a filter-based drop-shadow guarantees the glow paints
-      // in every browser. `none` kind keeps the filter off so the card
-      // renders flat in the default state.
-      style={
-        kind === 'none'
-          ? undefined
-          : { filter: `drop-shadow(0 0 12px ${KIND_GLOW[kind]})` }
-      }
+      style={{ filter: KIND_FILTER[kind] }}
     >
       <Text
         data-testid="combo-card-label"

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
@@ -7,7 +7,7 @@ import {
   getCardDescriptionKey,
 } from '../../lib/cardUtils';
 import { getCardRole, type CardRole } from '../../lib/cardRoles';
-import { CardImage } from '../styles/card-image';
+import { CardImage, hasArtFor } from '../styles/card-image';
 import type { HandCardInstance } from '../../lib/combo';
 
 interface HandCardProps {
@@ -98,10 +98,12 @@ export function HandCard({
   const glow = isSelected ? SELECT_GLOW : ROLE_GLOW[role];
 
   // Fixed card silhouette (~3:4) regardless of which text rows show —
-  // text now overlays the art rather than pushing the cell taller. The
-  // selected state widens + grows the cell slightly so the lift reads.
-  const width = isSelected ? 132 : 124;
-  const height = isSelected ? 184 : 172;
+  // text overlays the art rather than pushing the cell taller. Cell
+  // dimensions stay constant across selection so the lift doesn't
+  // displace neighbouring cards in the fan; the translateY + border
+  // swap + glow are enough to read selection.
+  const width = 124;
+  const height = 172;
 
   return (
     <YStack
@@ -237,12 +239,13 @@ interface CardArtProps {
 }
 
 /**
- * Full-bleed art slot. Renders the variant's sprite if `CardImage` has
- * art for the card; otherwise falls back to a centered role glyph at
- * the silhouette's scale. The slot fills the whole cell so the name +
- * description overlay scrim sits cleanly on top of the artwork.
+ * Full-bleed art slot. Renders the variant's sprite when art is
+ * available for `(variant, cardId)`; otherwise the role-keyed fallback
+ * glyph. Never both — stacking them caused the glyph to bleed through
+ * the sprite as a centre smudge.
  */
 function CardArt({ cardId, cardVariant, role, testId }: CardArtProps) {
+  const showArt = hasArtFor(cardVariant, cardId);
   return (
     <YStack
       data-testid={testId}
@@ -255,10 +258,13 @@ function CardArt({ cardId, cardVariant, role, testId }: CardArtProps) {
       justifyContent="center"
       backgroundColor="rgba(0,0,0,0.45)"
     >
-      <Text fontSize={56} lineHeight={60} opacity={0.55}>
-        {ROLE_FALLBACK_GLYPH[role]}
-      </Text>
-      <CardImage variant={cardVariant ?? ''} cardType={cardId} />
+      {showArt ? (
+        <CardImage variant={cardVariant ?? ''} cardType={cardId} />
+      ) : (
+        <Text fontSize={56} lineHeight={60} opacity={0.55}>
+          {ROLE_FALLBACK_GLYPH[role]}
+        </Text>
+      )}
     </YStack>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.test.tsx
@@ -114,6 +114,49 @@ describe('HandCards', () => {
     );
   });
 
+  it('keeps cell dimensions stable across selection so the fan does not shift', () => {
+    // Regression for PR #658 review §1.2 — the selected-state size delta
+    // (132×184 vs 124×172) pushed neighbours sideways because the row
+    // uses `gap`, not absolute positioning. Lift/glow/border swap now
+    // signal selection without disturbing layout.
+    const { rerender, props } = renderCards();
+    const before = screen.getByTestId('hand-card-strike-0');
+    expect(before.className).toMatch(/_w-124px/);
+    expect(before.className).toMatch(/_h-172px/);
+    rerender(
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+        <HandCards {...props} selectedUids={['strike-0']} />
+      </TamaguiProvider>,
+    );
+    const after = screen.getByTestId('hand-card-strike-0');
+    expect(after).toHaveAttribute('data-selected', 'true');
+    expect(after.className).toMatch(/_w-124px/);
+    expect(after.className).toMatch(/_h-172px/);
+  });
+
+  it('renders the role fallback glyph when the variant has no sprite art', () => {
+    // Regression for PR #658 review §1.1 — the glyph used to render
+    // beneath the sprite and bleed through. With no sprite for the
+    // default variant we should still see the role-keyed icon.
+    renderCards({
+      cards: handWithUids(['strike'] as CriticalCard[]),
+    });
+    const card = screen.getByTestId('hand-card-strike-0');
+    // strike → attack role → ⚔ glyph
+    expect(card.textContent).toContain('⚔');
+  });
+
+  it('omits the fallback glyph when the variant ships sprite art for the card', () => {
+    // Regression for PR #658 review §1.1 — the glyph must NOT stack with
+    // the sprite. Crime variant has a sprite sheet; strike is mapped.
+    renderCards({
+      cards: handWithUids(['strike'] as CriticalCard[]),
+      cardVariant: 'crime',
+    });
+    const card = screen.getByTestId('hand-card-strike-0');
+    expect(card.textContent).not.toContain('⚔');
+  });
+
   it('shows a duplicate-count badge only for cards with copies in hand', () => {
     renderCards({
       cards: handWithUids(['strike', 'strike', 'evade'] as CriticalCard[]),

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
@@ -57,12 +57,13 @@ export function HandCards({
       alignItems="flex-end"
       justifyContent="center"
       gap="$2"
-      // paddingTop reserves clearance for the combined lift + fan
-      // bounding-box growth. The selected lift is -8 / hover -10, and
-      // `getFanTransform` adds quadratic offsetY up to ~7px at the
-      // edges; rotation grows the rotated rect further still. 24 covers
-      // both at a 7-card hand with selected lift on an outer card.
-      paddingTop={24}
+      // paddingTop reserves clearance for the lift + fan bounding-box
+      // growth. Fanned (desktop): -8 lift + ~7px quadratic offsetY +
+      // rotation growth → 24 covers it. Unfanned (mobile): no fan
+      // growth, only the lift + hairline cushion → 14 is enough. The
+      // extra 10px matters on phones where the sticky bar adds its own
+      // safe-area padding below.
+      paddingTop={isFanned ? 24 : 14}
       paddingBottom={12}
       paddingHorizontal="$2"
       width="100%"

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandRail.tsx
@@ -42,6 +42,23 @@ const NEUTRAL_BG_HOVER = 'rgba(255, 255, 255, 0.12)';
 const NEUTRAL_BORDER = 'rgba(255, 255, 255, 0.10)';
 const NOPE_COLOR = '#f59e0b';
 
+// Defuse-card pill shape lookup. Hoisted so the literal object isn't
+// rebuilt on every render — that re-allocation prevented tamagui from
+// memoizing the style hash, so the rendered class changed across renders
+// even when nothing visual moved.
+const DEFUSE_VARIANT = {
+  low: {
+    bg: 'rgba(239,68,68,0.10)',
+    border: 'rgba(239,68,68,0.45)',
+    color: '#ef4444',
+  },
+  ok: {
+    bg: NEUTRAL_BG,
+    border: NEUTRAL_BORDER,
+    color: ACCENT,
+  },
+} as const;
+
 interface RailSectionProps {
   children: React.ReactNode;
 }
@@ -86,12 +103,16 @@ export function HandRail({
   const { t } = useTranslation();
   const hasCardToggles = !!(onToggleCardName || onToggleCardDescription);
   const hasChrome = !!(onOpenRules || onToggleFullscreen);
-  const lowDefuse = defuseCount === 0;
+  const defuseVariant =
+    defuseCount === 0 ? DEFUSE_VARIANT.low : DEFUSE_VARIANT.ok;
 
   return (
     <YStack
       data-testid="hand-rail"
-      width={128}
+      // 144 (up from 128) so the Play button label can fit "Play 3× …"
+      // on two lines without mid-word ellipsis. The hand track still has
+      // ample room — 144px is ≤6% of the 1240px max-width grid.
+      width={144}
       gap="$2"
       paddingHorizontal="$2"
       paddingVertical="$2.5"
@@ -136,15 +157,15 @@ export function HandRail({
           paddingVertical={8}
           paddingHorizontal={6}
           borderRadius={10}
-          backgroundColor={lowDefuse ? 'rgba(239,68,68,0.10)' : NEUTRAL_BG}
+          backgroundColor={defuseVariant.bg}
           borderWidth={1}
-          borderColor={lowDefuse ? 'rgba(239,68,68,0.45)' : NEUTRAL_BORDER}
+          borderColor={defuseVariant.border}
         >
           <Text
             fontSize={18}
             fontWeight="800"
             letterSpacing={0.5}
-            color={lowDefuse ? '#ef4444' : ACCENT}
+            color={defuseVariant.color}
           >
             🛡 {defuseCount}
           </Text>
@@ -163,32 +184,41 @@ export function HandRail({
 
       {/* Primary actions */}
       <YStack gap="$1.5">
-        <Button
-          data-testid="hand-rail-play"
-          data-combo-kind={combo.kind}
-          size="$3"
-          height={48}
-          borderRadius={12}
-          paddingHorizontal={4}
-          disabled={!canPlay}
-          opacity={canPlay ? 1 : 0.45}
-          backgroundColor={canPlay ? ACCENT : NEUTRAL_BG}
-          hoverStyle={canPlay ? { backgroundColor: '#22c55e' } : undefined}
-          pressStyle={canPlay ? { scale: 0.98 } : undefined}
-          onPress={canPlay ? onPlay : undefined}
-        >
-          <Text
-            fontSize={12}
-            fontWeight="900"
-            letterSpacing={0.3}
-            textTransform="uppercase"
-            color={canPlay ? '#062317' : 'rgba(255,255,255,0.5)'}
-            numberOfLines={2}
-            textAlign="center"
+        {/* Native tooltip carries the full combo label so the user can
+            hover-confirm what 'Play 3× Targeted…' truncates to. The
+            arena's ComboCard is the canonical surface for the verbose
+            label — the rail is the action surface. Wrapper div is the
+            only place we can attach `title` since tamagui's Button
+            doesn't forward HTML title through. */}
+        <div title={combo.label}>
+          <Button
+            data-testid="hand-rail-play"
+            data-combo-kind={combo.kind}
+            size="$3"
+            height={48}
+            width="100%"
+            borderRadius={12}
+            paddingHorizontal={6}
+            disabled={!canPlay}
+            opacity={canPlay ? 1 : 0.45}
+            backgroundColor={canPlay ? ACCENT : NEUTRAL_BG}
+            hoverStyle={canPlay ? { backgroundColor: '#22c55e' } : undefined}
+            pressStyle={canPlay ? { scale: 0.98 } : undefined}
+            onPress={canPlay ? onPlay : undefined}
           >
-            {combo.label}
-          </Text>
-        </Button>
+            <Text
+              fontSize={12}
+              fontWeight="900"
+              letterSpacing={0.3}
+              textTransform="uppercase"
+              color={canPlay ? '#062317' : 'rgba(255,255,255,0.5)'}
+              numberOfLines={2}
+              textAlign="center"
+            >
+              {combo.label}
+            </Text>
+          </Button>
+        </div>
         <Button
           data-testid="hand-rail-draw"
           size="$2"

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
@@ -4,7 +4,7 @@ import { XStack, YStack } from 'tamagui';
 import { HandCards } from './HandCards';
 import { HandRail } from './HandRail';
 import { MobileHandBar } from './MobileHandBar';
-import { useNarrowViewport } from '../../lib/useNarrowViewport';
+import { useIsNarrow } from '../../lib/useNarrowViewport';
 import type { HandCardInstance, ComboKind } from '../../lib/combo';
 
 interface HandZoneProps {
@@ -38,9 +38,10 @@ interface HandZoneProps {
  */
 export function HandZone(props: HandZoneProps) {
   // Tamagui's `sm` (≤800px) fires on tablet portrait where the desktop
-  // rail still has plenty of room. Use a strict ≤480px check so the
-  // sticky bar only takes over on phones, matching the preview spec.
-  const isMobile = useNarrowViewport(480);
+  // rail still has plenty of room. Read the ≤480px value broadcast by
+  // `NarrowViewportProvider` at the widget root so HandZone, Arena, and
+  // OpponentsRow commit the same flip on the same React frame.
+  const isMobile = useIsNarrow(480);
 
   if (isMobile) {
     return (

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
@@ -2,7 +2,6 @@
 
 import { YStack, XStack, Text } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
-import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { IdleBadge } from '@/shared/ui';
 import type { CriticalPlayerTableState } from '../../types';
 import { getPlayerColor } from '@/shared/lib/playerColors';
@@ -23,6 +22,19 @@ interface OpponentTileProps {
    * each tile fragmented the boundary across components.
    */
   isMobile?: boolean;
+  /**
+   * Computed avatar diameter from `OpponentsRow.getAvatarSize`. Scales
+   * with FFA opponent count so 5-up rows don't look avatar-dominated and
+   * 3-up rows don't look sparse. Optional — falls back to the legacy
+   * duel/non-duel branch if the parent forgot to thread it.
+   */
+  avatarSize?: number;
+  /**
+   * True when the player's id is in `gameStore.idlePlayers`. Lifted to
+   * `OpponentsRow` so the store subscription runs once instead of
+   * fan-out per tile (5 tiles × `.includes` scans on every state update).
+   */
+  isIdle?: boolean;
   /**
    * Click handler invoked when the tile is activated (mouse, touch, Enter,
    * or Space). Omitted when the tile isn't a valid attack target — e.g.
@@ -63,6 +75,8 @@ export function OpponentTile({
   isTarget = false,
   isDuel = false,
   isMobile = false,
+  avatarSize,
+  isIdle = false,
   onSelect,
   resolveDisplayName,
 }: OpponentTileProps) {
@@ -71,8 +85,6 @@ export function OpponentTile({
     player.playerId,
     `Player ${player.playerId.slice(0, 8)}`,
   );
-  const idlePlayers = useGameStore((s: GameState) => s.idlePlayers);
-  const isIdle = idlePlayers.includes(player.playerId);
   const alive = player.alive;
 
   const playerColor = getPlayerColor(player.playerId);
@@ -85,10 +97,15 @@ export function OpponentTile({
   const ringStyle = !alive ? 'dashed' : 'solid';
   // Duel mode pushes the lone opponent to focal size; FFA tiles are
   // smaller because up to 5 share the row. Mobile knocks both down so
-  // they fit thumb-width.
-  let avatarSize: number;
-  if (isMobile) avatarSize = isDuel ? 64 : 36;
-  else avatarSize = isDuel ? 88 : 48;
+  // they fit thumb-width. Caller (OpponentsRow) scales by opponent count
+  // — fallback to the duel/non-duel branch for components rendered in
+  // isolation (tests / storybook).
+  const finalAvatarSize =
+    avatarSize ?? (isMobile ? (isDuel ? 64 : 36) : isDuel ? 88 : 48);
+  // Keep `playerColor` on the avatar border at low opacity when dead so
+  // the eliminated seat still reads as that player rather than a generic
+  // grey pill. `66` ≈ 40% alpha against the hex base.
+  const avatarBorderColor = alive ? playerColor : `${playerColor}66`;
   const interactive = alive && !!onSelect;
   const handleKeyDown = interactive
     ? (e: React.KeyboardEvent) => {
@@ -138,12 +155,12 @@ export function OpponentTile({
       style={isMobile ? { scrollSnapAlign: 'start' } : undefined}
     >
       <YStack
-        width={avatarSize}
-        height={avatarSize}
+        width={finalAvatarSize}
+        height={finalAvatarSize}
         borderRadius={9999}
         backgroundColor="rgba(255,255,255,0.08)"
-        borderWidth={alive ? 2 : 0}
-        borderColor={alive ? playerColor : 'transparent'}
+        borderWidth={2}
+        borderColor={avatarBorderColor}
         alignItems="center"
         justifyContent="center"
       >

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentsRow.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { useMemo } from 'react';
 import { XStack } from 'tamagui';
 import { OpponentTile } from './OpponentTile';
-import { useNarrowViewport } from '../../lib/useNarrowViewport';
+import { useIsNarrow } from '../../lib/useNarrowViewport';
+import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import type { CriticalPlayerTableState } from '../../types';
 
 interface OpponentsRowProps {
@@ -41,8 +43,15 @@ export function OpponentsRow({
 }: OpponentsRowProps) {
   // Use the ≤480px hook (not tamagui's `sm`) so tablet portrait keeps
   // the desktop layout. Mobile picks up scroll-snap + smaller tiles.
-  const isMobile = useNarrowViewport(480);
+  // Value comes from `NarrowViewportProvider` at the widget root.
+  const isMobile = useIsNarrow(480);
   const isDuel = opponents.length <= 1;
+
+  // Idle players come from gameStore. Subscribing here once + memoizing a
+  // Set keeps the 5 tiles from each running `.includes` on every state
+  // update — at 5 opponents that's 5 subscriptions × O(n) scans per frame.
+  const idlePlayers = useGameStore((s: GameState) => s.idlePlayers);
+  const idleSet = useMemo(() => new Set(idlePlayers), [idlePlayers]);
 
   return (
     <XStack
@@ -78,6 +87,8 @@ export function OpponentsRow({
           isTarget={!!targetPlayerId && opponent.playerId === targetPlayerId}
           isDuel={isDuel}
           isMobile={isMobile}
+          avatarSize={getAvatarSize(opponents.length, isDuel, isMobile)}
+          isIdle={idleSet.has(opponent.playerId)}
           onSelect={
             onSelectTarget && opponent.alive
               ? () => onSelectTarget(opponent.playerId)
@@ -88,4 +99,22 @@ export function OpponentsRow({
       ))}
     </XStack>
   );
+}
+
+/**
+ * Avatar diameter for a tile, scaled by FFA opponent count so a 5-up row
+ * doesn't look avatar-dominated and a 3-up row doesn't look sparse. Duel
+ * mode locks to the focal size — there's only one tile, no crowding to
+ * worry about. Mobile knocks both branches down so tiles fit thumb-width.
+ */
+function getAvatarSize(
+  count: number,
+  isDuel: boolean,
+  isMobile: boolean,
+): number {
+  if (isMobile) return isDuel ? 64 : 36;
+  if (isDuel) return 88;
+  if (count >= 5) return 40;
+  if (count === 4) return 44;
+  return 56;
 }

--- a/apps/web/src/widgets/CriticalGame/ui/styles/card-image.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/card-image.tsx
@@ -8,6 +8,23 @@ interface CardImageProps {
   faceDown?: boolean;
 }
 
+/**
+ * True when the given variant ships a sprite sheet AND the cardType has a
+ * mapped sprite index. Callers (e.g. `HandCard`) use this to choose between
+ * rendering the sprite and a role-keyed fallback glyph, so the two never
+ * stack and bleed through each other.
+ */
+export function hasArtFor(
+  variant: string | undefined,
+  cardType: string,
+): boolean {
+  const spriteUrl = getVariantStyles(variant).cards.getCardSpriteUrl?.(
+    variant ?? '',
+  );
+  if (!spriteUrl) return false;
+  return Object.prototype.hasOwnProperty.call(CARD_SPRITE_MAP, cardType);
+}
+
 export function CardImage({
   variant,
   cardType = '',


### PR DESCRIPTION
## Summary

Follow-up to merged PR #658. Implements every item in §1 (parity gaps vs. Critical.html preview) and §2 (code/perf/correctness) of the design review, except items already covered upstream. A11y items (§3) and modernization (§4) ship as separate PRs (ARC-672, ARC-673+).

## What changed

**§1.1 — HandCard glyph/sprite double-render** (cherry-pick of 6a147f40)
Added `hasArtFor(variant, cardId)` to `card-image.tsx`. `CardArt` now renders either the variant sprite OR the role fallback glyph, never both stacked.

**§1.2 — HandCard selected-state size jump** (cherry-pick of 6a147f40)
Dropped the 132×184 ↔ 124×172 jump. Cell stays a constant 124×172; lift/glow/border swap signal selection without disturbing the fan.

**§1.3 — ComboCard filter map + redundant shadow props**
Hoisted `KIND_FILTER` to module scope. Dropped the tamagui `shadow*` trio so the glow only paints once (via `filter: drop-shadow`).

**§1.4 + §2.4 — NarrowViewportContext + sync initializer**
Added `NarrowViewportProvider` + `useIsNarrow` so the 5 components that subscribed to `matchMedia(max-width: 480px)` independently (Arena, HandZone, OpponentsRow, TurnBanner, and indirectly the piles via Arena) now commit the same viewport flip on the same React frame. The `useState` initializer reads `matchMedia` synchronously so phone users don't flash the desktop layout before the effect runs.

**§1.5 — OpponentTile avatar scales with FFA count**
`OpponentsRow.getAvatarSize(count, isDuel, isMobile)` returns 88 / 56 / 44 / 40 for duel / 3-up / 4-up / 5-up rows. Mobile knocks both branches down.

**§1.6 — HandRail Play button truncation**
Rail width 128 → 144 so two-line combo labels fit without mid-word ellipsis. Wrapping `<div title={combo.label}>` carries the full label as a native tooltip (tamagui's Button doesn't forward `title`).

**§1.7 — HandCards padding threads `isFanned`**
24 on the fanned desktop layout (covers lift + offsetY + rotation growth); 14 on the unfanned mobile layout.

**§1.8 — OpponentTile eliminated colour drift**
Avatar border keeps `playerColor` at ~40% alpha when dead instead of going transparent, so the eliminated seat still reads as that player.

**§2.1 — MatchWidget `validSelectedUids` identity check**
Element-wise comparison catches the same-length-different-uids case (Nope strips a card, fresh draw reuses the uid). Length-only check missed it.

**§2.3 — HandRail defuse variant lookup**
Hoisted the `{ bg, border, color }` shape lookup to module scope.

**§2.5 — OpponentsRow lifts idle lookup**
Subscribe once to `gameStore.idlePlayers` and pass `isIdle` as a prop, instead of each tile subscribing + running `.includes` per render.

**§2.6 — ComboCard shadow props** — folded into §1.3.

## Test plan

- [x] `pnpm vitest run src/widgets/CriticalGame` — 194/194 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` on the 10 changed files — clean
- [ ] Resize 800 → 481 → 480 → 479: layout shouldn't flicker at the boundary (verifies §1.4 + §2.4)
- [ ] Select a card then have it cleared by Nope: selection follows the card (verifies §2.1)
- [ ] 5-FFA with one eliminated player at front: dead seat still reads as that player's colour (verifies §1.8)
- [ ] Hand of 1 card on mobile, selected, no fan: lift not clipped by paddingTop (verifies §1.7)
- [ ] Hover Play button with long combo: native tooltip shows full label (verifies §1.6)

## Follow-ups

- ARC-672 — §3 accessibility items
- ARC-673+ — §4 modernization tickets in priority order

🤖 Generated with [Claude Code](https://claude.com/claude-code)