### PR TITLE
fix(critical): widget a11y §3.1–3.4 from PR #658 review (ARC-672)

### DIFF
--- a/apps/web/src/shared/i18n/messages/games/critical/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/by.ts
@@ -272,6 +272,11 @@ export const byMessages = {
       yourMove: 'Ваш ход',
       playerTurn: 'Ход {{name}}',
       waitingFor: 'Чаканне гульца...',
+      a11yState: {
+        eliminated: 'выбыў',
+        currentTurn: 'зараз яго ход',
+        armedTarget: 'абраны як мэта',
+      },
     },
     status: {
       gameCompleted: 'Гульня завершана',

--- a/apps/web/src/shared/i18n/messages/games/critical/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/en.ts
@@ -268,6 +268,11 @@ export const enMessages = {
       yourMove: 'Your move',
       playerTurn: "{{name}}'s turn",
       waitingFor: 'Waiting for player...',
+      a11yState: {
+        eliminated: 'eliminated',
+        currentTurn: 'currently their turn',
+        armedTarget: 'armed as target',
+      },
     },
     status: {
       gameCompleted: 'Game Completed',

--- a/apps/web/src/shared/i18n/messages/games/critical/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/es.ts
@@ -267,6 +267,11 @@ export const esMessages = {
       yourMove: 'Tu jugada',
       playerTurn: 'Turno de {{name}}',
       waitingFor: 'Esperando jugador...',
+      a11yState: {
+        eliminated: 'eliminado',
+        currentTurn: 'su turno actualmente',
+        armedTarget: 'seleccionado como objetivo',
+      },
     },
     status: {
       gameCompleted: 'Juego Completado',

--- a/apps/web/src/shared/i18n/messages/games/critical/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/fr.ts
@@ -262,6 +262,11 @@ export const frMessages = {
       yourMove: 'À vous de jouer',
       playerTurn: 'Tour de {{name}}',
       waitingFor: "En attente d'un joueur...",
+      a11yState: {
+        eliminated: 'éliminé',
+        currentTurn: 'tour en cours',
+        armedTarget: 'choisi comme cible',
+      },
     },
     status: {
       gameCompleted: 'Partie Terminée',

--- a/apps/web/src/shared/i18n/messages/games/critical/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/ru.ts
@@ -271,6 +271,11 @@ export const ruMessages = {
       yourMove: 'Ваш ход',
       playerTurn: 'Ход {{name}}',
       waitingFor: 'Ожидание игрока...',
+      a11yState: {
+        eliminated: 'выбыл',
+        currentTurn: 'сейчас его ход',
+        armedTarget: 'выбран как цель',
+      },
     },
     status: {
       gameCompleted: 'Игра завершена',

--- a/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/TurnBanner.tsx
@@ -141,6 +141,11 @@ export function TurnBanner({
         {extraLabel && (
           <span
             data-testid="turn-banner-extra"
+            // Explicit aria-label so AT users hear the full phrase
+            // ("plus two turns coming after this one") rather than the
+            // raw "+2" which some screen readers strip the sign from
+            // and announce as "two" — no longer self-explanatory.
+            aria-label={extraLabel}
             style={{
               position: 'relative',
               zIndex: 1,

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
@@ -96,6 +96,11 @@ export function HandCard({
   const description = t(getCardDescriptionKey(card.id));
   const borderColor = isSelected ? SELECT_RING : ROLE_BORDER[role];
   const glow = isSelected ? SELECT_GLOW : ROLE_GLOW[role];
+  // Stable id so the outer button can `aria-describedby` the visible
+  // description block. Screen readers otherwise stop at the aria-label
+  // (card name) and never hear the rules text.
+  const descriptionId = `hand-card-description-${card.uid}`;
+  const linkDescription = showDescription && !!description;
 
   // Fixed card silhouette (~3:4) regardless of which text rows show —
   // text overlays the art rather than pushing the cell taller. Cell
@@ -116,6 +121,7 @@ export function HandCard({
       aria-pressed={isSelected}
       aria-disabled={disabled}
       aria-label={name}
+      aria-describedby={linkDescription ? descriptionId : undefined}
       onPress={disabled ? undefined : onToggle}
       onKeyDown={
         disabled
@@ -148,6 +154,19 @@ export function HandCard({
           : {
               transform: [{ translateY: isSelected ? -10 : -4 }],
               shadowRadius: isSelected ? 18 : 12,
+            }
+      }
+      // Visible focus ring for keyboard users — the card is tabbable via
+      // `tabIndex={0}` but had no `:focus-visible` style, so a keyboard
+      // tab through the hand previously gave no visual feedback at all.
+      focusStyle={
+        disabled
+          ? undefined
+          : {
+              outlineColor: SELECT_RING,
+              outlineWidth: 2,
+              outlineStyle: 'solid',
+              outlineOffset: 2,
             }
       }
       flexShrink={0}
@@ -194,7 +213,8 @@ export function HandCard({
           )}
           {showDescription && (
             <Text
-              data-testid={`hand-card-description-${card.uid}`}
+              id={descriptionId}
+              data-testid={descriptionId}
               fontSize={9}
               lineHeight={12}
               textAlign="center"

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.test.tsx
@@ -157,6 +157,21 @@ describe('HandCards', () => {
     expect(card.textContent).not.toContain('⚔');
   });
 
+  it('links the card description via aria-describedby so screen readers hear it', () => {
+    // §3.1 — aria-label only carries the card name; the description
+    // (rules text) lives in a separate element. Connecting them via
+    // aria-describedby is what makes the description audible.
+    renderCards({
+      cards: handWithUids(['strike'] as CriticalCard[]),
+    });
+    const card = screen.getByTestId('hand-card-strike-0');
+    const describedBy = card.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const description = document.getElementById(describedBy!);
+    expect(description).not.toBeNull();
+    expect(description!.textContent).toBeTruthy();
+  });
+
   it('shows a duplicate-count badge only for cards with copies in hand', () => {
     renderCards({
       cards: handWithUids(['strike', 'strike', 'evade'] as CriticalCard[]),

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.test.tsx
@@ -127,4 +127,34 @@ describe('OpponentTile', () => {
     tile.click();
     expect(onSelect).not.toHaveBeenCalled();
   });
+
+  it('exposes alive/turn/target state in the accessible name', () => {
+    // §3.2 — visual ring states (turn, target, eliminated) must be
+    // mirrored in the aria-label so screen-reader users get the same
+    // context as sighted players. Mocked `t` echoes the i18n key, so
+    // each suffix appears as its key path in the rendered label.
+    renderTile({
+      player: makePlayer({ playerId: 'alice' }),
+      resolveDisplayName: () => 'Alice',
+      isCurrentTurn: true,
+      isTarget: true,
+      onSelect: vi.fn(),
+    });
+    const tile = screen.getByTestId('opponent-tile-alice');
+    const label = tile.getAttribute('aria-label') ?? '';
+    expect(label).toContain('Alice');
+    expect(label).toContain('games.table.players.a11yState.currentTurn');
+    expect(label).toContain('games.table.players.a11yState.armedTarget');
+  });
+
+  it('includes the eliminated suffix in the aria-label for dead tiles', () => {
+    renderTile({
+      player: makePlayer({ playerId: 'bob', alive: false, hand: [] }),
+      resolveDisplayName: () => 'Bob',
+    });
+    const tile = screen.getByTestId('opponent-tile-bob');
+    const label = tile.getAttribute('aria-label') ?? '';
+    expect(label).toContain('Bob');
+    expect(label).toContain('games.table.players.a11yState.eliminated');
+  });
 });

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
@@ -58,6 +58,29 @@ function initialsOf(name: string): string {
     .toUpperCase();
 }
 
+interface AriaLabelInput {
+  alive: boolean;
+  isCurrentTurn: boolean;
+  isTarget: boolean;
+  eliminatedSuffix: string;
+  currentTurnSuffix: string;
+  targetSuffix: string;
+}
+
+/**
+ * Builds the screen-reader label for an opponent tile by appending the
+ * active state suffixes (eliminated / on the clock / armed target) in
+ * parentheses. We keep all three states visible to AT users — the visual
+ * ring colour conveys the same thing for sighted users.
+ */
+function composeAriaLabel(name: string, input: AriaLabelInput): string {
+  const parts: string[] = [name];
+  if (!input.alive) parts.push(`(${input.eliminatedSuffix})`);
+  if (input.alive && input.isCurrentTurn) parts.push(`(${input.currentTurnSuffix})`);
+  if (input.alive && input.isTarget) parts.push(`(${input.targetSuffix})`);
+  return parts.join(' ');
+}
+
 /**
  * Single opponent in the widget-mode opponents row. Compact card with
  * avatar + name + hand count. Surfaces three ring states:
@@ -125,9 +148,18 @@ export function OpponentTile({
       role={interactive ? 'button' : undefined}
       tabIndex={interactive ? 0 : undefined}
       aria-pressed={interactive ? isTarget : undefined}
-      aria-label={
-        interactive ? `${displayName}${isTarget ? ' (target)' : ''}` : undefined
-      }
+      // Compose the accessible name from the visible visual states so a
+      // screen-reader user hears the same context a sighted player sees
+      // (turn ring, target ring, dead/dashed). Falls back to the bare
+      // name for non-interactive tiles (alive but not currently armable).
+      aria-label={composeAriaLabel(displayName, {
+        alive,
+        isCurrentTurn,
+        isTarget,
+        eliminatedSuffix: t('games.table.players.a11yState.eliminated'),
+        currentTurnSuffix: t('games.table.players.a11yState.currentTurn'),
+        targetSuffix: t('games.table.players.a11yState.armedTarget'),
+      })}
       onPress={interactive ? onSelect : undefined}
       onKeyDown={handleKeyDown}
       cursor={interactive ? 'pointer' : 'default'}


### PR DESCRIPTION
## Summary

Stacked on top of #659 (ARC-671). Implements §3 (Accessibility) from the PR #658 design review.

**Note:** Base branch is `ARC-671`, not `develop`. The diff below assumes #659 lands first; once that merges, GitHub will auto-rebase this PR onto develop.

## What changed

**§3.1 — HandCard `aria-describedby`**
Cell exposes only the card name via `aria-label`; the rules description (visible below the name) was a sibling Text with no semantic link. Screen-reader users heard "Strike" and stopped. The card now `aria-describedby`s the description block so the rules text is part of the announcement.

**§3.2 — OpponentTile `aria-label` exposes visual state**
Visual ring colour conveys eliminated / current-turn / armed-target to sighted players; the `aria-label` dropped those. New `composeAriaLabel` appends each state in parentheses (e.g. "Alice (currently their turn) (armed as target)"). Adds 3 i18n keys (`players.a11yState.{eliminated, currentTurn, armedTarget}`) across en / ru / es / fr / by.

**§3.3 — HandCard focus-visible style**
`tabIndex={0}` made the card focusable but had no focus style, so keyboard tabbing through the hand gave no visual feedback. `focusStyle` adds a 2px accent-green outline with 2px offset.

**§3.4 — TurnBanner extras chip `aria-label`**
"+2 turns" reads cleanly visually, but some screen readers normalize the "+" away and announce just "2 turns". Explicit `aria-label` on the chip forces the full phrase through.

## Test plan

- [x] `pnpm vitest run src/widgets/CriticalGame` — 197/197 pass (3 new tests)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` on the 10 changed files — clean
- [ ] Tab through the hand from an opponent tile: visible focus ring on each card (§3.3)
- [ ] Screen reader on an opponent tile during their turn: announces "name, currently their turn" (§3.2)
- [ ] Screen reader on a card: announces name AND description (§3.1)
- [ ] Screen reader on +2 chip: announces "plus 2 turns" or equivalent localized phrase (§3.4)

## Follow-ups

- ARC-673+ — §4 modernization tickets in priority order

🤖 Generated with [Claude Code](https://claude.com/claude-code)