### PR TITLE
test(header): retry language-switcher click on webkit (ARC-680)

### DIFF
--- a/apps/web/e2e/header-language.spec.ts
+++ b/apps/web/e2e/header-language.spec.ts
@@ -1,5 +1,27 @@
-import { expect } from '@playwright/test';
+import { expect, type Locator } from '@playwright/test';
 import { test, navigateTo } from './fixtures/test-utils';
+
+/**
+ * Tamagui's Select trigger opens the dropdown on `mousedown`, but on
+ * webkit-desktop the first synthetic click occasionally fails to register
+ * — the dropdown stays closed and the option locator times out. Wait for
+ * `aria-expanded="true"` to confirm the dropdown actually opened, and
+ * retry once if it didn't. Other browsers see the same code path; the
+ * retry is a no-op there because the first click already succeeded.
+ */
+async function openLanguageSwitcher(switcher: Locator): Promise<void> {
+  await switcher.click();
+  try {
+    await expect(switcher).toHaveAttribute('aria-expanded', 'true', {
+      timeout: 2000,
+    });
+  } catch {
+    await switcher.click();
+    await expect(switcher).toHaveAttribute('aria-expanded', 'true', {
+      timeout: 5000,
+    });
+  }
+}
 
 test.describe('Header Language Switcher', () => {
   test.beforeEach(async ({ page }) => {
@@ -20,7 +42,7 @@ test.describe('Header Language Switcher', () => {
     await expect(languageSwitcher).toContainText('EN');
 
     // Change language to Spanish
-    await languageSwitcher.click();
+    await openLanguageSwitcher(languageSwitcher);
     await page.getByRole('option', { name: 'ES' }).click();
 
     // The value should be updated
@@ -55,7 +77,7 @@ test.describe('Header Language Switcher', () => {
     await expect(menuLanguageSwitcher).not.toBeVisible();
 
     // 4. Change language from header while menu is open
-    await headerLanguageSwitcher.click();
+    await openLanguageSwitcher(headerLanguageSwitcher);
     await page.getByRole('option', { name: 'FR' }).click();
 
     // Verify language changed (header text should update)


### PR DESCRIPTION
## Summary

- The `header-language.spec.ts` test intermittently fails on **webkit-desktop** with a 20s timeout on `getByRole('option', { name: 'ES' }).click()`. The trigger click succeeds, but the Tamagui Select dropdown sometimes never opens, so the option locator can't resolve.
- Mobile/tablet webkit aren't affected — they hit a different code path in Tamagui's `SelectTrigger` (`isPointerCoarse=true` → `onPress` handler vs. desktop's `onMouseDown`).
- Add a small helper that waits for the trigger's `aria-expanded="true"` attribute (Tamagui stamps it when the dropdown actually opens) and retries the click once if the first attempt didn't take. Other browsers see the same path; the first click always succeeds there, so the retry is a free no-op.

## Root cause

Tamagui's [`SelectTrigger.tsx`](https://github.com/tamagui/tamagui/blob/main/packages/select/src/SelectTrigger.tsx) computes `isPointerCoarse` at **module load time** by reading `window.matchMedia('(pointer:coarse)').matches`. On webkit-desktop, this is false, so the trigger registers `onMouseDown` (via the floating-ui `useClick({ event: 'mousedown' })`). Playwright's synthetic mousedown _usually_ fires it, but occasionally — most often on the first click of a fresh page — webkit drops it.

A retry on `aria-expanded` is the cheapest defensive fix; reworking Tamagui's pointer detection or switching to a keyboard interaction would change the test's intent.

## Test plan

- [ ] Run `pnpm --filter web test:e2e -- e2e/header-language.spec.ts --project=webkit` 5× in a row; confirm all green.
- [ ] Same for `--project=chromium` and `--project=firefox`; the retry should be a no-op (first click always opens the dropdown).
- [ ] Confirm `--project="Mobile Safari"` and `--project="Tablet Safari"` still pass.
- [ ] Spot-check CI: this PR's CI should be green on the previously flaky `Web E2E (webkit, Shard 1/2)` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)