### PR TITLE
feat(critical): persist hand-card toggles to localStorage §4.6 (ARC-673)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/shared/lib/useTranslation', () => ({
   useTranslation: () => ({
@@ -61,6 +61,10 @@ vi.mock('./hand/HandZone', () => ({
     onOpenRules,
     onToggleFullscreen,
     isFullscreen,
+    showCardName,
+    showCardDescription,
+    onToggleCardName,
+    onToggleCardDescription,
   }: {
     combo: { kind: string; label: string };
     canPlay: boolean;
@@ -70,6 +74,10 @@ vi.mock('./hand/HandZone', () => ({
     onOpenRules?: () => void;
     onToggleFullscreen?: () => void;
     isFullscreen?: boolean;
+    showCardName?: boolean;
+    showCardDescription?: boolean;
+    onToggleCardName?: () => void;
+    onToggleCardDescription?: () => void;
   }) => (
     <div
       data-testid="hand-zone-stub"
@@ -78,6 +86,8 @@ vi.mock('./hand/HandZone', () => ({
       data-can-play={canPlay ? 'true' : 'false'}
       data-card-uids={cards.map((c) => c.uid).join(',')}
       data-is-fullscreen={isFullscreen ? 'true' : 'false'}
+      data-show-name={showCardName ? 'true' : 'false'}
+      data-show-description={showCardDescription ? 'true' : 'false'}
     >
       <button
         type="button"
@@ -111,6 +121,20 @@ vi.mock('./hand/HandZone', () => ({
           type="button"
           data-testid="hand-zone-stub-fullscreen"
           onClick={onToggleFullscreen}
+        />
+      )}
+      {onToggleCardName && (
+        <button
+          type="button"
+          data-testid="hand-zone-stub-toggle-name"
+          onClick={onToggleCardName}
+        />
+      )}
+      {onToggleCardDescription && (
+        <button
+          type="button"
+          data-testid="hand-zone-stub-toggle-description"
+          onClick={onToggleCardDescription}
         />
       )}
     </div>
@@ -205,11 +229,40 @@ function makeProps(override: Partial<MatchWidgetProps> = {}): MatchWidgetProps {
 }
 
 describe('MatchWidget (ARC-635)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it('renders the three-row layout: OpponentsRow + Arena + HandZone', () => {
     render(<MatchWidget {...makeProps()} />);
     expect(screen.getByTestId('opponents-row-stub')).toBeInTheDocument();
     expect(screen.getByTestId('arena-stub')).toBeInTheDocument();
     expect(screen.getByTestId('hand-zone-stub')).toBeInTheDocument();
+  });
+
+  it('restores persisted card-text toggles from localStorage on mount', () => {
+    // §4.6 — toggles are user preferences keyed per-userId, so a player
+    // who collapsed the description on match #5 keeps it collapsed on
+    // match #6 instead of having to re-collapse every game.
+    window.localStorage.setItem(
+      'critical:hand-toggles:p1',
+      JSON.stringify({ name: false, description: false }),
+    );
+    render(<MatchWidget {...makeProps()} />);
+    const handZone = screen.getByTestId('hand-zone-stub');
+    expect(handZone).toHaveAttribute('data-show-name', 'false');
+    expect(handZone).toHaveAttribute('data-show-description', 'false');
+  });
+
+  it('persists card-text toggles to localStorage when toggled', () => {
+    // §4.6 — the toggle round-trips through localStorage so reloading
+    // the page (or starting a fresh match) preserves the choice.
+    render(<MatchWidget {...makeProps()} />);
+    fireEvent.click(screen.getByTestId('hand-zone-stub-toggle-name'));
+    const raw = window.localStorage.getItem('critical:hand-toggles:p1');
+    expect(raw).toBeTruthy();
+    const stored = JSON.parse(raw ?? '{}') as Record<string, boolean>;
+    expect(stored.name).toBe(false);
   });
 
   it('hides HandZone when the current player is eliminated', () => {

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -30,6 +30,50 @@ const DEFUSE_CARDS: readonly CriticalCard[] = [
   'containment_field',
 ];
 
+type ToggleField = 'name' | 'description';
+
+/**
+ * Read a persisted hand-card toggle from localStorage. SSR-safe: returns
+ * the default on the server, and treats any localStorage failure (private
+ * browsing, quota, JSON corruption) as "use the default" so a bad cache
+ * entry never breaks the match.
+ */
+function readToggle(
+  key: string | null,
+  field: ToggleField,
+  fallback: boolean,
+): boolean {
+  if (!key || typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Partial<Record<ToggleField, boolean>>;
+    const value = parsed?.[field];
+    return typeof value === 'boolean' ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Write a persisted hand-card toggle. Failures are swallowed silently. */
+function writeToggle(
+  key: string | null,
+  field: ToggleField,
+  value: boolean,
+): void {
+  if (!key || typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(key);
+    const parsed = raw
+      ? ((JSON.parse(raw) as Partial<Record<ToggleField, boolean>>) ?? {})
+      : {};
+    parsed[field] = value;
+    window.localStorage.setItem(key, JSON.stringify(parsed));
+  } catch {
+    /* localStorage unavailable (Safari private mode, quota) — silent skip */
+  }
+}
+
 export type MatchWidgetProps = ComponentProps<typeof ActiveGameContent> & {
   /**
    * Format a raw `CriticalLogEntry.message` for display. Comes from
@@ -83,11 +127,26 @@ export function MatchWidget({
   const [selectedUids, setSelectedUids] = useState<string[]>([]);
   const [targetPlayerId, setTargetPlayerId] = useState<string | null>(null);
   const [rulesOpen, setRulesOpen] = useState(false);
-  // Per-session show/hide for the card name + description rows. Default
-  // both ON so first-time players see the rules text; experienced
-  // players can collapse to art-only via the rail toggles.
-  const [showCardName, setShowCardName] = useState(true);
-  const [showCardDescription, setShowCardDescription] = useState(true);
+  // Persist show/hide for the card name + description rows per user. New
+  // players see both rows by default (rules text helps them learn);
+  // experienced players who collapse to art-only stay collapsed across
+  // matches. Storage key is namespaced by user id so multiple accounts
+  // on the same browser don't share preferences.
+  const togglesStorageKey = currentUserId
+    ? `critical:hand-toggles:${currentUserId}`
+    : null;
+  const [showCardName, setShowCardName] = useState<boolean>(() =>
+    readToggle(togglesStorageKey, 'name', true),
+  );
+  const [showCardDescription, setShowCardDescription] = useState<boolean>(() =>
+    readToggle(togglesStorageKey, 'description', true),
+  );
+  useEffect(() => {
+    writeToggle(togglesStorageKey, 'name', showCardName);
+  }, [togglesStorageKey, showCardName]);
+  useEffect(() => {
+    writeToggle(togglesStorageKey, 'description', showCardDescription);
+  }, [togglesStorageKey, showCardDescription]);
   const handleOpenRules = useCallback(() => setRulesOpen(true), []);
   const handleCloseRules = useCallback(() => setRulesOpen(false), []);
   const handleToggleCardName = useCallback(


### PR DESCRIPTION
## Summary

First slice of the §4 modernization tier from the PR #658 design review. Stacked on #660 (ARC-672) — once that merges this PR's base will auto-rebase onto develop.

**§4.6 — Persist hand-card toggles** (UX win)
The card-name / card-description visibility toggles previously reset on every match — anyone who collapsed to art-only had to re-collapse each game. Now persists per-user via `localStorage`.

## Implementation

- Storage key namespaced by user id (`critical:hand-toggles:{uid}`).
- `useState` lazy initializer reads from `localStorage` synchronously on first render; SSR falls through to the default `true`.
- Two `useEffect`s write on change. Failures (Safari private mode, quota exceeded, JSON corruption) are swallowed silently — a broken cache entry should never break the match.

## Test plan

- [x] `pnpm vitest run src/widgets/CriticalGame/ui/MatchWidget.test.tsx` — 19/19 pass (2 new tests for the round-trip)
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Toggle card-name off mid-match, refresh: toggle stays off
- [ ] Switch accounts on the same browser: preferences are independent

## Remaining §4 items

- §4.1 (CSS shadow layers via `::after`) — perf refactor, deferred to ARC-674
- §4.4 (CSS fan via `--i`) — perf refactor, deferred to ARC-674
- §4.2 (View Transitions API) — delight, deferred to ARC-675
- §4.7 (history strip) — new feature, deferred to ARC-675
- §4.3 (CSS grid arena) — bigger refactor, deferred to ARC-676
- §4.5 (`@property` pulse) — refactor, deferred to ARC-676
- §4.8 (image-set art) — **blocked**: requires per-variant image assets at 1×/2× resolutions (no source assets exist in this repo today)
- §4.9 (emoji → icon set) — **blocked**: requires design call on which icon set (Lucide / Phosphor / etc.) and matching mobile-app strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)