### PR TITLE
refactor(critical): CSS grid arena, @property pulse, discard description (ARC-677)

### DIFF
--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
@@ -99,4 +99,15 @@ describe('Arena', () => {
       'true',
     );
   });
+
+  it('uses CSS grid with named areas for layout (§4.3)', () => {
+    // The layout (3-col desktop / re-stacked mobile) lives in CSS via
+    // .match-arena + data-area instead of a JS isNarrow branch.
+    renderArena();
+    const arena = screen.getByTestId('arena');
+    expect(arena).toHaveClass('match-arena');
+    expect(arena.querySelector('[data-area="draw"]')).not.toBeNull();
+    expect(arena.querySelector('[data-area="center"]')).not.toBeNull();
+    expect(arena.querySelector('[data-area="discard"]')).not.toBeNull();
+  });
 });

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.test.tsx
@@ -110,4 +110,13 @@ describe('Arena', () => {
     expect(arena.querySelector('[data-area="center"]')).not.toBeNull();
     expect(arena.querySelector('[data-area="discard"]')).not.toBeNull();
   });
+
+  it('renders the top discard card description as an overlay', () => {
+    // Played card on the discard pile carries the same description hand
+    // cards do — name alone lost context for action cards like Hack /
+    // Targeted Strike. Mocked `t` echoes the i18n key.
+    renderArena({ discardPile: ['strike'] as CriticalCard[] });
+    const scrim = screen.getByTestId('arena-discard-pile-description');
+    expect(scrim.textContent).toMatch(/strike/);
+  });
 });

--- a/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/Arena.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { XStack } from 'tamagui';
 import type { CriticalCard, CriticalLogEntry } from '../../types';
 import { DrawPile } from './DrawPile';
 import { DiscardPile } from './DiscardPile';
@@ -35,6 +34,12 @@ interface ArenaProps {
  * Three-column arena row (draw · center · discard) — Row 2 of the §7
  * widget layout. The center column hosts the turn pill, combo intent
  * card, threat strip, and an absolutely-positioned flash banner.
+ *
+ * Layout lives in CSS now (`.match-arena` in `hudStyles.tsx`) — desktop
+ * is a 3-column grid, mobile re-stacks via `grid-template-areas` to
+ * `center / center` over `draw / discard`. The JS `isNarrow` flip
+ * stays only for the pile / center children whose internal layout
+ * still differs between desktop and phone.
  */
 export function Arena({
   deck,
@@ -54,66 +59,48 @@ export function Arena({
   serverOverloadOdds,
   hiddenCount,
 }: ArenaProps) {
-  // Phones get smaller piles so the three-column row still fits at
-  // 390px; the layout otherwise stays identical so the threat strip,
-  // combo card, and FlashBanner don't fall down 200px below the piles.
-  // `useIsNarrow` reads the value broadcast by `NarrowViewportProvider`
-  // at the widget root so Arena / HandZone / OpponentsRow / TurnBanner
-  // all commit the same viewport flip on the same React frame.
   const isNarrow = useIsNarrow(480);
 
   return (
-    <XStack
+    <div
+      className="match-arena"
       data-testid="arena"
       data-layout={isNarrow ? 'mobile' : 'desktop'}
-      width="100%"
-      alignItems="center"
-      gap="$5"
-      paddingHorizontal="$4"
-      paddingVertical="$3"
-      borderRadius={isNarrow ? 0 : 18}
-      borderWidth={isNarrow ? 0 : 1}
-      borderColor="rgba(255,255,255,0.06)"
-      backgroundColor={isNarrow ? 'transparent' : 'rgba(8,12,20,0.55)'}
-      // overflow: hidden keeps hover glows on the piles inside the
-      // rounded border on desktop. On phones we drop the card chrome so
-      // the row reads as a strip and the FlashBanner overlay can extend
-      // past the arena bounds without clipping.
-      overflow={isNarrow ? 'visible' : 'hidden'}
-      $sm={{
-        gap: '$2',
-        paddingHorizontal: '$2',
-        paddingVertical: '$2',
-      }}
     >
-      <DrawPile
-        deck={deck}
-        count={deck.length}
-        disabled={!isMyTurn || isGameOver}
-        onDraw={onDrawAndEnd}
-        cardVariant={cardVariant}
-        isNarrow={isNarrow}
-      />
-      <ArenaCenter
-        isMyTurn={isMyTurn}
-        currentPlayerName={currentPlayerName}
-        pendingDraws={pendingDraws}
-        hand={hand}
-        allowActionCardCombos={allowActionCardCombos}
-        combo={combo}
-        deck={deck}
-        logs={logs}
-        formatLogMessage={formatLogMessage}
-        resolveDisplayName={resolveDisplayName}
-        serverOverloadOdds={serverOverloadOdds}
-        hiddenCount={hiddenCount}
-        isNarrow={isNarrow}
-      />
-      <DiscardPile
-        pile={discardPile}
-        cardVariant={cardVariant}
-        isNarrow={isNarrow}
-      />
-    </XStack>
+      <div data-area="draw">
+        <DrawPile
+          deck={deck}
+          count={deck.length}
+          disabled={!isMyTurn || isGameOver}
+          onDraw={onDrawAndEnd}
+          cardVariant={cardVariant}
+          isNarrow={isNarrow}
+        />
+      </div>
+      <div data-area="center">
+        <ArenaCenter
+          isMyTurn={isMyTurn}
+          currentPlayerName={currentPlayerName}
+          pendingDraws={pendingDraws}
+          hand={hand}
+          allowActionCardCombos={allowActionCardCombos}
+          combo={combo}
+          deck={deck}
+          logs={logs}
+          formatLogMessage={formatLogMessage}
+          resolveDisplayName={resolveDisplayName}
+          serverOverloadOdds={serverOverloadOdds}
+          hiddenCount={hiddenCount}
+          isNarrow={isNarrow}
+        />
+      </div>
+      <div data-area="discard">
+        <DiscardPile
+          pile={discardPile}
+          cardVariant={cardVariant}
+          isNarrow={isNarrow}
+        />
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '@/shared/lib/useTranslation';
 import type { CriticalCard } from '../../types';
 import { LastPlayedCardDisplay } from '../LastPlayedCardDisplay';
 import { CardSlot } from '../styles';
+import { getCardDescriptionKey } from '../../lib/cardUtils';
 
 interface DiscardPileProps {
   pile: CriticalCard[];
@@ -21,6 +22,8 @@ export function DiscardPile({
   const { t } = useTranslation();
   const count = pile.length;
   const tCompat = t as unknown as (key: string) => string;
+  const lastCard = pile.length > 0 ? pile[pile.length - 1] : null;
+  const description = lastCard ? t(getCardDescriptionKey(lastCard)) : '';
 
   return (
     <YStack
@@ -44,6 +47,47 @@ export function DiscardPile({
           t={tCompat}
           cardVariant={cardVariant}
         />
+        {/* Description overlay so the played card carries the same
+            context the hand cards do (name lives in CardNameContainer
+            inside LastPlayedCardDisplay already). Bottom-anchored scrim
+            so the artwork's top half stays visible. Hidden on phones
+            where the 80×112 slot can't accommodate readable text. */}
+        {!isNarrow && lastCard && description && (
+          <div
+            data-testid="arena-discard-pile-description"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              padding: '14px 8px 8px',
+              pointerEvents: 'none',
+              background:
+                'linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.55) 60%, rgba(0,0,0,0) 100%)',
+              borderBottomLeftRadius: 'inherit',
+              borderBottomRightRadius: 'inherit',
+              zIndex: 2,
+            }}
+          >
+            <span
+              style={{
+                display: '-webkit-box',
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                fontSize: 10,
+                lineHeight: '13px',
+                textAlign: 'center',
+                color: 'rgba(226, 232, 240, 0.92)',
+                fontWeight: 600,
+                letterSpacing: 0.2,
+              }}
+              title={description}
+            >
+              {description}
+            </span>
+          </div>
+        )}
       </CardSlot>
       <Text
         data-testid="arena-discard-pile-count"

--- a/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/arena/DiscardPile.tsx
@@ -51,7 +51,15 @@ export function DiscardPile({
             context the hand cards do (name lives in CardNameContainer
             inside LastPlayedCardDisplay already). Bottom-anchored scrim
             so the artwork's top half stays visible. Hidden on phones
-            where the 80×112 slot can't accommodate readable text. */}
+            where the 80×112 slot can't accommodate readable text.
+
+            `zIndex: 20` deliberately sits above `LastPlayedCard`'s
+            `zIndex: 10` — without this the card painted on top of the
+            scrim and the description never showed.
+
+            `borderRadius` matches the card's so the scrim bottom
+            follows the rounded card edge instead of extending past it
+            with square corners. */}
         {!isNarrow && lastCard && description && (
           <div
             data-testid="arena-discard-pile-description"
@@ -64,9 +72,9 @@ export function DiscardPile({
               pointerEvents: 'none',
               background:
                 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.55) 60%, rgba(0,0,0,0) 100%)',
-              borderBottomLeftRadius: 'inherit',
-              borderBottomRightRadius: 'inherit',
-              zIndex: 2,
+              borderBottomLeftRadius: 14,
+              borderBottomRightRadius: 14,
+              zIndex: 20,
             }}
           >
             <span

--- a/apps/web/src/widgets/CriticalGame/ui/hudStyles.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hudStyles.tsx
@@ -10,13 +10,9 @@
  */
 const HUD_KEYFRAMES_CSS = `
 @media (prefers-reduced-motion: no-preference) {
-  @keyframes threatPulse {
-    0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
-    50%      { box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.18); }
-  }
-  [data-testid="threat-strip"][data-pulse="true"] {
-    animation: threatPulse 1.4s ease-in-out infinite;
-  }
+  /* The old threatPulse keyframes used to live here; the @property
+     block below replaces them so the pulse value interpolates on the
+     compositor thread instead of re-rasterizing box-shadow each step. */
   @keyframes turnBannerDotPulse {
     0%, 100% { transform: scale(1); opacity: 1; }
     50%      { transform: scale(1.35); opacity: 0.6; }
@@ -97,6 +93,67 @@ const HUD_KEYFRAMES_CSS = `
   --offset-y: calc(var(--abs-offset) * var(--abs-offset) * 0.8);
   transform: rotate(calc(var(--angle) * 1deg))
              translateY(calc(var(--offset-y) * 1px));
+}
+
+/* §4.3 — Arena as CSS grid. Three-column row (draw · center · discard)
+   on desktop; on phones the centre column spans both tracks above
+   draw + discard via grid-template-areas. Eliminates the JS isNarrow
+   branch that previously toggled gap / padding / border / radius /
+   bg / overflow on the Arena root. Sub-components (piles, ArenaCenter)
+   still read isNarrow for their own internal layout — that prop stays. */
+.match-arena {
+  display: grid;
+  width: 100%;
+  align-items: center;
+  gap: 24px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(255,255,255,0.06);
+  background-color: rgba(8,12,20,0.55);
+  overflow: hidden;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: "draw center discard";
+}
+.match-arena > [data-area="draw"]    { grid-area: draw; }
+.match-arena > [data-area="center"]  { grid-area: center; }
+.match-arena > [data-area="discard"] { grid-area: discard; }
+@media (max-width: 480px) {
+  .match-arena {
+    gap: 8px;
+    padding: 8px;
+    border-radius: 0;
+    border: 0;
+    background-color: transparent;
+    overflow: visible;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "center center"
+      "draw   discard";
+  }
+}
+
+/* §4.5 — Threat-strip pulse via @property + custom-property
+   interpolation. The old keyframes drove box-shadow directly which
+   re-rasterized on every step; @property tells the engine the value
+   is a number so the compositor can interpolate it on its own thread,
+   and we read it into box-shadow once. Falls back gracefully where
+   @property is unsupported (older Firefox) — the rule just doesn't
+   animate, no broken visual. */
+@property --threat-pulse {
+  syntax: '<number>';
+  initial-value: 0;
+  inherits: false;
+}
+@media (prefers-reduced-motion: no-preference) {
+  [data-testid="threat-strip"][data-pulse="true"] {
+    animation: threatPulseProperty 1.4s ease-in-out infinite;
+    box-shadow: 0 0 calc(6px * var(--threat-pulse))
+                calc(2px * var(--threat-pulse)) rgba(239, 68, 68, 0.45);
+  }
+  @keyframes threatPulseProperty {
+    0%, 100% { --threat-pulse: 0; }
+    50%      { --threat-pulse: 1; }
+  }
 }
 `;
 


### PR DESCRIPTION
## Summary

Supersedes #664, which was force-pushed (rebase onto an updated ARC-675) and tripped the dropped-commit CI guard. Same content, fresh branch — no force-pushes involved.

Tier 3 of §4 modernization (refactor) from the PR #658 design review, plus two follow-up UI fixes the user flagged after seeing the running build.

## §4.3 — Arena as CSS grid

Arena root was a tamagui XStack with `isNarrow` flips for `gap` / `padding` / `borderRadius` / `borderWidth` / `backgroundColor` / `overflow`. All chrome decisions and the column layout itself now live in `.match-arena` CSS, with mobile re-stack expressed via `grid-template-areas` (`"center center"` / `"draw discard"`) under `@media (max-width: 480px)` — no JS branch for layout.

Children wrap in `<div data-area="draw|center|discard">` so the grid assigns them by name. Sub-components (`DrawPile`, `ArenaCenter`, `DiscardPile`) still receive `isNarrow` for their own internal layout decisions.

## §4.5 — Threat pulse via `@property`

Old `@keyframes threatPulse` animated `box-shadow` directly, which re-rasterized at every step. New version registers `--threat-pulse` as a `<number>` via `@property`. The keyframes animate the custom property; the `box-shadow` declaration reads it once into `calc()`. The browser interpolates the number on the compositor thread.

## Follow-up fixes from user feedback

**Discard description scrim** (`cfac4d0e`) — Hand cards showed name + description; the discard top only showed the name. Action cards like Hack / Targeted Strike lost their meaning the moment they landed on the table. Bottom-anchored gradient scrim now overlays the played card with the same description text the hand cards carry. Hidden on phones (80×112 slot too small).

**Z-index fix for the scrim** (`48a8c7c1`) — Initial implementation was technically rendering but invisible. `LastPlayedCard` styled component sets `zIndex: 10`; the scrim was at `zIndex: 2`, so the card painted on top. Bumped scrim to `zIndex: 20` and gave it explicit `borderRadius: 14` to match the card's rounded corners.

## Test plan

- [x] `pnpm vitest run src/widgets/CriticalGame` — 211/211 pass (1 new Arena grid test + 1 new discard description test)
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Resize from 800px → 480px: arena re-stacks center-over-piles cleanly
- [ ] Top discard card shows name + description on desktop, name-only on phone
- [ ] Threat-strip pulse animates smoothly in Chrome / Safari 17+

## Remaining §4 items (not in this PR — blocked)

- **§4.8 (image-set art)** — needs per-variant card art at 1×/2× resolutions; no source assets in this repo
- **§4.9 (emoji → icon set)** — needs design call on which icon set

🤖 Generated with [Claude Code](https://claude.com/claude-code)