### PR TITLE
feat(seo): BreadcrumbList everywhere + CollectionPage + ProfilePage structured data (ARC-707)

### DIFF
--- a/apps/web/src/app/[locale]/auth/layout.tsx
+++ b/apps/web/src/app/[locale]/auth/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 
 export async function generateMetadata({
@@ -11,10 +12,18 @@ export async function generateMetadata({
   return isLocale(locale) ? buildPageMetadata({ locale, page: 'auth' }) : {};
 }
 
-export default function AuthLayout({
+export default async function AuthLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: Promise<{ locale: string }>;
 }) {
-  return <>{children}</>;
+  const { locale } = await params;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="auth" />
+      {children}
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/blog/page.tsx
+++ b/apps/web/src/app/[locale]/blog/page.tsx
@@ -1,7 +1,11 @@
+import type { Metadata } from 'next';
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
-import { isLocale } from '@/shared/i18n';
-import type { Metadata } from 'next';
+import { buildBreadcrumbJsonLd } from '@/shared/seo/breadcrumbJsonLd';
+import { buildCollectionPageJsonLd } from '@/shared/seo/collectionPageJsonLd';
+import { buildRoutes } from '@/shared/config/routes';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { JsonLd } from '@/shared/ui/JsonLd';
 import BlogClient from './BlogClient';
 
 export async function generateMetadata({
@@ -16,13 +20,46 @@ export async function generateMetadata({
 }
 
 /**
- * Blog Page
- * Fetches translations on the server and passes them to BlogClient.
- * Use BlogClient for client-side only rendering to avoid Tamagui hydration issues.
+ * Blog index page. Fetches translations on the server and passes them
+ * to BlogClient. Use BlogClient for client-side rendering to avoid
+ * Tamagui hydration issues.
  */
-export default async function BlogPage() {
-  const messages = await getTranslations();
+export default async function BlogPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+  const messages = await getTranslations(locale);
   const t = messages.pages?.blog;
+  const routes = buildRoutes(locale);
 
-  return <BlogClient t={t} />;
+  const collectionPage = buildCollectionPageJsonLd({
+    locale,
+    pageUrl: routes.blog,
+    name: messages.seo?.blog?.title ?? 'Blog',
+    description: messages.seo?.blog?.description,
+    items: [],
+  });
+  const breadcrumb = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [
+      {
+        name: messages.seo?.blog?.title ?? 'Blog',
+        url: routes.blog,
+      },
+    ],
+  });
+
+  return (
+    <>
+      <JsonLd
+        id={`json-ld-blog-${locale}`}
+        data={[collectionPage, breadcrumb]}
+      />
+      <BlogClient t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/chat/page.tsx
+++ b/apps/web/src/app/[locale]/chat/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import dynamic from 'next/dynamic';
 import { YStack, Typography } from '@arcadeum/ui';
@@ -18,18 +19,26 @@ export async function generateMetadata({
 
 const ChatPage = dynamic(() => import('./ChatPage'));
 
-export default function ChatRoute() {
+export default async function ChatRoute({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   return (
-    <Suspense
-      fallback={
-        <YStack p="$7" ai="center">
-          <Typography uiSize="md" alpha="medium">
-            Loading...
-          </Typography>
-        </YStack>
-      }
-    >
-      <ChatPage />
-    </Suspense>
+    <>
+      <PageBreadcrumb locale={locale} page="chat" />
+      <Suspense
+        fallback={
+          <YStack p="$7" ai="center">
+            <Typography uiSize="md" alpha="medium">
+              Loading...
+            </Typography>
+          </YStack>
+        }
+      >
+        <ChatPage />
+      </Suspense>
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/chats/page.tsx
+++ b/apps/web/src/app/[locale]/chats/page.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import { getServerAccessToken } from '@/entities/session/api/serverTokens';
@@ -25,11 +26,19 @@ export async function generateMetadata({
     : {};
 }
 
-export default function ChatsRoute() {
+export default async function ChatsRoute({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   return (
-    <React.Suspense fallback={<ChatsLoading />}>
-      <ChatDataFetcher />
-    </React.Suspense>
+    <>
+      <PageBreadcrumb locale={locale} page="chats" />
+      <React.Suspense fallback={<ChatsLoading />}>
+        <ChatDataFetcher />
+      </React.Suspense>
+    </>
   );
 }
 

--- a/apps/web/src/app/[locale]/community/page.tsx
+++ b/apps/web/src/app/[locale]/community/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import CommunityClient from './CommunityClient';
@@ -20,9 +21,19 @@ export async function generateMetadata({
  * Fetches translations on the server and passes them to CommunityClient.
  * Use CommunityClient for client-side only rendering to avoid Tamagui hydration issues.
  */
-export default async function CommunityPage() {
+export default async function CommunityPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const t = messages.pages?.community;
 
-  return <CommunityClient t={t} />;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="community" />
+      <CommunityClient t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/contact/page.tsx
+++ b/apps/web/src/app/[locale]/contact/page.tsx
@@ -1,4 +1,5 @@
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import { getTranslations } from '@/shared/i18n/server';
@@ -20,15 +21,23 @@ export async function generateMetadata({
     : {};
 }
 
-export default async function ContactPage() {
+export default async function ContactPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const t = messages.legal?.contact;
 
   return (
-    <ContactView
-      t={t}
-      SUPPORT_EMAIL={SUPPORT_EMAIL}
-      WORKING_HOURS={WORKING_HOURS}
-    />
+    <>
+      <PageBreadcrumb locale={locale} page="contact" />
+      <ContactView
+        t={t}
+        SUPPORT_EMAIL={SUPPORT_EMAIL}
+        WORKING_HOURS={WORKING_HOURS}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/cookies/page.tsx
+++ b/apps/web/src/app/[locale]/cookies/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import CookiePolicyClient from './CookiePolicyClient';
@@ -20,9 +21,19 @@ export async function generateMetadata({
  * Fetches translations on the server and passes them to CookiePolicyClient.
  * Use CookiePolicyClient for client-side only rendering to avoid Tamagui hydration issues.
  */
-export default async function CookiePolicyPage() {
+export default async function CookiePolicyPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const t = messages.pages?.cookies;
 
-  return <CookiePolicyClient t={t} />;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="cookies" />
+      <CookiePolicyClient t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/developers/page.tsx
+++ b/apps/web/src/app/[locale]/developers/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import DevelopersClient from './DevelopersClient';
@@ -20,9 +21,19 @@ export async function generateMetadata({
  * Fetches translations on the server and passes them to DevelopersClient.
  * Use DevelopersClient for client-side only rendering to avoid Tamagui hydration issues.
  */
-export default async function DevelopersPage() {
+export default async function DevelopersPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const t = messages.pages?.developers;
 
-  return <DevelopersClient t={t} />;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="developers" />
+      <DevelopersClient t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/games/page.tsx
+++ b/apps/web/src/app/[locale]/games/page.tsx
@@ -1,11 +1,17 @@
 import { Suspense } from 'react';
-import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
-import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import { getServerAccessToken } from '@/entities/session/api/serverTokens';
 import { gamesApi } from '@/features/games/api';
-import { SSR_TIMEOUT } from '@/shared/config/app-config';
+import { appConfig, SSR_TIMEOUT } from '@/shared/config/app-config';
 import { handleSsrFetchError } from '@/shared/lib/ssr';
+import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { buildBreadcrumbJsonLd } from '@/shared/seo/breadcrumbJsonLd';
+import { buildCollectionPageJsonLd } from '@/shared/seo/collectionPageJsonLd';
+import { buildRoutes } from '@/shared/config/routes';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { getTranslations } from '@/shared/i18n/server';
+import { featuredGames } from '../home/data/games';
+import { JsonLd } from '@/shared/ui/JsonLd';
 import GamesClient from './GamesClient';
 import GamesLoading from './loading';
 
@@ -21,16 +27,72 @@ export async function generateMetadata({
 }
 
 interface PageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export default async function GamesRoute({ searchParams }: PageProps) {
+function resolveLocale(raw: string): Locale {
+  return isLocale(raw) ? raw : DEFAULT_LOCALE;
+}
+
+export default async function GamesRoute({ params, searchParams }: PageProps) {
+  const { locale: rawLocale } = await params;
+  const locale = resolveLocale(rawLocale);
   const resolvedSearchParams = await searchParams;
+  const messages = await getTranslations(locale);
+  const routes = buildRoutes(locale);
+
+  const gamesNamespace = messages.games as
+    | Record<
+        string,
+        { name?: string; description?: string; summary?: string } | undefined
+      >
+    | undefined;
+
+  const collectionItems = featuredGames
+    .filter((g) => g.isPlayable)
+    .map((g) => {
+      const name = gamesNamespace?.[g.id]?.name ?? g.id;
+      const description =
+        gamesNamespace?.[g.id]?.description ??
+        gamesNamespace?.[g.id]?.summary;
+      const url = g.landingHref
+        ? `/${locale}${g.landingHref}`
+        : routes.gameDetail(g.id);
+      return { name, url, description };
+    });
+
+  const collectionPage = buildCollectionPageJsonLd({
+    locale,
+    pageUrl: routes.games,
+    name:
+      messages.seo?.games?.title ??
+      `${messages.navigation?.gamesTab ?? 'Games'} · ${appConfig.appName}`,
+    description: messages.seo?.games?.description,
+    items: collectionItems,
+  });
+
+  const breadcrumb = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [
+      {
+        name: messages.navigation?.gamesTab ?? 'Games',
+        url: routes.games,
+      },
+    ],
+  });
 
   return (
-    <Suspense fallback={<GamesLoading />}>
-      <GamesDataFetcher searchParams={resolvedSearchParams} />
-    </Suspense>
+    <>
+      <JsonLd
+        id={`json-ld-games-${locale}`}
+        data={[collectionPage, breadcrumb]}
+      />
+      <Suspense fallback={<GamesLoading />}>
+        <GamesDataFetcher searchParams={resolvedSearchParams} />
+      </Suspense>
+    </>
   );
 }
 

--- a/apps/web/src/app/[locale]/help/page.tsx
+++ b/apps/web/src/app/[locale]/help/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import HelpClient from './HelpClient';
@@ -20,9 +21,19 @@ export async function generateMetadata({
  * Fetches translations on the server and passes them to HelpClient.
  * Use HelpClient for client-side only rendering to avoid Tamagui hydration issues.
  */
-export default async function HelpPage() {
+export default async function HelpPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const t = messages.pages?.help;
 
-  return <HelpClient t={t} />;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="help" />
+      <HelpClient t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/history/page.tsx
+++ b/apps/web/src/app/[locale]/history/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import { getServerAccessToken } from '@/entities/session/api/serverTokens';
 import { historyApi } from '@/features/history/api';
@@ -22,16 +23,21 @@ export async function generateMetadata({
 }
 
 interface PageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export default async function HistoryRoute({ searchParams }: PageProps) {
+export default async function HistoryRoute({ params, searchParams }: PageProps) {
+  const { locale } = await params;
   const resolvedSearchParams = await searchParams;
 
   return (
-    <Suspense fallback={<HistoryLoading />}>
-      <HistoryDataFetcher searchParams={resolvedSearchParams} />
-    </Suspense>
+    <>
+      <PageBreadcrumb locale={locale} page="history" />
+      <Suspense fallback={<HistoryLoading />}>
+        <HistoryDataFetcher searchParams={resolvedSearchParams} />
+      </Suspense>
+    </>
   );
 }
 

--- a/apps/web/src/app/[locale]/leaderboards/page.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/page.tsx
@@ -1,7 +1,11 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
-import { isLocale } from '@/shared/i18n';
+import { buildBreadcrumbJsonLd } from '@/shared/seo/breadcrumbJsonLd';
+import { buildCollectionPageJsonLd } from '@/shared/seo/collectionPageJsonLd';
+import { buildRoutes } from '@/shared/config/routes';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
 import { getServerAccessToken } from '@/entities/session/api/serverTokens';
+import { JsonLd } from '@/shared/ui/JsonLd';
 import type { Metadata } from 'next';
 import LeaderboardsClient from './LeaderboardsClient';
 
@@ -16,20 +20,54 @@ export async function generateMetadata({
     : {};
 }
 
-export default async function LeaderboardsPage() {
-  const messages = await getTranslations();
+export default async function LeaderboardsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+  const messages = await getTranslations(locale);
   const t = messages.pages?.leaderboards;
   const accessToken = await getServerAccessToken();
   // Mock fallback (NEXT_PUBLIC_E2E / NEXT_PUBLIC_USE_LEADERBOARD_MOCK) keys
   // its synthetic self row off this opaque id; the real BE resolves the user
   // from the access token via JwtOptionalAuthGuard.
   const selfId = accessToken ? accessToken.slice(0, 16) : undefined;
+  const routes = buildRoutes(locale);
+
+  // Leaderboard data is fetched client-side and changes constantly, so
+  // emit an empty ItemList shell — Google still picks up CollectionPage
+  // signal and renders the breadcrumb.
+  const collectionPage = buildCollectionPageJsonLd({
+    locale,
+    pageUrl: routes.leaderboards,
+    name: messages.seo?.leaderboards?.title ?? 'Leaderboards',
+    description: messages.seo?.leaderboards?.description,
+    items: [],
+  });
+  const breadcrumb = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [
+      {
+        name: messages.seo?.leaderboards?.title ?? 'Leaderboards',
+        url: routes.leaderboards,
+      },
+    ],
+  });
 
   return (
-    <LeaderboardsClient
-      t={t}
-      selfId={selfId}
-      accessToken={accessToken ?? undefined}
-    />
+    <>
+      <JsonLd
+        id={`json-ld-leaderboards-${locale}`}
+        data={[collectionPage, breadcrumb]}
+      />
+      <LeaderboardsClient
+        t={t}
+        selfId={selfId}
+        accessToken={accessToken ?? undefined}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/notes/page.tsx
+++ b/apps/web/src/app/[locale]/notes/page.tsx
@@ -1,5 +1,6 @@
 import { paymentApi } from '@/features/payment/api';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import { SSR_TIMEOUT } from '@/shared/config/app-config';
 import type { Metadata } from 'next';
@@ -35,6 +36,16 @@ async function NotesDataFetcher() {
   );
 }
 
-export default function Page() {
-  return <NotesDataFetcher />;
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="notes" />
+      <NotesDataFetcher />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/payment/page.tsx
+++ b/apps/web/src/app/[locale]/payment/page.tsx
@@ -1,5 +1,6 @@
 import PaymentClient from './PaymentClient';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 
@@ -14,6 +15,16 @@ export async function generateMetadata({
     : {};
 }
 
-export default function PaymentRoute() {
-  return <PaymentClient />;
+export default async function PaymentRoute({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="payment" />
+      <PaymentClient />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/players/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/players/[id]/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from 'next';
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { buildBreadcrumbJsonLd } from '@/shared/seo/breadcrumbJsonLd';
+import { buildProfilePageJsonLd } from '@/shared/seo/profilePageJsonLd';
+import { buildRoutes } from '@/shared/config/routes';
 import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { JsonLd } from '@/shared/ui/JsonLd';
 import PlayerProfileClient from './PlayerProfileClient';
 
 interface PageProps {
@@ -26,5 +30,40 @@ export default async function PlayerProfilePage({ params }: PageProps) {
   const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
   const messages = await getTranslations(locale);
   const t = messages.pages?.leaderboards;
-  return <PlayerProfileClient id={id} t={t} />;
+  const routes = buildRoutes(locale);
+
+  // Player display name is fetched client-side; emit a generic Person
+  // placeholder so the ProfilePage signal is still present in initial
+  // HTML for crawlers. The client may hydrate richer data after mount.
+  const profileLabel = messages.seo?.playerProfile?.title ?? 'Player profile';
+  const profile = buildProfilePageJsonLd({
+    locale,
+    playerId: id,
+    displayName: profileLabel,
+    description: messages.seo?.playerProfile?.description,
+  });
+  const breadcrumb = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [
+      {
+        name: messages.seo?.leaderboards?.title ?? 'Leaderboards',
+        url: routes.leaderboards,
+      },
+      {
+        name: profileLabel,
+        url: `${routes.home}/players/${encodeURIComponent(id)}`,
+      },
+    ],
+  });
+
+  return (
+    <>
+      <JsonLd
+        id={`json-ld-player-${id}-${locale}`}
+        data={[profile, breadcrumb]}
+      />
+      <PlayerProfileClient id={id} t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/privacy/page.tsx
+++ b/apps/web/src/app/[locale]/privacy/page.tsx
@@ -1,4 +1,5 @@
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import { getTranslations } from '@/shared/i18n/server';
@@ -18,14 +19,22 @@ export async function generateMetadata({
     : {};
 }
 
-export default async function PrivacyPage() {
+export default async function PrivacyPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
 
   return (
-    <PrivacyClient
-      t={messages.legal?.privacy}
-      contactT={messages.legal?.contact}
-      PRIVACY_EMAIL={PRIVACY_EMAIL}
-    />
+    <>
+      <PageBreadcrumb locale={locale} page="privacy" />
+      <PrivacyClient
+        t={messages.legal?.privacy}
+        contactT={messages.legal?.contact}
+        PRIVACY_EMAIL={PRIVACY_EMAIL}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/referrals/page.tsx
+++ b/apps/web/src/app/[locale]/referrals/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import ReferralsClient from './ReferralsClient';
 
@@ -14,6 +15,16 @@ export async function generateMetadata({
     : {};
 }
 
-export default function ReferralsPage() {
-  return <ReferralsClient />;
+export default async function ReferralsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="referrals" />
+      <ReferralsClient />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/rewards/page.tsx
+++ b/apps/web/src/app/[locale]/rewards/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import RewardsClient from './RewardsClient';
@@ -20,9 +21,19 @@ export async function generateMetadata({
  * Fetches translations on the server and passes them to RewardsClient.
  * Use RewardsClient for client-side only rendering to avoid Tamagui hydration issues.
  */
-export default async function RewardsPage() {
+export default async function RewardsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const t = messages.pages?.rewards;
 
-  return <RewardsClient t={t} />;
+  return (
+    <>
+      <PageBreadcrumb locale={locale} page="rewards" />
+      <RewardsClient t={t} />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/settings/page.tsx
+++ b/apps/web/src/app/[locale]/settings/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { appConfig } from '@/shared/config/app-config';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { getTranslations } from '@/shared/i18n/server';
 import { DEFAULT_LOCALE, isLocale } from '@/shared/i18n';
 import SettingsClient from './SettingsClient';
@@ -29,11 +30,14 @@ export default async function SettingsRoute({
     `Manage your appearance, language, and download preferences for the ${appConfig.appName} web experience.`;
 
   return (
-    <SettingsClient
-      appName={appConfig.appName}
-      downloads={appConfig.downloads}
-      supportCta={appConfig.supportCta}
-      description={description}
-    />
+    <>
+      <PageBreadcrumb locale={locale} page="settings" />
+      <SettingsClient
+        appName={appConfig.appName}
+        downloads={appConfig.downloads}
+        supportCta={appConfig.supportCta}
+        description={description}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/shop/page.tsx
+++ b/apps/web/src/app/[locale]/shop/page.tsx
@@ -7,7 +7,11 @@ import { getCatalog, getInventory } from '@/features/shop/server/shop.server';
 import { ShopPageView } from '@/features/shop/ui/ShopPageView';
 import { shopEn } from '@/shared/i18n/messages/pages/shop/en';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
-import { isLocale } from '@/shared/i18n';
+import { buildBreadcrumbJsonLd } from '@/shared/seo/breadcrumbJsonLd';
+import { buildCollectionPageJsonLd } from '@/shared/seo/collectionPageJsonLd';
+import { buildRoutes } from '@/shared/config/routes';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { JsonLd } from '@/shared/ui/JsonLd';
 import {
   EMPTY_INVENTORY,
   type InventoryView,
@@ -25,7 +29,13 @@ export async function generateMetadata({
 
 const EMPTY_BALANCE: WalletBalanceView = { coins: 0, gems: 0 };
 
-export default async function ShopPage() {
+export default async function ShopPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
   const accessToken = await getServerAccessToken();
 
   const catalog = await getCatalog().catch(() => []);
@@ -47,17 +57,46 @@ export default async function ShopPage() {
     // fall back to the default rate
   }
 
-  const messages = await getTranslations();
+  const messages = await getTranslations(locale);
   const labels = (messages.pages?.shop ?? shopEn) as typeof shopEn;
+  const routes = buildRoutes(locale);
+
+  // Shop items use translation keys (`nameKey`) for their display
+  // names — emitting a CollectionPage shell (no per-item enumeration)
+  // keeps the schema valid without requiring extra translation lookups
+  // for every catalog entry.
+  const collectionPage = buildCollectionPageJsonLd({
+    locale,
+    pageUrl: routes.shop,
+    name: messages.seo?.shop?.title ?? 'Shop',
+    description: messages.seo?.shop?.description,
+    items: [],
+  });
+  const breadcrumb = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [
+      {
+        name: messages.navigation?.shopTab ?? 'Shop',
+        url: routes.shop,
+      },
+    ],
+  });
 
   return (
-    <ShopPageView
-      catalog={catalog}
-      inventory={inventory}
-      balance={balance}
-      gemToCoinRate={gemToCoinRate}
-      isAuthenticated={Boolean(accessToken)}
-      labels={labels}
-    />
+    <>
+      <JsonLd
+        id={`json-ld-shop-${locale}`}
+        data={[collectionPage, breadcrumb]}
+      />
+      <ShopPageView
+        catalog={catalog}
+        inventory={inventory}
+        balance={balance}
+        gemToCoinRate={gemToCoinRate}
+        isAuthenticated={Boolean(accessToken)}
+        labels={labels}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/stats/page.tsx
+++ b/apps/web/src/app/[locale]/stats/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import { getServerAccessToken } from '@/entities/session/api/serverTokens';
@@ -24,16 +25,21 @@ export async function generateMetadata({
 }
 
 interface PageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export default async function Statistics({ searchParams }: PageProps) {
+export default async function Statistics({ params, searchParams }: PageProps) {
+  const { locale } = await params;
   const resolvedSearchParams = await searchParams;
 
   return (
-    <Suspense fallback={<StatsLoading />}>
-      <StatsDataFetcher searchParams={resolvedSearchParams} />
-    </Suspense>
+    <>
+      <PageBreadcrumb locale={locale} page="stats" />
+      <Suspense fallback={<StatsLoading />}>
+        <StatsDataFetcher searchParams={resolvedSearchParams} />
+      </Suspense>
+    </>
   );
 }
 

--- a/apps/web/src/app/[locale]/support/page.tsx
+++ b/apps/web/src/app/[locale]/support/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from '@/shared/i18n/server';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import SupportClient from './client';
@@ -84,17 +85,25 @@ function buildActions(): SupportAction[] {
   return actions;
 }
 
-export default async function SupportRoute() {
+export default async function SupportRoute({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
   const supportT = messages.support;
   const actions = buildActions();
 
   return (
-    <SupportClient
-      appName={appConfig.appName}
-      supportT={supportT}
-      teamMembers={TEAM_MEMBERS}
-      actions={actions}
-    />
+    <>
+      <PageBreadcrumb locale={locale} page="support" />
+      <SupportClient
+        appName={appConfig.appName}
+        supportT={supportT}
+        teamMembers={TEAM_MEMBERS}
+        actions={actions}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/terms/page.tsx
+++ b/apps/web/src/app/[locale]/terms/page.tsx
@@ -1,4 +1,5 @@
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 import type { Metadata } from 'next';
 import { getTranslations } from '@/shared/i18n/server';
@@ -25,17 +26,25 @@ export async function generateMetadata({
     : {};
 }
 
-export default async function TermsPage() {
+export default async function TermsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const messages = await getTranslations();
 
   return (
-    <TermsClient
-      t={messages.legal?.terms}
-      contactT={messages.legal?.contact}
-      LEGAL_NAME={LEGAL_NAME}
-      ID_CODE={ID_CODE}
-      SUPPORT_EMAIL={SUPPORT_EMAIL}
-      WORKING_HOURS={WORKING_HOURS}
-    />
+    <>
+      <PageBreadcrumb locale={locale} page="terms" />
+      <TermsClient
+        t={messages.legal?.terms}
+        contactT={messages.legal?.contact}
+        LEGAL_NAME={LEGAL_NAME}
+        ID_CODE={ID_CODE}
+        SUPPORT_EMAIL={SUPPORT_EMAIL}
+        WORKING_HOURS={WORKING_HOURS}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/[locale]/tournaments/page.tsx
+++ b/apps/web/src/app/[locale]/tournaments/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from 'next';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
-import { isLocale } from '@/shared/i18n';
+import { buildBreadcrumbJsonLd } from '@/shared/seo/breadcrumbJsonLd';
+import { buildCollectionPageJsonLd } from '@/shared/seo/collectionPageJsonLd';
+import { buildRoutes } from '@/shared/config/routes';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { getTranslations } from '@/shared/i18n/server';
+import { JsonLd } from '@/shared/ui/JsonLd';
 import TournamentsClient from './TournamentsClient';
 
 export async function generateMetadata({
@@ -18,6 +23,41 @@ export async function generateMetadata({
  * Tournaments Page (public). Translations are read on the client via
  * useLanguage to support the locale + nested list shape.
  */
-export default function TournamentsPage() {
-  return <TournamentsClient />;
+export default async function TournamentsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: rawLocale } = await params;
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+  const messages = await getTranslations(locale);
+  const routes = buildRoutes(locale);
+
+  const collectionPage = buildCollectionPageJsonLd({
+    locale,
+    pageUrl: routes.tournaments,
+    name: messages.seo?.tournaments?.title ?? 'Tournaments',
+    description: messages.seo?.tournaments?.description,
+    items: [],
+  });
+  const breadcrumb = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [
+      {
+        name: messages.seo?.tournaments?.title ?? 'Tournaments',
+        url: routes.tournaments,
+      },
+    ],
+  });
+
+  return (
+    <>
+      <JsonLd
+        id={`json-ld-tournaments-${locale}`}
+        data={[collectionPage, breadcrumb]}
+      />
+      <TournamentsClient />
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/wallet/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/page.tsx
@@ -17,6 +17,7 @@ import { ConvertGemsForm } from '@/features/gems/ui/ConvertGemsForm';
 import { getConversionRate } from '@/features/gems/server/gems.server';
 import { DailyRewardCard } from '@/features/daily-rewards/ui/DailyRewardCard';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
 import { isLocale } from '@/shared/i18n';
 
 // <WalletLiveBridge /> is mounted once in apps/web/src/app/layout.tsx — no
@@ -46,10 +47,13 @@ const EMPTY_BALANCE: WalletBalance = { coins: 0, gems: 0 };
 const EMPTY_PAGE: PaginatedWalletTransactions = { items: [], nextCursor: null };
 
 export default async function WalletPage({
+  params,
   searchParams,
 }: {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<SearchParams>;
 }) {
+  const { locale } = await params;
   const sp = await searchParams;
   const currency = parseCurrency(sp.currency);
   const cursor = sp.cursor;
@@ -71,6 +75,7 @@ export default async function WalletPage({
   if (!accessToken) {
     return (
       <div>
+        <PageBreadcrumb locale={locale} page="wallet" />
         <WalletPageView
           balance={EMPTY_BALANCE}
           page={EMPTY_PAGE}
@@ -113,6 +118,7 @@ export default async function WalletPage({
 
   return (
     <div>
+      <PageBreadcrumb locale={locale} page="wallet" />
       {/* Daily reward CTA. Rendered above the wallet view so the claim flow is
           the first thing a returning player sees. The card self-suppresses
           (returns null) when the BE call fails — same defensive pattern as

--- a/apps/web/src/shared/seo/PageBreadcrumb.tsx
+++ b/apps/web/src/shared/seo/PageBreadcrumb.tsx
@@ -1,0 +1,63 @@
+import { JsonLd } from '@/shared/ui/JsonLd';
+import { buildBreadcrumbJsonLd } from './breadcrumbJsonLd';
+import { buildRoutes, type Routes } from '@/shared/config/routes';
+import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
+import { getTranslations } from '@/shared/i18n/server';
+import type { SeoPageKey } from './buildPageMetadata';
+
+interface PageBreadcrumbProps {
+  /** Active locale from `params.locale`. */
+  locale: string;
+  /**
+   * Page identifier — used to look up the localized breadcrumb label
+   * (from `seo[page].title`) and the canonical URL via `buildRoutes`.
+   */
+  page: SeoPageKey;
+  /**
+   * Optional override for the page's URL (for dynamic routes that don't
+   * map 1:1 onto a `Routes` field).
+   */
+  pathFor?: (routes: Routes) => string;
+  /**
+   * Optional override for the visible label. Defaults to
+   * `seo[page].title`. Useful when the SEO title is longer than the
+   * desired breadcrumb crumb.
+   */
+  label?: string;
+}
+
+/**
+ * Drop-in `<PageBreadcrumb locale={locale} page="settings" />` for any
+ * `[locale]/<page>/page.tsx`. Emits a schema.org BreadcrumbList with
+ * the localized home label as position 1 and the page label as
+ * position 2. Server component — no hydration cost.
+ */
+export async function PageBreadcrumb({
+  locale: rawLocale,
+  page,
+  pathFor,
+  label,
+}: PageBreadcrumbProps) {
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+  const messages = await getTranslations(locale);
+  const routes = buildRoutes(locale);
+
+  const url = pathFor
+    ? pathFor(routes)
+    : (routes[page as keyof Routes] as string | undefined);
+
+  if (!url) return null;
+
+  const name =
+    label ??
+    messages.seo?.[page]?.title ??
+    page.charAt(0).toUpperCase() + page.slice(1);
+
+  const data = buildBreadcrumbJsonLd({
+    locale,
+    homeLabel: messages.navigation?.homeTab ?? 'Home',
+    trail: [{ name, url }],
+  });
+
+  return <JsonLd id={`json-ld-breadcrumb-${page}-${locale}`} data={data} />;
+}

--- a/apps/web/src/shared/seo/breadcrumbJsonLd.ts
+++ b/apps/web/src/shared/seo/breadcrumbJsonLd.ts
@@ -1,0 +1,46 @@
+import { appConfig } from '@/shared/config/app-config';
+import { buildRoutes } from '@/shared/config/routes';
+import type { Locale } from '@/shared/i18n';
+
+export interface BreadcrumbItem {
+  /** Display label (already localized by the caller). */
+  name: string;
+  /** Absolute or root-relative URL of the breadcrumb step. */
+  url: string;
+}
+
+/**
+ * Build a schema.org BreadcrumbList. Caller passes already-localized
+ * labels + per-locale URLs; the helper adds the Home item at position
+ * 1 automatically so every breadcrumb starts at the locale root.
+ */
+export function buildBreadcrumbJsonLd({
+  locale,
+  homeLabel,
+  trail,
+}: {
+  locale: Locale;
+  homeLabel: string;
+  /** Steps AFTER home, in order. */
+  trail: BreadcrumbItem[];
+}): Record<string, unknown> {
+  const routes = buildRoutes(locale);
+  const home: BreadcrumbItem = {
+    name: homeLabel,
+    url: `${appConfig.siteUrl}${routes.home}`,
+  };
+  const all = [home, ...trail];
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: all.map((step, idx) => ({
+      '@type': 'ListItem',
+      position: idx + 1,
+      name: step.name,
+      item: step.url.startsWith('http')
+        ? step.url
+        : `${appConfig.siteUrl}${step.url}`,
+    })),
+  };
+}

--- a/apps/web/src/shared/seo/collectionPageJsonLd.ts
+++ b/apps/web/src/shared/seo/collectionPageJsonLd.ts
@@ -1,0 +1,84 @@
+import { appConfig } from '@/shared/config/app-config';
+import { buildRoutes } from '@/shared/config/routes';
+import type { Locale } from '@/shared/i18n';
+
+const SCHEMA_LANGUAGE_MAP: Record<Locale, string> = {
+  en: 'en-US',
+  es: 'es-ES',
+  fr: 'fr-FR',
+  ru: 'ru-RU',
+  by: 'be-BY',
+};
+
+interface CollectionItem {
+  /** Display name shown in the rich-result snippet. */
+  name: string;
+  /** Locale-prefixed URL (e.g. `routes.gameDetail('critical_v1')`). */
+  url: string;
+  /** Optional thumbnail/preview image (absolute URL). */
+  image?: string;
+  /** Optional short description. */
+  description?: string;
+}
+
+/**
+ * Build a schema.org CollectionPage with an inline ItemList for
+ * catalog-style pages (games index, leaderboards, shop, blog,
+ * tournaments). Signals to Google that the page is a curated list
+ * rather than article-like content.
+ */
+export function buildCollectionPageJsonLd({
+  locale,
+  pageUrl,
+  name,
+  description,
+  items,
+}: {
+  locale: Locale;
+  /** Absolute or path-relative URL of the page itself. */
+  pageUrl: string;
+  /** Localized page title (used as CollectionPage.name). */
+  name: string;
+  /** Localized page description. */
+  description?: string;
+  items: CollectionItem[];
+}): Record<string, unknown> {
+  const fullPageUrl = pageUrl.startsWith('http')
+    ? pageUrl
+    : `${appConfig.siteUrl}${pageUrl}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name,
+    description,
+    url: fullPageUrl,
+    inLanguage: SCHEMA_LANGUAGE_MAP[locale],
+    isPartOf: {
+      '@type': 'WebSite',
+      name: appConfig.appName,
+      url: `${appConfig.siteUrl}${buildRoutes(locale).home}`,
+    },
+    mainEntity: {
+      '@type': 'ItemList',
+      numberOfItems: items.length,
+      itemListElement: items.map((item, idx) => {
+        const itemUrl = item.url.startsWith('http')
+          ? item.url
+          : `${appConfig.siteUrl}${item.url}`;
+        return {
+          '@type': 'ListItem',
+          position: idx + 1,
+          url: itemUrl,
+          item: {
+            '@type': 'Thing',
+            name: item.name,
+            url: itemUrl,
+            ...(item.description ? { description: item.description } : {}),
+            ...(item.image ? { image: item.image } : {}),
+          },
+        };
+      }),
+    },
+  };
+}

--- a/apps/web/src/shared/seo/profilePageJsonLd.ts
+++ b/apps/web/src/shared/seo/profilePageJsonLd.ts
@@ -1,0 +1,53 @@
+import { appConfig } from '@/shared/config/app-config';
+import { buildRoutes } from '@/shared/config/routes';
+import type { Locale } from '@/shared/i18n';
+
+const SCHEMA_LANGUAGE_MAP: Record<Locale, string> = {
+  en: 'en-US',
+  es: 'es-ES',
+  fr: 'fr-FR',
+  ru: 'ru-RU',
+  by: 'be-BY',
+};
+
+/**
+ * Build schema.org ProfilePage + Person structured data for a player
+ * profile. Google uses ProfilePage to recognize social-style pages and
+ * surface them with author-attributed snippets.
+ */
+export function buildProfilePageJsonLd({
+  locale,
+  playerId,
+  displayName,
+  avatarUrl,
+  description,
+}: {
+  locale: Locale;
+  playerId: string;
+  /** Visible username / display name. */
+  displayName: string;
+  /** Absolute URL of the player's avatar, if any. */
+  avatarUrl?: string;
+  /** Short biography or tagline. */
+  description?: string;
+}): Record<string, unknown> {
+  const routes = buildRoutes(locale);
+  const pageUrl = `${appConfig.siteUrl}${routes.home}/players/${encodeURIComponent(
+    playerId,
+  )}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    url: pageUrl,
+    inLanguage: SCHEMA_LANGUAGE_MAP[locale],
+    mainEntity: {
+      '@type': 'Person',
+      name: displayName,
+      identifier: playerId,
+      url: pageUrl,
+      ...(avatarUrl ? { image: avatarUrl } : {}),
+      ...(description ? { description } : {}),
+    },
+  };
+}


### PR DESCRIPTION
> Stacked on **#694 (ARC-706)**. Retarget to \`develop\` once #694 merges.

Adds structured data signals to every page that didn't already have its own (sea-battle has its bespoke VideoGame + FAQPage; ARC-705 covered the locale-layout WebSite + SoftwareApplication).

## Helpers
- [\`buildBreadcrumbJsonLd\`](apps/web/src/shared/seo/breadcrumbJsonLd.ts) — schema.org BreadcrumbList with home auto-prepended.
- [\`buildCollectionPageJsonLd\`](apps/web/src/shared/seo/collectionPageJsonLd.ts) — schema.org CollectionPage with inline ItemList. Carries \`inLanguage\` + \`isPartOf\` so the catalog ties back to the locale-specific WebSite.
- [\`buildProfilePageJsonLd\`](apps/web/src/shared/seo/profilePageJsonLd.ts) — schema.org ProfilePage with Person \`mainEntity\` for player profile pages.
- [\`<PageBreadcrumb locale page>\`](apps/web/src/shared/seo/PageBreadcrumb.tsx) — drop-in server component that turns a page key into a localized BreadcrumbList. One line per page.

## Coverage
**BreadcrumbList added to ~18 pages**: settings, history, stats, referrals, support, payment, notes, terms, privacy, contact, cookies, help, community, rewards, wallet, developers, chat, chats, auth (via layout).

**CollectionPage added** to /games (with item list of featured games), /leaderboards, /tournaments, /shop, /blog (shells where rows are client-fetched).

**ProfilePage** added to /players/[id] with Leaderboards → Player profile breadcrumb.

## Skipped
- FAQPage on /help and /support — no Q&A content in those translation namespaces. Sea-battle landing already has its FAQPage from earlier.
- HowTo schema on game rule modals — modals aren't standalone pages; not a good fit.
- Article schema on /blog — no dynamic blog posts yet; just a static landing.

## Test plan
- [ ] CI: build + unit + e2e
- [ ] Manual: view-source on \`/en/settings\`, \`/fr/parametres\`, \`/ru/nastroyki\` → \`BreadcrumbList\` JSON-LD with localized labels.
- [ ] Manual: \`/en/games\` → \`CollectionPage\` with at least 3 \`itemListElement\` entries (one per playable featured game).
- [ ] Manual: \`/en/players/<some-id>\` → \`ProfilePage\` + \`Person\` JSON-LD with Leaderboards in breadcrumb trail.
- [ ] Manual: validate any of the above via Google's Rich Results Test (https://search.google.com/test/rich-results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)