### PR TITLE
fix(be): raise per-socket listener cap on games namespace (ARC-683)

### DIFF
--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -36,6 +36,26 @@ export class GamesGateway {
 
   afterInit(): void {
     this.realtime.registerServer(this.server);
+
+    // Six gateways share the `games` socket.io namespace
+    // (GamesGateway, CriticalGateway, CriticalActionsGateway,
+    // SeaBattleGateway, TexasHoldemGateway, GlimwormGateway). For each
+    // gateway, `@nestjs/websockets` unconditionally attaches a
+    // `disconnect` listener on every connecting client via
+    // `bindClientDisconnect` (see `getConnectionHandler` in
+    // `@nestjs/websockets/web-sockets-controller`), regardless of
+    // whether the gateway implements `OnGatewayDisconnect`. Combined
+    // with engine.io's own internal cleanup listeners, a healthy
+    // socket reaches ~8-11 listeners and trips Node's default
+    // 10-listener `EventEmitter` cap. Raise the per-socket cap via
+    // namespace middleware so the bump is in place before NestJS's
+    // connection handlers run.
+    const PER_SOCKET_LISTENER_CAP = 20;
+    this.server.use((socket, next) => {
+      socket.setMaxListeners(PER_SOCKET_LISTENER_CAP);
+      next();
+    });
+
     this.logger.debug('Games gateway initialized.');
   }
 


### PR DESCRIPTION
## Summary

Silences the recurring `MaxListenersExceededWarning: 11 disconnect listeners added to [Socket]` printed by the BE on each client connection.

## Root cause

Six gateways share the `games` socket.io namespace: `GamesGateway`, `CriticalGateway`, `CriticalActionsGateway`, `SeaBattleGateway`, `TexasHoldemGateway`, `GlimwormGateway`.

\`@nestjs/websockets@11.1.8\` unconditionally attaches a \`disconnect\` listener per gateway on every connecting client — confirmed in the installed source at \`@nestjs/websockets/web-sockets-controller.js\`:

\`\`\`js
// getConnectionHandler (lines 58-68)
const disconnectHook = adapter.bindClientDisconnect;
disconnectHook &&
  disconnectHook.call(adapter, client, () => disconnect.next(client));
\`\`\`

This runs for **every** gateway, regardless of whether the gateway implements \`OnGatewayDisconnect\`. With 6 gateways on \`games\`, plus engine.io's internal cleanup listeners, a fresh client socket reaches ~8-11 \`disconnect\` listeners — past Node's default 10-listener \`EventEmitter\` cap.

## Fix

Raise the per-socket listener cap to 20 via a namespace-level connection middleware in \`GamesGateway.afterInit\`. The middleware runs before NestJS's connection handlers attach their disconnect listeners, so the bump is in place beforehand. Surgical — touches only the affected namespace.

Other namespaces (\`/\`, \`/wallet\`, \`leaderboards\`) have one gateway each and stay under the default.

## Why not consolidate the gateways

That'd be the architecturally cleanest fix but the gateways are independent feature modules (Critical actions, SeaBattle, Texas Holdem, Glimworm). Merging them into one giant gateway sacrifices module boundaries to work around a NestJS internal. Left as a possible future refactor.

## Branch base

This PR is stacked on **#671 (ARC-682 — fullscreen mode)** because the i18n refactor in that PR is required for the pre-commit \`check-file-length\` hook to pass on develop. Once #671 merges, rebase or re-target this PR to develop.

## Test plan

- [ ] Start the BE in dev (\`pnpm dev\`).
- [ ] Open a games room from the web app, connect/disconnect a few times.
- [ ] Confirm no \`MaxListenersExceededWarning: ... disconnect listeners added to [Socket]\` is printed.
- [ ] Confirm \`games.gateway.spec.ts\` still passes (\`pnpm jest games.gateway\`).
- [ ] Spot-check that connect/disconnect lifecycle still works (idle events, room cleanup, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)