### PR TITLE
feat(ui): PlayerAvatar — equipped cosmetics across the app (ARC-730)

### DIFF
--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -481,6 +481,9 @@ export class AuthService {
       equippedAvatarId: user.equippedAvatarId ?? null,
       equippedBadgeId: user.equippedBadgeId ?? null,
       equippedNameColorId: user.equippedNameColorId ?? null,
+      equippedFrameId: user.equippedFrameId ?? null,
+      equippedAuraId: user.equippedAuraId ?? null,
+      equippedBannerId: user.equippedBannerId ?? null,
     };
 
     const createdAt = (user as Partial<{ createdAt: Date }>).createdAt;

--- a/apps/be/src/auth/lib/types.ts
+++ b/apps/be/src/auth/lib/types.ts
@@ -53,6 +53,12 @@ export interface AuthUserProfile {
   equippedBadgeId?: string | null;
   /** Currently-equipped name-color item id, or null. */
   equippedNameColorId?: string | null;
+  /** Currently-equipped frame item id, or null. */
+  equippedFrameId?: string | null;
+  /** Currently-equipped aura item id, or null. */
+  equippedAuraId?: string | null;
+  /** Currently-equipped banner item id, or null. */
+  equippedBannerId?: string | null;
 }
 
 /**

--- a/apps/be/src/chat/chat-helper.service.ts
+++ b/apps/be/src/chat/chat-helper.service.ts
@@ -110,6 +110,9 @@ export class ChatHelperService {
         equippedAvatarId: string | null;
         equippedBadgeId: string | null;
         equippedNameColorId: string | null;
+        equippedFrameId: string | null;
+        equippedAuraId: string | null;
+        equippedBannerId: string | null;
       }
     >();
 
@@ -128,6 +131,9 @@ export class ChatHelperService {
               'equippedAvatarId',
               'equippedBadgeId',
               'equippedNameColorId',
+              'equippedFrameId',
+              'equippedAuraId',
+              'equippedBannerId',
             ])
             .exec()) as UserDocument[])
         : [];
@@ -149,6 +155,9 @@ export class ChatHelperService {
           equippedAvatarId: user.equippedAvatarId ?? null,
           equippedBadgeId: user.equippedBadgeId ?? null,
           equippedNameColorId: user.equippedNameColorId ?? null,
+          equippedFrameId: user.equippedFrameId ?? null,
+          equippedAuraId: user.equippedAuraId ?? null,
+          equippedBannerId: user.equippedBannerId ?? null,
         });
       }
     }
@@ -175,6 +184,9 @@ export class ChatHelperService {
         senderEquippedAvatarId: equipped?.equippedAvatarId ?? null,
         senderEquippedBadgeId: equipped?.equippedBadgeId ?? null,
         senderEquippedNameColorId: equipped?.equippedNameColorId ?? null,
+        senderEquippedFrameId: equipped?.equippedFrameId ?? null,
+        senderEquippedAuraId: equipped?.equippedAuraId ?? null,
+        senderEquippedBannerId: equipped?.equippedBannerId ?? null,
         receiverIds: Array.isArray(message.receiverIds)
           ? message.receiverIds.map((id): string =>
               typeof id === 'string'

--- a/apps/be/src/chat/chat.service.ts
+++ b/apps/be/src/chat/chat.service.ts
@@ -19,6 +19,12 @@ export interface MessageView {
   senderEquippedBadgeId?: string | null;
   /** Sender's currently-equipped name-color item id (resolved client-side). */
   senderEquippedNameColorId?: string | null;
+  /** Sender's currently-equipped frame item id (resolved client-side). */
+  senderEquippedFrameId?: string | null;
+  /** Sender's currently-equipped aura item id (resolved client-side). */
+  senderEquippedAuraId?: string | null;
+  /** Sender's currently-equipped banner item id (resolved client-side). */
+  senderEquippedBannerId?: string | null;
   receiverIds: string[];
   content: string;
   timestamp: string;

--- a/apps/be/src/games/history/game-history-stats.service.ts
+++ b/apps/be/src/games/history/game-history-stats.service.ts
@@ -166,7 +166,7 @@ export class GameHistoryStatsService {
         ? await this.userModel
             .find({ _id: { $in: userIds } })
             .select(
-              'username equippedAvatarId equippedBadgeId equippedNameColorId',
+              'username equippedAvatarId equippedBadgeId equippedNameColorId equippedFrameId equippedAuraId equippedBannerId',
             )
             .exec()
         : [];
@@ -182,6 +182,9 @@ export class GameHistoryStatsService {
           equippedAvatarId: u.equippedAvatarId ?? null,
           equippedBadgeId: u.equippedBadgeId ?? null,
           equippedNameColorId: u.equippedNameColorId ?? null,
+          equippedFrameId: u.equippedFrameId ?? null,
+          equippedAuraId: u.equippedAuraId ?? null,
+          equippedBannerId: u.equippedBannerId ?? null,
         },
       ]),
     );
@@ -200,6 +203,9 @@ export class GameHistoryStatsService {
         equippedAvatarId: userInfo?.equippedAvatarId ?? null,
         equippedBadgeId: userInfo?.equippedBadgeId ?? null,
         equippedNameColorId: userInfo?.equippedNameColorId ?? null,
+        equippedFrameId: userInfo?.equippedFrameId ?? null,
+        equippedAuraId: userInfo?.equippedAuraId ?? null,
+        equippedBannerId: userInfo?.equippedBannerId ?? null,
       };
     });
 

--- a/apps/be/src/games/history/game-history.types.ts
+++ b/apps/be/src/games/history/game-history.types.ts
@@ -73,4 +73,7 @@ export interface LeaderboardEntry {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }

--- a/apps/be/src/games/rooms/game-rooms.mapper.ts
+++ b/apps/be/src/games/rooms/game-rooms.mapper.ts
@@ -126,7 +126,7 @@ export class GameRoomsMapper {
     const users = await this.userModel
       .find({ _id: { $in: validUserIds } })
       .select(
-        'username email equippedAvatarId equippedBadgeId equippedNameColorId',
+        'username email equippedAvatarId equippedBadgeId equippedNameColorId equippedFrameId equippedAuraId equippedBannerId',
       )
       .exec();
 
@@ -160,6 +160,9 @@ export class GameRoomsMapper {
       equippedAvatarId: user?.equippedAvatarId ?? null,
       equippedBadgeId: user?.equippedBadgeId ?? null,
       equippedNameColorId: user?.equippedNameColorId ?? null,
+      equippedFrameId: user?.equippedFrameId ?? null,
+      equippedAuraId: user?.equippedAuraId ?? null,
+      equippedBannerId: user?.equippedBannerId ?? null,
     };
   }
 

--- a/apps/be/src/games/rooms/game-rooms.types.ts
+++ b/apps/be/src/games/rooms/game-rooms.types.ts
@@ -9,6 +9,9 @@ export interface GameRoomMemberSummary {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 export interface GameRoomSummary {

--- a/apps/be/src/leaderboards/dtos/leaderboard-snapshot.dto.ts
+++ b/apps/be/src/leaderboards/dtos/leaderboard-snapshot.dto.ts
@@ -32,6 +32,9 @@ export type LeaderboardPlayerDto = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 export type MythicPlayerDto = LeaderboardPlayerDto & {
@@ -99,6 +102,9 @@ export type PlayerProfileDto = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 export type LeaderboardSnapshotDto = {

--- a/apps/be/src/leaderboards/leaderboards.hydrate.ts
+++ b/apps/be/src/leaderboards/leaderboards.hydrate.ts
@@ -50,6 +50,9 @@ export type RealLeaderboardEntry = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 function hashSeed(input: string): number {
@@ -143,6 +146,9 @@ export function hydratePlayer(
     equippedAvatarId: real.equippedAvatarId ?? null,
     equippedBadgeId: real.equippedBadgeId ?? null,
     equippedNameColorId: real.equippedNameColorId ?? null,
+    equippedFrameId: real.equippedFrameId ?? null,
+    equippedAuraId: real.equippedAuraId ?? null,
+    equippedBannerId: real.equippedBannerId ?? null,
   };
 }
 

--- a/apps/be/src/leaderboards/leaderboards.service.ts
+++ b/apps/be/src/leaderboards/leaderboards.service.ts
@@ -225,22 +225,34 @@ export class LeaderboardsService {
     let equippedAvatarId: string | null = null;
     let equippedBadgeId: string | null = null;
     let equippedNameColorId: string | null = null;
+    let equippedFrameId: string | null = null;
+    let equippedAuraId: string | null = null;
+    let equippedBannerId: string | null = null;
     if (Types.ObjectId.isValid(userId)) {
       const userDoc = await this.userModel
         .findById(userId, {
           equippedAvatarId: 1,
           equippedBadgeId: 1,
           equippedNameColorId: 1,
+          equippedFrameId: 1,
+          equippedAuraId: 1,
+          equippedBannerId: 1,
         })
         .lean<{
           equippedAvatarId?: string | null;
           equippedBadgeId?: string | null;
           equippedNameColorId?: string | null;
+          equippedFrameId?: string | null;
+          equippedAuraId?: string | null;
+          equippedBannerId?: string | null;
         } | null>();
       if (userDoc) {
         equippedAvatarId = userDoc.equippedAvatarId ?? null;
         equippedBadgeId = userDoc.equippedBadgeId ?? null;
         equippedNameColorId = userDoc.equippedNameColorId ?? null;
+        equippedFrameId = userDoc.equippedFrameId ?? null;
+        equippedAuraId = userDoc.equippedAuraId ?? null;
+        equippedBannerId = userDoc.equippedBannerId ?? null;
       }
     }
 
@@ -251,6 +263,9 @@ export class LeaderboardsService {
       equippedAvatarId,
       equippedBadgeId,
       equippedNameColorId,
+      equippedFrameId,
+      equippedAuraId,
+      equippedBannerId,
     };
   }
 

--- a/apps/web/src/app/[locale]/chat/ChatPage.tsx
+++ b/apps/web/src/app/[locale]/chat/ChatPage.tsx
@@ -24,6 +24,7 @@ import { useChatStore } from '@/features/chat/store/chatStore';
 import { useChatSocket } from '@/features/chat/hooks/useChatSocket';
 import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { formatSafeTime } from '@/shared/lib/date';
 import { ScrollView } from 'tamagui';
 
@@ -230,10 +231,15 @@ function ChatMessageRow({
   isOwn: boolean;
   isEncrypted: boolean;
 }) {
-  const { avatarUrl, badgeUrl, nameColor } = useEquippedCosmetics({
+  // The hook resolves name-color (used in the sender label outside the
+  // avatar slot). Avatar/badge/frame/aura come back through PlayerAvatar.
+  const { nameColor } = useEquippedCosmetics({
     equippedAvatarId: msg.senderEquippedAvatarId,
     equippedBadgeId: msg.senderEquippedBadgeId,
     equippedNameColorId: msg.senderEquippedNameColorId,
+    equippedFrameId: msg.senderEquippedFrameId,
+    equippedAuraId: msg.senderEquippedAuraId,
+    equippedBannerId: msg.senderEquippedBannerId,
   });
   const nameProps = nameColorRenderProps(nameColor);
   return (
@@ -242,8 +248,18 @@ function ChatMessageRow({
       senderName={msg.senderUsername}
       senderColor={nameProps.color}
       senderNameStyle={nameProps.style}
-      avatarUrl={avatarUrl ?? undefined}
-      badgeUrl={badgeUrl ?? undefined}
+      senderAvatar={
+        <EquippedPlayerAvatar
+          name={msg.senderUsername}
+          size="sm"
+          equippedAvatarId={msg.senderEquippedAvatarId}
+          equippedBadgeId={msg.senderEquippedBadgeId}
+          equippedNameColorId={msg.senderEquippedNameColorId}
+          equippedFrameId={msg.senderEquippedFrameId}
+          equippedAuraId={msg.senderEquippedAuraId}
+          equippedBannerId={msg.senderEquippedBannerId}
+        />
+      }
       timestamp={formatSafeTime(msg.timestamp)}
       isOwn={isOwn}
       isEncrypted={isEncrypted}

--- a/apps/web/src/app/[locale]/chats/ChatListPage.tsx
+++ b/apps/web/src/app/[locale]/chats/ChatListPage.tsx
@@ -21,6 +21,7 @@ import {
   Spinner,
   EmptyState,
 } from '@/shared/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { chatApi, ChatParticipant, ChatSummary } from '@/features/chat/api';
 import { formatSafeDate } from '@/shared/lib/date';
 import { DEBOUNCE } from '@/shared/config/constants';
@@ -151,10 +152,11 @@ export default function ChatListPage({ initialData }: ChatListPageProps) {
                     isLast={index === displaySearchResults.length - 1}
                     onClick={() => handleSelectUser(result)}
                   >
-                    <Avatar
+                    <EquippedPlayerAvatar
                       name={result.displayName || result.username}
-                      size="sm"
-                      alt=""
+                      size="icon"
+                      equippedAvatarId={null}
+                      equippedBadgeId={null}
                     />
                     <YStack>
                       <Text fontWeight="600">

--- a/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
@@ -26,7 +26,8 @@ import {
   MetaValue,
   MetaListContainer,
 } from './room-card.styles';
-import { LinkButton, Avatar } from '@arcadeum/ui';
+import { LinkButton } from '@arcadeum/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { XStack, YStack } from 'tamagui';
 
 import { useRoutes } from '@/shared/config/useRoutes';
@@ -164,7 +165,16 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
                       className={cardStyles.avatarOverlap}
                       title={formatMemberLabel(member)}
                     >
-                      <Avatar name={formatMemberLabel(member)} size="sm" />
+                      <EquippedPlayerAvatar
+                        name={formatMemberLabel(member)}
+                        size="icon"
+                        equippedAvatarId={member.equippedAvatarId ?? null}
+                        equippedBadgeId={member.equippedBadgeId ?? null}
+                        equippedNameColorId={member.equippedNameColorId}
+                        equippedFrameId={member.equippedFrameId}
+                        equippedAuraId={member.equippedAuraId}
+                        equippedBannerId={member.equippedBannerId}
+                      />
                     </div>
                   ))}
                 {room.members.length > MAX_VISIBLE_PARTICIPANTS && (

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -110,6 +110,9 @@ export function GamePageLayout(props: GamePageLayoutProps) {
         equippedAvatarId: member.equippedAvatarId ?? null,
         equippedBadgeId: member.equippedBadgeId ?? null,
         equippedNameColorId: member.equippedNameColorId ?? null,
+        equippedFrameId: member.equippedFrameId ?? null,
+        equippedAuraId: member.equippedAuraId ?? null,
+        equippedBannerId: member.equippedBannerId ?? null,
       };
     },
     [room.members],
@@ -183,6 +186,9 @@ export function GamePageLayout(props: GamePageLayoutProps) {
             senderEquippedAvatarId={popupSender?.equippedAvatarId ?? null}
             senderEquippedBadgeId={popupSender?.equippedBadgeId ?? null}
             senderEquippedNameColorId={popupSender?.equippedNameColorId ?? null}
+            senderEquippedFrameId={popupSender?.equippedFrameId ?? null}
+            senderEquippedAuraId={popupSender?.equippedAuraId ?? null}
+            senderEquippedBannerId={popupSender?.equippedBannerId ?? null}
             message={latestMessage.message}
             visible={!!latestMessage}
             onDismiss={dismissPopup}

--- a/apps/web/src/app/[locale]/history/components/HistoryDetailModal.tsx
+++ b/apps/web/src/app/[locale]/history/components/HistoryDetailModal.tsx
@@ -1,13 +1,7 @@
 'use client';
 
-import {
-  Button,
-  Avatar,
-  Badge,
-  Card,
-  ArrowLeftIcon,
-  XStack,
-} from '@arcadeum/ui';
+import { Button, Badge, Card, ArrowLeftIcon, XStack } from '@arcadeum/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import {
   Modal,
@@ -158,10 +152,15 @@ export function HistoryDetailModal({
                 {detail.summary.participants.map((participant) => (
                   <ParticipantRow key={participant.id}>
                     <ParticipantInfo>
-                      <Avatar
+                      <EquippedPlayerAvatar
                         name={formatParticipantName(participant)}
                         size="sm"
-                        alt=""
+                        equippedAvatarId={participant.equippedAvatarId ?? null}
+                        equippedBadgeId={participant.equippedBadgeId ?? null}
+                        equippedNameColorId={participant.equippedNameColorId}
+                        equippedFrameId={participant.equippedFrameId}
+                        equippedAuraId={participant.equippedAuraId}
+                        equippedBannerId={participant.equippedBannerId}
                       />
                       <ParticipantName>
                         {formatParticipantName(participant)}

--- a/apps/web/src/app/[locale]/history/types.ts
+++ b/apps/web/src/app/[locale]/history/types.ts
@@ -5,6 +5,12 @@ export interface HistoryParticipant {
   username: string;
   email: string | null;
   isHost: boolean;
+  equippedAvatarId?: string | null;
+  equippedBadgeId?: string | null;
+  equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 export interface HistorySummary {

--- a/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
@@ -332,7 +332,7 @@ export default function LeaderboardsPageContent({
                   portrait={
                     <EquippedPlayerAvatar
                       name={mythic.name}
-                      size="card"
+                      size="lg"
                       equippedAvatarId={mythic.equippedAvatarId}
                       equippedBadgeId={mythic.equippedBadgeId}
                       equippedNameColorId={mythic.equippedNameColorId}

--- a/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
@@ -22,6 +22,7 @@ import {
   RunnerUpCard,
 } from '@arcadeum/ui';
 import { Text, View } from 'tamagui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useLeaderboard } from '@/entities/leaderboard/model/useLeaderboard';
 import type {
   GameMode,
@@ -328,6 +329,20 @@ export default function LeaderboardsPageContent({
                     regionLabels[mythic.region] ?? mythic.region.toUpperCase()
                   }
                   recentForm={mythic.recentForm}
+                  portrait={
+                    <EquippedPlayerAvatar
+                      name={mythic.name}
+                      size="card"
+                      equippedAvatarId={mythic.equippedAvatarId}
+                      equippedBadgeId={mythic.equippedBadgeId}
+                      equippedNameColorId={mythic.equippedNameColorId}
+                      equippedFrameId={mythic.equippedFrameId}
+                      equippedAuraId={mythic.equippedAuraId}
+                      equippedBannerId={mythic.equippedBannerId}
+                      fallbackAvatarUrl={mythic.avatarUrl}
+                      priority
+                    />
+                  }
                   streakLabel={(
                     mythicLabels.streak ?? '{count}-game streak'
                   ).replace('{count}', String(mythic.streak))}
@@ -356,6 +371,19 @@ export default function LeaderboardsPageContent({
                       regionLabels[second.region] ?? second.region.toUpperCase()
                     }
                     placeLabel={mythicLabels.runnerUp ?? 'Runner · Up'}
+                    avatar={
+                      <EquippedPlayerAvatar
+                        name={second.name}
+                        size="sm"
+                        equippedAvatarId={second.equippedAvatarId}
+                        equippedBadgeId={second.equippedBadgeId}
+                        equippedNameColorId={second.equippedNameColorId}
+                        equippedFrameId={second.equippedFrameId}
+                        equippedAuraId={second.equippedAuraId}
+                        equippedBannerId={second.equippedBannerId}
+                        fallbackAvatarUrl={second.avatarUrl}
+                      />
+                    }
                   />
                   {third ? (
                     <RunnerUpCard
@@ -368,6 +396,19 @@ export default function LeaderboardsPageContent({
                         regionLabels[third.region] ?? third.region.toUpperCase()
                       }
                       placeLabel={mythicLabels.thirdPlace ?? '3rd · Place'}
+                      avatar={
+                        <EquippedPlayerAvatar
+                          name={third.name}
+                          size="sm"
+                          equippedAvatarId={third.equippedAvatarId}
+                          equippedBadgeId={third.equippedBadgeId}
+                          equippedNameColorId={third.equippedNameColorId}
+                          equippedFrameId={third.equippedFrameId}
+                          equippedAuraId={third.equippedAuraId}
+                          equippedBannerId={third.equippedBannerId}
+                          fallbackAvatarUrl={third.avatarUrl}
+                        />
+                      }
                     />
                   ) : null}
                 </YStack>

--- a/apps/web/src/app/[locale]/leaderboards/_components/RankTable.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/_components/RankTable.tsx
@@ -1,14 +1,13 @@
 'use client';
 import { XStack, YStack, Text, View, styled } from 'tamagui';
-import Image from 'next/image';
 import {
-  Avatar,
   RankBadge,
   FormPips,
   TrendPill,
   EnergyBar,
   LiveChip,
 } from '@arcadeum/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import type { LeaderboardPlayer } from '@/entities/leaderboard/model/types';
 import type { PageTranslations } from '@/shared/i18n/page-translations';
 import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
@@ -206,10 +205,13 @@ function RankRow({
 }) {
   const live = p.isInMatch ?? false;
   const flag = p.countryCode ? regionFlag(p.countryCode) : null;
-  const { avatarUrl, badgeUrl, nameColor } = useEquippedCosmetics({
+  const { nameColor } = useEquippedCosmetics({
     equippedAvatarId: p.equippedAvatarId,
     equippedBadgeId: p.equippedBadgeId,
     equippedNameColorId: p.equippedNameColorId,
+    equippedFrameId: p.equippedFrameId,
+    equippedAuraId: p.equippedAuraId,
+    equippedBannerId: p.equippedBannerId,
   });
   const nameProps = nameColorRenderProps(nameColor);
   return (
@@ -222,11 +224,18 @@ function RankRow({
       </View>
       <YStack flex={1} gap={2}>
         <XStack gap="$2" alignItems="center" flexWrap="wrap">
-          <Avatar
+          <EquippedPlayerAvatar
             size="sm"
             name={p.name}
-            src={avatarUrl ?? p.avatarUrl ?? undefined}
+            equippedAvatarId={p.equippedAvatarId}
+            equippedBadgeId={p.equippedBadgeId}
+            equippedNameColorId={p.equippedNameColorId}
+            equippedFrameId={p.equippedFrameId}
+            equippedAuraId={p.equippedAuraId}
+            equippedBannerId={p.equippedBannerId}
+            fallbackAvatarUrl={p.avatarUrl}
             priority={priority}
+            data-testid={`leaderboard-row-${p.rank}-avatar`}
           />
           {flag ? (
             <Text fontSize="$3" aria-label={p.countryCode}>
@@ -241,18 +250,6 @@ function RankRow({
           >
             {p.name}
           </Text>
-          {badgeUrl ? (
-            <View width={16} height={16}>
-              <Image
-                src={badgeUrl}
-                alt=""
-                width={16}
-                height={16}
-                data-testid={`leaderboard-row-${p.rank}-badge`}
-                unoptimized
-              />
-            </View>
-          ) : null}
           {p.isOnline ? (
             <View
               width={8}

--- a/apps/web/src/app/[locale]/players/[id]/PlayerProfileClient.tsx
+++ b/apps/web/src/app/[locale]/players/[id]/PlayerProfileClient.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image';
 import {
   PageLayout,
   Container,
@@ -11,9 +10,9 @@ import {
   FormPips,
   EnergyBar,
   EmptyState,
-  Avatar,
 } from '@arcadeum/ui';
 import { Text, View } from 'tamagui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import type { PageTranslations } from '@/shared/i18n/page-translations';
 import type { PlayerProfile } from '@/entities/leaderboard/model/types';
 import { getPlayer } from '@/shared/api/leaderboard';
@@ -101,12 +100,20 @@ function Profile({
     equippedAvatarId,
     equippedBadgeId,
     equippedNameColorId,
+    equippedFrameId,
+    equippedAuraId,
+    equippedBannerId,
   } = profile;
   const max = modeRanks[0]?.rating ?? player.rating;
-  const { avatarUrl, badgeUrl, nameColor } = useEquippedCosmetics({
+  // PlayerAvatar renders the avatar disc + badge corner + frame + aura.
+  // The name color still drives the surrounding name `<Text>` below.
+  const { nameColor } = useEquippedCosmetics({
     equippedAvatarId,
     equippedBadgeId,
     equippedNameColorId,
+    equippedFrameId,
+    equippedAuraId,
+    equippedBannerId,
   });
   const nameProps = nameColorRenderProps(nameColor);
   return (
@@ -120,10 +127,16 @@ function Profile({
         {eyebrow}
       </Text>
       <XStack alignItems="center" gap="$3" flexWrap="wrap">
-        <Avatar
+        <EquippedPlayerAvatar
           name={player.name}
-          src={avatarUrl ?? undefined}
-          size="xl"
+          size="md"
+          equippedAvatarId={equippedAvatarId}
+          equippedBadgeId={equippedBadgeId}
+          equippedNameColorId={equippedNameColorId}
+          equippedFrameId={equippedFrameId}
+          equippedAuraId={equippedAuraId}
+          equippedBannerId={equippedBannerId}
+          fallbackAvatarUrl={player.avatarUrl}
           data-testid="player-profile-avatar"
         />
         <YStack gap="$1">
@@ -137,17 +150,6 @@ function Profile({
             >
               {player.name}
             </Text>
-            {badgeUrl ? (
-              <View width={32} height={32} data-testid="player-profile-badge">
-                <Image
-                  src={badgeUrl}
-                  alt=""
-                  width={32}
-                  height={32}
-                  unoptimized
-                />
-              </View>
-            ) : null}
           </XStack>
           <XStack alignItems="center" gap="$2">
             <RankBadge

--- a/apps/web/src/app/[locale]/stats/components/Leaderboard.tsx
+++ b/apps/web/src/app/[locale]/stats/components/Leaderboard.tsx
@@ -2,7 +2,8 @@ import React, { useRef, useCallback, useEffect } from 'react';
 import { styled, XStack, YStack, Text } from 'tamagui';
 import type { LeaderboardEntry } from '@/features/history/api';
 import { useTranslation } from '@/shared/lib/useTranslation';
-import { Avatar, Badge, Section, EmptyState } from '@/shared/ui';
+import { Badge, Section, EmptyState } from '@/shared/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { SkeletonCircle, SkeletonText, ProgressBar } from '@arcadeum/ui';
 import { Spinner } from '@/shared/ui';
 
@@ -195,7 +196,16 @@ export function Leaderboard({
             >
               <RankDisplay rank={entry.rank} />
               <PlayerInfo>
-                <Avatar name={entry.username} size="lg" alt="" />
+                <EquippedPlayerAvatar
+                  name={entry.username}
+                  size="md"
+                  equippedAvatarId={entry.equippedAvatarId ?? null}
+                  equippedBadgeId={entry.equippedBadgeId ?? null}
+                  equippedNameColorId={entry.equippedNameColorId}
+                  equippedFrameId={entry.equippedFrameId}
+                  equippedAuraId={entry.equippedAuraId}
+                  equippedBannerId={entry.equippedBannerId}
+                />
                 <PlayerName>
                   <Text>{entry.username}</Text>
                   {entry.playerId === currentUserId && (

--- a/apps/web/src/entities/leaderboard/model/types.ts
+++ b/apps/web/src/entities/leaderboard/model/types.ts
@@ -37,6 +37,9 @@ export type LeaderboardPlayer = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 export type MythicPlayer = LeaderboardPlayer & {
@@ -105,6 +108,9 @@ export type PlayerProfile = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 export type LeaderboardSnapshot = {

--- a/apps/web/src/entities/session/api/authApi.ts
+++ b/apps/web/src/entities/session/api/authApi.ts
@@ -11,6 +11,9 @@ export type AuthUserProfile = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 export type LoginResponse = {

--- a/apps/web/src/entities/session/model/types.ts
+++ b/apps/web/src/entities/session/model/types.ts
@@ -30,6 +30,9 @@ export type SessionTokensSnapshot = {
   equippedAvatarId: string | null;
   equippedBadgeId: string | null;
   equippedNameColorId: string | null;
+  equippedFrameId: string | null;
+  equippedAuraId: string | null;
+  equippedBannerId: string | null;
 };
 
 export type SetSessionTokensInput = {
@@ -47,6 +50,9 @@ export type SetSessionTokensInput = {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 };
 
 export type LocalAuthMode = 'login' | 'register';

--- a/apps/web/src/entities/session/store/sessionStore.ts
+++ b/apps/web/src/entities/session/store/sessionStore.ts
@@ -26,6 +26,9 @@ const defaultSnapshot: SessionTokensSnapshot = {
   equippedAvatarId: null,
   equippedBadgeId: null,
   equippedNameColorId: null,
+  equippedFrameId: null,
+  equippedAuraId: null,
+  equippedBannerId: null,
 };
 
 interface SessionState {
@@ -82,6 +85,18 @@ function buildSnapshot(
       input.equippedNameColorId === undefined
         ? (current.equippedNameColorId ?? null)
         : input.equippedNameColorId,
+    equippedFrameId:
+      input.equippedFrameId === undefined
+        ? (current.equippedFrameId ?? null)
+        : input.equippedFrameId,
+    equippedAuraId:
+      input.equippedAuraId === undefined
+        ? (current.equippedAuraId ?? null)
+        : input.equippedAuraId,
+    equippedBannerId:
+      input.equippedBannerId === undefined
+        ? (current.equippedBannerId ?? null)
+        : input.equippedBannerId,
   };
 }
 
@@ -114,6 +129,12 @@ function enrichWithResponse(
       response.user?.equippedNameColorId ??
       snapshot.equippedNameColorId ??
       null,
+    equippedFrameId:
+      response.user?.equippedFrameId ?? snapshot.equippedFrameId ?? null,
+    equippedAuraId:
+      response.user?.equippedAuraId ?? snapshot.equippedAuraId ?? null,
+    equippedBannerId:
+      response.user?.equippedBannerId ?? snapshot.equippedBannerId ?? null,
   });
 }
 

--- a/apps/web/src/features/chat/api.ts
+++ b/apps/web/src/features/chat/api.ts
@@ -28,6 +28,12 @@ export interface ChatMessage {
   senderEquippedBadgeId?: string | null;
   /** Sender's currently-equipped shop name-color id (resolved client-side). */
   senderEquippedNameColorId?: string | null;
+  /** Sender's currently-equipped shop frame id (resolved client-side). */
+  senderEquippedFrameId?: string | null;
+  /** Sender's currently-equipped shop aura id (resolved client-side). */
+  senderEquippedAuraId?: string | null;
+  /** Sender's currently-equipped shop banner id (resolved client-side). */
+  senderEquippedBannerId?: string | null;
   receiverIds: string[];
   content: string;
   timestamp: string;

--- a/apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
 import {
-  Avatar,
   Badge,
   Button,
   Card,
@@ -12,8 +10,8 @@ import {
   XStack,
   YStack,
 } from '@arcadeum/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useTranslation } from '@/shared/lib/useTranslation';
-import { View } from 'tamagui';
 import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
 import {
@@ -32,6 +30,9 @@ export interface TeamSlotsMember {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 interface TeamSlotsBoardProps {
@@ -350,15 +351,28 @@ function TeamMemberIdentity({
   showBotBadge: boolean;
   botLabel: string;
 }) {
-  const { avatarUrl, badgeUrl, nameColor } = useEquippedCosmetics({
+  const { nameColor } = useEquippedCosmetics({
     equippedAvatarId: member?.equippedAvatarId,
     equippedBadgeId: member?.equippedBadgeId,
     equippedNameColorId: member?.equippedNameColorId,
+    equippedFrameId: member?.equippedFrameId,
+    equippedAuraId: member?.equippedAuraId,
+    equippedBannerId: member?.equippedBannerId,
   });
   const nameProps = nameColorRenderProps(nameColor);
   return (
     <XStack gap="$2" alignItems="center" flex={1}>
-      <Avatar size="sm" name={display} src={avatarUrl ?? undefined} />
+      <EquippedPlayerAvatar
+        size="sm"
+        name={display}
+        equippedAvatarId={member?.equippedAvatarId ?? null}
+        equippedBadgeId={member?.equippedBadgeId ?? null}
+        equippedNameColorId={member?.equippedNameColorId}
+        equippedFrameId={member?.equippedFrameId}
+        equippedAuraId={member?.equippedAuraId}
+        equippedBannerId={member?.equippedBannerId}
+        fallbackAvatarUrl={member?.avatarUrl}
+      />
       <Typography
         variant="body"
         uiSize="sm"
@@ -367,17 +381,6 @@ function TeamMemberIdentity({
       >
         {display}
       </Typography>
-      {badgeUrl ? (
-        <View width={16} height={16}>
-          <Image
-            src={badgeUrl}
-            alt=""
-            width={16}
-            height={16}
-            unoptimized
-          />
-        </View>
-      ) : null}
       {showBotBadge ? (
         <Badge variant="neutral" size="sm">
           {botLabel}

--- a/apps/web/src/features/games/sea-battle/lobby/UnassignedPool.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/UnassignedPool.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { Avatar, Button, Card, Typography, XStack, YStack } from '@arcadeum/ui';
+import { Button, Card, Typography, XStack, YStack } from '@arcadeum/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type { SeaBattleTeam } from './team-mode.types';
 
 export interface UnassignedPoolMember {
   userId: string;
   displayName?: string;
+  equippedAvatarId?: string | null;
+  equippedBadgeId?: string | null;
+  equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 interface UnassignedPoolProps {
@@ -50,7 +57,16 @@ export function UnassignedPool(props: UnassignedPoolProps) {
                   alignItems="center"
                   data-testid={`unassigned-${m.userId}`}
                 >
-                  <Avatar size="sm" name={display} />
+                  <EquippedPlayerAvatar
+                    size="icon"
+                    name={display}
+                    equippedAvatarId={m.equippedAvatarId ?? null}
+                    equippedBadgeId={m.equippedBadgeId ?? null}
+                    equippedNameColorId={m.equippedNameColorId}
+                    equippedFrameId={m.equippedFrameId}
+                    equippedAuraId={m.equippedAuraId}
+                    equippedBannerId={m.equippedBannerId}
+                  />
                   <Typography variant="body" uiSize="sm">
                     {display}
                   </Typography>

--- a/apps/web/src/features/games/sea-battle/lobby/__tests__/TeamSlotsBoard.test.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/__tests__/TeamSlotsBoard.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@arcadeum/ui', () => ({
     </button>
   ),
   Avatar: ({ name }: { name?: string }) => <span>{name}</span>,
+  PlayerAvatar: ({ name }: { name?: string }) => <span>{name}</span>,
   Input: (
     props: { value?: string; onChange?: (e: unknown) => void } & Record<
       string,

--- a/apps/web/src/features/history/api.ts
+++ b/apps/web/src/features/history/api.ts
@@ -50,6 +50,12 @@ export interface LeaderboardEntry {
   wins: number;
   losses: number;
   winRate: number;
+  equippedAvatarId?: string | null;
+  equippedBadgeId?: string | null;
+  equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 export interface LeaderboardResponse {

--- a/apps/web/src/features/shop/hooks/useEquippedCosmetics.test.ts
+++ b/apps/web/src/features/shop/hooks/useEquippedCosmetics.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useEquippedCosmetics } from './useEquippedCosmetics';
+import * as catalogCache from '../lib/catalogCache';
+import type { EffectiveShopItem } from '../server/shop.types';
+
+vi.mock('../lib/catalogCache');
+
+function item(
+  id: string,
+  category: EffectiveShopItem['category'],
+  colorValue: string,
+): EffectiveShopItem {
+  return {
+    id,
+    category,
+    rarity: 'common',
+    nameKey: `items.${category}.${id}.name`,
+    descKey: `items.${category}.${id}.desc`,
+    assetUrl: `/assets/${id}.png`,
+    colorValue,
+    defaultPriceAmount: 0,
+    defaultPriceCurrency: 'coins',
+    available: true,
+    priceAmount: 0,
+    priceCurrency: 'coins',
+    overridden: false,
+  };
+}
+
+describe('useEquippedCosmetics', () => {
+  beforeEach(() => {
+    vi.mocked(catalogCache.loadCatalog).mockResolvedValue([
+      item('avatar-1', 'avatar', ''),
+      item('badge-1', 'badge', ''),
+      item('frame-1', 'frame', '#abcdef'),
+      item('aura-1', 'aura', 'linear-gradient(135deg, #1e293b, #334155)'),
+      item('banner-1', 'banner', '#0f172a'),
+      item('nc-1', 'name_color', '#ff00ff'),
+    ]);
+  });
+
+  it('returns nulls while catalog is loading', () => {
+    const { result } = renderHook(() =>
+      useEquippedCosmetics({
+        equippedAvatarId: 'avatar-1',
+        equippedBadgeId: 'badge-1',
+      }),
+    );
+    expect(result.current.avatarUrl).toBeNull();
+    expect(result.current.frameColor).toBeNull();
+  });
+
+  it('resolves frame/aura/banner colors from the catalog', async () => {
+    const { result } = renderHook(() =>
+      useEquippedCosmetics({
+        equippedAvatarId: 'avatar-1',
+        equippedBadgeId: 'badge-1',
+        equippedFrameId: 'frame-1',
+        equippedAuraId: 'aura-1',
+        equippedBannerId: 'banner-1',
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.frameColor).toBe('#abcdef');
+    });
+    expect(result.current.auraColor).toContain('linear-gradient');
+    expect(result.current.bannerColor).toBe('#0f172a');
+    expect(result.current.frameItem?.id).toBe('frame-1');
+  });
+
+  it('returns null for ids not in the catalog', async () => {
+    const { result } = renderHook(() =>
+      useEquippedCosmetics({
+        equippedAvatarId: null,
+        equippedBadgeId: null,
+        equippedFrameId: 'missing-id',
+      }),
+    );
+    await waitFor(() => {
+      expect(result.current.frameColor).toBeNull();
+    });
+    expect(result.current.frameItem).toBeNull();
+  });
+});

--- a/apps/web/src/features/shop/hooks/useEquippedCosmetics.ts
+++ b/apps/web/src/features/shop/hooks/useEquippedCosmetics.ts
@@ -17,6 +17,15 @@ export interface EquippedCosmetics {
    */
   nameColor: string | null;
   nameColorItem: EffectiveShopItem | null;
+  /** CSS color (hex or linear-gradient) for the equipped frame ring. */
+  frameColor: string | null;
+  frameItem: EffectiveShopItem | null;
+  /** CSS color (hex or linear-gradient) for the equipped aura halo. */
+  auraColor: string | null;
+  auraItem: EffectiveShopItem | null;
+  /** CSS color (hex or linear-gradient) for the equipped banner backdrop. */
+  bannerColor: string | null;
+  bannerItem: EffectiveShopItem | null;
 }
 
 const EMPTY_MAP: ReadonlyMap<string, EffectiveShopItem> = new Map();
@@ -34,8 +43,18 @@ export function useEquippedCosmetics(args: {
   equippedAvatarId: string | null | undefined;
   equippedBadgeId: string | null | undefined;
   equippedNameColorId?: string | null | undefined;
+  equippedFrameId?: string | null | undefined;
+  equippedAuraId?: string | null | undefined;
+  equippedBannerId?: string | null | undefined;
 }): EquippedCosmetics {
-  const { equippedAvatarId, equippedBadgeId, equippedNameColorId } = args;
+  const {
+    equippedAvatarId,
+    equippedBadgeId,
+    equippedNameColorId,
+    equippedFrameId,
+    equippedAuraId,
+    equippedBannerId,
+  } = args;
   const [catalogMap, setCatalogMap] =
     useState<ReadonlyMap<string, EffectiveShopItem>>(EMPTY_MAP);
 
@@ -60,6 +79,15 @@ export function useEquippedCosmetics(args: {
     const nameColor = equippedNameColorId
       ? (catalogMap.get(equippedNameColorId) ?? null)
       : null;
+    const frame = equippedFrameId
+      ? (catalogMap.get(equippedFrameId) ?? null)
+      : null;
+    const aura = equippedAuraId
+      ? (catalogMap.get(equippedAuraId) ?? null)
+      : null;
+    const banner = equippedBannerId
+      ? (catalogMap.get(equippedBannerId) ?? null)
+      : null;
     return {
       avatarItem: avatar,
       avatarUrl: avatar?.assetUrl ?? null,
@@ -67,6 +95,20 @@ export function useEquippedCosmetics(args: {
       badgeUrl: badge?.assetUrl ?? null,
       nameColorItem: nameColor,
       nameColor: nameColor?.colorValue ?? null,
+      frameItem: frame,
+      frameColor: frame?.colorValue ?? null,
+      auraItem: aura,
+      auraColor: aura?.colorValue ?? null,
+      bannerItem: banner,
+      bannerColor: banner?.colorValue ?? null,
     };
-  }, [equippedAvatarId, equippedBadgeId, equippedNameColorId, catalogMap]);
+  }, [
+    equippedAvatarId,
+    equippedBadgeId,
+    equippedNameColorId,
+    equippedFrameId,
+    equippedAuraId,
+    equippedBannerId,
+    catalogMap,
+  ]);
 }

--- a/apps/web/src/features/shop/lib/syncEquippedToSession.ts
+++ b/apps/web/src/features/shop/lib/syncEquippedToSession.ts
@@ -21,5 +21,8 @@ export function syncEquippedToSession(equipped: EquippedView): void {
     equippedAvatarId: equipped.avatar,
     equippedBadgeId: equipped.badge,
     equippedNameColorId: equipped.name_color,
+    equippedFrameId: equipped.frame,
+    equippedAuraId: equipped.aura,
+    equippedBannerId: equipped.banner,
   });
 }

--- a/apps/web/src/shared/types/games.ts
+++ b/apps/web/src/shared/types/games.ts
@@ -7,6 +7,9 @@ export interface GameRoomMemberSummary {
   equippedAvatarId?: string | null;
   equippedBadgeId?: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 // Game Options Interface

--- a/apps/web/src/shared/ui/PlayerAvatar/EquippedPlayerAvatar.test.tsx
+++ b/apps/web/src/shared/ui/PlayerAvatar/EquippedPlayerAvatar.test.tsx
@@ -1,0 +1,72 @@
+import { render as rtlRender, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import config from '@/shared/config/tamagui.config';
+import { EquippedPlayerAvatar } from './EquippedPlayerAvatar';
+import * as hook from '@/features/shop/hooks/useEquippedCosmetics';
+
+vi.mock('@/features/shop/hooks/useEquippedCosmetics');
+
+const render = (ui: React.ReactElement) =>
+  rtlRender(
+    <TamaguiProvider config={config} defaultTheme="dark">
+      {ui}
+    </TamaguiProvider>,
+  );
+
+const allNulls = {
+  avatarUrl: null,
+  avatarItem: null,
+  badgeUrl: null,
+  badgeItem: null,
+  nameColor: null,
+  nameColorItem: null,
+  frameColor: null,
+  frameItem: null,
+  auraColor: null,
+  auraItem: null,
+  bannerColor: null,
+  bannerItem: null,
+};
+
+describe('EquippedPlayerAvatar', () => {
+  it('passes resolved urls/colors to PlayerAvatar', () => {
+    vi.mocked(hook.useEquippedCosmetics).mockReturnValue({
+      ...allNulls,
+      avatarUrl: '/a.png',
+      badgeUrl: '/b.png',
+      nameColor: '#fff',
+      frameColor: '#ff0',
+      auraColor: '#0ff',
+      bannerColor: '#f0f',
+    });
+    render(
+      <EquippedPlayerAvatar
+        name="Jane"
+        size="card"
+        equippedAvatarId="a-1"
+        equippedBadgeId="b-1"
+        equippedFrameId="f-1"
+        equippedAuraId="au-1"
+        equippedBannerId="bn-1"
+        data-testid="epa"
+      />,
+    );
+    expect(screen.getByTestId('epa-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('epa-name')).toHaveTextContent('Jane');
+  });
+
+  it('falls back to fallbackAvatarUrl when catalog returns null', () => {
+    vi.mocked(hook.useEquippedCosmetics).mockReturnValue(allNulls);
+    render(
+      <EquippedPlayerAvatar
+        name="Jane"
+        equippedAvatarId={null}
+        equippedBadgeId={null}
+        fallbackAvatarUrl="/legacy.png"
+        data-testid="epa"
+      />,
+    );
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/legacy.png');
+  });
+});

--- a/apps/web/src/shared/ui/PlayerAvatar/EquippedPlayerAvatar.tsx
+++ b/apps/web/src/shared/ui/PlayerAvatar/EquippedPlayerAvatar.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { memo } from 'react';
+import { PlayerAvatar, type PlayerAvatarSize } from '@arcadeum/ui';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+
+export interface EquippedPlayerAvatarProps {
+  name: string;
+  size?: PlayerAvatarSize;
+  equippedAvatarId: string | null | undefined;
+  equippedBadgeId: string | null | undefined;
+  equippedNameColorId?: string | null | undefined;
+  equippedFrameId?: string | null | undefined;
+  equippedAuraId?: string | null | undefined;
+  equippedBannerId?: string | null | undefined;
+  /** Legacy `avatarUrl` from older payloads (pre-shop catalog). Used when the
+   *  catalog doesn't resolve an equipped item. */
+  fallbackAvatarUrl?: string;
+  level?: number | null;
+  presenceLine?: string;
+  priority?: boolean;
+  'data-testid'?: string;
+  onPress?: () => void;
+}
+
+export const EquippedPlayerAvatar = memo(function EquippedPlayerAvatar(
+  props: EquippedPlayerAvatarProps,
+) {
+  const cosmetics = useEquippedCosmetics({
+    equippedAvatarId: props.equippedAvatarId,
+    equippedBadgeId: props.equippedBadgeId,
+    equippedNameColorId: props.equippedNameColorId,
+    equippedFrameId: props.equippedFrameId,
+    equippedAuraId: props.equippedAuraId,
+    equippedBannerId: props.equippedBannerId,
+  });
+  return (
+    <PlayerAvatar
+      name={props.name}
+      size={props.size}
+      avatarUrl={cosmetics.avatarUrl ?? props.fallbackAvatarUrl ?? null}
+      badgeUrl={cosmetics.badgeUrl}
+      frameColor={cosmetics.frameColor}
+      auraColor={cosmetics.auraColor}
+      bannerColor={cosmetics.bannerColor}
+      nameColor={cosmetics.nameColor}
+      level={props.level}
+      presenceLine={props.presenceLine}
+      priority={props.priority}
+      data-testid={props['data-testid']}
+      onPress={props.onPress}
+    />
+  );
+});

--- a/apps/web/src/shared/ui/PlayerAvatar/index.ts
+++ b/apps/web/src/shared/ui/PlayerAvatar/index.ts
@@ -1,0 +1,2 @@
+export { EquippedPlayerAvatar } from './EquippedPlayerAvatar';
+export type { EquippedPlayerAvatarProps } from './EquippedPlayerAvatar';

--- a/apps/web/src/widgets/GameChat/ui/ChatMessageBubble.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatMessageBubble.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import Image from 'next/image';
 import { XStack, YStack } from '@arcadeum/ui';
 import { Text, View } from 'tamagui';
 import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import type { ChatScope } from '../store/gameChatStore';
 
 interface ChatMessageBubbleProps {
@@ -16,31 +16,17 @@ interface ChatMessageBubbleProps {
   senderEquippedBadgeId?: string | null;
   /** Sender's currently-equipped name-color id (from chat message payload). */
   senderEquippedNameColorId?: string | null;
+  /** Sender's currently-equipped frame id (from chat message payload). */
+  senderEquippedFrameId?: string | null;
+  /** Sender's currently-equipped aura id (from chat message payload). */
+  senderEquippedAuraId?: string | null;
+  /** Sender's currently-equipped banner id (from chat message payload). */
+  senderEquippedBannerId?: string | null;
   message: string;
   type: 'system' | 'action' | 'message';
   scope?: ChatScope;
   isOwn?: boolean;
 }
-
-const getUserColor = (id: string) => {
-  const colors = [
-    '#EF4444',
-    '#F97316',
-    '#F59E0B',
-    '#84CC16',
-    '#10B981',
-    '#06B6D4',
-    '#3B82F6',
-    '#6366F1',
-    '#8B5CF6',
-    '#EC4899',
-  ];
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = id.charCodeAt(i) + ((hash << 5) - hash);
-  }
-  return colors[Math.abs(hash) % colors.length];
-};
 
 export function ChatMessageBubble({
   senderId,
@@ -48,16 +34,22 @@ export function ChatMessageBubble({
   senderEquippedAvatarId,
   senderEquippedBadgeId,
   senderEquippedNameColorId,
+  senderEquippedFrameId,
+  senderEquippedAuraId,
+  senderEquippedBannerId,
   message,
   type,
   isOwn,
 }: ChatMessageBubbleProps) {
-  // Resolve sender's equipped cosmetics via the shop catalog. Cheap — module-
-  // level cached map; safe to call even when the ids are null (returns nulls).
-  const { avatarUrl, badgeUrl, nameColor } = useEquippedCosmetics({
+  // The hook resolves the name-color (used in the sender label outside the
+  // PlayerAvatar slot). Avatar/badge/frame/aura come through PlayerAvatar.
+  const { nameColor } = useEquippedCosmetics({
     equippedAvatarId: senderEquippedAvatarId,
     equippedBadgeId: senderEquippedBadgeId,
     equippedNameColorId: senderEquippedNameColorId,
+    equippedFrameId: senderEquippedFrameId,
+    equippedAuraId: senderEquippedAuraId,
+    equippedBannerId: senderEquippedBannerId,
   });
   const nameColorProps = nameColorRenderProps(nameColor);
 
@@ -71,8 +63,7 @@ export function ChatMessageBubble({
     );
   }
 
-  const initial = (senderName ?? senderId ?? '?').charAt(0).toUpperCase();
-  const avatarColor = getUserColor(senderId ?? senderName ?? '?');
+  const displayName = senderName ?? senderId ?? '?';
 
   return (
     <XStack
@@ -82,28 +73,17 @@ export function ChatMessageBubble({
       flexDirection={isOwn ? 'row-reverse' : 'row'}
       alignItems="flex-start"
     >
-      <View
-        width={38}
-        height={38}
-        borderRadius={avatarUrl ? 19 : '$3'}
-        backgroundColor={avatarUrl ? 'transparent' : avatarColor}
-        alignItems="center"
-        justifyContent="center"
-        flexShrink={0}
-      >
-        {avatarUrl ? (
-          <Image
-            src={avatarUrl}
-            alt=""
-            width={38}
-            height={38}
-            unoptimized
-          />
-        ) : (
-          <Text fontSize="$4" fontWeight="700" color="white">
-            {initial}
-          </Text>
-        )}
+      <View flexShrink={0}>
+        <EquippedPlayerAvatar
+          name={displayName}
+          size="sm"
+          equippedAvatarId={senderEquippedAvatarId ?? null}
+          equippedBadgeId={senderEquippedBadgeId ?? null}
+          equippedNameColorId={senderEquippedNameColorId}
+          equippedFrameId={senderEquippedFrameId}
+          equippedAuraId={senderEquippedAuraId}
+          equippedBannerId={senderEquippedBannerId}
+        />
       </View>
       <YStack
         flex={1}
@@ -127,17 +107,6 @@ export function ChatMessageBubble({
             >
               {senderName}
             </Text>
-            {badgeUrl ? (
-              <View width={16} height={16}>
-                <Image
-                  src={badgeUrl}
-                  alt=""
-                  width={16}
-                  height={16}
-                  unoptimized
-                />
-              </View>
-            ) : null}
           </XStack>
         )}
         <Text fontSize="$4" color="$color">

--- a/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
@@ -8,6 +8,9 @@ interface ChatMessagePopupProps {
   senderEquippedAvatarId?: string | null;
   senderEquippedBadgeId?: string | null;
   senderEquippedNameColorId?: string | null;
+  senderEquippedFrameId?: string | null;
+  senderEquippedAuraId?: string | null;
+  senderEquippedBannerId?: string | null;
   message: string;
   visible: boolean;
   onDismiss: () => void;
@@ -20,6 +23,9 @@ export function ChatMessagePopup({
   senderEquippedAvatarId,
   senderEquippedBadgeId,
   senderEquippedNameColorId,
+  senderEquippedFrameId,
+  senderEquippedAuraId,
+  senderEquippedBannerId,
   message,
   visible,
   onDismiss,
@@ -55,6 +61,9 @@ export function ChatMessagePopup({
         senderEquippedAvatarId={senderEquippedAvatarId ?? null}
         senderEquippedBadgeId={senderEquippedBadgeId ?? null}
         senderEquippedNameColorId={senderEquippedNameColorId ?? null}
+        senderEquippedFrameId={senderEquippedFrameId ?? null}
+        senderEquippedAuraId={senderEquippedAuraId ?? null}
+        senderEquippedBannerId={senderEquippedBannerId ?? null}
         message={message}
         type="message"
         isOwn={isOwn}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -15,6 +15,7 @@ import { scrollbarStyles } from '@/shared/lib/styles';
 import { getPlayerColor } from '@/shared/lib/playerColors';
 import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useGameChatStore } from '../store/gameChatStore';
 import type { ChatScope } from '../store/gameChatStore';
 
@@ -22,6 +23,9 @@ export interface ResolvedEquipped {
   equippedAvatarId: string | null;
   equippedBadgeId: string | null;
   equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
 }
 
 export type EquippedResolver = (id?: string | null) => ResolvedEquipped | null;
@@ -267,10 +271,15 @@ function GameChatRow({
   resolveEquipped?: EquippedResolver;
 }) {
   const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
-  const { avatarUrl, badgeUrl, nameColor } = useEquippedCosmetics({
+  // The hook resolves name-color (used on the sender label outside the
+  // avatar slot). Avatar/badge/frame/aura now come through PlayerAvatar.
+  const { nameColor } = useEquippedCosmetics({
     equippedAvatarId: resolved?.equippedAvatarId,
     equippedBadgeId: resolved?.equippedBadgeId,
     equippedNameColorId: resolved?.equippedNameColorId,
+    equippedFrameId: resolved?.equippedFrameId,
+    equippedAuraId: resolved?.equippedAuraId,
+    equippedBannerId: resolved?.equippedBannerId,
   });
   // Shop name-color overrides the per-match actor color when present —
   // cosmetic personal choice wins over contextual game coloring.
@@ -287,8 +296,20 @@ function GameChatRow({
       contentNode={contentNode}
       type={type}
       isOwn={isOwn}
-      avatarUrl={avatarUrl ?? undefined}
-      badgeUrl={badgeUrl ?? undefined}
+      senderAvatar={
+        senderName ? (
+          <EquippedPlayerAvatar
+            name={senderName}
+            size="sm"
+            equippedAvatarId={resolved?.equippedAvatarId ?? null}
+            equippedBadgeId={resolved?.equippedBadgeId ?? null}
+            equippedNameColorId={resolved?.equippedNameColorId}
+            equippedFrameId={resolved?.equippedFrameId}
+            equippedAuraId={resolved?.equippedAuraId}
+            equippedBannerId={resolved?.equippedBannerId}
+          />
+        ) : undefined
+      }
     />
   );
 }

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -147,6 +147,9 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
     equippedAvatarId: m.equippedAvatarId ?? null,
     equippedBadgeId: m.equippedBadgeId ?? null,
     equippedNameColorId: m.equippedNameColorId ?? null,
+    equippedFrameId: m.equippedFrameId ?? null,
+    equippedAuraId: m.equippedAuraId ?? null,
+    equippedBannerId: m.equippedBannerId ?? null,
   }));
 
   // Sync with room variant when it changes from server

--- a/apps/web/src/widgets/header/ui/MobileMenu.tsx
+++ b/apps/web/src/widgets/header/ui/MobileMenu.tsx
@@ -23,7 +23,7 @@ import { Button } from '@arcadeum/ui/components/Button/Button';
 import { LinkButton } from '@arcadeum/ui/components/Button/LinkButton';
 import { Divider } from '@arcadeum/ui/components/Divider/Divider';
 import { RoleBadge } from '@arcadeum/ui/components/RoleBadge/RoleBadge';
-import { Avatar } from '@arcadeum/ui/components/Avatar/Avatar';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import {
   BarChartIcon,
   CardsIcon,
@@ -112,7 +112,16 @@ export default function MobileMenu({ navItems }: MobileMenuProps) {
     <MobileNav data-mobile-menu data-testid="mobile-nav">
       {isAuthenticated && displayName ? (
         <MobileUserCard data-testid="mobile-user-card">
-          <Avatar name={displayName} size="md" />
+          <EquippedPlayerAvatar
+            name={displayName}
+            size="md"
+            equippedAvatarId={snapshot.equippedAvatarId}
+            equippedBadgeId={snapshot.equippedBadgeId}
+            equippedNameColorId={snapshot.equippedNameColorId}
+            equippedFrameId={snapshot.equippedFrameId}
+            equippedAuraId={snapshot.equippedAuraId}
+            equippedBannerId={snapshot.equippedBannerId}
+          />
           <YStack flex={1} minWidth={120} gap="$1">
             <XStack alignItems="center" gap="$2" flexWrap="wrap">
               <UserNameEllipsis>{displayName}</UserNameEllipsis>

--- a/apps/web/src/widgets/header/ui/ProfileMenu.tsx
+++ b/apps/web/src/widgets/header/ui/ProfileMenu.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import React, { useCallback, useEffect } from 'react';
-import Image from 'next/image';
-import { Avatar } from '@arcadeum/ui/components/Avatar/Avatar';
 import { Button } from '@arcadeum/ui/components/Button/Button';
 import { Divider } from '@arcadeum/ui/components/Divider/Divider';
-import { View } from 'tamagui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { RoleBadge } from '@arcadeum/ui/components/RoleBadge/RoleBadge';
 import {
   SettingsIcon,
@@ -44,14 +42,13 @@ export default function ProfileMenu() {
     snapshot.displayName || snapshot.username || snapshot.email;
   const role = snapshot.role || 'free';
   const { data: cosmeticBadges } = useCosmeticBadges();
-  const {
-    avatarUrl: equippedAvatarUrl,
-    badgeUrl: equippedBadgeUrl,
-    nameColor: equippedNameColor,
-  } = useEquippedCosmetics({
+  const { nameColor: equippedNameColor } = useEquippedCosmetics({
     equippedAvatarId: snapshot.equippedAvatarId,
     equippedBadgeId: snapshot.equippedBadgeId,
     equippedNameColorId: snapshot.equippedNameColorId,
+    equippedFrameId: snapshot.equippedFrameId,
+    equippedAuraId: snapshot.equippedAuraId,
+    equippedBannerId: snapshot.equippedBannerId,
   });
   const nameColorProps = nameColorRenderProps(equippedNameColor);
 
@@ -93,29 +90,16 @@ export default function ProfileMenu() {
         pressStyle={{ scale: 0.98 }}
         style={{ transition: 'all 0.2s ease' }}
       >
-        <Avatar
+        <EquippedPlayerAvatar
           name={displayName}
-          src={equippedAvatarUrl ?? undefined}
           size="sm"
-          borderWidth={
-            role === 'admin' || role === 'vip' || role === 'premium'
-              ? 1
-              : undefined
-          }
-          borderColor={
-            role === 'admin'
-              ? 'var(--danger)'
-              : role === 'vip' || role === 'premium'
-                ? 'var(--roleVip)'
-                : undefined
-          }
-          boxShadow={
-            role === 'admin'
-              ? '0 0 8px color-mix(in srgb, var(--danger) 50%, transparent)'
-              : role === 'vip' || role === 'premium'
-                ? '0 0 8px color-mix(in srgb, var(--roleVip) 50%, transparent)'
-                : undefined
-          }
+          equippedAvatarId={snapshot.equippedAvatarId}
+          equippedBadgeId={snapshot.equippedBadgeId}
+          equippedNameColorId={snapshot.equippedNameColorId}
+          equippedFrameId={snapshot.equippedFrameId}
+          equippedAuraId={snapshot.equippedAuraId}
+          equippedBannerId={snapshot.equippedBannerId}
+          data-testid="header-equipped-avatar"
         />
         <UserNameEllipsis
           data-testid="header-username"
@@ -124,18 +108,6 @@ export default function ProfileMenu() {
         >
           {displayName}
         </UserNameEllipsis>
-        {equippedBadgeUrl ? (
-          <View width={20} height={20}>
-            <Image
-              src={equippedBadgeUrl}
-              alt=""
-              width={20}
-              height={20}
-              data-testid="header-equipped-badge"
-              unoptimized
-            />
-          </View>
-        ) : null}
         {role !== 'free' && (
           <RoleBadge role={role}>{t(`common.roles.${role}`)}</RoleBadge>
         )}

--- a/docs/superpowers/plans/2026-05-20-player-avatar.md
+++ b/docs/superpowers/plans/2026-05-20-player-avatar.md
@@ -1,0 +1,1345 @@
+# PlayerAvatar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** [`docs/superpowers/specs/2026-05-20-player-avatar-design.md`](../specs/2026-05-20-player-avatar-design.md)
+
+**Goal:** Ship a reusable `PlayerAvatar` that composites every equipped shop cosmetic (avatar, badge, frame, aura, banner, name color) into one component in four sizes (icon/sm/md/card), backed by a connected wrapper that resolves equipped ids via the catalog, and migrate every player-avatar render site to use it.
+
+**Architecture:** Two-layer split — presentational `PlayerAvatar` in `@arcadeum/ui` consumes resolved URLs and color values; connected `EquippedPlayerAvatar` in `apps/web/src/shared/ui/PlayerAvatar/` calls `useEquippedCosmetics` (extended to resolve frame/aura/banner) and forwards. BE payload builders are widened to surface `equippedFrameId` / `equippedAuraId` / `equippedBannerId` (schema already has them). `ChatMessage` gets an additive `senderAvatar?: ReactNode` slot so the migration is non-breaking.
+
+**Tech Stack:** TypeScript, NestJS (BE), Next.js 16 + React 19 + Tamagui (Web), Vitest, Jest, Playwright, Storybook.
+
+---
+
+## Phase 0 — Pre-flight
+
+### Task 0.1: Verify branch + clean tree
+
+- [ ] **Step 1:** Confirm on branch `ARC-730` based on `develop`
+
+```bash
+git status && git log --oneline -3
+```
+
+Expected: branch is `ARC-730`, HEAD is the spec commit on top of develop.
+
+- [ ] **Step 2:** Confirm install is good
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Expected: completes cleanly.
+
+---
+
+## Phase 1 — BE payload widening
+
+### Task 1.1: Widen `AuthUserProfile`
+
+**Files:**
+
+- Modify: `apps/be/src/auth/lib/types.ts`
+- Modify: `apps/be/src/auth/auth.service.ts` (buildAuthUserProfile)
+- Modify: `apps/be/src/auth/auth.service.spec.ts` (if assertions cover the profile shape)
+
+- [ ] **Step 1: Extend `AuthUserProfile`**
+
+In `apps/be/src/auth/lib/types.ts` after the existing `equippedNameColorId?` field, add:
+
+```ts
+  /** Currently-equipped frame item id, or null. */
+  equippedFrameId?: string | null;
+  /** Currently-equipped aura item id, or null. */
+  equippedAuraId?: string | null;
+  /** Currently-equipped banner item id, or null. */
+  equippedBannerId?: string | null;
+```
+
+- [ ] **Step 2: Populate in `auth.service.ts#buildAuthUserProfile`**
+
+Add three lines next to `equippedNameColorId`:
+
+```ts
+      equippedFrameId: user.equippedFrameId ?? null,
+      equippedAuraId: user.equippedAuraId ?? null,
+      equippedBannerId: user.equippedBannerId ?? null,
+```
+
+- [ ] **Step 3: BE typecheck + test**
+
+```bash
+pnpm --filter be lint && pnpm --filter be test --runInBand --testPathPattern=auth
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/be/src/auth
+git commit -m "feat(be): expose equipped frame/aura/banner ids on AuthUserProfile (ARC-730)"
+```
+
+### Task 1.2: Widen chat sender payload
+
+**Files:**
+
+- Modify: `apps/be/src/chat/chat-helper.service.ts`
+- Modify: existing chat spec files (`chat.controller.spec.ts` or similar) only if they assert the sender shape; if no such assertion exists, no spec update is needed in this task.
+
+- [ ] **Step 1: Widen `equippedLookup` map entry type and the `select` projection**
+
+In `chat-helper.service.ts`, locate the existing `equippedLookup` Map<string, {...}> declaration. Extend its value type and the `.select([...])` projection with the three new fields. Then update the `equippedLookup.set(id, {...})` call to populate them. Finally extend the returned message object with `senderEquippedFrameId` / `senderEquippedAuraId` / `senderEquippedBannerId` (same `?? null` pattern as the existing fields).
+
+- [ ] **Step 2: Update spec**
+
+If the existing test asserts the sender shape, extend the assertion to include the three new optional fields.
+
+- [ ] **Step 3: Verify**
+
+```bash
+pnpm --filter be lint && pnpm --filter be test --testPathPattern=chat-helper
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/be/src/chat
+git commit -m "feat(be): chat sender payload exposes equipped frame/aura/banner (ARC-730)"
+```
+
+> **Pattern reused in Tasks 1.3–1.5:**
+>
+> - Types: add three optional `equippedFrameId?: string | null` etc. fields next to the existing equipped ids.
+> - Mongoose select strings: append `equippedFrameId equippedAuraId equippedBannerId`.
+> - Object projections (`{ equippedAvatarId: 1, ... }`): add three lines.
+> - Mappers (`return {...}` / `.set(id, {...})`): add three `?? null` lines.
+
+### Task 1.3: Widen room member payload
+
+**Files:**
+
+- Modify: `apps/be/src/games/rooms/game-rooms.types.ts`
+- Modify: `apps/be/src/games/rooms/game-rooms.mapper.ts` (select + map)
+- Modify: `apps/be/src/games/rooms/game-rooms.mapper.spec.ts` (if it asserts member shape)
+
+- [ ] **Step 1:** Apply the pattern above to all four locations in these files.
+- [ ] **Step 2:** Verify
+  ```bash
+  pnpm --filter be lint && pnpm --filter be test --testPathPattern=game-rooms
+  ```
+- [ ] **Step 3:** Commit
+  ```bash
+  git add apps/be/src/games/rooms
+  git commit -m "feat(be): room member payload exposes equipped frame/aura/banner (ARC-730)"
+  ```
+
+### Task 1.4: Widen game-history player payload
+
+**Files:**
+
+- Modify: `apps/be/src/games/history/game-history.types.ts`
+- Modify: `apps/be/src/games/history/game-history-stats.service.ts` (select string + two map sites at lines 169, 182, 200)
+- Modify: `apps/be/src/games/history/game-history-stats.service.spec.ts` (if shape-asserting)
+
+- [ ] **Step 1:** Apply the pattern. Both map sites in the service file (lines 182 and 200) need the three fields.
+- [ ] **Step 2:** Verify
+  ```bash
+  pnpm --filter be lint && pnpm --filter be test --testPathPattern=game-history
+  ```
+- [ ] **Step 3:** Commit
+  ```bash
+  git add apps/be/src/games/history
+  git commit -m "feat(be): game history player payload exposes equipped frame/aura/banner (ARC-730)"
+  ```
+
+### Task 1.5: Widen leaderboard payload
+
+**Files:**
+
+- Modify: `apps/be/src/leaderboards/dtos/leaderboard-snapshot.dto.ts` (both occurrences — see lines 32 and 99)
+- Modify: `apps/be/src/leaderboards/leaderboards.hydrate.ts` (the player base type + the hydrate mapper around line 143)
+- Modify: `apps/be/src/leaderboards/leaderboards.service.ts` (the projection at line 231 and the return shape at line 251)
+- Modify: relevant `.spec.ts` files if they assert shape
+
+- [ ] **Step 1:** Apply the pattern across all sites.
+- [ ] **Step 2:** Verify
+  ```bash
+  pnpm --filter be lint && pnpm --filter be test --testPathPattern=leaderboards
+  ```
+- [ ] **Step 3:** Commit
+  ```bash
+  git add apps/be/src/leaderboards
+  git commit -m "feat(be): leaderboard payload exposes equipped frame/aura/banner (ARC-730)"
+  ```
+
+---
+
+## Phase 2 — FE shared types + hook extension
+
+### Task 2.1: Extend session + leaderboard + game types
+
+**Files:**
+
+- Modify: `apps/web/src/entities/session/model/types.ts`
+- Modify: `apps/web/src/entities/session/api/authApi.ts`
+- Modify: `apps/web/src/entities/session/store/sessionStore.ts` (defaults + merge)
+- Modify: `apps/web/src/entities/leaderboard/model/types.ts`
+- Modify: `apps/web/src/shared/types/games.ts` (Player base)
+- Modify: `apps/web/src/features/shop/lib/syncEquippedToSession.ts` (sync 3 new fields)
+
+- [ ] **Step 1: Add `equippedFrameId` / `equippedAuraId` / `equippedBannerId` everywhere the existing equipped ids appear in these files.**
+
+Use the same `string | null` (or `string | null | undefined`) pattern as the existing fields. In `sessionStore.ts`, both the default-state object and the merge helper need the three new lines.
+
+In `syncEquippedToSession.ts`, the existing code reads `equipped.avatar` / `equipped.badge` / `equipped.name_color` from the inventory `EquippedView`. Add `equipped.frame` / `equipped.aura` / `equipped.banner` lines.
+
+- [ ] **Step 2: Verify**
+
+```bash
+pnpm --filter web type-check
+```
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/entities apps/web/src/shared/types apps/web/src/features/shop/lib
+git commit -m "feat(web): session + leaderboard + game types carry equipped frame/aura/banner (ARC-730)"
+```
+
+### Task 2.2: Extend `useEquippedCosmetics`
+
+**Files:**
+
+- Modify: `apps/web/src/features/shop/hooks/useEquippedCosmetics.ts`
+- Create: `apps/web/src/features/shop/hooks/useEquippedCosmetics.test.ts` (no test file exists today)
+
+- [ ] **Step 1: Widen the `EquippedCosmetics` return type**
+
+```ts
+export interface EquippedCosmetics {
+  avatarUrl: string | null;
+  avatarItem: EffectiveShopItem | null;
+  badgeUrl: string | null;
+  badgeItem: EffectiveShopItem | null;
+  nameColor: string | null;
+  nameColorItem: EffectiveShopItem | null;
+  /** CSS color (hex or linear-gradient) for the equipped frame ring. */
+  frameColor: string | null;
+  frameItem: EffectiveShopItem | null;
+  /** CSS color (hex or linear-gradient) for the equipped aura halo. */
+  auraColor: string | null;
+  auraItem: EffectiveShopItem | null;
+  /** CSS color (hex or linear-gradient) for the equipped banner backdrop. */
+  bannerColor: string | null;
+  bannerItem: EffectiveShopItem | null;
+}
+```
+
+- [ ] **Step 2: Widen the args + resolution**
+
+```ts
+export function useEquippedCosmetics(args: {
+  equippedAvatarId: string | null | undefined;
+  equippedBadgeId: string | null | undefined;
+  equippedNameColorId?: string | null | undefined;
+  equippedFrameId?: string | null | undefined;
+  equippedAuraId?: string | null | undefined;
+  equippedBannerId?: string | null | undefined;
+}): EquippedCosmetics {
+  // ... existing avatar/badge/nameColor resolution unchanged
+  const frame = args.equippedFrameId
+    ? (catalogMap.get(args.equippedFrameId) ?? null)
+    : null;
+  const aura = args.equippedAuraId
+    ? (catalogMap.get(args.equippedAuraId) ?? null)
+    : null;
+  const banner = args.equippedBannerId
+    ? (catalogMap.get(args.equippedBannerId) ?? null)
+    : null;
+  return {
+    // ... existing returns unchanged
+    frameItem: frame,
+    frameColor: frame?.colorValue ?? null,
+    auraItem: aura,
+    auraColor: aura?.colorValue ?? null,
+    bannerItem: banner,
+    bannerColor: banner?.colorValue ?? null,
+  };
+}
+```
+
+Don't forget to add the new ids to the `useMemo` deps.
+
+- [ ] **Step 3: Test**
+
+If no test file exists, create `apps/web/src/features/shop/hooks/useEquippedCosmetics.test.ts`:
+
+```ts
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEquippedCosmetics } from './useEquippedCosmetics';
+import * as catalogCache from '../lib/catalogCache';
+
+vi.mock('../lib/catalogCache');
+
+describe('useEquippedCosmetics', () => {
+  beforeEach(() => {
+    vi.mocked(catalogCache.loadCatalog).mockResolvedValue([
+      {
+        id: 'frame-1',
+        category: 'frame',
+        colorValue: '#abcdef',
+        assetUrl: '' /* ...minimal stub */,
+      } as never,
+      {
+        id: 'aura-1',
+        category: 'aura',
+        colorValue: 'linear-gradient(#1, #2)',
+        assetUrl: '' /* ... */,
+      } as never,
+      {
+        id: 'banner-1',
+        category: 'banner',
+        colorValue: '#0f172a',
+        assetUrl: '' /* ... */,
+      } as never,
+    ]);
+  });
+
+  it('resolves frame/aura/banner colors from the catalog', async () => {
+    const { result, rerender } = renderHook(() =>
+      useEquippedCosmetics({
+        equippedAvatarId: null,
+        equippedBadgeId: null,
+        equippedFrameId: 'frame-1',
+        equippedAuraId: 'aura-1',
+        equippedBannerId: 'banner-1',
+      }),
+    );
+    // Hook starts with empty map; rerender after async resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    rerender();
+    expect(result.current.frameColor).toBe('#abcdef');
+    expect(result.current.auraColor).toContain('linear-gradient');
+    expect(result.current.bannerColor).toBe('#0f172a');
+  });
+});
+```
+
+- [ ] **Step 4: Run**
+
+```bash
+pnpm --filter web test useEquippedCosmetics
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/features/shop/hooks
+git commit -m "feat(shop): useEquippedCosmetics resolves frame/aura/banner colors (ARC-730)"
+```
+
+---
+
+## Phase 3 — Build `PlayerAvatar` (presentational) in `@arcadeum/ui`
+
+### Task 3.1: Skeleton + types
+
+**Files:**
+
+- Create: `packages/ui/src/components/PlayerAvatar/PlayerAvatar.tsx`
+- Create: `packages/ui/src/components/PlayerAvatar/index.ts`
+- Modify: `packages/ui/src/index.ts` (re-export)
+
+- [ ] **Step 1: Create the file skeleton**
+
+```tsx
+'use client';
+
+import { memo } from 'react';
+import { Stack, Text, View, YStack, styled } from 'tamagui';
+import { Avatar } from '../Avatar/Avatar';
+
+export type PlayerAvatarSize = 'icon' | 'sm' | 'md' | 'card';
+
+export interface PlayerAvatarProps {
+  name: string;
+  size?: PlayerAvatarSize;
+  avatarUrl?: string | null;
+  badgeUrl?: string | null;
+  frameColor?: string | null;
+  auraColor?: string | null;
+  bannerColor?: string | null;
+  nameColor?: string | null;
+  level?: number | null;
+  presenceLine?: string;
+  priority?: boolean;
+  'data-testid'?: string;
+  onPress?: () => void;
+}
+
+const DISC_SIZE: Record<PlayerAvatarSize, number> = {
+  icon: 28,
+  sm: 40,
+  md: 72,
+  card: 140,
+};
+const BADGE_SIZE: Record<PlayerAvatarSize, number> = {
+  icon: 0,
+  sm: 14,
+  md: 24,
+  card: 36,
+};
+const RING_WIDTH: Record<PlayerAvatarSize, number> = {
+  icon: 0,
+  sm: 2,
+  md: 3,
+  card: 3,
+};
+
+function pickSwatchColor(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(/#[0-9a-fA-F]{3,8}/);
+  if (match) return match[0];
+  return value.includes('gradient') ? null : value;
+}
+
+export const PlayerAvatar = memo(function PlayerAvatar(
+  props: PlayerAvatarProps,
+) {
+  const size = props.size ?? 'sm';
+  const disc = DISC_SIZE[size];
+  // Implementation in subsequent steps.
+  return (
+    <Stack data-testid={props['data-testid']} onPress={props.onPress}>
+      <Avatar
+        name={props.name}
+        src={props.avatarUrl ?? undefined}
+        size="sm"
+        priority={props.priority}
+      />
+    </Stack>
+  );
+});
+```
+
+- [ ] **Step 2: Wire exports**
+
+`packages/ui/src/components/PlayerAvatar/index.ts`:
+
+```ts
+export { PlayerAvatar } from './PlayerAvatar';
+export type { PlayerAvatarProps, PlayerAvatarSize } from './PlayerAvatar';
+```
+
+In `packages/ui/src/index.ts` add:
+
+```ts
+export * from './components/PlayerAvatar';
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm --filter @arcadeum/ui type-check
+```
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/PlayerAvatar packages/ui/src/index.ts
+git commit -m "feat(ui): PlayerAvatar component skeleton (ARC-730)"
+```
+
+### Task 3.2: TDD — composition behavior
+
+**Files:**
+
+- Create: `packages/ui/src/components/PlayerAvatar/PlayerAvatar.test.tsx`
+- Modify: `packages/ui/src/components/PlayerAvatar/PlayerAvatar.tsx`
+
+Follow the existing `Avatar.test.tsx` pattern (uses `@testing-library/react` + vitest + the package's Tamagui test setup).
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PlayerAvatar } from './PlayerAvatar';
+
+// Tamagui requires a config provider in package tests — reuse whatever the
+// existing Avatar.test.tsx uses. Mirror its setup verbatim.
+
+describe('PlayerAvatar', () => {
+  it('renders the player name as initials when no avatar URL', () => {
+    render(<PlayerAvatar name="Jane Doe" />);
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('renders the avatar image when avatarUrl is provided', () => {
+    render(<PlayerAvatar name="Jane" avatarUrl="/x.png" />);
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/x.png');
+  });
+
+  it('renders the badge at sm/md/card sizes but not at icon', () => {
+    const { rerender } = render(
+      <PlayerAvatar name="J" badgeUrl="/b.png" size="icon" data-testid="pa" />,
+    );
+    expect(screen.queryByTestId('pa-badge')).toBeNull();
+
+    rerender(
+      <PlayerAvatar name="J" badgeUrl="/b.png" size="sm" data-testid="pa" />,
+    );
+    expect(screen.getByTestId('pa-badge')).toBeInTheDocument();
+
+    rerender(
+      <PlayerAvatar name="J" badgeUrl="/b.png" size="card" data-testid="pa" />,
+    );
+    expect(screen.getByTestId('pa-badge')).toBeInTheDocument();
+  });
+
+  it('renders the frame ring at sm/md/card but not icon', () => {
+    const { rerender } = render(
+      <PlayerAvatar
+        name="J"
+        frameColor="#ff00ff"
+        size="icon"
+        data-testid="pa"
+      />,
+    );
+    expect(screen.queryByTestId('pa-frame')).toBeNull();
+
+    rerender(
+      <PlayerAvatar name="J" frameColor="#ff00ff" size="md" data-testid="pa" />,
+    );
+    expect(screen.getByTestId('pa-frame')).toBeInTheDocument();
+  });
+
+  it('renders the aura halo at md/card only', () => {
+    const { rerender } = render(
+      <PlayerAvatar name="J" auraColor="#ff0" size="sm" data-testid="pa" />,
+    );
+    expect(screen.queryByTestId('pa-aura')).toBeNull();
+
+    rerender(
+      <PlayerAvatar name="J" auraColor="#ff0" size="md" data-testid="pa" />,
+    );
+    expect(screen.getByTestId('pa-aura')).toBeInTheDocument();
+  });
+
+  it('renders the banner backdrop, name label, and level only at card', () => {
+    const { rerender } = render(
+      <PlayerAvatar
+        name="Jane"
+        bannerColor="#0f0"
+        level={42}
+        size="md"
+        data-testid="pa"
+      />,
+    );
+    expect(screen.queryByTestId('pa-banner')).toBeNull();
+    expect(screen.queryByTestId('pa-name')).toBeNull();
+
+    rerender(
+      <PlayerAvatar
+        name="Jane"
+        bannerColor="#0f0"
+        level={42}
+        size="card"
+        data-testid="pa"
+        presenceLine="Level 42"
+      />,
+    );
+    expect(screen.getByTestId('pa-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('pa-name')).toHaveTextContent('Jane');
+    expect(screen.getByText('Level 42')).toBeInTheDocument();
+  });
+
+  it('applies onPress as click handler', () => {
+    const onPress = vi.fn();
+    render(<PlayerAvatar name="J" onPress={onPress} data-testid="pa" />);
+    screen.getByTestId('pa').click();
+    expect(onPress).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+pnpm --filter @arcadeum/ui test PlayerAvatar
+```
+
+Expected: most assertions fail (component is still the skeleton).
+
+Implementation is split into three sub-steps so each TDD cycle is small:
+
+- [ ] **Step 3a: Inner disc + frame ring** — make the disc-render, frame-ring, and initials-fallback tests pass. Leave badge/aura/banner/name as no-ops.
+
+- [ ] **Step 3b: Badge + aura** — extend the disc with the badge corner and aura halo. Make the badge and aura tests pass.
+
+- [ ] **Step 3c: Card chrome (banner + name + presence)** — make the card-only tests pass. Make `onPress` work.
+
+Below is the full target composition for reference; apply it incrementally across 3a/3b/3c. Mirror the inset/zIndex layering from `ShopMannequinStage.tsx` lines 240-282.
+
+```tsx
+export const PlayerAvatar = memo(function PlayerAvatar({
+  name,
+  size = 'sm',
+  avatarUrl,
+  badgeUrl,
+  frameColor,
+  auraColor,
+  bannerColor,
+  nameColor,
+  level,
+  presenceLine,
+  priority,
+  'data-testid': testId,
+  onPress,
+}: PlayerAvatarProps) {
+  const disc = DISC_SIZE[size];
+  const badge = BADGE_SIZE[size];
+  const ring = RING_WIDTH[size];
+  const showBadge = size !== 'icon' && !!badgeUrl;
+  const showFrame = size !== 'icon' && !!frameColor;
+  const showAura = (size === 'md' || size === 'card') && !!auraColor;
+  const showCardChrome = size === 'card';
+
+  const ringStyle: React.CSSProperties = showFrame
+    ? frameColor!.includes('gradient')
+      ? {
+          backgroundImage: `linear-gradient(rgba(15,23,42,0.55), rgba(15,23,42,0.55)), ${frameColor}`,
+          borderColor: pickSwatchColor(frameColor) ?? 'rgba(255,255,255,0.35)',
+        }
+      : { backgroundColor: `${frameColor}33`, borderColor: frameColor! }
+    : {
+        backgroundColor: 'rgba(255,255,255,0.04)',
+        borderColor: 'rgba(255,255,255,0.18)',
+      };
+
+  const auraSwatch = showAura
+    ? (pickSwatchColor(auraColor) ?? 'rgba(96,165,250,0.45)')
+    : null;
+
+  const bannerStyle: React.CSSProperties | undefined =
+    showCardChrome && bannerColor
+      ? bannerColor.includes('gradient')
+        ? { backgroundImage: bannerColor }
+        : { backgroundColor: bannerColor }
+      : undefined;
+
+  // The image element should be ~75% of the disc so the ring is visible.
+  const innerImage = Math.round(disc * 0.78);
+
+  const inner = (
+    <Stack
+      width={disc}
+      height={disc}
+      borderRadius={disc / 2}
+      alignItems="center"
+      justifyContent="center"
+      borderWidth={showFrame ? ring : 0}
+      position="relative"
+      style={{
+        ...(showFrame ? ringStyle : {}),
+        ...(auraSwatch
+          ? { boxShadow: `0 0 ${disc * 0.4}px ${auraSwatch}` }
+          : {}),
+      }}
+      data-testid={testId ? `${testId}-disc` : undefined}
+    >
+      {showFrame ? (
+        <View
+          position="absolute"
+          inset={0}
+          borderRadius={disc / 2}
+          data-testid={testId ? `${testId}-frame` : undefined}
+          pointerEvents="none"
+        />
+      ) : null}
+      {showAura ? (
+        <View
+          position="absolute"
+          inset={-Math.round(disc * 0.15)}
+          borderRadius={disc}
+          data-testid={testId ? `${testId}-aura` : undefined}
+          pointerEvents="none"
+        />
+      ) : null}
+      <Avatar
+        name={name}
+        src={avatarUrl ?? undefined}
+        size="sm" // we override visual size with the wrapper
+        priority={priority}
+        style={{ width: innerImage, height: innerImage }}
+      />
+      {showBadge ? (
+        <View
+          position="absolute"
+          bottom={-Math.round(badge * 0.2)}
+          right={-Math.round(badge * 0.2)}
+          width={badge}
+          height={badge}
+          borderRadius={badge / 2}
+          backgroundColor="rgba(2,6,23,0.85)"
+          borderWidth={1}
+          borderColor="rgba(255,255,255,0.20)"
+          alignItems="center"
+          justifyContent="center"
+          data-testid={testId ? `${testId}-badge` : undefined}
+        >
+          <img
+            src={badgeUrl!}
+            alt=""
+            width={Math.round(badge * 0.75)}
+            height={Math.round(badge * 0.75)}
+            style={{ objectFit: 'contain' }}
+          />
+        </View>
+      ) : null}
+    </Stack>
+  );
+
+  if (!showCardChrome) {
+    return (
+      <Stack
+        data-testid={testId}
+        onPress={onPress}
+        cursor={onPress ? 'pointer' : 'default'}
+      >
+        {inner}
+      </Stack>
+    );
+  }
+
+  // Card chrome: banner backdrop, name, presence line.
+  return (
+    <YStack
+      data-testid={testId}
+      onPress={onPress}
+      cursor={onPress ? 'pointer' : 'default'}
+      width={220}
+      borderRadius="$5"
+      paddingHorizontal="$4"
+      paddingVertical="$4"
+      alignItems="center"
+      gap="$3"
+      overflow="hidden"
+      style={bannerStyle ?? { backgroundColor: 'rgba(15,23,42,0.55)' }}
+    >
+      {bannerStyle ? (
+        <View
+          data-testid={testId ? `${testId}-banner` : undefined}
+          display="none"
+        />
+      ) : null}
+      {inner}
+      <YStack alignItems="center" gap={4}>
+        <Text
+          fontSize="$6"
+          fontWeight="900"
+          color={
+            nameColor && !nameColor.includes('gradient') ? nameColor : '$white'
+          }
+          data-testid={testId ? `${testId}-name` : undefined}
+          {...(nameColor && nameColor.includes('gradient')
+            ? {
+                style: {
+                  background: nameColor,
+                  WebkitBackgroundClip: 'text',
+                  WebkitTextFillColor: 'transparent',
+                  backgroundClip: 'text',
+                },
+              }
+            : {})}
+        >
+          {name}
+        </Text>
+        {presenceLine ? (
+          <Text
+            fontSize={10}
+            letterSpacing={2}
+            textTransform="uppercase"
+            color="$gray11"
+            fontWeight="700"
+          >
+            {presenceLine}
+          </Text>
+        ) : null}
+      </YStack>
+    </YStack>
+  );
+});
+```
+
+Notes for the implementer:
+
+- Test-id sentinels are guarded by their corresponding prop being set (e.g., `pa-banner` only rendered when `bannerColor` is provided at `card` size). The tests assert presence/absence based on the same condition, so the guarded approach is correct.
+- Reuse `Avatar` for the image disc; override its rendered size via the `style` prop (already supported by `Avatar`).
+- `pickSwatchColor` mirrors the function in `ShopMannequinStage.tsx`. Phase 7 will deduplicate by importing the version from `PlayerAvatar` — for now, leave both inline.
+
+- [ ] **Step 4: Run tests — expect green**
+
+After each sub-step (3a, 3b, 3c):
+
+```bash
+pnpm --filter @arcadeum/ui test PlayerAvatar
+```
+
+Expect the corresponding tests to flip from red → green incrementally. Common adjustments:
+
+- If `data-testid="pa-frame"` isn't found, ensure the dedicated `<View data-testid={...}-frame>` renders inside the `showFrame` branch (only rendered when `frameColor` is provided AND size is not `icon`).
+- If `data-testid="pa-banner"` isn't found, verify the sentinel `<View>` is inside the `showCardChrome` branch and gated on `bannerColor` being set.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/components/PlayerAvatar
+git commit -m "feat(ui): PlayerAvatar composes frame/aura/badge/banner/name across 4 sizes (ARC-730)"
+```
+
+### Task 3.3: Storybook
+
+**Files:**
+
+- Create: `packages/ui/src/components/PlayerAvatar/PlayerAvatar.stories.tsx`
+
+- [ ] **Step 1: Mirror `Avatar.stories.tsx`**
+
+Read `packages/ui/src/components/Avatar/Avatar.stories.tsx` first to pick up the Meta/StoryObj pattern, decorators, and any required Tamagui provider. Then create the new file with at minimum the following stories:
+
+- `Icon`, `Sm`, `Md`, `Card` — one per size
+- `FullyDecked` — card size with frame + aura + badge + banner + nameColor + level
+- `LoadingFromCatalog` — no URLs set (initials only) to demo the resolved-null state
+
+Each story should be a 1-2 prop assignment. Keep file under ~120 lines.
+
+- [ ] **Step 2: Verify the package's Storybook builds (if `storybook:build` is wired)**
+
+```bash
+pnpm --filter @arcadeum/ui build 2>&1 | tail -20
+```
+
+Expected: typecheck passes; Storybook story file does not need to render at build time.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/PlayerAvatar/PlayerAvatar.stories.tsx
+git commit -m "test(ui): PlayerAvatar Storybook stories (ARC-730)"
+```
+
+---
+
+## Phase 4 — Build `EquippedPlayerAvatar` (connected) in web
+
+### Task 4.1: Create the connected wrapper
+
+**Files:**
+
+- Create: `apps/web/src/shared/ui/PlayerAvatar/EquippedPlayerAvatar.tsx`
+- Create: `apps/web/src/shared/ui/PlayerAvatar/index.ts`
+- Create: `apps/web/src/shared/ui/PlayerAvatar/EquippedPlayerAvatar.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { EquippedPlayerAvatar } from './EquippedPlayerAvatar';
+import * as hook from '@/features/shop/hooks/useEquippedCosmetics';
+
+vi.mock('@/features/shop/hooks/useEquippedCosmetics');
+
+describe('EquippedPlayerAvatar', () => {
+  it('passes resolved urls/colors to PlayerAvatar', () => {
+    vi.mocked(hook.useEquippedCosmetics).mockReturnValue({
+      avatarUrl: '/a.png',
+      avatarItem: null,
+      badgeUrl: '/b.png',
+      badgeItem: null,
+      nameColor: '#fff',
+      nameColorItem: null,
+      frameColor: '#ff0',
+      frameItem: null,
+      auraColor: '#0ff',
+      auraItem: null,
+      bannerColor: '#f0f',
+      bannerItem: null,
+    });
+    render(
+      <EquippedPlayerAvatar
+        name="Jane"
+        size="card"
+        equippedAvatarId="a-1"
+        equippedBadgeId="b-1"
+        equippedFrameId="f-1"
+        equippedAuraId="au-1"
+        equippedBannerId="bn-1"
+        data-testid="epa"
+      />,
+    );
+    expect(screen.getByTestId('epa-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('epa-name')).toHaveTextContent('Jane');
+  });
+
+  it('falls back to fallbackAvatarUrl when catalog returns null', () => {
+    vi.mocked(hook.useEquippedCosmetics).mockReturnValue({
+      avatarUrl: null,
+      avatarItem: null,
+      badgeUrl: null,
+      badgeItem: null,
+      nameColor: null,
+      nameColorItem: null,
+      frameColor: null,
+      frameItem: null,
+      auraColor: null,
+      auraItem: null,
+      bannerColor: null,
+      bannerItem: null,
+    });
+    render(
+      <EquippedPlayerAvatar
+        name="Jane"
+        equippedAvatarId={null}
+        equippedBadgeId={null}
+        fallbackAvatarUrl="/legacy.png"
+        data-testid="epa"
+      />,
+    );
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/legacy.png');
+  });
+});
+```
+
+- [ ] **Step 2: Implementation**
+
+`EquippedPlayerAvatar.tsx`:
+
+```tsx
+'use client';
+
+import { memo } from 'react';
+import { PlayerAvatar, type PlayerAvatarSize } from '@arcadeum/ui';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+
+export interface EquippedPlayerAvatarProps {
+  name: string;
+  size?: PlayerAvatarSize;
+  equippedAvatarId: string | null | undefined;
+  equippedBadgeId: string | null | undefined;
+  equippedNameColorId?: string | null | undefined;
+  equippedFrameId?: string | null | undefined;
+  equippedAuraId?: string | null | undefined;
+  equippedBannerId?: string | null | undefined;
+  fallbackAvatarUrl?: string;
+  level?: number | null;
+  presenceLine?: string;
+  priority?: boolean;
+  'data-testid'?: string;
+  onPress?: () => void;
+}
+
+export const EquippedPlayerAvatar = memo(function EquippedPlayerAvatar(
+  props: EquippedPlayerAvatarProps,
+) {
+  const cosmetics = useEquippedCosmetics({
+    equippedAvatarId: props.equippedAvatarId,
+    equippedBadgeId: props.equippedBadgeId,
+    equippedNameColorId: props.equippedNameColorId,
+    equippedFrameId: props.equippedFrameId,
+    equippedAuraId: props.equippedAuraId,
+    equippedBannerId: props.equippedBannerId,
+  });
+  return (
+    <PlayerAvatar
+      name={props.name}
+      size={props.size}
+      avatarUrl={cosmetics.avatarUrl ?? props.fallbackAvatarUrl ?? null}
+      badgeUrl={cosmetics.badgeUrl}
+      frameColor={cosmetics.frameColor}
+      auraColor={cosmetics.auraColor}
+      bannerColor={cosmetics.bannerColor}
+      nameColor={cosmetics.nameColor}
+      level={props.level}
+      presenceLine={props.presenceLine}
+      priority={props.priority}
+      data-testid={props['data-testid']}
+      onPress={props.onPress}
+    />
+  );
+});
+```
+
+`index.ts`:
+
+```ts
+export { EquippedPlayerAvatar } from './EquippedPlayerAvatar';
+export type { EquippedPlayerAvatarProps } from './EquippedPlayerAvatar';
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+pnpm --filter web test EquippedPlayerAvatar
+```
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/shared/ui/PlayerAvatar
+git commit -m "feat(web): EquippedPlayerAvatar resolves equipped ids and renders PlayerAvatar (ARC-730)"
+```
+
+---
+
+## Phase 5 — Additive `senderAvatar` slot on `ChatMessage`
+
+### Task 5.1: Add the slot
+
+**Files:**
+
+- Modify: `packages/ui/src/components/Chat/ChatMessage.tsx`
+- Modify: `packages/ui/src/components/Chat/ChatMessage.stories.tsx` (add a story using the slot)
+
+- [ ] **Step 1: Extend `ChatMessageProps`**
+
+Add `senderAvatar?: ReactNode` after the existing `avatarUrl?` / `badgeUrl?` props (keep those for backward compatibility, with a JSDoc note marking them deprecated in favor of `senderAvatar`).
+
+- [ ] **Step 2a: Audit the existing render**
+
+Open `packages/ui/src/components/Chat/ChatMessage.tsx` and read lines 149-200. Note the exact JSX of the inline `<Avatar>` + badge block in both branches. The legacy fallback in step 2b MUST be byte-equivalent (same `<Avatar>` props, same `<View width=16>`, same `<img style={{ objectFit: 'contain' }} />`) so no migrated-yet caller regresses.
+
+- [ ] **Step 2b: Render the slot**
+
+In both the `!isOwn && !isSystem` and `isOwn && !isSystem` branches, wrap the existing inline `<Avatar ...>` + badge `<View>` block in a conditional that prefers `senderAvatar`:
+
+```tsx
+{
+  senderAvatar ?? (
+    <>
+      <Avatar name={senderName} size="sm" src={avatarUrl} />
+      {badgeUrl ? (
+        <View width={16} height={16}>
+          <img
+            src={badgeUrl}
+            alt=""
+            width={16}
+            height={16}
+            style={{ objectFit: 'contain' }}
+          />
+        </View>
+      ) : null}
+    </>
+  );
+}
+```
+
+So existing callers that pass `avatarUrl` + `badgeUrl` continue to work; new callers pass a `senderAvatar={<EquippedPlayerAvatar ... />}` and the legacy block is skipped.
+
+- [ ] **Step 3: Add a story**
+
+In `ChatMessage.stories.tsx`, add a `WithSenderAvatarSlot` story that passes a placeholder ReactNode in `senderAvatar`.
+
+- [ ] **Step 4: Verify**
+
+```bash
+pnpm --filter @arcadeum/ui test ChatMessage
+pnpm --filter @arcadeum/ui type-check
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/components/Chat
+git commit -m "feat(ui): ChatMessage adds optional senderAvatar slot (ARC-730)"
+```
+
+---
+
+## Phase 6 — Migrate call sites
+
+> Each task in this phase: replace the existing `<Avatar src={avatarUrl}>` + sibling badge `<View>/<Image>` + separate name-color application with a single `<EquippedPlayerAvatar ... />` (or for `ChatMessage` consumers, pass `senderAvatar={<EquippedPlayerAvatar ... />}`). Pass through any new equipped-id fields. Keep the existing `useEquippedCosmetics` calls where they're used to derive things other than what `EquippedPlayerAvatar` handles (e.g., gradient name color for the surrounding `<Text>` — but if the surrounding text is now inside `EquippedPlayerAvatar size="card">`, drop the duplicate hook call).
+
+For every task in this phase, run `pnpm --filter web type-check` after the edit and commit only when green.
+
+### Task 6.1: Locale chat — `ChatPage.tsx`
+
+**Files:** `apps/web/src/app/[locale]/chat/ChatPage.tsx`
+
+- [ ] **Step 1:** In `ChatMessageRow`, build the avatar:
+  ```tsx
+  const senderAvatar = (
+    <EquippedPlayerAvatar
+      name={msg.senderUsername}
+      size="sm"
+      equippedAvatarId={msg.senderEquippedAvatarId}
+      equippedBadgeId={msg.senderEquippedBadgeId}
+      equippedNameColorId={msg.senderEquippedNameColorId}
+      equippedFrameId={msg.senderEquippedFrameId}
+      equippedAuraId={msg.senderEquippedAuraId}
+      equippedBannerId={msg.senderEquippedBannerId}
+    />
+  );
+  ```
+  and pass it to `<ChatMessage senderAvatar={senderAvatar} ... />`. Remove the now-redundant `useEquippedCosmetics` call and `avatarUrl`/`badgeUrl` props (keep `senderColor`/`senderNameStyle` until visible name-color rendering moves into PlayerAvatar at sm size — not done in this PR, so leave them).
+  Extend `ChatMessageData` (locate its declaration via `grep` — likely in `features/chat/api.ts` or similar) to include the three new optional fields.
+- [ ] **Step 2:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/app/[locale]/chat apps/web/src/features/chat
+  git commit -m "refactor(chat): use EquippedPlayerAvatar in locale chat (ARC-730)"
+  ```
+
+### Task 6.2: In-game chat — `GameChat.tsx` + `ChatMessageBubble.tsx` + `ChatMessagePopup.tsx`
+
+**Files:**
+
+- Modify: `apps/web/src/widgets/GameChat/ui/GameChat.tsx` (`EquippedResolver` type + `GameChatRow`)
+- Modify: `apps/web/src/widgets/GameChat/ui/ChatMessageBubble.tsx`
+- Modify: `apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx`
+
+- [ ] **Step 1:** Widen `EquippedResolver` to also return frame/aura/banner ids; widen `GamePageLayout.resolveEquipped` (`apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx`) to populate them.
+- [ ] **Step 2:** In `GameChatRow`, replace the inline hook + ChatMessage avatar props with `senderAvatar={<EquippedPlayerAvatar ... />}`.
+- [ ] **Step 3:** In `ChatMessageBubble`, replace the manual `<View><Image>` avatar disc + badge inline block with `<EquippedPlayerAvatar size="sm" ... />`. Keep the surrounding bubble layout. The sender-name `<Text>` keeps its `nameColorRenderProps` derivation for now (sm doesn't render the name through PlayerAvatar).
+- [ ] **Step 4:** In `ChatMessagePopup`, add the three new props and forward them down to `ChatMessageBubble`.
+- [ ] **Step 5:** typecheck + run game-chat tests
+  ```bash
+  pnpm --filter web type-check
+  pnpm --filter web test GameChat
+  ```
+- [ ] **Step 6:** Commit
+  ```bash
+  git add apps/web/src/widgets/GameChat apps/web/src/app/[locale]/games/rooms
+  git commit -m "refactor(games): in-game chat uses EquippedPlayerAvatar (ARC-730)"
+  ```
+
+### Task 6.3: Leaderboards — `RankTable.tsx`
+
+**Files:** `apps/web/src/app/[locale]/leaderboards/_components/RankTable.tsx`
+
+- [ ] **Step 1:** Replace the `<Avatar src={avatarUrl ?? p.avatarUrl ?? undefined}>` + separate badge `<Image>` block with:
+  ```tsx
+  <EquippedPlayerAvatar
+    name={p.name}
+    size="sm"
+    equippedAvatarId={p.equippedAvatarId}
+    equippedBadgeId={p.equippedBadgeId}
+    equippedNameColorId={p.equippedNameColorId}
+    equippedFrameId={p.equippedFrameId}
+    equippedAuraId={p.equippedAuraId}
+    equippedBannerId={p.equippedBannerId}
+    fallbackAvatarUrl={p.avatarUrl ?? undefined}
+    priority={priority}
+  />
+  ```
+  Keep the surrounding name `<Text>` with its `nameColorRenderProps` since the name is outside PlayerAvatar at sm. Drop the inline badge `<View>` (PlayerAvatar renders it now).
+- [ ] **Step 2:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/app/[locale]/leaderboards
+  git commit -m "refactor(leaderboards): use EquippedPlayerAvatar in RankTable (ARC-730)"
+  ```
+
+### Task 6.4: Player profile — `PlayerProfileClient.tsx`
+
+**Files:** `apps/web/src/app/[locale]/players/[id]/PlayerProfileClient.tsx`
+
+- [ ] **Step 1:** Replace the `<Avatar size="xl" src={avatarUrl ?? undefined}>` and the inline badge `<View><Image>` with `<EquippedPlayerAvatar size="md" ... />`. (Size `md` is intentionally chosen — the profile hero already has its own surrounding name/level chrome; we don't want to double-render.)
+      Pass all six equipped ids and the player's `avatarUrl` as `fallbackAvatarUrl`.
+- [ ] **Step 2:** Extend `PlayerProfile` type to include the new ids (the BE payload now carries them).
+- [ ] **Step 3:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/app/[locale]/players
+  git commit -m "refactor(players): profile hero uses EquippedPlayerAvatar (ARC-730)"
+  ```
+
+### Task 6.5: Header menus — `ProfileMenu.tsx` + `MobileMenu.tsx`
+
+**Files:**
+
+- `apps/web/src/widgets/header/ui/ProfileMenu.tsx`
+- `apps/web/src/widgets/header/ui/MobileMenu.tsx`
+
+- [ ] **Step 1:** Replace `<Avatar size="md">` with `<EquippedPlayerAvatar size="md" ... />` reading from `useSessionStore` (or whatever snapshot is already used at line ~52 of ProfileMenu). Forward all six new equipped-id fields from the session snapshot.
+- [ ] **Step 2:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/widgets/header
+  git commit -m "refactor(header): profile + mobile menu use EquippedPlayerAvatar (ARC-730)"
+  ```
+
+### Task 6.6: Games — RoomCard + sea-battle lobby
+
+**Files:**
+
+- `apps/web/src/app/[locale]/games/RoomCardComponent.tsx`
+- `apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx`
+- `apps/web/src/features/games/sea-battle/lobby/UnassignedPool.tsx`
+- `apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx` (mapper into Player)
+
+- [ ] **Step 1:** Each `<Avatar>` consuming `member` or `player` props swaps to `<EquippedPlayerAvatar>` with all six equipped-id fields read from the source object. Use `size="icon"` for tight tile contexts (RoomCard member row, UnassignedPool) and `size="sm"` for `TeamSlotsBoard` slots. Extend `Player` type in `apps/web/src/shared/types/games.ts` if not already.
+- [ ] **Step 2:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/app/[locale]/games apps/web/src/features/games apps/web/src/widgets/SeaBattleGame
+  git commit -m "refactor(games): room card + sea-battle lobby use EquippedPlayerAvatar (ARC-730)"
+  ```
+
+### Task 6.7: Chat list page
+
+**Files:** `apps/web/src/app/[locale]/chats/ChatListPage.tsx`
+
+- [ ] **Step 1:** Each `<Avatar>` in chat list rows (lines 154 and 231) swaps to `<EquippedPlayerAvatar size="icon" ... />`. The 231 site uses the chat `title` as `name` and may not have equipped ids — pass `equippedAvatarId={null}` etc., and it will fall back to initials.
+- [ ] **Step 2:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/app/[locale]/chats
+  git commit -m "refactor(chats): chat list uses EquippedPlayerAvatar (ARC-730)"
+  ```
+
+### Task 6.8: History modal + stats leaderboard
+
+**Files:**
+
+- `apps/web/src/app/[locale]/history/components/HistoryDetailModal.tsx`
+- `apps/web/src/app/[locale]/stats/components/Leaderboard.tsx`
+
+- [ ] **Step 1:** Each `<Avatar>` swap. Use `sm` for the modal player list, `md` for the stats leaderboard's hero row (today `lg` — promote to `md` via PlayerAvatar for parity).
+- [ ] **Step 2:** typecheck + commit
+  ```bash
+  pnpm --filter web type-check
+  git add apps/web/src/app/[locale]/history apps/web/src/app/[locale]/stats
+  git commit -m "refactor(web): history modal + stats leaderboard use EquippedPlayerAvatar (ARC-730)"
+  ```
+
+---
+
+## Phase 7 — Refactor `ShopMannequinStage` to use `PlayerAvatar`
+
+### Task 7.1: Extract composition
+
+**Files:**
+
+- Modify: `apps/web/src/features/shop/ui/ShopMannequinStage.tsx`
+- Modify: `apps/web/src/features/shop/ui/ShopMannequinStage.test.tsx` (if exists)
+
+- [ ] **Step 1:** Replace the inline avatar disc + frame ring + aura halo + badge corner + name + level stack (lines 240-307 of the current file) with a single `<PlayerAvatar size="card">` instance. The `TryOnTag`, `SkinChip`, and `RaysLayer` chrome stays. Wire `preview.*` items into `PlayerAvatar` props.
+- [ ] **Step 1b:** Delete the local `pickSwatchColor` helper (`ShopMannequinStage.tsx` lines 86-91) — its callers (`accentGlow`, `frameStyle`) move into PlayerAvatar, so the helper becomes dead. If `accentGlow` is still needed for the `RaysLayer` chrome, derive it from `aura?.colorValue` directly using a tiny inline regex match (it doesn't justify a shared helper for one caller).
+- [ ] **Step 2:** typecheck + run any existing shop preview test
+  ```bash
+  pnpm --filter web type-check
+  pnpm --filter web test ShopMannequinStage
+  ```
+- [ ] **Step 3:** Commit
+  ```bash
+  git add apps/web/src/features/shop/ui/ShopMannequinStage.tsx
+  git commit -m "refactor(shop): ShopMannequinStage uses shared PlayerAvatar (ARC-730)"
+  ```
+
+---
+
+## Phase 8 — Final verification + PR
+
+### Task 8.1: Whole-repo lint + typecheck + test
+
+- [ ] **Step 1:** Lint + typecheck
+  ```bash
+  pnpm lint
+  pnpm --filter be type-check
+  pnpm --filter web type-check
+  pnpm --filter @arcadeum/ui type-check
+  ```
+- [ ] **Step 2:** Unit tests
+  ```bash
+  pnpm --filter be test
+  pnpm --filter web test
+  pnpm --filter @arcadeum/ui test
+  ```
+- [ ] **Step 3:** File-length check
+  ```bash
+  pnpm check-file-length
+  ```
+- [ ] **Step 4:** If anything fails, fix and commit as part of the relevant phase. Do not bundle fixes into a single "fix lint" commit unless the issues are trivial formatter results.
+
+### Task 8.2: Manual smoke (web dev server)
+
+- [ ] **Step 1:** Start the dev server
+  ```bash
+  pnpm dev --filter web
+  ```
+- [ ] **Step 2:** With a user who has equipped frame/aura/banner items in the shop, visually verify:
+  - Locale chat shows the composed avatar in the message header
+  - In-game chat (sea battle room) — open the chat panel and confirm composition
+  - Leaderboards row shows frame ring on equipped users
+  - Profile page hero shows frame + aura + badge
+  - Header `ProfileMenu` shows the composed avatar
+  - Shop "Try On" still works (regression check on ShopMannequinStage)
+- [ ] **Step 3:** Record findings; if anything looks wrong, file under the relevant phase and fix.
+
+### Task 8.3: Playwright e2e (light touch)
+
+- [ ] **Step 1:** Open the canonical chat spec at `apps/web/e2e/chat.spec.ts` (the one stabilized in commit `acaef362`). If that path doesn't exist, `find apps/web -name "chat*.spec.ts"` and pick the most recent.
+- [ ] **Step 2:** Inside an existing test that has a user with an equipped frame seeded, add an assertion that the composed avatar's frame sentinel is present:
+  ```ts
+  await expect(page.locator('[data-testid$="-frame"]').first()).toBeVisible();
+  ```
+  This verifies actual composition, not just that an avatar element rendered.
+- [ ] **Step 3:** Run the spec
+  ```bash
+  pnpm e2e --filter web -- --grep "chat"
+  ```
+- [ ] **Step 4:** Commit
+  ```bash
+  git add apps/web/e2e
+  git commit -m "test(e2e): chat avatar composition smoke (ARC-730)"
+  ```
+
+### Task 8.4: Open the PR
+
+- [ ] **Step 1:** Push the branch
+  ```bash
+  git push -u origin ARC-730
+  ```
+- [ ] **Step 2:** Use the `/pr-description` skill to draft the body, then:
+
+  ```bash
+  gh pr create --base develop --title "feat(ui): PlayerAvatar — composed equipped cosmetics across the app (ARC-730)" --body "$(cat <<'EOF'
+  ## Summary
+  - New `PlayerAvatar` in `@arcadeum/ui` composes avatar + badge + frame + aura + banner + name color in 4 sizes.
+  - `EquippedPlayerAvatar` wrapper in `apps/web/src/shared/ui/PlayerAvatar/` resolves equipped ids via the shop catalog.
+  - BE payload builders (auth, chat, room members, history, leaderboards) now surface `equippedFrameId` / `equippedAuraId` / `equippedBannerId` (schema already had the fields).
+  - Migrated chat, in-game chat, leaderboards, player profile, header menus, sea-battle lobby, history modal, stats leaderboard, and chat list to the new component. `ShopMannequinStage` refactored to consume it.
+
+  ## Test plan
+  - [ ] BE unit tests pass (auth, chat-helper, leaderboards, history, room mapper)
+  - [ ] Web unit tests pass (PlayerAvatar, EquippedPlayerAvatar, useEquippedCosmetics)
+  - [ ] @arcadeum/ui Storybook builds
+  - [ ] Manual smoke: equipped frame/aura/banner items render in chat, leaderboards, profile, header menu
+  - [ ] Shop "Try On" still works after the ShopMannequinStage refactor
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+- [ ] **Step 3:** Return the PR URL to the user.
+
+---
+
+## Risk notes
+
+- `pnpm --filter web type-check` is the canary throughout phase 6 — any missed equipped-id wiring in BE → FE plumbing surfaces there.
+- The presentational `PlayerAvatar` test relies on Tamagui's render configuration. If the new test file fails to render at all (provider-missing), mirror the exact provider used by `Avatar.test.tsx` — same package, same setup, no special tricks.
+- The `ChatMessage` slot stays backward compatible; if any callers slip through phase 6 without being migrated, they'll still work via the legacy `avatarUrl`/`badgeUrl` path.

--- a/docs/superpowers/specs/2026-05-20-player-avatar-design.md
+++ b/docs/superpowers/specs/2026-05-20-player-avatar-design.md
@@ -1,0 +1,210 @@
+# PlayerAvatar — design
+
+**Ticket:** ARC-730 — feat: avatar in games
+**Status:** Draft
+
+## Problem
+
+The current `Avatar` in `@arcadeum/ui` only renders an image + initials. Every place that wants to show a player with their equipped cosmetics duplicates a pattern: call `useEquippedCosmetics(...)`, render `<Avatar src={avatarUrl}>`, render the badge image inline, apply name‑color separately. That pattern is repeated in chat lists, chat messages, the chat popup, leaderboards, the player profile, the room card, the sea‑battle lobby, header menus, history, and stats. It is divergent (some sites show the badge, some don't; some are rendered with `next/image`, others with `<img>`), and it doesn't compose the rest of the catalog (frame, aura, banner) at all — only the shop preview does.
+
+The intent of ARC‑730 is: **one component that renders a player with all of their equipped cosmetics**, available in small, inline, medium, and large‑card sizes, and used everywhere a user avatar appears.
+
+## Scope
+
+### In scope
+
+- New presentational `PlayerAvatar` in `@arcadeum/ui` (sizes: `icon` / `sm` / `md` / `card`)
+- New connected `EquippedPlayerAvatar` in `apps/web/src/shared/ui/PlayerAvatar/` that resolves equipped IDs → URLs and renders `PlayerAvatar`. (Not under `features/shop/` — it's consumed by chat / leaderboards / games / header, none of which should reach into a feature folder for shared UI.)
+- Extend `useEquippedCosmetics` to also resolve `equippedFrameId`, `equippedAuraId`, `equippedBannerId`
+- BE payload widening: surface `equippedFrameId`, `equippedAuraId`, `equippedBannerId` on
+  - `AuthUserProfile` (lib/types.ts) + `auth.service.ts#buildAuthUserProfile`
+  - chat message sender shape (`chat-helper.service.ts`)
+  - room member shape (games rooms payload)
+  - leaderboard player shape
+  - player profile API response
+- Migrate call sites to `EquippedPlayerAvatar`:
+
+  1. `apps/web/src/app/[locale]/chat/ChatPage.tsx` (ChatMessageRow)
+  2. `apps/web/src/app/[locale]/chats/ChatListPage.tsx`
+  3. `apps/web/src/app/[locale]/players/[id]/PlayerProfileClient.tsx`
+  4. `apps/web/src/app/[locale]/leaderboards/_components/RankTable.tsx`
+  5. `apps/web/src/app/[locale]/games/RoomCardComponent.tsx`
+  6. `apps/web/src/widgets/GameChat/ui/GameChat.tsx` (the in-game chat panel — its inline `GameChatRow` calls `useEquippedCosmetics` and renders `ChatMessage`)
+  7. `apps/web/src/widgets/GameChat/ui/ChatMessageBubble.tsx` (parallel in-game chat row used by the popup; same migration as GameChatRow)
+  8. `apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx` (just propagates the new equipped-id props down to ChatMessageBubble)
+  9. `apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx` (the `resolveEquipped` callback feeding the popup — extend it with frame/aura/banner ids)
+  10. `apps/web/src/app/[locale]/history/components/HistoryDetailModal.tsx`
+  11. `apps/web/src/app/[locale]/stats/components/Leaderboard.tsx`
+  12. `apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx`
+  13. `apps/web/src/features/games/sea-battle/lobby/UnassignedPool.tsx`
+  14. `apps/web/src/widgets/header/ui/ProfileMenu.tsx`
+  15. `apps/web/src/widgets/header/ui/MobileMenu.tsx`
+  16. `packages/ui/src/components/Chat/ChatMessage.tsx` — additive prop change (see "ChatMessage migration" below); does NOT break existing callers in a separate commit.
+
+  Skipped intentionally:
+
+  - `apps/web/src/features/games/ui/PlayerList.tsx` — file is dead sample data (hardcoded `player1`/`player2`); a separate ticket should delete it or wire it to real data. Out of scope here.
+  - `apps/web/src/features/pwa/InstallPWAModalContent.tsx`, `apps/web/src/features/admin-users/ui/UsersTableRow.tsx` — not player avatars (app icon / admin thumbnails). Keep base `Avatar`.
+
+- Stories + tests for `PlayerAvatar` (Vitest + Storybook); unit test for `EquippedPlayerAvatar` resolution; smoke Playwright e2e for chat + game lobby cards.
+
+### Out of scope
+
+- `game_skin` does not have a user equip slot (it's a session‑level cosmetic per `equipKeyFor`) — not rendered on the avatar.
+- DB migration / schema changes — schema already has the fields.
+- Mobile integration. `apps/mobile` is left alone. The presentational `PlayerAvatar` lives in `@arcadeum/ui` so mobile can adopt it later with its own resolver.
+- The PWA install modal and admin users table — they show non‑player avatars (app icon, admin user thumbnails). Keep the base `Avatar`.
+- Removing the base `Avatar` from `@arcadeum/ui`. It stays for the non‑player use cases above and as the building block inside `PlayerAvatar`.
+
+## Architecture
+
+Two‑layer split:
+
+```
+@arcadeum/ui
+  PlayerAvatar  ← presentational, takes resolved URLs / colors
+    └── uses Avatar internally for the image disc
+
+apps/web/src/shared/ui/PlayerAvatar
+  EquippedPlayerAvatar  ← connected, takes equipped IDs
+    └── useEquippedCosmetics() to resolve IDs → URLs
+    └── renders <PlayerAvatar />
+```
+
+Why the split:
+
+- The shop catalog cache (`useEquippedCosmetics`) is web‑only and depends on a Next.js fetch path. Keeping the catalog read out of `@arcadeum/ui` lets mobile reuse the presentational layer later with its own resolver.
+- The catalog is loaded lazily; consumers that render lists of avatars (chat history, leaderboard) want a single hook call per row, not per cosmetic — `useEquippedCosmetics` already does that and stays the single resolver.
+
+### `PlayerAvatar` (presentational) — `packages/ui/src/components/PlayerAvatar/`
+
+```ts
+export type PlayerAvatarSize = 'icon' | 'sm' | 'md' | 'card';
+
+export interface PlayerAvatarProps {
+  name: string;
+  size?: PlayerAvatarSize; // default 'sm'
+  avatarUrl?: string | null;
+  badgeUrl?: string | null;
+  frameColor?: string | null; // hex or linear-gradient
+  auraColor?: string | null; // hex or linear-gradient
+  bannerColor?: string | null; // hex or linear-gradient — card size only
+  nameColor?: string | null; // applied to name label — card size only
+  level?: number | null; // rendered in the chip on card size
+  presenceLine?: string; // localized 'Online' / 'Level {n}' — card only
+  priority?: boolean; // forwarded to the image
+  'data-testid'?: string;
+  onPress?: () => void; // optional click-through (e.g. ProfileMenu)
+}
+```
+
+### Size tiers (visual contract)
+
+| Size |  Disc | Composes                                                        | Use cases                                                 |
+| ---- | ----: | --------------------------------------------------------------- | --------------------------------------------------------- |
+| icon |  28px | avatar image only                                               | chat list rows, room card member tiles, lobby slot pool   |
+| sm   |  40px | avatar + badge corner (≈14px) + frame ring (2px)                | chat message sender, leaderboard rows                     |
+| md   |  72px | avatar + badge corner (≈24px) + frame ring (3px) + aura halo    | player profile inline, ProfileMenu / MobileMenu           |
+| card | 200px | everything + banner backdrop + name label + optional level chip | player profile hero, game waiting screens, profile modals |
+
+Frame and aura are skipped at `icon` because a 28px circle can't carry the additional ring weight legibly. Banner only renders at `card` because it needs surrounding chrome.
+
+The composition logic (frame ring style, aura glow conic gradient, banner backdrop) is lifted from the existing `ShopMannequinStage` (`apps/web/src/features/shop/ui/ShopMannequinStage.tsx`) — the shop preview today already does this composition; we extract the reusable parts into `PlayerAvatar` and keep the shop‑specific chrome (TryOn tag, skin chip, t() copy) in `ShopMannequinStage`. After the extraction, `ShopMannequinStage` renders `<PlayerAvatar size="card">` plus its own shop chrome on top.
+
+### ChatMessage migration (additive, non-breaking)
+
+`ChatMessage` in `@arcadeum/ui` is consumed by `ChatPage` (locale chat) and `ChatMessageBubble` (in-game chat, which is also re-exported through `ChatMessagePopup`). Changing the prop shape on `ChatMessage` is a cross-cutting break that would force three sites to be edited in the same commit.
+
+Instead, the migration is additive:
+
+- Add a new optional `senderAvatar?: ReactNode` slot to `ChatMessageProps`. When present, `ChatMessage` renders it where the inline `<Avatar>` + badge span currently sits.
+- Keep the existing `avatarUrl` / `badgeUrl` / `senderColor` / `senderNameStyle` props intact for backward compatibility; they're used only when `senderAvatar` is not supplied.
+- Migrate `ChatPage.ChatMessageRow` and `ChatMessageBubble` to pass `senderAvatar={<EquippedPlayerAvatar size="sm" ... />}`. Once both call sites use the slot, the deprecated props can be cleaned up in a follow-up — but they don't have to be removed in this PR.
+
+This decouples the `@arcadeum/ui` change from the call-site migrations.
+
+### `EquippedPlayerAvatar` (connected) — `apps/web/src/shared/ui/PlayerAvatar/`
+
+```ts
+export interface EquippedPlayerAvatarProps {
+  name: string;
+  size?: PlayerAvatarSize;
+  equippedAvatarId: string | null | undefined;
+  equippedBadgeId: string | null | undefined;
+  equippedNameColorId?: string | null | undefined;
+  equippedFrameId?: string | null | undefined;
+  equippedAuraId?: string | null | undefined;
+  equippedBannerId?: string | null | undefined;
+  fallbackAvatarUrl?: string;
+  level?: number | null;
+  presenceLine?: string;
+  priority?: boolean;
+  'data-testid'?: string;
+}
+```
+
+Resolution rules (extended `useEquippedCosmetics`):
+
+- Each id resolves via the cached catalog to an `EffectiveShopItem`.
+- `avatarUrl` ← `avatarItem.assetUrl` (or `fallbackAvatarUrl`)
+- `badgeUrl` ← `badgeItem.assetUrl`
+- `frameColor` ← `frameItem.colorValue`
+- `auraColor` ← `auraItem.colorValue`
+- `bannerColor` ← `bannerItem.colorValue`
+- `nameColor` ← `nameColorItem.colorValue`
+
+Unresolved (catalog still loading) → all `null`. The component then renders the same fallback the base `Avatar` does today (initials + plain disc).
+
+## Data flow / BE changes
+
+The user schema already has `equippedBannerId`, `equippedAuraId`, `equippedFrameId` and `equipKeyFor` returns the right field for each category. Three things need updating:
+
+1. **`AuthUserProfile`** (`apps/be/src/auth/lib/types.ts`) — add the three optional fields. `auth.service.ts#buildAuthUserProfile` populates them.
+2. **Chat sender payload** (`apps/be/src/chat/chat-helper.service.ts`) — extend the `select(...)` projection and the per‑message return shape with `senderEquippedFrameId`, `senderEquippedAuraId`, `senderEquippedBannerId`. Web `ChatMessageData` type widens to match.
+3. **Room members + leaderboard + player profile** — same three fields added to whatever shape feeds them today. (Will be enumerated in the implementation plan.)
+
+No DB migration. No new endpoints. No new shop categories.
+
+## Error / empty / loading states
+
+- Catalog still loading → `PlayerAvatar` renders disc with initials, no frame/aura/banner/badge yet. The hook re‑renders when catalog resolves.
+- Equipped id points at a missing/unavailable item → that slot resolves to `null`; the component renders without it. Matches the existing `useEquippedCosmetics` behavior.
+- Image src 404 → `<img onError>` hides itself, initials fall back. Matches current `Avatar`.
+- No id at all → identical to "loading then resolved to null" — initials disc.
+
+## Testing
+
+- **Vitest unit tests** (in `packages/ui/src/components/PlayerAvatar/PlayerAvatar.test.tsx`)
+  - renders initials when no avatarUrl
+  - renders badge corner at sm/md/card (not at icon)
+  - renders frame ring at sm/md/card (not at icon)
+  - renders aura halo at md/card (not at icon/sm)
+  - renders banner + name + level only at card
+  - applies hex name color and gradient name color correctly
+  - clickable when onPress provided
+- **Vitest unit tests** for `EquippedPlayerAvatar` — uses a mocked catalog map and asserts the right URLs/colors are passed through.
+- **Storybook** stories for each size + a "fully decked out" combo + a loading state.
+- **Playwright e2e** — one happy‑path test that visits the chat after stubbing an equipped frame/aura/banner and asserts the composited avatar renders. Extends an existing chat e2e rather than adding a new spec.
+
+## File size
+
+Both `PlayerAvatar.tsx` and `EquippedPlayerAvatar.tsx` are well under the 500‑line limit. The existing `ShopMannequinStage.tsx` (~310 lines) shrinks after extraction.
+
+## Migration strategy
+
+A single PR. Land in this order so review can be incremental:
+
+1. BE payload widening + schema‑side type updates.
+2. `PlayerAvatar` in `@arcadeum/ui` + stories + tests.
+3. `useEquippedCosmetics` extension + `EquippedPlayerAvatar` wrapper.
+4. Swap call sites one feature at a time (chat first → games → profile/leaderboards/menus).
+5. `ShopMannequinStage` refactor to use `PlayerAvatar` underneath.
+
+Each step is independently reviewable and leaves the app working.
+
+## Risks
+
+- **Catalog cache miss on first paint** — already a known UX (avatar pops in after the catalog loads). Not regressing.
+- **Frame/aura/banner color values** — verified during design: every banner/aura/frame entry in `apps/be/src/shop/lib/shop-catalog.ts` already has a populated `colorValue` (hex or linear-gradient). If a future catalog entry is added without one, the corresponding slot will silently no-op — acceptable.
+- **`ChatMessage` prop change** — mitigated by the additive `senderAvatar` slot described above. No atomic cross-package commit required.
+- **Playwright e2e selection** — extend `e2e/chat.spec.ts` (or whichever chat spec is currently green per the most recent run) rather than adding a new file, given recent flake-stabilization work on the chat specs.

--- a/packages/ui/src/components/Chat/ChatMessage.tsx
+++ b/packages/ui/src/components/Chat/ChatMessage.tsx
@@ -22,9 +22,16 @@ export type ChatMessageProps = {
   targetColor?: string;
   timestamp?: string;
   isOwn?: boolean;
+  /** @deprecated pass `senderAvatar` instead. Kept for backward compat with
+   *  callers that pre-date the PlayerAvatar slot. */
   avatarUrl?: string;
-  /** Sender's equipped shop badge URL — rendered inline next to the name. */
+  /** Sender's equipped shop badge URL — rendered inline next to the name.
+   *  @deprecated pass `senderAvatar` instead. */
   badgeUrl?: string;
+  /** Rich avatar slot. When provided, replaces the legacy `<Avatar>` + badge
+   *  block in the sender row. Designed for an `<EquippedPlayerAvatar>` from
+   *  the web shared UI. */
+  senderAvatar?: React.ReactNode;
   isEncrypted?: boolean;
   type?: 'system' | 'action' | 'message';
 };
@@ -135,6 +142,7 @@ export const ChatMessage = memo(function ChatMessage({
   isOwn = false,
   avatarUrl,
   badgeUrl,
+  senderAvatar,
   isEncrypted,
   type = 'message',
 }: ChatMessageProps) {
@@ -148,7 +156,22 @@ export const ChatMessage = memo(function ChatMessage({
     >
       {!isOwn && !isSystem && senderName && (
         <XStack ai="center" gap="$2" mb="$1" px="$2">
-          <Avatar name={senderName} size="sm" src={avatarUrl} />
+          {senderAvatar ?? (
+            <>
+              <Avatar name={senderName} size="sm" src={avatarUrl} />
+              {badgeUrl ? (
+                <View width={16} height={16}>
+                  <img
+                    src={badgeUrl}
+                    alt=""
+                    width={16}
+                    height={16}
+                    style={{ objectFit: 'contain' }}
+                  />
+                </View>
+              ) : null}
+            </>
+          )}
           <Typography
             uiSize="xs"
             weight="600"
@@ -159,32 +182,10 @@ export const ChatMessage = memo(function ChatMessage({
           >
             {senderName}
           </Typography>
-          {badgeUrl ? (
-            <View width={16} height={16}>
-              <img
-                src={badgeUrl}
-                alt=""
-                width={16}
-                height={16}
-                style={{ objectFit: 'contain' }}
-              />
-            </View>
-          ) : null}
         </XStack>
       )}
       {isOwn && !isSystem && senderName && (
         <XStack ai="center" gap="$2" mb="$1" px="$2" alignSelf="flex-end">
-          {badgeUrl ? (
-            <View width={16} height={16}>
-              <img
-                src={badgeUrl}
-                alt=""
-                width={16}
-                height={16}
-                style={{ objectFit: 'contain' }}
-              />
-            </View>
-          ) : null}
           <Typography
             uiSize="xs"
             weight="600"
@@ -195,7 +196,22 @@ export const ChatMessage = memo(function ChatMessage({
           >
             {senderName}
           </Typography>
-          <Avatar name={senderName} size="sm" src={avatarUrl} />
+          {senderAvatar ?? (
+            <>
+              {badgeUrl ? (
+                <View width={16} height={16}>
+                  <img
+                    src={badgeUrl}
+                    alt=""
+                    width={16}
+                    height={16}
+                    style={{ objectFit: 'contain' }}
+                  />
+                </View>
+              ) : null}
+              <Avatar name={senderName} size="sm" src={avatarUrl} />
+            </>
+          )}
         </XStack>
       )}
       <MessageBubble isOwn={isOwn} type={type} data-testid="chat-message">

--- a/packages/ui/src/components/MythicSpotlight/MythicSpotlight.tsx
+++ b/packages/ui/src/components/MythicSpotlight/MythicSpotlight.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { XStack, YStack, Text, View, styled } from 'tamagui';
 import { Button } from '../Button/Button';
 import { RankBadge } from '../RankBadge/RankBadge';
@@ -18,6 +19,9 @@ export type MythicSpotlightProps = {
   challengeLabel?: string;
   watchLabel?: string;
   followLabel?: string;
+  /** Rich portrait slot — when provided, replaces the default initials
+   *  monogram. Designed for `<EquippedPlayerAvatar size="card" />`. */
+  portrait?: ReactNode;
   onChallenge?: () => void;
   onWatch?: () => void;
   onFollow?: () => void;
@@ -71,6 +75,7 @@ export function MythicSpotlight({
   challengeLabel = '⚔ Challenge',
   watchLabel = '▶ Watch replay',
   followLabel = 'Follow',
+  portrait,
   onChallenge,
   onWatch,
   onFollow,
@@ -85,7 +90,7 @@ export function MythicSpotlight({
         }}
       />
       <XStack alignItems="center" gap="$5" flexWrap="wrap">
-        <MythicPortrait monogram={name} />
+        {portrait ?? <MythicPortrait monogram={name} />}
         <YStack gap="$2" flex={1} minWidth={240}>
           <XStack gap="$2" alignItems="center" flexWrap="wrap">
             <RankBadge tier="mythic">{`#${rank}`}</RankBadge>

--- a/packages/ui/src/components/PlayerAvatar/PlayerAvatar.stories.tsx
+++ b/packages/ui/src/components/PlayerAvatar/PlayerAvatar.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof PlayerAvatar> = {
   argTypes: {
     size: {
       control: 'select',
-      options: ['icon', 'sm', 'md', 'card'],
+      options: ['icon', 'sm', 'md', 'lg', 'card'],
     },
   },
 };

--- a/packages/ui/src/components/PlayerAvatar/PlayerAvatar.stories.tsx
+++ b/packages/ui/src/components/PlayerAvatar/PlayerAvatar.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { PlayerAvatar } from './PlayerAvatar';
+
+const meta: Meta<typeof PlayerAvatar> = {
+  title: 'Data Display/PlayerAvatar',
+  component: PlayerAvatar,
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['icon', 'sm', 'md', 'card'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlayerAvatar>;
+
+export const Icon: Story = {
+  args: { name: 'Jane Doe', size: 'icon' },
+};
+
+export const Sm: Story = {
+  args: {
+    name: 'Jane Doe',
+    size: 'sm',
+    badgeUrl: '/shop/badges/star.png',
+    frameColor: '#6366f1',
+  },
+};
+
+export const Md: Story = {
+  args: {
+    name: 'Jane Doe',
+    size: 'md',
+    badgeUrl: '/shop/badges/star.png',
+    frameColor: '#22d3ee',
+    auraColor: 'rgba(34, 211, 238, 0.6)',
+  },
+};
+
+export const Card: Story = {
+  args: {
+    name: 'Jane Doe',
+    size: 'card',
+    badgeUrl: '/shop/badges/star.png',
+    frameColor: '#a855f7',
+    auraColor: 'rgba(168, 85, 247, 0.6)',
+    bannerColor: 'linear-gradient(135deg, #1e293b 0%, #6366f1 100%)',
+    nameColor: 'linear-gradient(90deg, #f59e0b, #ef4444)',
+    presenceLine: 'Level 42',
+  },
+};
+
+export const LoadingFromCatalog: Story = {
+  args: {
+    name: 'Jane Doe',
+    size: 'md',
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '2rem' }}>
+      <PlayerAvatar name="J" size="icon" />
+      <PlayerAvatar name="Jane" size="sm" frameColor="#6366f1" />
+      <PlayerAvatar
+        name="Jane"
+        size="md"
+        frameColor="#22d3ee"
+        auraColor="#22d3ee"
+      />
+      <PlayerAvatar
+        name="Jane"
+        size="card"
+        frameColor="#a855f7"
+        auraColor="#a855f7"
+        bannerColor="#1e293b"
+        presenceLine="Online"
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/components/PlayerAvatar/PlayerAvatar.test.tsx
+++ b/packages/ui/src/components/PlayerAvatar/PlayerAvatar.test.tsx
@@ -1,0 +1,138 @@
+import { render as rtlRender, screen, fireEvent } from '@testing-library/react';
+import { TamaguiProvider } from 'tamagui';
+import config from '../../tamagui.config';
+import { PlayerAvatar } from './PlayerAvatar';
+import { describe, it, expect, vi } from 'vitest';
+
+const render = (ui: React.ReactElement) =>
+  rtlRender(
+    <TamaguiProvider config={config} defaultTheme="dark">
+      {ui}
+    </TamaguiProvider>,
+  );
+
+describe('PlayerAvatar', () => {
+  it('renders initials when no avatarUrl', () => {
+    render(<PlayerAvatar name="Jane Doe" />);
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('renders the avatar image when avatarUrl is provided', () => {
+    render(<PlayerAvatar name="Jane" avatarUrl="/x.png" />);
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/x.png');
+  });
+
+  it('does not render badge / frame / aura / banner at icon size', () => {
+    render(
+      <PlayerAvatar
+        name="J"
+        size="icon"
+        badgeUrl="/b.png"
+        frameColor="#abcdef"
+        auraColor="#ff0"
+        bannerColor="#0f0"
+        data-testid="pa"
+      />,
+    );
+    expect(screen.queryByTestId('pa-badge')).toBeNull();
+    expect(screen.queryByTestId('pa-frame')).toBeNull();
+    expect(screen.queryByTestId('pa-aura')).toBeNull();
+    expect(screen.queryByTestId('pa-banner')).toBeNull();
+  });
+
+  it('renders the badge at sm/md/card sizes', () => {
+    const { rerender } = render(
+      <PlayerAvatar name="J" badgeUrl="/b.png" size="sm" data-testid="pa" />,
+    );
+    expect(screen.getByTestId('pa-badge')).toBeInTheDocument();
+
+    rerender(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <PlayerAvatar name="J" badgeUrl="/b.png" size="md" data-testid="pa" />
+      </TamaguiProvider>,
+    );
+    expect(screen.getByTestId('pa-badge')).toBeInTheDocument();
+
+    rerender(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <PlayerAvatar name="J" badgeUrl="/b.png" size="card" data-testid="pa" />
+      </TamaguiProvider>,
+    );
+    expect(screen.getByTestId('pa-badge')).toBeInTheDocument();
+  });
+
+  it('renders the frame ring at sm/md/card', () => {
+    const { rerender } = render(
+      <PlayerAvatar
+        name="J"
+        frameColor="#ff00ff"
+        size="sm"
+        data-testid="pa"
+      />,
+    );
+    expect(screen.getByTestId('pa-frame')).toBeInTheDocument();
+
+    rerender(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <PlayerAvatar
+          name="J"
+          frameColor="#ff00ff"
+          size="md"
+          data-testid="pa"
+        />
+      </TamaguiProvider>,
+    );
+    expect(screen.getByTestId('pa-frame')).toBeInTheDocument();
+  });
+
+  it('renders the aura halo at md/card only', () => {
+    const { rerender } = render(
+      <PlayerAvatar name="J" auraColor="#ff0" size="sm" data-testid="pa" />,
+    );
+    expect(screen.queryByTestId('pa-aura')).toBeNull();
+
+    rerender(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <PlayerAvatar name="J" auraColor="#ff0" size="md" data-testid="pa" />
+      </TamaguiProvider>,
+    );
+    expect(screen.getByTestId('pa-aura')).toBeInTheDocument();
+  });
+
+  it('renders banner sentinel, name label, and presence line only at card', () => {
+    const { rerender } = render(
+      <PlayerAvatar
+        name="Jane"
+        bannerColor="#0f0"
+        presenceLine="Level 42"
+        size="md"
+        data-testid="pa"
+      />,
+    );
+    expect(screen.queryByTestId('pa-banner')).toBeNull();
+    expect(screen.queryByTestId('pa-name')).toBeNull();
+    expect(screen.queryByText('Level 42')).toBeNull();
+
+    rerender(
+      <TamaguiProvider config={config} defaultTheme="dark">
+        <PlayerAvatar
+          name="Jane"
+          bannerColor="#0f0"
+          presenceLine="Level 42"
+          size="card"
+          data-testid="pa"
+        />
+      </TamaguiProvider>,
+    );
+    expect(screen.getByTestId('pa-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('pa-name')).toHaveTextContent('Jane');
+    expect(screen.getByText('Level 42')).toBeInTheDocument();
+  });
+
+  it('calls onPress when clicked', () => {
+    const onPress = vi.fn();
+    render(<PlayerAvatar name="J" onPress={onPress} data-testid="pa" />);
+    fireEvent.click(screen.getByTestId('pa'));
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/PlayerAvatar/PlayerAvatar.tsx
+++ b/packages/ui/src/components/PlayerAvatar/PlayerAvatar.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { memo } from 'react';
+import { Text, View, YStack } from 'tamagui';
+import { Avatar } from '../Avatar/Avatar';
+
+export type PlayerAvatarSize = 'icon' | 'sm' | 'md' | 'card';
+
+export interface PlayerAvatarProps {
+  name: string;
+  size?: PlayerAvatarSize;
+  avatarUrl?: string | null;
+  badgeUrl?: string | null;
+  frameColor?: string | null;
+  auraColor?: string | null;
+  bannerColor?: string | null;
+  nameColor?: string | null;
+  level?: number | null;
+  presenceLine?: string;
+  priority?: boolean;
+  'data-testid'?: string;
+  onPress?: () => void;
+}
+
+const DISC_SIZE: Record<PlayerAvatarSize, number> = {
+  icon: 28,
+  sm: 40,
+  md: 72,
+  card: 140,
+};
+const BADGE_SIZE: Record<PlayerAvatarSize, number> = {
+  icon: 0,
+  sm: 14,
+  md: 24,
+  card: 36,
+};
+const RING_WIDTH: Record<PlayerAvatarSize, number> = {
+  icon: 0,
+  sm: 2,
+  md: 3,
+  card: 3,
+};
+
+function pickSwatchColor(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = value.match(/#[0-9a-fA-F]{3,8}/);
+  if (match) return match[0];
+  return value.includes('gradient') ? null : value;
+}
+
+function isGradient(value: string | null | undefined): boolean {
+  return !!value && value.includes('gradient');
+}
+
+export const PlayerAvatar = memo(function PlayerAvatar({
+  name,
+  size = 'sm',
+  avatarUrl,
+  badgeUrl,
+  frameColor,
+  auraColor,
+  bannerColor,
+  nameColor,
+  presenceLine,
+  priority,
+  'data-testid': testId,
+  onPress,
+}: PlayerAvatarProps) {
+  const disc = DISC_SIZE[size];
+  const badge = BADGE_SIZE[size];
+  const ring = RING_WIDTH[size];
+
+  const showBadge = size !== 'icon' && !!badgeUrl;
+  const showFrame = size !== 'icon' && !!frameColor;
+  const showAura = (size === 'md' || size === 'card') && !!auraColor;
+  const showCardChrome = size === 'card';
+
+  const ringHexBackground = showFrame
+    ? isGradient(frameColor)
+      ? {
+          backgroundImage: `linear-gradient(rgba(15,23,42,0.55), rgba(15,23,42,0.55)), ${frameColor}`,
+          borderColor: pickSwatchColor(frameColor) ?? 'rgba(255,255,255,0.35)',
+        }
+      : {
+          backgroundColor: `${frameColor}33`,
+          borderColor: frameColor as string,
+        }
+    : {
+        backgroundColor: 'rgba(255,255,255,0.04)',
+        borderColor: 'rgba(255,255,255,0.18)',
+      };
+
+  const auraSwatch = showAura
+    ? (pickSwatchColor(auraColor) ?? 'rgba(96,165,250,0.45)')
+    : null;
+
+  const bannerStyle: React.CSSProperties | undefined =
+    showCardChrome && bannerColor
+      ? isGradient(bannerColor)
+        ? { backgroundImage: bannerColor }
+        : { backgroundColor: bannerColor }
+      : undefined;
+
+  const innerImage = Math.round(disc * 0.78);
+
+  const inner = (
+    <YStack
+      width={disc}
+      height={disc}
+      borderRadius={disc / 2}
+      alignItems="center"
+      justifyContent="center"
+      borderWidth={showFrame ? ring : 0}
+      position="relative"
+      style={{
+        ...(showFrame ? ringHexBackground : {}),
+        ...(auraSwatch
+          ? { boxShadow: `0 0 ${Math.round(disc * 0.4)}px ${auraSwatch}` }
+          : {}),
+      }}
+      data-testid={testId ? `${testId}-disc` : undefined}
+    >
+      {showFrame ? (
+        <View
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          left={0}
+          borderRadius={disc / 2}
+          pointerEvents="none"
+          data-testid={testId ? `${testId}-frame` : undefined}
+        />
+      ) : null}
+      {showAura ? (
+        <View
+          position="absolute"
+          top={-Math.round(disc * 0.15)}
+          right={-Math.round(disc * 0.15)}
+          bottom={-Math.round(disc * 0.15)}
+          left={-Math.round(disc * 0.15)}
+          borderRadius={disc}
+          pointerEvents="none"
+          data-testid={testId ? `${testId}-aura` : undefined}
+        />
+      ) : null}
+      <Avatar
+        name={name}
+        src={avatarUrl ?? undefined}
+        size="sm"
+        priority={priority}
+        style={{ width: innerImage, height: innerImage }}
+      />
+      {showBadge ? (
+        <View
+          position="absolute"
+          bottom={-Math.round(badge * 0.2)}
+          right={-Math.round(badge * 0.2)}
+          width={badge}
+          height={badge}
+          borderRadius={badge / 2}
+          backgroundColor="rgba(2,6,23,0.85)"
+          borderWidth={1}
+          borderColor="rgba(255,255,255,0.20)"
+          alignItems="center"
+          justifyContent="center"
+          data-testid={testId ? `${testId}-badge` : undefined}
+        >
+          <img
+            src={badgeUrl as string}
+            alt=""
+            width={Math.round(badge * 0.75)}
+            height={Math.round(badge * 0.75)}
+            style={{ objectFit: 'contain' }}
+          />
+        </View>
+      ) : null}
+    </YStack>
+  );
+
+  if (!showCardChrome) {
+    return (
+      <YStack
+        data-testid={testId}
+        onPress={onPress}
+        cursor={onPress ? 'pointer' : 'default'}
+      >
+        {inner}
+      </YStack>
+    );
+  }
+
+  return (
+    <YStack
+      data-testid={testId}
+      onPress={onPress}
+      cursor={onPress ? 'pointer' : 'default'}
+      width={220}
+      borderRadius="$5"
+      paddingHorizontal="$4"
+      paddingVertical="$4"
+      alignItems="center"
+      gap="$3"
+      overflow="hidden"
+      style={bannerStyle ?? { backgroundColor: 'rgba(15,23,42,0.55)' }}
+    >
+      {bannerStyle ? (
+        <View
+          width={0}
+          height={0}
+          data-testid={testId ? `${testId}-banner` : undefined}
+        />
+      ) : null}
+      {inner}
+      <YStack alignItems="center" gap={4}>
+        <Text
+          fontSize="$6"
+          fontWeight="900"
+          color={nameColor && !isGradient(nameColor) ? nameColor : '$white'}
+          data-testid={testId ? `${testId}-name` : undefined}
+          {...(nameColor && isGradient(nameColor)
+            ? {
+                style: {
+                  background: nameColor,
+                  WebkitBackgroundClip: 'text',
+                  WebkitTextFillColor: 'transparent',
+                  backgroundClip: 'text',
+                },
+              }
+            : {})}
+        >
+          {name}
+        </Text>
+        {presenceLine ? (
+          <Text
+            fontSize={10}
+            letterSpacing={2}
+            textTransform="uppercase"
+            color="$gray11"
+            fontWeight="700"
+          >
+            {presenceLine}
+          </Text>
+        ) : null}
+      </YStack>
+    </YStack>
+  );
+});

--- a/packages/ui/src/components/PlayerAvatar/PlayerAvatar.tsx
+++ b/packages/ui/src/components/PlayerAvatar/PlayerAvatar.tsx
@@ -4,7 +4,7 @@ import { memo } from 'react';
 import { Text, View, YStack } from 'tamagui';
 import { Avatar } from '../Avatar/Avatar';
 
-export type PlayerAvatarSize = 'icon' | 'sm' | 'md' | 'card';
+export type PlayerAvatarSize = 'icon' | 'sm' | 'md' | 'lg' | 'card';
 
 export interface PlayerAvatarProps {
   name: string;
@@ -26,18 +26,21 @@ const DISC_SIZE: Record<PlayerAvatarSize, number> = {
   icon: 28,
   sm: 40,
   md: 72,
+  lg: 140,
   card: 140,
 };
 const BADGE_SIZE: Record<PlayerAvatarSize, number> = {
   icon: 0,
   sm: 14,
   md: 24,
+  lg: 36,
   card: 36,
 };
 const RING_WIDTH: Record<PlayerAvatarSize, number> = {
   icon: 0,
   sm: 2,
   md: 3,
+  lg: 3,
   card: 3,
 };
 

--- a/packages/ui/src/components/PlayerAvatar/index.ts
+++ b/packages/ui/src/components/PlayerAvatar/index.ts
@@ -1,0 +1,2 @@
+export { PlayerAvatar } from './PlayerAvatar';
+export type { PlayerAvatarProps, PlayerAvatarSize } from './PlayerAvatar';

--- a/packages/ui/src/components/RunnerUpCard/RunnerUpCard.tsx
+++ b/packages/ui/src/components/RunnerUpCard/RunnerUpCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { XStack, YStack, Text, View, styled } from 'tamagui';
 
 export type RunnerUpCardProps = {
@@ -9,6 +10,8 @@ export type RunnerUpCardProps = {
   region?: string;
   placeLabel?: string;
   testID?: string;
+  /** Optional avatar slot — designed for `<EquippedPlayerAvatar size="sm" />`. */
+  avatar?: ReactNode;
 };
 
 const MEDAL_BY_PLACE: Record<2 | 3, string> = { 2: '🥈', 3: '🥉' };
@@ -33,10 +36,12 @@ export function RunnerUpCard({
   region,
   placeLabel,
   testID,
+  avatar,
 }: RunnerUpCardProps) {
   return (
     <Card testID={testID ?? `runner-up-${place}`}>
       <XStack alignItems="center" gap="$2">
+        {avatar}
         <Text fontSize="$6">{MEDAL_BY_PLACE[place]}</Text>
         <Text
           fontSize="$1"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ import './tamagui.config';
 export * from './components/Button';
 
 export * from './components/Avatar/Avatar';
+export * from './components/PlayerAvatar';
 export * from './components/Badge/Badge';
 export * from './components/StatusBadge';
 export * from './components/Toggle';


### PR DESCRIPTION
## Summary

- New presentational `PlayerAvatar` in `@arcadeum/ui` composes avatar + badge + frame + aura + banner + name color in four sizes (`icon` / `sm` / `md` / `card`). Frame/aura/banner light up only at the sizes where they read legibly.
- New connected `EquippedPlayerAvatar` in `apps/web/src/shared/ui/PlayerAvatar/` resolves equipped item IDs via the shop catalog and feeds the presentational component.
- `useEquippedCosmetics` extended to resolve `equippedFrameId` / `equippedAuraId` / `equippedBannerId` alongside the existing avatar/badge/name-color.
- BE payload builders (auth profile, chat sender, room members, game history, leaderboard profile) now surface the three new equipped fields. **No DB migration needed** — the user schema already had them.
- `ChatMessage` in `@arcadeum/ui` adds an additive `senderAvatar?: ReactNode` slot. Legacy `avatarUrl` / `badgeUrl` props kept for backward compat, so the migration is non-breaking.
- 14 call sites migrated to `EquippedPlayerAvatar`: locale chat, in-game chat (GameChat row + ChatMessageBubble + ChatMessagePopup), leaderboards, player profile, header ProfileMenu + MobileMenu, room card, sea-battle TeamSlots + UnassignedPool, chat list search row, history detail modal, stats leaderboard.

## Notes

- **`ShopMannequinStage` refactor deferred to a follow-up.** The shop preview's avatar block uses `ItemAsset` (shop-specific catalog renderer with gradient handling) — extracting it under `PlayerAvatar` risks a visual regression in the highest-stakes shop UX without clear benefit. PlayerAvatar already mirrors the stage's composition logic.
- `apps/web/src/features/games/ui/PlayerList.tsx` left untouched — it's dead sample data with hardcoded `player1`/`player2` and a separate cleanup ticket.
- Header role-border styling (red/gold ring on admin/vip avatars) replaced by the equipped frame. Role is still indicated by the adjacent `<RoleBadge>` chip.

## Test plan

- [x] BE: `pnpm --filter be test` — 912/912 passing
- [x] Web: `pnpm --filter web test` — 981/981 passing
- [x] BE + web + UI type-checks clean
- [x] File-length check passes
- [ ] Manual smoke (reviewer): equip a frame/aura/banner in the shop, then visit chat, in-game chat, leaderboards, player profile, and the header menu — composed avatar should render correctly in each
- [ ] Manual smoke (reviewer): shop "Try On" preview still works
- [ ] Manual smoke (reviewer): existing users with only avatar/badge equipped should see the same UX as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)