### PR TITLE
feat(seo): per-locale JSON-LD, og:locale:alternate, 404, dynamic pages (ARC-705)

### DIFF
--- a/apps/web/src/app/[locale]/games/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/games/[id]/page.tsx
@@ -32,11 +32,13 @@ export async function generateMetadata({
   const { locale, id } = await params;
   if (!isLocale(locale)) return {};
   const gameName = await getGameName(id, locale);
+  // Title is per-game so the SERP entry is distinctive; description falls
+  // back to the localized `seo.games.description` for a coherent
+  // per-locale snippet across the catalog.
   return buildPageMetadata({
     locale,
     page: 'games',
     title: `${gameName} · ${appConfig.appName}`,
-    description: `Browse open ${gameName} rooms on ${appConfig.appName} — join an existing match or start your own.`,
     pathFor: (r) => r.gameDetail(id),
   });
 }

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -10,6 +10,9 @@ import { PWAProvider } from '@/features/pwa/PWAContext';
 import { WalletLiveBridge } from '@/features/wallet/ui/WalletLiveBridge';
 import { getServerAccessToken } from '@/entities/session/api/serverTokens';
 import { isLocale, SUPPORTED_LOCALES, type Locale } from '@/shared/i18n';
+import { getTranslations } from '@/shared/i18n/server';
+import { buildRoutes } from '@/shared/config/routes';
+import { JsonLd } from '@/shared/ui/JsonLd';
 
 const OG_LOCALE_MAP: Record<Locale, string> = {
   en: 'en_US',
@@ -17,6 +20,14 @@ const OG_LOCALE_MAP: Record<Locale, string> = {
   fr: 'fr_FR',
   ru: 'ru_RU',
   by: 'be_BY',
+};
+
+const SCHEMA_LANGUAGE_MAP: Record<Locale, string> = {
+  en: 'en-US',
+  es: 'es-ES',
+  fr: 'fr-FR',
+  ru: 'ru-RU',
+  by: 'be-BY',
 };
 
 export function generateStaticParams() {
@@ -44,6 +55,9 @@ export async function generateMetadata({
     openGraph: {
       type: 'website',
       locale: OG_LOCALE_MAP[locale],
+      alternateLocale: SUPPORTED_LOCALES.filter((l) => l !== locale).map(
+        (l) => OG_LOCALE_MAP[l],
+      ),
       url: localeUrl,
       siteName: appConfig.appName,
       title: appConfig.seoTitle,
@@ -70,11 +84,60 @@ export default async function LocaleLayout({
   const { locale } = await params;
   if (!isLocale(locale)) notFound();
 
-  const authToken = await getServerAccessToken();
+  const [authToken, messages] = await Promise.all([
+    getServerAccessToken(),
+    getTranslations(locale),
+  ]);
+
+  const localeUrl = `${appConfig.siteUrl}/${locale}`;
+  const routes = buildRoutes(locale);
+  const localizedDescription =
+    messages.seo?.home?.description ?? appConfig.seoDescription;
+  const inLanguage = SCHEMA_LANGUAGE_MAP[locale];
+
+  // WebSite + SoftwareApplication structured data, localized via `inLanguage`
+  // and translated descriptions. The Organization entity is locale-agnostic
+  // and lives in the root layout.
+  const localeJsonLd = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'WebSite',
+      name: appConfig.appName,
+      url: localeUrl,
+      inLanguage,
+      description: localizedDescription,
+      potentialAction: {
+        '@type': 'SearchAction',
+        target: `${appConfig.siteUrl}${routes.games}?q={search_term_string}`,
+        'query-input': 'required name=search_term_string',
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: appConfig.appName,
+      url: localeUrl,
+      inLanguage,
+      description: localizedDescription,
+      operatingSystem: 'Any',
+      applicationCategory: 'GameApplication',
+      aggregateRating: {
+        '@type': 'AggregateRating',
+        ratingValue: '4.8',
+        ratingCount: '1240',
+      },
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+    },
+  ];
 
   return (
     <LanguageProvider locale={locale}>
       <PWAProvider>
+        <JsonLd id={`json-ld-locale-${locale}`} data={localeJsonLd} />
         <AnnouncementBanner />
         <Header />
         {children}

--- a/apps/web/src/app/[locale]/not-found.tsx
+++ b/apps/web/src/app/[locale]/not-found.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { getTranslations } from '@/shared/i18n/server';
+import { buildRoutes } from '@/shared/config/routes';
+import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+
+// `not-found.tsx` is rendered outside the normal segment context, so we
+// can't read params here. Fall back to the language cookie that the
+// middleware/LanguageProvider keeps in sync with the URL.
+async function getLocale(): Promise<Locale> {
+  const store = await cookies();
+  const raw = store.get('app-language')?.value;
+  return isLocale(raw) ? raw : DEFAULT_LOCALE;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  // 404 should not be indexed even though it's technically discoverable.
+  return buildPageMetadata({ locale, page: 'notFound', noIndex: true });
+}
+
+export default async function NotFound() {
+  const locale = await getLocale();
+  const messages = await getTranslations(locale);
+  const seo = messages.seo?.notFound;
+  const routes = buildRoutes(locale);
+
+  const title = seo?.title ?? 'Page not found';
+  const description =
+    seo?.description ??
+    "The page you're looking for doesn't exist. Browse our games or head back home.";
+
+  return (
+    <main
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: '48px 24px',
+        gap: '24px',
+      }}
+    >
+      <h1
+        style={{
+          fontSize: 'clamp(2rem, 5vw, 3rem)',
+          margin: 0,
+          fontWeight: 700,
+        }}
+      >
+        {title}
+      </h1>
+      <p style={{ maxWidth: 560, margin: 0, opacity: 0.8, lineHeight: 1.5 }}>
+        {description}
+      </p>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        <Link
+          href={routes.home}
+          className="home-link-button home-link-button-primary"
+        >
+          {messages.common?.actions?.openApp ?? 'Open app'}
+        </Link>
+        <Link
+          href={routes.games}
+          className="home-link-button"
+          style={{ opacity: 0.85 }}
+        >
+          {messages.navigation?.gamesTab ?? 'Games'}
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/players/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/players/[id]/page.tsx
@@ -1,19 +1,30 @@
-import { getTranslations } from '@/shared/i18n/server';
 import type { Metadata } from 'next';
+import { getTranslations } from '@/shared/i18n/server';
+import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
 import PlayerProfileClient from './PlayerProfileClient';
 
-export const metadata: Metadata = {
-  title: 'Player profile',
-  description: 'Player rank, stats, and recent matches.',
-};
-
 interface PageProps {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; id: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale: rawLocale, id } = await params;
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+  return buildPageMetadata({
+    locale,
+    page: 'playerProfile',
+    // /<locale>/players/<id> — same shape across locales.
+    pathFor: (r) => `${r.home}/players/${encodeURIComponent(id)}`,
+  });
 }
 
 export default async function PlayerProfilePage({ params }: PageProps) {
-  const { id } = await params;
-  const messages = await getTranslations();
+  const { locale: rawLocale, id } = await params;
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+  const messages = await getTranslations(locale);
   const t = messages.pages?.leaderboards;
   return <PlayerProfileClient id={id} t={t} />;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -82,6 +82,9 @@ export default async function RootLayout({
   const cookieLocale = cookieStore.get('app-language')?.value;
   const htmlLang = isLocale(cookieLocale) ? cookieLocale : DEFAULT_LOCALE;
 
+  // Organization is locale-agnostic — same legal entity across languages.
+  // WebSite and SoftwareApplication schemas live in [locale]/layout where
+  // they can carry `inLanguage` + localized description.
   const jsonLd = [
     {
       '@context': 'https://schema.org',
@@ -90,34 +93,6 @@ export default async function RootLayout({
       url: appConfig.siteUrl,
       logo: `${appConfig.siteUrl}/logo.png`,
       sameAs: Object.values(appConfig.social).filter(Boolean),
-    },
-    {
-      '@context': 'https://schema.org',
-      '@type': 'WebSite',
-      name: appConfig.appName,
-      url: appConfig.siteUrl,
-      potentialAction: {
-        '@type': 'SearchAction',
-        target: `${appConfig.siteUrl}/${htmlLang}/games?q={search_term_string}`,
-        'query-input': 'required name=search_term_string',
-      },
-    },
-    {
-      '@context': 'https://schema.org',
-      '@type': 'SoftwareApplication',
-      name: appConfig.appName,
-      operatingSystem: 'Any',
-      applicationCategory: 'GameApplication',
-      aggregateRating: {
-        '@type': 'AggregateRating',
-        ratingValue: '4.8',
-        ratingCount: '1240',
-      },
-      offers: {
-        '@type': 'Offer',
-        price: '0',
-        priceCurrency: 'USD',
-      },
     },
   ];
 

--- a/apps/web/src/shared/i18n/messages/seo/by.ts
+++ b/apps/web/src/shared/i18n/messages/seo/by.ts
@@ -129,4 +129,12 @@ export const by: DeepPartial<SeoMessages> = {
     title: `Адмін · ${APP}`,
     description: `Адміністрацыйныя налады ${APP}.`,
   },
+  playerProfile: {
+    title: `Профіль гульца · ${APP}`,
+    description: `Паглядзіце рэйтынг, статыстыку і нядаўнія матчы гэтага гульца на ${APP}.`,
+  },
+  notFound: {
+    title: `Старонка не знойдзена · ${APP}`,
+    description: `Запытаная старонка не існуе на ${APP}. Перайдзіце да гульняў ці вярніцеся на галоўную.`,
+  },
 };

--- a/apps/web/src/shared/i18n/messages/seo/en.ts
+++ b/apps/web/src/shared/i18n/messages/seo/en.ts
@@ -127,6 +127,14 @@ export const en = {
     title: `Admin · ${APP}`,
     description: `Administrative controls for ${APP}.`,
   },
+  playerProfile: {
+    title: `Player profile · ${APP}`,
+    description: `View this player's ${APP} rank, stats, and recent matches.`,
+  },
+  notFound: {
+    title: `Page not found · ${APP}`,
+    description: `The page you're looking for doesn't exist on ${APP}. Browse our games or head back home.`,
+  },
 };
 
 export type SeoMessages = typeof en;

--- a/apps/web/src/shared/i18n/messages/seo/es.ts
+++ b/apps/web/src/shared/i18n/messages/seo/es.ts
@@ -129,4 +129,12 @@ export const es: DeepPartial<SeoMessages> = {
     title: `Admin · ${APP}`,
     description: `Controles administrativos de ${APP}.`,
   },
+  playerProfile: {
+    title: `Perfil del jugador · ${APP}`,
+    description: `Consulta el rango, las estadísticas y las partidas recientes de este jugador en ${APP}.`,
+  },
+  notFound: {
+    title: `Página no encontrada · ${APP}`,
+    description: `La página que buscas no existe en ${APP}. Explora nuestros juegos o vuelve al inicio.`,
+  },
 };

--- a/apps/web/src/shared/i18n/messages/seo/fr.ts
+++ b/apps/web/src/shared/i18n/messages/seo/fr.ts
@@ -129,4 +129,12 @@ export const fr: DeepPartial<SeoMessages> = {
     title: `Admin · ${APP}`,
     description: `Contrôles administratifs de ${APP}.`,
   },
+  playerProfile: {
+    title: `Profil du joueur · ${APP}`,
+    description: `Consultez le rang, les statistiques et les parties récentes de ce joueur sur ${APP}.`,
+  },
+  notFound: {
+    title: `Page introuvable · ${APP}`,
+    description: `La page recherchée n'existe pas sur ${APP}. Parcourez nos jeux ou retournez à l'accueil.`,
+  },
 };

--- a/apps/web/src/shared/i18n/messages/seo/ru.ts
+++ b/apps/web/src/shared/i18n/messages/seo/ru.ts
@@ -129,4 +129,12 @@ export const ru: DeepPartial<SeoMessages> = {
     title: `Админ · ${APP}`,
     description: `Административные настройки ${APP}.`,
   },
+  playerProfile: {
+    title: `Профиль игрока · ${APP}`,
+    description: `Посмотрите рейтинг, статистику и недавние матчи этого игрока на ${APP}.`,
+  },
+  notFound: {
+    title: `Страница не найдена · ${APP}`,
+    description: `Запрошенная страница не существует на ${APP}. Перейдите к играм или вернитесь на главную.`,
+  },
 };

--- a/apps/web/src/shared/seo/buildPageMetadata.ts
+++ b/apps/web/src/shared/seo/buildPageMetadata.ts
@@ -61,6 +61,10 @@ const DEFAULT_PATH_BUILDERS: Partial<Record<SeoPageKey, PathBuilder>> = {
   community: (r) => r.community,
   developers: (r) => r.developers,
   admin: (r) => r.admin,
+  // playerProfile is dynamic — callers must pass `pathFor`, but we map it
+  // here to the locale root so hreflang at least covers all locales.
+  playerProfile: (r) => r.home,
+  notFound: (r) => r.home,
 };
 
 export interface BuildPageMetadataOptions {
@@ -144,6 +148,12 @@ export async function buildPageMetadata({
     openGraph: {
       type: 'website',
       locale: OG_LOCALE_MAP[locale],
+      // og:locale:alternate — Facebook/Discord use these to pick the right
+      // unfurl when the same URL is shared in a different locale context.
+      // Complements `alternates.languages` (hreflang).
+      alternateLocale: SUPPORTED_LOCALES.filter((l) => l !== locale).map(
+        (l) => OG_LOCALE_MAP[l],
+      ),
       siteName: appConfig.appName,
       title,
       description,


### PR DESCRIPTION
> Stacked on **#692 (ARC-703)** — base is ARC-703 so the diff stays focused on the four follow-up items. Will retarget to `develop` once #692 merges.

## Summary
- **og:locale:alternate** added to [buildPageMetadata](apps/web/src/shared/seo/buildPageMetadata.ts) so Facebook/Discord unfurls pick up the alternate locales (complements `alternates.languages`).
- **JSON-LD per locale**: split out of the root layout. [src/app/layout.tsx](apps/web/src/app/layout.tsx) keeps only the locale-agnostic Organization entity; [src/app/[locale]/layout.tsx](apps/web/src/app/[locale]/layout.tsx) now emits WebSite + SoftwareApplication with `inLanguage`, a localized description (pulled from `seo.home`), and a per-locale `SearchAction` URL.
- **/[locale]/players/[id]** uses `buildPageMetadata` with a custom `pathFor` so each player profile has a locale-correct canonical + full hreflang map.
- **/[locale]/games/[id]** drops the English-hardcoded description; the localized `seo.games.description` flows through. Per-game title (`{gameName} · Arcadeum`) stays distinct for SERP differentiation.
- **Localized 404** at [src/app/[locale]/not-found.tsx](apps/web/src/app/[locale]/not-found.tsx) with translated title/description + CTAs back to the locale home and games index. Reads locale from the `app-language` cookie since `not-found.tsx` has no params.

## Test plan
- [ ] CI: build + unit + e2e
- [ ] Manual: view-source on `/en`, `/fr`, `/ru` → confirm `og:locale:alternate` tags for the other four locales each.
- [ ] Manual: confirm `<script type="application/ld+json">` on `/en` has WebSite + SoftwareApplication with `inLanguage: "en-US"`; on `/fr` with `inLanguage: "fr-FR"`.
- [ ] Manual: `/en/players/<id>` has `<link rel="alternate" hreflang="fr" href="https://.../fr/players/<id>">` for all five locales.
- [ ] Manual: visit a non-existent URL like `/en/does-not-exist` → renders localized 404 with `robots: noindex`.
- [ ] Manual: `/fr/games/sea_battle_v1` description is in French (from `seo.games.description`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)