### PR TITLE
perf(critical): CSS-driven hand glow + fan §4.1 + §4.4 (ARC-674)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCard.tsx
@@ -40,16 +40,9 @@ const ROLE_BORDER: Record<CardRole, string> = {
   special: '#f472b6',
 };
 
-const ROLE_GLOW: Record<CardRole, string> = {
-  attack: 'rgba(239, 68, 68, 0.35)',
-  defuse: 'rgba(52, 211, 153, 0.35)',
-  skip: 'rgba(56, 189, 248, 0.35)',
-  nope: 'rgba(245, 158, 11, 0.35)',
-  favor: 'rgba(167, 139, 250, 0.35)',
-  see: 'rgba(34, 211, 238, 0.35)',
-  combo: 'rgba(250, 204, 21, 0.35)',
-  special: 'rgba(244, 114, 182, 0.40)',
-};
+// Glow colours are now CSS-attribute-keyed in `hudStyles.tsx` (§4.1) —
+// the ::after pseudo-element reads `data-role` and `data-selected` and
+// drives box-shadow + radius via custom properties. No JS payload.
 
 /**
  * Fallback glyph used when the active card variant has no sprite sheet
@@ -68,7 +61,6 @@ const ROLE_FALLBACK_GLYPH: Record<CardRole, string> = {
 };
 
 const SELECT_RING = '#34d399';
-const SELECT_GLOW = 'rgba(52, 211, 153, 0.55)';
 
 /**
  * Single-card cell for the widget-mode hand. Renders the variant's
@@ -95,7 +87,6 @@ export function HandCard({
   const name = t(getCardTranslationKey(card.id, cardVariant));
   const description = t(getCardDescriptionKey(card.id));
   const borderColor = isSelected ? SELECT_RING : ROLE_BORDER[role];
-  const glow = isSelected ? SELECT_GLOW : ROLE_GLOW[role];
   // Stable id so the outer button can `aria-describedby` the visible
   // description block. Screen readers otherwise stop at the aria-label
   // (card name) and never hear the rules text.
@@ -144,16 +135,15 @@ export function HandCard({
       transform={isSelected ? [{ translateY: -8 }] : undefined}
       cursor={disabled ? 'default' : 'pointer'}
       opacity={disabled ? 0.7 : 1}
-      shadowColor={glow}
-      shadowRadius={isSelected ? 14 : 8}
-      shadowOpacity={1}
-      shadowOffset={{ width: 0, height: 0 }}
+      // Glow is driven by the `::after` rule in `hudStyles.tsx` keyed on
+      // `data-role` + `data-selected` (§4.1). No tamagui shadow props
+      // here so the glow doesn't double-paint and can animate via the
+      // compositor when selection toggles.
       hoverStyle={
         disabled
           ? undefined
           : {
               transform: [{ translateY: isSelected ? -10 : -4 }],
-              shadowRadius: isSelected ? 18 : 12,
             }
       }
       // Visible focus ring for keyboard users — the card is tabbable via

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.test.tsx
@@ -114,6 +114,28 @@ describe('HandCards', () => {
     );
   });
 
+  it('exposes hand-index and hand-count as CSS custom properties for the fan', () => {
+    // §4.4 — the fan rotation is now CSS-driven; JS only sets
+    // --hand-index per card and --hand-count once. CSS reads these via
+    // `abs()` and `clamp()` to compute rotate/translate.
+    renderCards();
+    const wrappers = document.querySelectorAll<HTMLElement>(
+      '.hand-card-wrapper',
+    );
+    expect(wrappers.length).toBe(3);
+    wrappers.forEach((w, i) => {
+      expect(w.style.getPropertyValue('--hand-index')).toBe(String(i));
+      expect(w.style.getPropertyValue('--hand-count')).toBe('3');
+      expect(w.getAttribute('data-fan')).toBe('true');
+    });
+  });
+
+  it('flips data-fan to "false" when the row is unfanned (mobile)', () => {
+    renderCards({ isFanned: false });
+    const first = document.querySelector('.hand-card-wrapper');
+    expect(first?.getAttribute('data-fan')).toBe('false');
+  });
+
   it('keeps cell dimensions stable across selection so the fan does not shift', () => {
     // Regression for PR #658 review §1.2 — the selected-state size delta
     // (132×184 vs 124×172) pushed neighbours sideways because the row

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandCards.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, type CSSProperties } from 'react';
 import { XStack } from 'tamagui';
 import { HandCard } from './HandCard';
-import { getFanTransform } from '../../lib/handLayout';
 import type { HandCardInstance } from '../../lib/combo';
 
 interface HandCardsProps {
@@ -83,20 +82,23 @@ export function HandCards({
       }}
     >
       {cards.map((card, i) => {
-        const fan = isFanned ? getFanTransform(i, cards.length) : null;
-        // Apply the fan via a wrapping div instead of HandCard's
-        // transform prop — HandCard already uses transform for the
-        // selected-state lift, so we keep the two concerns separated.
-        const fanStyle = fan
-          ? {
-              transform: `rotate(${fan.angle}deg) translateY(${fan.offsetY}px)`,
-              transformOrigin: 'bottom center',
-              display: 'inline-flex',
-              flexShrink: 0,
-            }
-          : { display: 'inline-flex', flexShrink: 0 };
+        // §4.4 — fan transform lives in CSS now (see `hudStyles.tsx`);
+        // we only set the index/count custom properties here. JS does
+        // not compute the transform per render. CSS reads `--hand-index`
+        // / `--hand-count` and produces the rotate + translateY.
+        // Browsers without `abs()` / `clamp()` (very old) fall through
+        // to no fan — cards still render in order, no broken state.
+        const wrapperStyle = {
+          '--hand-index': i,
+          '--hand-count': cards.length,
+        } as CSSProperties & Record<'--hand-index' | '--hand-count', number>;
         return (
-          <div key={card.uid} style={fanStyle}>
+          <div
+            key={card.uid}
+            className="hand-card-wrapper"
+            data-fan={isFanned ? 'true' : 'false'}
+            style={wrapperStyle}
+          >
             <HandCard
               card={card}
               isSelected={selected.has(card.uid)}

--- a/apps/web/src/widgets/CriticalGame/ui/hudStyles.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hudStyles.tsx
@@ -29,6 +29,75 @@ const HUD_KEYFRAMES_CSS = `
   from { opacity: 0; transform: translateY(-4px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+
+/* §4.1 — HandCard glow via ::after pseudo-element instead of tamagui's
+   shadow* props. The pseudo-layer composites on the GPU and animates
+   the box-shadow on the compositor thread; the role/selection state
+   are attribute-keyed so React doesn't have to push a render to update
+   the glow when selection toggles. */
+[data-testid^="hand-card-"] {
+  --glow-radius: 8px;
+  --glow-color: transparent;
+}
+[data-testid^="hand-card-"]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 var(--glow-radius) var(--glow-color);
+  pointer-events: none;
+  z-index: -1;
+}
+@media (prefers-reduced-motion: no-preference) {
+  [data-testid^="hand-card-"]::after {
+    transition: box-shadow 180ms ease-out;
+  }
+}
+[data-testid^="hand-card-"][data-role="attack"]   { --glow-color: rgba(239,68,68,0.35); }
+[data-testid^="hand-card-"][data-role="defuse"]   { --glow-color: rgba(52,211,153,0.35); }
+[data-testid^="hand-card-"][data-role="skip"]     { --glow-color: rgba(56,189,248,0.35); }
+[data-testid^="hand-card-"][data-role="nope"]     { --glow-color: rgba(245,158,11,0.35); }
+[data-testid^="hand-card-"][data-role="favor"]    { --glow-color: rgba(167,139,250,0.35); }
+[data-testid^="hand-card-"][data-role="see"]      { --glow-color: rgba(34,211,238,0.35); }
+[data-testid^="hand-card-"][data-role="combo"]    { --glow-color: rgba(250,204,21,0.35); }
+[data-testid^="hand-card-"][data-role="special"]  { --glow-color: rgba(244,114,182,0.40); }
+[data-testid^="hand-card-"][data-selected="true"] {
+  --glow-radius: 14px;
+  --glow-color: rgba(52,211,153,0.55);
+}
+[data-testid^="hand-card-"]:hover {
+  --glow-radius: 12px;
+}
+[data-testid^="hand-card-"][data-selected="true"]:hover {
+  --glow-radius: 18px;
+}
+
+/* §4.4 — Hand fan transform driven by CSS custom properties. JS only
+   sets --hand-index and --hand-count on each card wrapper; the math
+   lives in CSS so the fan re-paints without a React re-render when
+   another card is added/removed. Targets Chrome 116+, Firefox 118+,
+   Safari 17.4+ (abs() and clamp() with numeric args). Older browsers
+   gracefully fall through to no fan — cards still render in order.
+
+   --centre splits the row symmetrically; --offset is the per-card
+   distance from centre. Angle steps 2deg from centre, clamped to ±14;
+   offsetY grows quadratically (distance² × 0.8 px) so the fan arcs
+   upward at the edges. Matches the previous JS getFanTransform exactly. */
+.hand-card-wrapper {
+  display: inline-flex;
+  flex-shrink: 0;
+  transform-origin: bottom center;
+}
+.hand-card-wrapper[data-fan="true"] {
+  --centre: calc((var(--hand-count, 1) - 1) / 2);
+  --offset: calc(var(--hand-index, 0) - var(--centre));
+  --raw-angle: calc(var(--offset) * 2);
+  --angle: clamp(-14, var(--raw-angle), 14);
+  --abs-offset: abs(var(--offset));
+  --offset-y: calc(var(--abs-offset) * var(--abs-offset) * 0.8);
+  transform: rotate(calc(var(--angle) * 1deg))
+             translateY(calc(var(--offset-y) * 1px));
+}
 `;
 
 export function HudStyles() {


### PR DESCRIPTION
## Summary

Tier 1 of §4 modernization (perf + UX wins) from the PR #658 design review. Two CSS refactors that move per-render JS off the hot path for the player's hand.

## §4.1 — Hand card glow via `::after` pseudo-element

**Before:** Every HandCard pushed `shadowColor` / `shadowRadius` / `shadowOpacity` / `shadowOffset` through tamagui's prop pipeline on every render. Selection toggles meant re-hashing the style and emitting a fresh `box-shadow` declaration through the runtime.

**After:** A single `::after` rule in `hudStyles.tsx` reads `data-role` and `data-selected` (both already on the cell) and drives `box-shadow` via `--glow-radius` / `--glow-color` custom properties. Selection toggles are an attribute change — no React re-render needed for the glow to update. The compositor animates the `box-shadow` transition on its own thread.

Removed `ROLE_GLOW` / `SELECT_GLOW` JS constants and the four tamagui shadow props from `HandCard`'s YStack.

## §4.4 — Hand fan via CSS custom properties

**Before:** `getFanTransform(i, n)` ran in JS on every card render and produced an inline `rotate(…) translateY(…)` string.

**After:** Wrapper gets `--hand-index` and `--hand-count` set inline; CSS computes the transform with `abs()` + `clamp()`. Same quadratic offsetY (distance² × 0.8 px) and 2deg-step / ±14deg-clamp rotation as the JS version, byte-for-byte equivalent visual.

`getFanTransform()` stays in `handLayout.ts` because the legacy `PlayerHand` (flag-off path) still uses it. The widget path is JS-free for the fan.

## Browser support

Targets Chrome 116+ / Firefox 118+ / Safari 17.4+. Older browsers drop the transform property gracefully — cards render in order, just without rotation. No broken state.

## Test plan

- [x] `pnpm vitest run src/widgets/CriticalGame` — 199/199 pass (2 new fan-wiring tests)
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Select / deselect a card rapidly: glow transitions smoothly, no jank (verifies §4.1 compositor)
- [ ] Resize the hand from 2 → 7 → 2 cards: each card re-fans without React re-render churn (verifies §4.4)
- [ ] Test on Safari 17 / Firefox 118: fan still works (verifies modern-CSS support)

## Remaining §4 items (next stacked PRs)

- §4.2 (View Transitions) + §4.7 (history strip) — ARC-675
- §4.3 (CSS grid arena) + §4.5 (`@property` pulse) — ARC-676
- §4.8 + §4.9 — blocked (asset / design dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)