### PR TITLE
feat(chat): in-game chat popup inside widget + premium redesign (ARC-735)

### DIFF
--- a/apps/web/e2e/fixtures/sea-battle-chat-utils.ts
+++ b/apps/web/e2e/fixtures/sea-battle-chat-utils.ts
@@ -8,6 +8,7 @@ export interface ChatLogEntry {
 export interface GameChatStore {
   getState: () => {
     logs: ChatLogEntry[];
+    setChatPanelOpen: (open: boolean) => void;
   };
 }
 

--- a/apps/web/e2e/sea-battle-chat-popup-hidden.spec.ts
+++ b/apps/web/e2e/sea-battle-chat-popup-hidden.spec.ts
@@ -1,0 +1,134 @@
+import { expect } from '@playwright/test';
+import {
+  test,
+  mockSession,
+  mockRoomInfo,
+  MOCK_OBJECT_ID,
+  mockGameSocket,
+  waitForRoomReady,
+} from './fixtures/test-utils';
+import {
+  createSeaBattleState,
+  TestWindow,
+} from './fixtures/sea-battle-chat-utils';
+
+test.describe('Sea Battle Chat Message Popup — suppression', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSession(page);
+  });
+
+  test('should hide popup when chat panel is already open', async ({
+    page,
+  }) => {
+    const roomId = '507f1f77bcf86cd799439011';
+    const userId = MOCK_OBJECT_ID;
+    const otherUserId = 'opponent-user-id';
+
+    const initialState = createSeaBattleState(userId, otherUserId);
+
+    await mockRoomInfo(page, {
+      room: {
+        id: roomId,
+        name: 'Sea Battle Hidden Popup Test',
+        gameId: 'sea_battle_v1',
+        status: 'active',
+        members: [
+          {
+            id: userId,
+            userId,
+            displayName: 'Me',
+            isHost: true,
+          },
+          {
+            id: otherUserId,
+            userId: otherUserId,
+            displayName: 'Commander',
+            isHost: false,
+          },
+        ],
+      },
+      session: {
+        id: 'session-1',
+        status: 'active',
+        state: initialState,
+      },
+    });
+
+    await mockGameSocket(page, roomId, userId, {
+      gameId: 'sea_battle_v1',
+      roomJoinedPayload: {
+        status: 'active',
+        session: {
+          id: 'session-1',
+          status: 'active',
+          state: initialState,
+        },
+      },
+    });
+
+    await page.goto(`/games/rooms/${roomId}`);
+    await waitForRoomReady(page);
+
+    await page.waitForFunction(
+      () => {
+        const socket = (window as unknown as TestWindow).gameSocket;
+        const store = (window as unknown as TestWindow).useGameChatStore;
+        return (
+          socket?.connected &&
+          socket._mockListeners?.['games.session.snapshot'] &&
+          !!store
+        );
+      },
+      { timeout: 60000 },
+    );
+
+    // Force the chat panel open via the store so the test does not depend on
+    // viewport-dependent default visibility or button placement.
+    await page.evaluate(() => {
+      const store = (window as unknown as TestWindow).useGameChatStore;
+      store?.getState().setChatPanelOpen(true);
+    });
+
+    const expectedMsg = 'You should not see this popup';
+    const state = createSeaBattleState(userId, otherUserId, [
+      {
+        id: `chat-msg-hidden-${Date.now()}`,
+        type: 'message',
+        senderId: otherUserId,
+        senderName: 'Commander',
+        message: expectedMsg,
+        createdAt: new Date().toISOString(),
+      },
+    ]);
+
+    await expect
+      .poll(
+        async () => {
+          await page.evaluate(
+            ({ roomId, state }) => {
+              const snapshot = {
+                roomId,
+                session: {
+                  id: 'session-1',
+                  status: 'active',
+                  state,
+                },
+              };
+              window.gameSocket?.trigger('games.session.snapshot', snapshot);
+            },
+            { roomId, state },
+          );
+
+          return await page.evaluate((msg) => {
+            const store = (window as unknown as TestWindow).useGameChatStore;
+            return store?.getState().logs.some((l) => l.message === msg);
+          }, expectedMsg);
+        },
+        { timeout: 30000, intervals: [1000] },
+      )
+      .toBe(true);
+
+    // Popup must NOT be visible while chat panel is open.
+    await expect(page.getByTestId('chat-message-popup')).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/sea-battle-chat-popup.spec.ts
+++ b/apps/web/e2e/sea-battle-chat-popup.spec.ts
@@ -124,6 +124,13 @@ test.describe('Sea Battle Chat Message Popup', () => {
       { timeout: 60000 },
     );
 
+    // On wide viewports GamePageLayout auto-opens the chat panel, which now
+    // suppresses the popup overlay. Force it closed so the popup can render.
+    await page.evaluate(() => {
+      const store = (window as unknown as TestWindow).useGameChatStore;
+      store?.getState().setChatPanelOpen(false);
+    });
+
     const expectedMsg = 'Prepare for battle!';
     const state = createSeaBattleState(userId, otherUserId, [
       {
@@ -234,6 +241,13 @@ test.describe('Sea Battle Chat Message Popup', () => {
       },
       { timeout: 60000 },
     );
+
+    // On wide viewports GamePageLayout auto-opens the chat panel, which now
+    // suppresses the popup overlay. Force it closed so the popup can render.
+    await page.evaluate(() => {
+      const store = (window as unknown as TestWindow).useGameChatStore;
+      store?.getState().setChatPanelOpen(false);
+    });
 
     const expectedMsg = 'I will sink you!';
     const state = createSeaBattleState(userId, otherUserId, [
@@ -348,6 +362,13 @@ test.describe('Sea Battle Chat Message Popup', () => {
       },
       { timeout: 60000 },
     );
+
+    // On wide viewports GamePageLayout auto-opens the chat panel, which now
+    // suppresses the popup overlay. Force it closed so the popup can render.
+    await page.evaluate(() => {
+      const store = (window as unknown as TestWindow).useGameChatStore;
+      store?.getState().setChatPanelOpen(false);
+    });
 
     const expectedMsg = 'My own message';
     const state = createSeaBattleState(userId, otherUserId, [

--- a/apps/web/e2e/sea-battle-team-mode.spec.ts
+++ b/apps/web/e2e/sea-battle-team-mode.spec.ts
@@ -330,10 +330,10 @@ test.describe('Sea Battle Team Mode UI smoke tests', () => {
     const chatArea = page.getByTestId('game-chat-area');
     await expect(chatArea).toBeVisible();
     await expect(
-      chatArea.getByRole('button', { name: 'Team', exact: true }),
+      chatArea.getByRole('tab', { name: /Team/, exact: false }),
     ).toBeVisible();
     await expect(
-      chatArea.getByRole('button', { name: 'All', exact: true }),
+      chatArea.getByRole('tab', { name: /All/, exact: false }),
     ).toBeVisible();
   });
 });

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -7,12 +7,7 @@ import { useTranslation } from '@/shared/lib/useTranslation';
 import { useFullscreen } from '@/features/games/hooks/useFullscreen';
 import { ConnectionOverlay } from '@arcadeum/ui/components/ConnectionOverlay/ConnectionOverlay';
 import { GamesControlPanel } from '@/widgets/GamesControlPanel';
-import {
-  GameChat,
-  useGameChatStore,
-  ChatMessagePopup,
-  useLatestChatMessage,
-} from '@/widgets/GameChat';
+import { GameChat, useGameChatStore } from '@/widgets/GameChat';
 import type { GameRoomSummary } from '@/shared/types/games';
 
 import { Container, fullscreenStyles } from './styles';
@@ -78,27 +73,13 @@ export function GamePageLayout(props: GamePageLayoutProps) {
     });
   }, [media.gtMd]);
 
-  // Chat message popup — reads from global store written by game widgets
-  const logs = useGameChatStore((s) => s.logs);
-  const registeredResolver = useGameChatStore((s) => s.resolveDisplayName);
-  const { latestMessage, dismiss: dismissPopup } = useLatestChatMessage(logs);
-
-  const fallbackResolver = useCallback(
-    (id?: string, fallback?: string) => {
+  const resolveDisplayName = useCallback(
+    (id?: string, fallback?: string): string | undefined => {
       if (id && userId && id === userId) return t('chat.you');
       const member = room.members?.find((m) => m.id === id);
-      return member?.displayName ?? fallback ?? id;
+      return member?.displayName ?? fallback ?? id ?? undefined;
     },
     [room.members, userId, t],
-  );
-
-  const resolveDisplayName = useCallback(
-    (id?: string, fallback?: string) => {
-      const fromGame = registeredResolver?.(id, fallback);
-      if (fromGame && fromGame !== 'Unknown') return fromGame;
-      return fallbackResolver(id, fallback);
-    },
-    [registeredResolver, fallbackResolver],
   );
 
   const resolveEquipped = useCallback(
@@ -118,13 +99,35 @@ export function GamePageLayout(props: GamePageLayoutProps) {
     [room.members],
   );
 
-  const popupSender = latestMessage
-    ? resolveEquipped(latestMessage.senderId ?? null)
-    : null;
-  const popupSenderName = latestMessage
-    ? (resolveDisplayName(latestMessage.senderId, latestMessage.senderName) ??
-      latestMessage.senderName)
-    : '';
+  const gameRegisteredResolver = useGameChatStore((s) => s.resolveDisplayName);
+  const resolveDisplayNameForList = useCallback(
+    (id?: string, fallback?: string): string | undefined => {
+      const fromGame = gameRegisteredResolver?.(id, fallback);
+      if (fromGame && fromGame !== 'Unknown') return fromGame;
+      return resolveDisplayName(id, fallback);
+    },
+    [gameRegisteredResolver, resolveDisplayName],
+  );
+
+  // Sync layout-owned state into the chat store so GameChatPopupOverlay
+  // (mounted inside GameWidgetContainer) can render with full context.
+  useEffect(() => {
+    useGameChatStore.getState().setCurrentUserId(userId);
+  }, [userId]);
+
+  useEffect(() => {
+    useGameChatStore.getState().registerResolveEquipped(resolveEquipped);
+  }, [resolveEquipped]);
+
+  useEffect(() => {
+    useGameChatStore.getState().setChatPanelOpen(showChat);
+  }, [showChat]);
+
+  useEffect(() => {
+    useGameChatStore
+      .getState()
+      .registerFallbackResolveDisplayName(resolveDisplayName);
+  }, [resolveDisplayName]);
 
   return (
     <>
@@ -171,30 +174,12 @@ export function GamePageLayout(props: GamePageLayoutProps) {
             <GameChat
               onClose={() => setShowChat(false)}
               teamMode={teamMode}
-              resolveDisplayName={resolveDisplayName}
+              resolveDisplayName={resolveDisplayNameForList}
               resolveEquipped={resolveEquipped}
               currentUserId={userId}
             />
           </ChatPanel>
         </GameRow>
-
-        {latestMessage && (
-          <ChatMessagePopup
-            key={latestMessage.id}
-            senderId={latestMessage.senderId ?? null}
-            senderName={popupSenderName}
-            senderEquippedAvatarId={popupSender?.equippedAvatarId ?? null}
-            senderEquippedBadgeId={popupSender?.equippedBadgeId ?? null}
-            senderEquippedNameColorId={popupSender?.equippedNameColorId ?? null}
-            senderEquippedFrameId={popupSender?.equippedFrameId ?? null}
-            senderEquippedAuraId={popupSender?.equippedAuraId ?? null}
-            senderEquippedBannerId={popupSender?.equippedBannerId ?? null}
-            message={latestMessage.message}
-            visible={!!latestMessage}
-            onDismiss={dismissPopup}
-            isOwn={latestMessage.senderId === userId}
-          />
-        )}
       </Container>
     </>
   );

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -11,6 +11,7 @@ import {
 import { MaximizeIcon, MinimizeIcon } from '@/shared/ui';
 import { useFullscreen } from '../hooks/useFullscreen';
 import { scrollbarStyles } from '@/shared/lib/styles';
+import { GameChatPopupOverlay } from '@/widgets/GameChat';
 
 // --- Styled components (based on CriticalGame's layout.tsx) ---
 
@@ -398,6 +399,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
           </SharedHandSection>
         )}
         {modals}
+        <GameChatPopupOverlay />
       </Container>
     </>
   );

--- a/apps/web/src/widgets/GameChat/hooks/__tests__/useLatestChatMessage.test.ts
+++ b/apps/web/src/widgets/GameChat/hooks/__tests__/useLatestChatMessage.test.ts
@@ -3,11 +3,16 @@ import { renderHook, act } from '@testing-library/react';
 import { useLatestChatMessage } from '../useLatestChatMessage';
 import type { ChatLogEntry } from '../../store/gameChatStore';
 
+// Default createdAt is deliberately set to "future" so that messages arriving
+// after the hook mounts qualify as fresh and trigger a popup.
+const futureIso = () => new Date(Date.now() + 60_000).toISOString();
+const pastIso = () => new Date(Date.now() - 60_000).toISOString();
+
 const makeLog = (overrides: Partial<ChatLogEntry> = {}): ChatLogEntry => ({
   id: 'log-1',
   type: 'message',
   message: 'hello',
-  createdAt: new Date().toISOString(),
+  createdAt: futureIso(),
   senderId: 'user-1',
   senderName: 'Alice',
   scope: 'all',
@@ -20,7 +25,7 @@ describe('useLatestChatMessage', () => {
     expect(result.current.latestMessage).toBeNull();
   });
 
-  it('shows popup when a new message log arrives', () => {
+  it('shows popup when a fresh message arrives after mount', () => {
     const log = makeLog();
     const { result, rerender } = renderHook(
       ({ logs }) => useLatestChatMessage(logs),
@@ -31,6 +36,34 @@ describe('useLatestChatMessage', () => {
       id: 'log-1',
       senderName: 'Alice',
       message: 'hello',
+    });
+  });
+
+  it('suppresses popup for historical messages already present at mount', () => {
+    // Simulates a page-refresh snapshot — the most recent chat message was
+    // created BEFORE the hook mounted, so it must not pop.
+    const historicalLog = makeLog({ id: 'old-1', createdAt: pastIso() });
+    const { result, rerender } = renderHook(
+      ({ logs }) => useLatestChatMessage(logs),
+      { initialProps: { logs: [] as ChatLogEntry[] } },
+    );
+    rerender({ logs: [historicalLog] });
+    expect(result.current.latestMessage).toBeNull();
+  });
+
+  it('still pops a fresh message arriving after some history was present', () => {
+    const historicalLog = makeLog({ id: 'old-1', createdAt: pastIso() });
+    const newLog = makeLog({ id: 'new-1', message: 'just sent' });
+    const { result, rerender } = renderHook(
+      ({ logs }) => useLatestChatMessage(logs),
+      { initialProps: { logs: [] as ChatLogEntry[] } },
+    );
+    rerender({ logs: [historicalLog] });
+    expect(result.current.latestMessage).toBeNull();
+    rerender({ logs: [historicalLog, newLog] });
+    expect(result.current.latestMessage).toMatchObject({
+      id: 'new-1',
+      message: 'just sent',
     });
   });
 

--- a/apps/web/src/widgets/GameChat/hooks/useChatCollapsed.ts
+++ b/apps/web/src/widgets/GameChat/hooks/useChatCollapsed.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+const STORAGE_KEY = 'arcadeum.chat.collapsed';
+
+function readInitial(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+export function useChatCollapsed(): [boolean, (next: boolean) => void] {
+  const [collapsed, setCollapsedState] = useState<boolean>(() => readInitial());
+
+  const setCollapsed = useCallback((next: boolean) => {
+    setCollapsedState(next);
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next ? '1' : '0');
+    } catch {
+      // best-effort persistence
+    }
+  }, []);
+
+  return [collapsed, setCollapsed];
+}

--- a/apps/web/src/widgets/GameChat/hooks/useLatestChatMessage.ts
+++ b/apps/web/src/widgets/GameChat/hooks/useLatestChatMessage.ts
@@ -17,13 +17,24 @@ export function useLatestChatMessage(
   logs: ChatLogEntry[],
 ): UseLatestChatMessageResult {
   const [dismissedId, setDismissedId] = useState<string | null>(null);
+  // Only messages created after the hook mounted are eligible for a popup.
+  // Otherwise every page refresh would replay the latest historical message
+  // as if it had just been sent. useState's lazy initializer captures the
+  // mount time exactly once.
+  const [mountTime] = useState<number>(() => Date.now());
 
   const derivedMessage = useMemo<LatestChatMessage | null>(() => {
     if (logs.length === 0) return null;
 
     const lastChatMessage = [...logs]
       .reverse()
-      .find((log) => log.type === 'message' && log.senderId);
+      .find((log) => {
+        if (log.type !== 'message' || !log.senderId) return false;
+        const t = log.createdAt
+          ? new Date(log.createdAt).getTime()
+          : Number.POSITIVE_INFINITY;
+        return t > mountTime;
+      });
 
     if (!lastChatMessage) return null;
 
@@ -33,7 +44,7 @@ export function useLatestChatMessage(
       senderName: lastChatMessage.senderName || 'Player',
       message: lastChatMessage.message,
     };
-  }, [logs]);
+  }, [logs, mountTime]);
 
   const latestMessage = useMemo(() => {
     return derivedMessage && derivedMessage.id !== dismissedId

--- a/apps/web/src/widgets/GameChat/index.ts
+++ b/apps/web/src/widgets/GameChat/index.ts
@@ -1,6 +1,7 @@
 export { GameChat } from './ui/GameChat';
 export { ChatMessageBubble } from './ui/ChatMessageBubble';
 export { ChatMessagePopup } from './ui/ChatMessagePopup';
+export { GameChatPopupOverlay } from './ui/GameChatPopupOverlay';
 export { useGameChatStore } from './store/gameChatStore';
 export { useLatestChatMessage } from './hooks/useLatestChatMessage';
 export type {

--- a/apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts
+++ b/apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts
@@ -42,4 +42,51 @@ describe('gameChatStore', () => {
     expect(useGameChatStore.getState().logs).toEqual([]);
     expect(useGameChatStore.getState().sendMessage).toBeNull();
   });
+
+  it('setCurrentUserId updates currentUserId', () => {
+    expect(useGameChatStore.getState().currentUserId).toBeNull();
+    useGameChatStore.getState().setCurrentUserId('user-1');
+    expect(useGameChatStore.getState().currentUserId).toBe('user-1');
+  });
+
+  it('registerResolveEquipped sets resolver', () => {
+    const fn = (id: string | null) =>
+      id === 'u1'
+        ? {
+            equippedAvatarId: 'a1',
+            equippedBadgeId: null,
+            equippedNameColorId: null,
+            equippedFrameId: null,
+            equippedAuraId: null,
+            equippedBannerId: null,
+          }
+        : null;
+    useGameChatStore.getState().registerResolveEquipped(fn);
+    expect(useGameChatStore.getState().resolveEquipped).toBe(fn);
+  });
+
+  it('registerFallbackResolveDisplayName sets fallback resolver', () => {
+    const fn = (_id?: string | null, _fallback?: string | null) => 'Player';
+    useGameChatStore.getState().registerFallbackResolveDisplayName(fn);
+    expect(useGameChatStore.getState().fallbackResolveDisplayName).toBe(fn);
+  });
+
+  it('setChatPanelOpen updates chatPanelOpen', () => {
+    expect(useGameChatStore.getState().chatPanelOpen).toBe(false);
+    useGameChatStore.getState().setChatPanelOpen(true);
+    expect(useGameChatStore.getState().chatPanelOpen).toBe(true);
+  });
+
+  it('clear resets new fields', () => {
+    useGameChatStore.getState().setCurrentUserId('user-1');
+    useGameChatStore.getState().registerResolveEquipped(() => null);
+    useGameChatStore.getState().registerFallbackResolveDisplayName(() => 'X');
+    useGameChatStore.getState().setChatPanelOpen(true);
+    useGameChatStore.getState().clear();
+    const s = useGameChatStore.getState();
+    expect(s.currentUserId).toBeNull();
+    expect(s.resolveEquipped).toBeNull();
+    expect(s.fallbackResolveDisplayName).toBeNull();
+    expect(s.chatPanelOpen).toBe(false);
+  });
 });

--- a/apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts
+++ b/apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts
@@ -50,7 +50,7 @@ describe('gameChatStore', () => {
   });
 
   it('registerResolveEquipped sets resolver', () => {
-    const fn = (id: string | null) =>
+    const fn = (id?: string | null) =>
       id === 'u1'
         ? {
             equippedAvatarId: 'a1',

--- a/apps/web/src/widgets/GameChat/store/gameChatStore.ts
+++ b/apps/web/src/widgets/GameChat/store/gameChatStore.ts
@@ -8,8 +8,8 @@ export type { CriticalLogEntry as ChatLogEntry } from '@/shared/types/games';
 export type { ChatScope } from '@/shared/types/games';
 
 export type ChatDisplayNameResolver = (
-  id?: string | null,
-  fallback?: string | null,
+  id?: string,
+  fallback?: string,
 ) => string | undefined;
 
 export type ChatActorColorResolver = (id?: string | null) => string | undefined;
@@ -24,7 +24,7 @@ export interface ChatEquippedItems {
 }
 
 export type ChatEquippedResolver = (
-  id: string | null,
+  id?: string | null,
 ) => ChatEquippedItems | null;
 
 interface GameChatStore {

--- a/apps/web/src/widgets/GameChat/store/gameChatStore.ts
+++ b/apps/web/src/widgets/GameChat/store/gameChatStore.ts
@@ -12,21 +12,42 @@ export type ChatDisplayNameResolver = (
   fallback?: string | null,
 ) => string | undefined;
 
-export type ChatActorColorResolver = (
-  id?: string | null,
-) => string | undefined;
+export type ChatActorColorResolver = (id?: string | null) => string | undefined;
+
+export interface ChatEquippedItems {
+  equippedAvatarId: string | null;
+  equippedBadgeId: string | null;
+  equippedNameColorId: string | null;
+  equippedFrameId: string | null;
+  equippedAuraId: string | null;
+  equippedBannerId: string | null;
+}
+
+export type ChatEquippedResolver = (
+  id: string | null,
+) => ChatEquippedItems | null;
 
 interface GameChatStore {
   logs: ChatLogEntry[];
   sendMessage: ((message: string, scope: ChatScope) => void) | null;
   resolveDisplayName: ChatDisplayNameResolver | null;
+  fallbackResolveDisplayName: ChatDisplayNameResolver | null;
   resolveActorColor: ChatActorColorResolver | null;
+  resolveEquipped: ChatEquippedResolver | null;
+  currentUserId: string | null;
+  chatPanelOpen: boolean;
   setLogs: (logs: ChatLogEntry[]) => void;
   registerSendMessage: (
     fn: (message: string, scope: ChatScope) => void,
   ) => void;
   registerResolveDisplayName: (fn: ChatDisplayNameResolver | null) => void;
+  registerFallbackResolveDisplayName: (
+    fn: ChatDisplayNameResolver | null,
+  ) => void;
   registerResolveActorColor: (fn: ChatActorColorResolver | null) => void;
+  registerResolveEquipped: (fn: ChatEquippedResolver | null) => void;
+  setCurrentUserId: (id: string | null) => void;
+  setChatPanelOpen: (open: boolean) => void;
   clear: () => void;
 }
 
@@ -34,17 +55,30 @@ export const useGameChatStore = create<GameChatStore>((set) => ({
   logs: [],
   sendMessage: null,
   resolveDisplayName: null,
+  fallbackResolveDisplayName: null,
   resolveActorColor: null,
+  resolveEquipped: null,
+  currentUserId: null,
+  chatPanelOpen: false,
   setLogs: (logs) => set({ logs }),
   registerSendMessage: (fn) => set({ sendMessage: fn }),
   registerResolveDisplayName: (fn) => set({ resolveDisplayName: fn }),
+  registerFallbackResolveDisplayName: (fn) =>
+    set({ fallbackResolveDisplayName: fn }),
   registerResolveActorColor: (fn) => set({ resolveActorColor: fn }),
+  registerResolveEquipped: (fn) => set({ resolveEquipped: fn }),
+  setCurrentUserId: (id) => set({ currentUserId: id }),
+  setChatPanelOpen: (open) => set({ chatPanelOpen: open }),
   clear: () =>
     set({
       logs: [],
       sendMessage: null,
       resolveDisplayName: null,
+      fallbackResolveDisplayName: null,
       resolveActorColor: null,
+      resolveEquipped: null,
+      currentUserId: null,
+      chatPanelOpen: false,
     }),
 }));
 

--- a/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
@@ -46,7 +46,7 @@ export function ChatMessagePopup({
       style={{
         cursor: 'pointer',
         maxWidth: 340,
-        position: 'fixed',
+        position: 'absolute',
         top: 24,
         right: 24,
         zIndex: 10000,

--- a/apps/web/src/widgets/GameChat/ui/GameChat.styled.ts
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.styled.ts
@@ -1,0 +1,266 @@
+import { styled, XStack, YStack, Text } from 'tamagui';
+
+export const ACCENT_PINK = '#EC4899';
+export const ACCENT_AMBER = '#F59E0B';
+export const ACCENT_GRADIENT = `linear-gradient(135deg, ${ACCENT_PINK}, ${ACCENT_AMBER})`;
+
+export const SYS_COLOR: Record<'elim' | 'round' | 'combo' | 'join', string> = {
+  elim: '#F87171',
+  round: '#22D3EE',
+  combo: '#F59E0B',
+  join: '#34D399',
+};
+
+export const Panel = styled(YStack, {
+  name: 'GameChatPanel',
+  width: '100%',
+  height: '100%',
+  minHeight: 360,
+  borderRadius: 18,
+  borderWidth: 1,
+  borderColor: 'rgba(255,255,255,0.08)',
+  backgroundColor: 'rgba(15,17,18,0.78)',
+  overflow: 'hidden',
+  position: 'relative',
+});
+
+export const Head = styled(YStack, {
+  name: 'GameChatHead',
+  gap: 10,
+  paddingHorizontal: 12,
+  paddingTop: 12,
+  paddingBottom: 10,
+  borderBottomWidth: 1,
+  borderBottomColor: 'rgba(255,255,255,0.06)',
+});
+
+export const HeadRow = styled(XStack, {
+  name: 'GameChatHeadRow',
+  alignItems: 'center',
+  gap: 8,
+});
+
+export const TitleDot = styled(YStack, {
+  name: 'GameChatTitleDot',
+  width: 7,
+  height: 7,
+  borderRadius: 999,
+  backgroundColor: '#34D399',
+  shadowColor: '#34D399',
+  shadowRadius: 8,
+});
+
+export const Title = styled(Text, {
+  name: 'GameChatTitle',
+  fontSize: 13,
+  fontWeight: '600',
+  color: '$color',
+  letterSpacing: 0.2,
+});
+
+export const TabsRow = styled(XStack, {
+  name: 'GameChatTabs',
+  alignItems: 'center',
+  padding: 3,
+  borderRadius: 999,
+  borderWidth: 1,
+  borderColor: 'rgba(255,255,255,0.06)',
+  backgroundColor: 'rgba(255,255,255,0.04)',
+  gap: 2,
+});
+
+export const Tab = styled(XStack, {
+  name: 'GameChatTab',
+  flex: 1,
+  cursor: 'pointer',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingHorizontal: 10,
+  paddingVertical: 5,
+  borderRadius: 999,
+  gap: 6,
+  hoverStyle: { backgroundColor: 'rgba(255,255,255,0.04)' },
+});
+
+export const TabLabel = styled(Text, {
+  name: 'GameChatTabLabel',
+  fontSize: 11.5,
+  fontWeight: '600',
+  color: '$colorMuted',
+});
+
+export const TabCount = styled(Text, {
+  name: 'GameChatTabCount',
+  minWidth: 16,
+  textAlign: 'center',
+  fontSize: 9.5,
+  paddingHorizontal: 4,
+  paddingVertical: 1,
+  borderRadius: 999,
+  color: 'rgba(255,255,255,0.7)',
+  backgroundColor: 'rgba(255,255,255,0.08)',
+});
+
+export const Body = styled(YStack, {
+  name: 'GameChatBody',
+  flex: 1,
+  minHeight: 0,
+});
+
+export const ListGap = styled(YStack, {
+  name: 'GameChatListGap',
+  gap: 10,
+  paddingTop: 4,
+  paddingBottom: 6,
+  paddingHorizontal: 14,
+});
+
+export const Divider = styled(XStack, {
+  name: 'GameChatDivider',
+  alignItems: 'center',
+  justifyContent: 'center',
+  paddingVertical: 4,
+});
+
+export const DividerLabel = styled(Text, {
+  name: 'GameChatDividerLabel',
+  fontSize: 9.5,
+  fontWeight: '700',
+  letterSpacing: 1.2,
+  color: '$colorMuted',
+  textTransform: 'uppercase',
+  paddingHorizontal: 10,
+});
+
+export const Foot = styled(YStack, {
+  name: 'GameChatFoot',
+  gap: 8,
+  paddingHorizontal: 14,
+  paddingTop: 10,
+  paddingBottom: 12,
+  borderTopWidth: 1,
+  borderTopColor: 'rgba(255,255,255,0.06)',
+});
+
+export const QuickRow = styled(XStack, {
+  name: 'GameChatQuickRow',
+  gap: 6,
+  flexWrap: 'wrap',
+});
+
+export const QuickButton = styled(XStack, {
+  name: 'GameChatQuickBtn',
+  alignItems: 'center',
+  gap: 4,
+  cursor: 'pointer',
+  height: 24,
+  paddingHorizontal: 10,
+  borderRadius: 999,
+  borderWidth: 1,
+  borderColor: 'rgba(255,255,255,0.06)',
+  backgroundColor: 'rgba(255,255,255,0.03)',
+  hoverStyle: { backgroundColor: 'rgba(255,255,255,0.06)' },
+});
+
+export const QuickButtonText = styled(Text, {
+  name: 'GameChatQuickBtnText',
+  fontSize: 11,
+  fontWeight: '500',
+  color: '$color',
+});
+
+export const InputPill = styled(XStack, {
+  name: 'GameChatInputPill',
+  alignItems: 'center',
+  gap: 8,
+  paddingLeft: 12,
+  paddingRight: 4,
+  height: 38,
+  borderRadius: 12,
+  borderWidth: 1,
+  borderColor: 'rgba(255,255,255,0.08)',
+  backgroundColor: 'rgba(0,0,0,0.25)',
+});
+
+export const ChannelChip = styled(Text, {
+  name: 'GameChatChannelChip',
+  fontSize: 10,
+  fontWeight: '700',
+  letterSpacing: 1,
+  textTransform: 'uppercase',
+  paddingRight: 8,
+  borderRightWidth: 1,
+  borderRightColor: 'rgba(255,255,255,0.08)',
+});
+
+export const MetaLine = styled(XStack, {
+  name: 'GameChatMetaLine',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const MetaText = styled(Text, {
+  name: 'GameChatMetaText',
+  fontSize: 9.5,
+  letterSpacing: 0.8,
+  textTransform: 'uppercase',
+  color: '$colorMuted',
+});
+
+export const CollapsedShell = styled(XStack, {
+  name: 'GameChatCollapsedShell',
+  cursor: 'pointer',
+  width: '100%',
+  height: 44,
+  borderRadius: 999,
+  borderWidth: 1,
+  borderColor: 'rgba(255,255,255,0.08)',
+  backgroundColor: 'rgba(15,17,18,0.85)',
+  alignItems: 'center',
+  paddingHorizontal: 12,
+  gap: 8,
+  hoverStyle: { borderColor: 'rgba(255,255,255,0.16)' },
+});
+
+export const CollapsedPreview = styled(Text, {
+  name: 'GameChatCollapsedPreview',
+  fontSize: 12,
+  color: '$colorMuted',
+  flex: 1,
+  numberOfLines: 1,
+});
+
+export const UnreadBadge = styled(Text, {
+  name: 'GameChatUnreadBadge',
+  fontSize: 10,
+  fontWeight: '700',
+  color: '#06011b',
+  paddingHorizontal: 8,
+  paddingVertical: 2,
+  borderRadius: 999,
+  letterSpacing: 0.4,
+});
+
+export const SysWrap = styled(XStack, {
+  name: 'GameChatSysWrap',
+  gap: 8,
+  alignItems: 'center',
+  paddingVertical: 7,
+  paddingHorizontal: 10,
+  borderRadius: 10,
+  borderLeftWidth: 2,
+  borderLeftColor: 'rgba(255,255,255,0.18)',
+});
+
+export const SysText = styled(Text, {
+  name: 'GameChatSysText',
+  fontSize: 11,
+  color: '$color',
+  flex: 1,
+});
+
+export const SysTime = styled(Text, {
+  name: 'GameChatSysTime',
+  fontSize: 10,
+  color: '$colorMuted',
+});

--- a/apps/web/src/widgets/GameChat/ui/GameChat.styled.ts
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.styled.ts
@@ -18,8 +18,8 @@ export const Panel = styled(YStack, {
   minHeight: 360,
   borderRadius: 18,
   borderWidth: 1,
-  borderColor: 'rgba(255,255,255,0.08)',
-  backgroundColor: 'rgba(15,17,18,0.78)',
+  borderColor: '$glassBorder',
+  backgroundColor: '$glassBg',
   overflow: 'hidden',
   position: 'relative',
 });
@@ -31,7 +31,7 @@ export const Head = styled(YStack, {
   paddingTop: 12,
   paddingBottom: 10,
   borderBottomWidth: 1,
-  borderBottomColor: 'rgba(255,255,255,0.06)',
+  borderBottomColor: '$glassBorder',
 });
 
 export const HeadRow = styled(XStack, {
@@ -64,8 +64,8 @@ export const TabsRow = styled(XStack, {
   padding: 3,
   borderRadius: 999,
   borderWidth: 1,
-  borderColor: 'rgba(255,255,255,0.06)',
-  backgroundColor: 'rgba(255,255,255,0.04)',
+  borderColor: '$glassBorder',
+  backgroundColor: '$backgroundHover',
   gap: 2,
 });
 
@@ -79,7 +79,7 @@ export const Tab = styled(XStack, {
   paddingVertical: 5,
   borderRadius: 999,
   gap: 6,
-  hoverStyle: { backgroundColor: 'rgba(255,255,255,0.04)' },
+  hoverStyle: { backgroundColor: '$backgroundHover' },
 });
 
 export const TabLabel = styled(Text, {
@@ -97,8 +97,8 @@ export const TabCount = styled(Text, {
   paddingHorizontal: 4,
   paddingVertical: 1,
   borderRadius: 999,
-  color: 'rgba(255,255,255,0.7)',
-  backgroundColor: 'rgba(255,255,255,0.08)',
+  color: '$colorMuted',
+  backgroundColor: '$backgroundHover',
 });
 
 export const Body = styled(YStack, {
@@ -139,7 +139,7 @@ export const Foot = styled(YStack, {
   paddingTop: 10,
   paddingBottom: 12,
   borderTopWidth: 1,
-  borderTopColor: 'rgba(255,255,255,0.06)',
+  borderTopColor: '$glassBorder',
 });
 
 export const QuickRow = styled(XStack, {
@@ -157,9 +157,9 @@ export const QuickButton = styled(XStack, {
   paddingHorizontal: 10,
   borderRadius: 999,
   borderWidth: 1,
-  borderColor: 'rgba(255,255,255,0.06)',
-  backgroundColor: 'rgba(255,255,255,0.03)',
-  hoverStyle: { backgroundColor: 'rgba(255,255,255,0.06)' },
+  borderColor: '$glassBorder',
+  backgroundColor: '$backgroundHover',
+  hoverStyle: { backgroundColor: '$backgroundPress' },
 });
 
 export const QuickButtonText = styled(Text, {
@@ -178,8 +178,8 @@ export const InputPill = styled(XStack, {
   height: 38,
   borderRadius: 12,
   borderWidth: 1,
-  borderColor: 'rgba(255,255,255,0.08)',
-  backgroundColor: 'rgba(0,0,0,0.25)',
+  borderColor: '$glassBorder',
+  backgroundColor: '$backgroundHover',
 });
 
 export const ChannelChip = styled(Text, {
@@ -190,7 +190,7 @@ export const ChannelChip = styled(Text, {
   textTransform: 'uppercase',
   paddingRight: 8,
   borderRightWidth: 1,
-  borderRightColor: 'rgba(255,255,255,0.08)',
+  borderRightColor: '$glassBorder',
 });
 
 export const MetaLine = styled(XStack, {
@@ -214,12 +214,12 @@ export const CollapsedShell = styled(XStack, {
   height: 44,
   borderRadius: 999,
   borderWidth: 1,
-  borderColor: 'rgba(255,255,255,0.08)',
-  backgroundColor: 'rgba(15,17,18,0.85)',
+  borderColor: '$glassBorder',
+  backgroundColor: '$glassBg',
   alignItems: 'center',
   paddingHorizontal: 12,
   gap: 8,
-  hoverStyle: { borderColor: 'rgba(255,255,255,0.16)' },
+  hoverStyle: { borderColor: '$glassBorderHover' },
 });
 
 export const CollapsedPreview = styled(Text, {

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
   type KeyboardEvent,
 } from 'react';
-import { XStack, YStack, ScrollView, Text } from 'tamagui';
+import { XStack, YStack, ScrollView, Text, useTheme } from 'tamagui';
 import { IconButton, CloseIcon, Typography } from '@arcadeum/ui';
 import type { ScrollView as TamaguiScrollView } from 'tamagui';
 import { scrollbarStyles } from '@/shared/lib/styles';
@@ -156,6 +156,9 @@ export function GameChat({
   const logs = useGameChatStore((s) => s.logs);
   const sendMessage = useGameChatStore((s) => s.sendMessage);
   const resolveActorColor = useGameChatStore((s) => s.resolveActorColor);
+  const theme = useTheme();
+  const inputColor =
+    (theme.color?.get?.() as string | undefined) ?? '#ecefee';
 
   const scopes = teamMode ? TEAM_SCOPES : FFA_SCOPES;
   const [draft, setDraft] = useState('');
@@ -433,7 +436,7 @@ export function GameChat({
               background: 'transparent',
               border: 'none',
               outline: 'none',
-              color: '#ecefee',
+              color: inputColor,
               fontSize: 13,
               fontFamily: 'inherit',
             }}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -1,72 +1,110 @@
-import { useState, useRef, useEffect, type ReactNode } from 'react';
+'use client';
+
 import {
-  XStack,
-  YStack,
-  ScrollView,
-  Button,
-  ChatMessage,
-  ChatInput,
-  Typography,
-  GlassCard,
-  CloseIcon,
-} from '@arcadeum/ui';
+  useState,
+  useRef,
+  useEffect,
+  useMemo,
+  type ReactNode,
+  type KeyboardEvent,
+} from 'react';
+import { XStack, YStack, ScrollView, Text } from 'tamagui';
+import { IconButton, CloseIcon, Typography } from '@arcadeum/ui';
 import type { ScrollView as TamaguiScrollView } from 'tamagui';
 import { scrollbarStyles } from '@/shared/lib/styles';
 import { getPlayerColor } from '@/shared/lib/playerColors';
-import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
-import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
-import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useGameChatStore } from '../store/gameChatStore';
-import type { ChatScope } from '../store/gameChatStore';
+import type { ChatScope, ChatLogEntry } from '../store/gameChatStore';
+import { useChatCollapsed } from '../hooks/useChatCollapsed';
+import { GameChatRow } from './GameChatRow';
+import { GameChatSystemRow, type SystemRowKind } from './GameChatSystemRow';
+import type { EquippedResolver } from './types';
+import {
+  ACCENT_GRADIENT,
+  ACCENT_PINK,
+  Body,
+  ChannelChip,
+  CollapsedPreview,
+  CollapsedShell,
+  Divider,
+  DividerLabel,
+  Foot,
+  Head,
+  HeadRow,
+  InputPill,
+  ListGap,
+  MetaLine,
+  MetaText,
+  Panel,
+  QuickButton,
+  QuickButtonText,
+  QuickRow,
+  Tab,
+  TabCount,
+  TabLabel,
+  TabsRow,
+  Title,
+  TitleDot,
+  UnreadBadge,
+} from './GameChat.styled';
 
-export interface ResolvedEquipped {
-  equippedAvatarId: string | null;
-  equippedBadgeId: string | null;
-  equippedNameColorId?: string | null;
-  equippedFrameId?: string | null;
-  equippedAuraId?: string | null;
-  equippedBannerId?: string | null;
-}
-
-export type EquippedResolver = (id?: string | null) => ResolvedEquipped | null;
+export type { ResolvedEquipped, EquippedResolver } from './types';
 
 interface GameChatProps {
   resolveDisplayName?: (id?: string, fallback?: string) => string | undefined;
-  /**
-   * Maps a senderId to that user's currently-equipped shop cosmetics, used
-   * to render avatars and inline badges in chat rows. Caller is expected to
-   * derive this from the lobby's room.members payload (which now carries
-   * equippedAvatarId / equippedBadgeId per member).
-   */
   resolveEquipped?: EquippedResolver;
   currentUserId?: string | null;
   onClose?: () => void;
   teamMode?: boolean;
 }
 
-const FFA_SCOPES: { value: ChatScope; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'players', label: 'Players' },
-  { value: 'private', label: 'Private' },
-];
+const FFA_SCOPES: ChatScope[] = ['all', 'players', 'private'];
+const TEAM_SCOPES: ChatScope[] = ['team', 'all', 'private'];
 
-const TEAM_SCOPES: { value: ChatScope; label: string }[] = [
-  { value: 'team', label: 'Team' },
-  { value: 'all', label: 'All' },
-  { value: 'private', label: 'Private' },
-];
+const SCOPE_LABEL: Record<ChatScope, string> = {
+  all: 'All',
+  team: 'Team',
+  players: 'Players',
+  private: 'Whispers',
+};
+
+const SCOPE_CHIP: Record<ChatScope, string> = {
+  all: 'ALL',
+  team: 'TEAM',
+  players: 'TEAM',
+  private: 'DM',
+};
+
+const SCOPE_PLACEHOLDER: Record<ChatScope, string> = {
+  all: 'Send to everyone',
+  team: 'Send to team',
+  players: 'Send to players',
+  private: 'Private note',
+};
+
+const SCOPE_CHIP_COLOR: Record<ChatScope, string> = {
+  all: '#9CA3AF',
+  team: '#22D3EE',
+  players: '#22D3EE',
+  private: '#A78BFA',
+};
+
+const QUICK_PHRASES = ['gl hf', 'nice play', 'thinking…', 'gg'];
 
 const RESULT_COLORS: Record<string, string> = {
-  HIT: '#F97316', // orange
-  MISS: '#94A3B8', // slate
-  SUNK: '#EF4444', // red
+  HIT: '#F97316',
+  MISS: '#94A3B8',
+  SUNK: '#EF4444',
 };
 
 const RESULT_PATTERN = /\b(HIT|MISS|SUNK)\b/;
 
+const MONO_STYLE: React.CSSProperties = {
+  fontFamily:
+    "ui-monospace, SFMono-Regular, 'JetBrains Mono', 'Menlo', monospace",
+};
+
 function renderResultHighlights(message: string): ReactNode {
-  // Split on the first occurrence of a result keyword; wrap that keyword
-  // in a colored, bold span. The rest of the message stays as-is.
   const match = RESULT_PATTERN.exec(message);
   if (!match) return message;
   const idx = match.index;
@@ -75,12 +113,37 @@ function renderResultHighlights(message: string): ReactNode {
   return (
     <>
       {message.slice(0, idx)}
-      <span style={{ color, fontWeight: 800, fontStyle: 'normal' }}>
-        {keyword}
-      </span>
+      <span style={{ color, fontWeight: 800 }}>{keyword}</span>
       {message.slice(idx + keyword.length)}
     </>
   );
+}
+
+function inferSysKind(log: ChatLogEntry): SystemRowKind {
+  const msg = log.message?.toLowerCase() ?? '';
+  if (msg.includes('round')) return 'round';
+  if (msg.includes('combo')) return 'combo';
+  if (msg.includes('join')) return 'join';
+  return log.type === 'action' ? 'combo' : 'elim';
+}
+
+function logBelongsToScope(log: ChatLogEntry, scope: ChatScope): boolean {
+  if (log.type !== 'message') return scope === 'all';
+  const logScope = (log as ChatLogEntry & { scope?: ChatScope }).scope;
+  if (!logScope) return scope === 'all';
+  return logScope === scope;
+}
+
+function lastMessagePreview(logs: ChatLogEntry[]): string {
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const log = logs[i];
+    if (log.type === 'message') {
+      const name = log.senderName ?? 'Someone';
+      const text = log.message ?? '';
+      return `${name}: ${text}`;
+    }
+  }
+  return 'No messages yet';
 }
 
 export function GameChat({
@@ -95,221 +158,314 @@ export function GameChat({
   const resolveActorColor = useGameChatStore((s) => s.resolveActorColor);
 
   const scopes = teamMode ? TEAM_SCOPES : FFA_SCOPES;
-  const [chatMessage, setChatMessage] = useState('');
-  const [chatScope, setChatScope] = useState<ChatScope>(
-    teamMode ? 'team' : 'all',
-  );
+  const [draft, setDraft] = useState('');
+  const [scope, setScope] = useState<ChatScope>(teamMode ? 'team' : 'all');
+  const [collapsed, setCollapsed] = useChatCollapsed();
+  const [unread, setUnread] = useState(0);
+  const lastSeenIdRef = useRef<string | null>(null);
   const scrollRef = useRef<TamaguiScrollView>(null);
 
   useEffect(() => {
-    scrollRef.current?.scrollToEnd({ animated: true });
-  }, [logs.length]);
+    if (!collapsed) scrollRef.current?.scrollToEnd({ animated: true });
+  }, [logs.length, collapsed]);
 
-  const handleSend = () => {
-    const trimmed = chatMessage.trim();
+  useEffect(() => {
+    if (collapsed) return;
+    lastSeenIdRef.current = logs.at(-1)?.id ?? null;
+    setUnread(0);
+  }, [collapsed, logs]);
+
+  useEffect(() => {
+    if (!collapsed) return;
+    const seenId = lastSeenIdRef.current;
+    const lastIdx = seenId ? logs.findIndex((l) => l.id === seenId) : -1;
+    const newOnes = logs
+      .slice(lastIdx + 1)
+      .filter((l) => l.type === 'message' && l.senderId !== currentUserId);
+    if (newOnes.length > 0) {
+      setUnread((u) => Math.min(99, u + newOnes.length));
+      lastSeenIdRef.current = logs.at(-1)?.id ?? seenId;
+    }
+  }, [logs, collapsed, currentUserId]);
+
+  const counts = useMemo(() => {
+    const c: Record<ChatScope, number> = {
+      all: 0,
+      team: 0,
+      players: 0,
+      private: 0,
+    };
+    for (const log of logs) {
+      if (log.type !== 'message') continue;
+      const s = (log as ChatLogEntry & { scope?: ChatScope }).scope ?? 'all';
+      if (s in c) c[s]! += 1;
+    }
+    return c;
+  }, [logs]);
+
+  const visibleLogs = useMemo(
+    () => logs.filter((l) => logBelongsToScope(l, scope)),
+    [logs, scope],
+  );
+
+  const send = () => {
+    const trimmed = draft.trim();
     if (!trimmed || !sendMessage) return;
-    sendMessage(trimmed, chatScope);
-    setChatMessage('');
+    sendMessage(trimmed, scope);
+    setDraft('');
   };
 
-  return (
-    <GlassCard
-      flex={1}
-      minHeight={350}
-      p={0}
-      overflow="hidden"
-      borderWidth={1}
-      borderColor="$glassBorder"
-    >
-      {/* Header */}
-      <XStack
-        paddingHorizontal="$4"
-        paddingVertical="$3"
-        alignItems="center"
-        justifyContent="space-between"
-        borderBottomWidth={1}
-        borderBottomColor="$glassBorder"
-        backgroundColor="$glassBg"
-      >
-        <Typography uiSize="md" weight="700">
-          Table Chat
-        </Typography>
-        {onClose && (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onClose}
-            circular
-            icon={<CloseIcon size={16} />}
-            aria-label="Close Chat"
-          />
-        )}
-      </XStack>
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
 
-      {/* Scope toggle */}
-      <XStack
-        paddingHorizontal="$3"
-        paddingVertical="$2"
-        gap="$2"
-        backgroundColor="$glassBg"
-        borderBottomWidth={1}
-        borderBottomColor="$glassBorder"
+  if (collapsed) {
+    return (
+      <CollapsedShell
+        role="button"
+        aria-label="Expand chat"
+        onPress={() => setCollapsed(false)}
       >
-        {scopes.map(({ value, label }) => (
-          <Button
-            key={value}
-            size="sm"
-            variant={chatScope === value ? 'primary' : 'secondary'}
-            onClick={() => setChatScope(value)}
-            flex={1}
+        <TitleDot />
+        <Title>Chat</Title>
+        <CollapsedPreview>{lastMessagePreview(logs)}</CollapsedPreview>
+        {unread > 0 ? (
+          <UnreadBadge
+            style={{
+              ...MONO_STYLE,
+              background: ACCENT_GRADIENT,
+            }}
           >
-            {label}
-          </Button>
-        ))}
-      </XStack>
+            {unread >= 99 ? '99+' : String(unread)}
+          </UnreadBadge>
+        ) : null}
+      </CollapsedShell>
+    );
+  }
 
-      {/* Messages */}
-      <ScrollView
-        flex={1}
-        ref={scrollRef}
-        paddingHorizontal="$4"
-        paddingVertical="$2"
-        className={scrollbarStyles.className}
-      >
-        {logs.length === 0 ? (
-          <YStack flex={1} ai="center" jc="center" py="$10">
-            <Typography alpha="low" textAlign="center" uiSize="sm">
-              No messages yet. Break the ice!
-            </Typography>
-          </YStack>
-        ) : (
-          <YStack gap="$1">
-            {logs.map((log) => {
-              const isOwn = !!currentUserId && log.senderId === currentUserId;
-              const senderName = resolveDisplayName
-                ? resolveDisplayName(
-                    log.senderId ?? undefined,
-                    log.senderName ?? undefined,
-                  )
-                : (log.senderName ?? undefined);
-              const senderColor = log.senderId
-                ? (resolveActorColor?.(log.senderId) ??
-                  getPlayerColor(log.senderId))
-                : undefined;
-              const targetId = log.targetId;
-              const targetName =
-                targetId && resolveDisplayName
-                  ? resolveDisplayName(targetId, undefined)
-                  : (targetId ?? undefined);
-              const targetColor = targetId
-                ? (resolveActorColor?.(targetId) ?? getPlayerColor(targetId))
-                : undefined;
-              const contentNode =
-                log.type === 'action' || log.type === 'system'
-                  ? renderResultHighlights(log.message)
-                  : undefined;
-              return (
-                <GameChatRow
-                  key={log.id}
-                  senderId={log.senderId ?? null}
-                  senderName={log.senderId ? senderName : undefined}
-                  senderColor={senderColor}
-                  targetName={targetId ? targetName : undefined}
-                  targetColor={targetColor}
-                  content={log.message}
-                  contentNode={contentNode}
-                  type={log.type}
-                  isOwn={isOwn}
-                  resolveEquipped={resolveEquipped}
-                />
-              );
-            })}
-          </YStack>
-        )}
-      </ScrollView>
-
-      {/* Input row */}
-      <ChatInput
-        value={chatMessage}
-        onChange={setChatMessage}
-        onSend={handleSend}
-        placeholder={
-          chatScope === 'all'
-            ? 'Send to everyone'
-            : chatScope === 'players'
-              ? 'Send to players'
-              : chatScope === 'team'
-                ? 'Send to team'
-                : 'Private note'
-        }
-      />
-    </GlassCard>
-  );
-}
-
-function GameChatRow({
-  senderId,
-  senderName,
-  senderColor,
-  targetName,
-  targetColor,
-  content,
-  contentNode,
-  type,
-  isOwn,
-  resolveEquipped,
-}: {
-  senderId: string | null;
-  senderName?: string;
-  senderColor?: string;
-  targetName?: string;
-  targetColor?: string;
-  content: string;
-  contentNode?: ReactNode;
-  type: 'system' | 'action' | 'message';
-  isOwn: boolean;
-  resolveEquipped?: EquippedResolver;
-}) {
-  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
-  // The hook resolves name-color (used on the sender label outside the
-  // avatar slot). Avatar/badge/frame/aura now come through PlayerAvatar.
-  const { nameColor } = useEquippedCosmetics({
-    equippedAvatarId: resolved?.equippedAvatarId,
-    equippedBadgeId: resolved?.equippedBadgeId,
-    equippedNameColorId: resolved?.equippedNameColorId,
-    equippedFrameId: resolved?.equippedFrameId,
-    equippedAuraId: resolved?.equippedAuraId,
-    equippedBannerId: resolved?.equippedBannerId,
-  });
-  // Shop name-color overrides the per-match actor color when present —
-  // cosmetic personal choice wins over contextual game coloring.
-  const nameProps = nameColorRenderProps(nameColor);
-  const resolvedSenderColor = nameProps.color ?? senderColor;
   return (
-    <ChatMessage
-      senderName={senderName}
-      senderColor={resolvedSenderColor}
-      senderNameStyle={nameProps.style}
-      targetName={targetName}
-      targetColor={targetColor}
-      content={content}
-      contentNode={contentNode}
-      type={type}
-      isOwn={isOwn}
-      senderAvatar={
-        senderName ? (
-          <EquippedPlayerAvatar
-            name={senderName}
+    <Panel data-testid="game-chat-panel">
+      <Head>
+        <HeadRow>
+          <TitleDot />
+          <Title>Table Chat</Title>
+          <YStack flex={1} />
+          <IconButton
             size="sm"
-            equippedAvatarId={resolved?.equippedAvatarId ?? null}
-            equippedBadgeId={resolved?.equippedBadgeId ?? null}
-            equippedNameColorId={resolved?.equippedNameColorId}
-            equippedFrameId={resolved?.equippedFrameId}
-            equippedAuraId={resolved?.equippedAuraId}
-            equippedBannerId={resolved?.equippedBannerId}
+            padding="$1"
+            title="Settings"
+            aria-label="Chat settings"
+          >
+            <Text fontSize={14}>⚙</Text>
+          </IconButton>
+          <IconButton
+            size="sm"
+            padding="$1"
+            onClick={() => setCollapsed(true)}
+            title="Minimize"
+            aria-label="Minimize chat"
+          >
+            <Text fontSize={14}>—</Text>
+          </IconButton>
+          {onClose ? (
+            <IconButton
+              size="sm"
+              padding="$1"
+              onClick={onClose}
+              title="Close"
+              aria-label="Close chat"
+            >
+              <CloseIcon size={14} />
+            </IconButton>
+          ) : null}
+        </HeadRow>
+
+        <TabsRow role="tablist">
+          {scopes.map((s) => {
+            const active = s === scope;
+            return (
+              <Tab
+                key={s}
+                role="tab"
+                aria-selected={active}
+                onPress={() => setScope(s)}
+                style={
+                  active
+                    ? {
+                        background: ACCENT_GRADIENT,
+                        boxShadow: `0 4px 12px -4px ${ACCENT_PINK}80, 0 0 0 1px rgba(255,255,255,0.18) inset`,
+                      }
+                    : undefined
+                }
+              >
+                <TabLabel color={active ? '#06011b' : undefined}>
+                  {SCOPE_LABEL[s]}
+                </TabLabel>
+                {counts[s] > 0 ? (
+                  <TabCount
+                    style={MONO_STYLE}
+                    backgroundColor={
+                      active ? 'rgba(6,1,27,0.25)' : 'rgba(255,255,255,0.08)'
+                    }
+                    color={
+                      active ? 'rgba(6,1,27,0.9)' : 'rgba(255,255,255,0.7)'
+                    }
+                  >
+                    {counts[s]}
+                  </TabCount>
+                ) : null}
+              </Tab>
+            );
+          })}
+        </TabsRow>
+      </Head>
+
+      <Body>
+        <ScrollView
+          ref={scrollRef}
+          flex={1}
+          className={scrollbarStyles.className}
+        >
+          {visibleLogs.length === 0 ? (
+            <YStack flex={1} ai="center" jc="center" py="$10">
+              <Typography alpha="low" textAlign="center" uiSize="sm">
+                No messages yet. Break the ice!
+              </Typography>
+            </YStack>
+          ) : (
+            <ListGap role="log" aria-live="polite" aria-relevant="additions">
+              <Divider>
+                <YStack
+                  height={1}
+                  flex={1}
+                  backgroundColor="rgba(255,255,255,0.06)"
+                />
+                <DividerLabel style={MONO_STYLE}>Match</DividerLabel>
+                <YStack
+                  height={1}
+                  flex={1}
+                  backgroundColor="rgba(255,255,255,0.06)"
+                />
+              </Divider>
+              {visibleLogs.map((log) => {
+                if (log.type === 'system' || log.type === 'action') {
+                  return (
+                    <GameChatSystemRow
+                      key={log.id}
+                      kind={inferSysKind(log)}
+                      content={renderResultHighlights(log.message)}
+                    />
+                  );
+                }
+                const isOwn = !!currentUserId && log.senderId === currentUserId;
+                const senderName = resolveDisplayName
+                  ? resolveDisplayName(
+                      log.senderId ?? undefined,
+                      log.senderName ?? undefined,
+                    )
+                  : (log.senderName ?? undefined);
+                const senderColor = log.senderId
+                  ? (resolveActorColor?.(log.senderId) ??
+                    getPlayerColor(log.senderId))
+                  : undefined;
+                const targetId = log.targetId;
+                const targetName =
+                  targetId && resolveDisplayName
+                    ? resolveDisplayName(targetId, undefined)
+                    : (targetId ?? undefined);
+                const targetColor = targetId
+                  ? (resolveActorColor?.(targetId) ?? getPlayerColor(targetId))
+                  : undefined;
+                return (
+                  <GameChatRow
+                    key={log.id}
+                    senderId={log.senderId ?? null}
+                    senderName={log.senderId ? senderName : undefined}
+                    senderColor={senderColor}
+                    targetName={targetId ? targetName : undefined}
+                    targetColor={targetColor}
+                    content={log.message}
+                    type={log.type}
+                    isOwn={isOwn}
+                    resolveEquipped={resolveEquipped}
+                  />
+                );
+              })}
+            </ListGap>
+          )}
+        </ScrollView>
+      </Body>
+
+      <Foot>
+        <QuickRow role="toolbar" aria-label="Quick phrases">
+          {QUICK_PHRASES.map((p) => (
+            <QuickButton
+              key={p}
+              onPress={() => setDraft((d) => (d ? `${d} ${p}` : p))}
+              aria-label={p}
+            >
+              <QuickButtonText>{p}</QuickButtonText>
+            </QuickButton>
+          ))}
+        </QuickRow>
+
+        <InputPill
+          focusStyle={{
+            borderColor: `${ACCENT_PINK}88`,
+            backgroundColor: 'rgba(0,0,0,0.32)',
+          }}
+        >
+          <ChannelChip style={MONO_STYLE} color={SCOPE_CHIP_COLOR[scope]}>
+            {SCOPE_CHIP[scope]}
+          </ChannelChip>
+          <input
+            value={draft}
+            maxLength={240}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={SCOPE_PLACEHOLDER[scope]}
+            aria-label="Message"
+            style={{
+              flex: 1,
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              color: '#ecefee',
+              fontSize: 13,
+              fontFamily: 'inherit',
+            }}
           />
-        ) : undefined
-      }
-    />
+          <IconButton
+            size="sm"
+            padding="$1"
+            onClick={send}
+            disabled={!draft.trim()}
+            aria-label="Send message"
+            style={{
+              background: draft.trim() ? ACCENT_GRADIENT : undefined,
+              opacity: draft.trim() ? 1 : 0.4,
+              width: 30,
+              height: 30,
+              borderRadius: 9,
+            }}
+          >
+            <Text fontSize={14} color="#06011b" fontWeight="700">
+              ↑
+            </Text>
+          </IconButton>
+        </InputPill>
+
+        <MetaLine>
+          <MetaText style={MONO_STYLE}>{draft.length}/240</MetaText>
+          <XStack gap={6} alignItems="center">
+            <MetaText style={MONO_STYLE}>↵ send</MetaText>
+            <MetaText style={MONO_STYLE}>⇧↵ newline</MetaText>
+          </XStack>
+        </MetaLine>
+      </Foot>
+    </Panel>
   );
 }

--- a/apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useGameChatStore } from '../store/gameChatStore';
+import { useLatestChatMessage } from '../hooks/useLatestChatMessage';
+import { ChatMessagePopup } from './ChatMessagePopup';
+
+export function GameChatPopupOverlay() {
+  const logs = useGameChatStore((s) => s.logs);
+  const gameResolveDisplayName = useGameChatStore((s) => s.resolveDisplayName);
+  const fallbackResolveDisplayName = useGameChatStore(
+    (s) => s.fallbackResolveDisplayName,
+  );
+  const resolveEquipped = useGameChatStore((s) => s.resolveEquipped);
+  const currentUserId = useGameChatStore((s) => s.currentUserId);
+  const chatPanelOpen = useGameChatStore((s) => s.chatPanelOpen);
+
+  const { latestMessage, dismiss } = useLatestChatMessage(logs);
+
+  if (chatPanelOpen) return null;
+  if (!latestMessage) return null;
+
+  const fromGame = gameResolveDisplayName?.(
+    latestMessage.senderId,
+    latestMessage.senderName,
+  );
+  const senderName =
+    fromGame && fromGame !== 'Unknown'
+      ? fromGame
+      : (fallbackResolveDisplayName?.(
+          latestMessage.senderId,
+          latestMessage.senderName,
+        ) ?? latestMessage.senderName);
+
+  const equipped = resolveEquipped?.(latestMessage.senderId ?? null) ?? null;
+
+  const isOwn =
+    !!currentUserId &&
+    !!latestMessage.senderId &&
+    latestMessage.senderId === currentUserId;
+
+  return (
+    <ChatMessagePopup
+      key={latestMessage.id}
+      senderId={latestMessage.senderId ?? null}
+      senderName={senderName}
+      senderEquippedAvatarId={equipped?.equippedAvatarId ?? null}
+      senderEquippedBadgeId={equipped?.equippedBadgeId ?? null}
+      senderEquippedNameColorId={equipped?.equippedNameColorId ?? null}
+      senderEquippedFrameId={equipped?.equippedFrameId ?? null}
+      senderEquippedAuraId={equipped?.equippedAuraId ?? null}
+      senderEquippedBannerId={equipped?.equippedBannerId ?? null}
+      message={latestMessage.message}
+      visible
+      onDismiss={dismiss}
+      isOwn={isOwn}
+    />
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx
@@ -19,19 +19,16 @@ export function GameChatPopupOverlay() {
   if (chatPanelOpen) return null;
   if (!latestMessage) return null;
 
-  const fromGame = gameResolveDisplayName?.(
-    latestMessage.senderId,
-    latestMessage.senderName,
-  );
+  const senderIdArg = latestMessage.senderId ?? undefined;
+  const senderNameArg = latestMessage.senderName ?? undefined;
+  const fromGame = gameResolveDisplayName?.(senderIdArg, senderNameArg);
   const senderName =
     fromGame && fromGame !== 'Unknown'
       ? fromGame
-      : (fallbackResolveDisplayName?.(
-          latestMessage.senderId,
-          latestMessage.senderName,
-        ) ?? latestMessage.senderName);
+      : (fallbackResolveDisplayName?.(senderIdArg, senderNameArg) ??
+        latestMessage.senderName);
 
-  const equipped = resolveEquipped?.(latestMessage.senderId ?? null) ?? null;
+  const equipped = resolveEquipped?.(senderIdArg) ?? null;
 
   const isOwn =
     !!currentUserId &&

--- a/apps/web/src/widgets/GameChat/ui/GameChatRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatRow.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { ChatMessage } from '@arcadeum/ui';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
+import type { EquippedResolver } from './types';
+
+interface GameChatRowProps {
+  senderId: string | null;
+  senderName?: string;
+  senderColor?: string;
+  targetName?: string;
+  targetColor?: string;
+  content: string;
+  contentNode?: ReactNode;
+  type: 'system' | 'action' | 'message';
+  isOwn: boolean;
+  resolveEquipped?: EquippedResolver;
+}
+
+export function GameChatRow({
+  senderId,
+  senderName,
+  senderColor,
+  targetName,
+  targetColor,
+  content,
+  contentNode,
+  type,
+  isOwn,
+  resolveEquipped,
+}: GameChatRowProps) {
+  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
+  const { nameColor } = useEquippedCosmetics({
+    equippedAvatarId: resolved?.equippedAvatarId,
+    equippedBadgeId: resolved?.equippedBadgeId,
+    equippedNameColorId: resolved?.equippedNameColorId,
+    equippedFrameId: resolved?.equippedFrameId,
+    equippedAuraId: resolved?.equippedAuraId,
+    equippedBannerId: resolved?.equippedBannerId,
+  });
+  const nameProps = nameColorRenderProps(nameColor);
+  const resolvedSenderColor = nameProps.color ?? senderColor;
+  return (
+    <ChatMessage
+      senderName={senderName}
+      senderColor={resolvedSenderColor}
+      senderNameStyle={nameProps.style}
+      targetName={targetName}
+      targetColor={targetColor}
+      content={content}
+      contentNode={contentNode}
+      type={type}
+      isOwn={isOwn}
+      senderAvatar={
+        senderName ? (
+          <EquippedPlayerAvatar
+            name={senderName}
+            size="sm"
+            equippedAvatarId={resolved?.equippedAvatarId ?? null}
+            equippedBadgeId={resolved?.equippedBadgeId ?? null}
+            equippedNameColorId={resolved?.equippedNameColorId}
+            equippedFrameId={resolved?.equippedFrameId}
+            equippedAuraId={resolved?.equippedAuraId}
+            equippedBannerId={resolved?.equippedBannerId}
+          />
+        ) : undefined
+      }
+    />
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { SYS_COLOR, SysText, SysTime, SysWrap } from './GameChat.styled';
+
+export type SystemRowKind = 'elim' | 'round' | 'combo' | 'join';
+
+interface Props {
+  kind: SystemRowKind;
+  content: ReactNode;
+  time?: string;
+}
+
+const GLYPHS: Record<SystemRowKind, string> = {
+  elim: '☠',
+  round: '◷',
+  combo: '✦',
+  join: '⇢',
+};
+
+export function GameChatSystemRow({ kind, content, time }: Props) {
+  const color = SYS_COLOR[kind];
+  return (
+    <SysWrap
+      borderLeftColor={color}
+      backgroundColor={`color-mix(in srgb, ${color} 12%, transparent)`}
+    >
+      <SysText color={color} fontWeight="700">
+        {GLYPHS[kind]}
+      </SysText>
+      <SysText>{content}</SysText>
+      {time ? <SysTime>{time}</SysTime> : null}
+    </SysWrap>
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx
@@ -1,29 +1,39 @@
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '@/shared/config/tamagui.config';
 
 import { GameChat } from '../GameChat';
 import { useGameChatStore } from '../../store/gameChatStore';
 import type { ChatLogEntry } from '../../store/gameChatStore';
 
+function renderChat(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      {ui}
+    </TamaguiProvider>,
+  );
+}
+
 vi.mock('@arcadeum/ui', async () => {
-  const React = await import('react');
-  // Lightweight stubs for the Tamagui surface used by GameChat — we only
-  // need to verify what GameChat passes to ChatMessage.
   const passthrough = (name: string) =>
     function Stub({ children }: { children?: React.ReactNode }) {
       return React.createElement('div', { 'data-stub': name }, children);
     };
+  const button = ({
+    children,
+    onClick,
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+  }) => React.createElement('button', { onClick }, children);
   return {
     XStack: passthrough('XStack'),
     YStack: passthrough('YStack'),
     ScrollView: passthrough('ScrollView'),
-    Button: ({
-      children,
-      onClick,
-    }: {
-      children?: React.ReactNode;
-      onClick?: () => void;
-    }) => React.createElement('button', { onClick }, children),
+    Button: button,
+    IconButton: button,
     GlassCard: passthrough('GlassCard'),
     CloseIcon: () => React.createElement('span'),
     Typography: ({ children }: { children?: React.ReactNode }) =>
@@ -75,7 +85,7 @@ describe('GameChat', () => {
     useGameChatStore.getState().clear();
   });
 
-  it('marks a message as own when senderId matches currentUserId', () => {
+  it('marks a chat message as own when senderId matches currentUserId', () => {
     useGameChatStore
       .getState()
       .setLogs([
@@ -83,7 +93,7 @@ describe('GameChat', () => {
         makeLog({ id: 'b', senderId: 'other', message: 'theirs' }),
       ]);
 
-    render(
+    renderChat(
       <GameChat
         currentUserId="me"
         resolveDisplayName={(id) => (id === 'me' ? 'You' : 'Bob')}
@@ -91,47 +101,50 @@ describe('GameChat', () => {
     );
 
     const rendered = screen.getAllByTestId('chat-message');
+    expect(rendered).toHaveLength(2);
     expect(rendered[0]?.getAttribute('data-is-own')).toBe('true');
     expect(rendered[0]?.getAttribute('data-sender')).toBe('You');
     expect(rendered[1]?.getAttribute('data-is-own')).toBe('false');
     expect(rendered[1]?.getAttribute('data-sender')).toBe('Bob');
   });
 
-  it('passes raw message, sender name and a deterministic color for action/system logs', () => {
+  it('renders system and action logs separately from chat messages', () => {
     useGameChatStore
       .getState()
       .setLogs([
-        makeLog({ id: 'a', type: 'action', senderId: 'p1', message: 'Drew a card' }),
-        makeLog({ id: 'b', type: 'system', senderId: 'p2', message: 'exploded!' }),
+        makeLog({
+          id: 'a',
+          type: 'action',
+          senderId: 'p1',
+          message: 'Drew a card',
+        }),
+        makeLog({
+          id: 'b',
+          type: 'system',
+          senderId: 'p2',
+          message: 'exploded!',
+        }),
         makeLog({ id: 'c', type: 'message', senderId: 'p1', message: 'hi' }),
-        makeLog({ id: 'd', type: 'action', senderId: null, message: 'Game started' }),
       ]);
 
-    render(
+    renderChat(
       <GameChat
         currentUserId="p1"
         resolveDisplayName={(id) => (id === 'p1' ? 'You' : 'Bob')}
       />,
     );
 
-    const rendered = screen.getAllByTestId('chat-message');
+    // Only `message` logs use the ChatMessage component; system/action rows
+    // render via the new GameChatSystemRow surface.
+    const chatRendered = screen.getAllByTestId('chat-message');
+    expect(chatRendered).toHaveLength(1);
+    expect(chatRendered[0]?.textContent).toBe('hi');
+    expect(chatRendered[0]?.getAttribute('data-sender')).toBe('You');
+    expect(chatRendered[0]?.getAttribute('data-sender-color')).toMatch(/^#/);
 
-    // Action log: raw content, sender name resolved, deterministic color set.
-    expect(rendered[0]?.textContent).toBe('Drew a card');
-    expect(rendered[0]?.getAttribute('data-sender')).toBe('You');
-    const p1Color = rendered[0]?.getAttribute('data-sender-color');
-    expect(p1Color).toMatch(/^#/);
-
-    // Same player id in a chat message gets the SAME color.
-    expect(rendered[2]?.getAttribute('data-sender-color')).toBe(p1Color);
-
-    // Different player → different color (probabilistically, but our palette is small)
-    expect(rendered[1]?.getAttribute('data-sender')).toBe('Bob');
-    expect(rendered[1]?.getAttribute('data-sender-color')).toMatch(/^#/);
-
-    // Log without a senderId → no sender, no color.
-    expect(rendered[3]?.getAttribute('data-sender')).toBe('');
-    expect(rendered[3]?.getAttribute('data-sender-color')).toBe('');
+    // System / action messages still appear somewhere in the rendered tree.
+    expect(screen.getByText('Drew a card')).toBeTruthy();
+    expect(screen.getByText('exploded!')).toBeTruthy();
   });
 
   it('treats messages as not-own when currentUserId is missing', () => {
@@ -139,7 +152,7 @@ describe('GameChat', () => {
       .getState()
       .setLogs([makeLog({ id: 'a', senderId: 'someone', message: 'hi' })]);
 
-    render(
+    renderChat(
       <GameChat
         resolveDisplayName={(id) => (id === 'someone' ? 'Alice' : id)}
       />,

--- a/apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx
@@ -33,7 +33,7 @@ const baseLog = {
   senderId: 'opponent-1',
   senderName: 'Admiral',
   message: 'Prepare for battle!',
-  createdAt: '2026-05-21T00:00:00Z',
+  createdAt: new Date(Date.now() + 60_000).toISOString(),
   scope: 'all' as const,
 };
 

--- a/apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GameChatPopupOverlay } from '../GameChatPopupOverlay';
+import { useGameChatStore } from '../../store/gameChatStore';
+
+vi.mock('../ChatMessagePopup', () => ({
+  ChatMessagePopup: ({
+    senderName,
+    message,
+    isOwn,
+  }: {
+    senderName: string;
+    message: string;
+    isOwn?: boolean;
+  }) =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'chat-message-popup', 'data-is-own': String(!!isOwn) },
+      React.createElement(
+        'span',
+        { 'data-testid': 'popup-sender' },
+        senderName,
+      ),
+      React.createElement('span', { 'data-testid': 'popup-message' }, message),
+    ),
+}));
+
+const baseLog = {
+  id: 'msg-1',
+  type: 'message' as const,
+  senderId: 'opponent-1',
+  senderName: 'Admiral',
+  message: 'Prepare for battle!',
+  createdAt: '2026-05-21T00:00:00Z',
+  scope: 'all' as const,
+};
+
+describe('GameChatPopupOverlay', () => {
+  beforeEach(() => {
+    useGameChatStore.getState().clear();
+  });
+
+  it('renders nothing when there are no messages', () => {
+    render(<GameChatPopupOverlay />);
+    expect(screen.queryByTestId('chat-message-popup')).toBeNull();
+  });
+
+  it('renders the popup for the latest message when chat panel is closed', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    render(<GameChatPopupOverlay />);
+    expect(screen.getByTestId('chat-message-popup')).toBeTruthy();
+    expect(screen.getByTestId('popup-sender').textContent).toBe('Admiral');
+    expect(screen.getByTestId('popup-message').textContent).toBe(
+      'Prepare for battle!',
+    );
+  });
+
+  it('renders nothing when chat panel is open', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    useGameChatStore.getState().setChatPanelOpen(true);
+    render(<GameChatPopupOverlay />);
+    expect(screen.queryByTestId('chat-message-popup')).toBeNull();
+  });
+
+  it('prefers game resolver over fallback for sender name', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    useGameChatStore
+      .getState()
+      .registerResolveDisplayName((id) =>
+        id === 'opponent-1' ? 'Captain Game' : undefined,
+      );
+    useGameChatStore
+      .getState()
+      .registerFallbackResolveDisplayName(() => 'Fallback Name');
+    render(<GameChatPopupOverlay />);
+    expect(screen.getByTestId('popup-sender').textContent).toBe('Captain Game');
+  });
+
+  it('falls back to fallback resolver when game resolver returns Unknown', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    useGameChatStore.getState().registerResolveDisplayName(() => 'Unknown');
+    useGameChatStore
+      .getState()
+      .registerFallbackResolveDisplayName(() => 'Member Name');
+    render(<GameChatPopupOverlay />);
+    expect(screen.getByTestId('popup-sender').textContent).toBe('Member Name');
+  });
+
+  it('marks popup as own when sender matches currentUserId', () => {
+    useGameChatStore
+      .getState()
+      .setLogs([{ ...baseLog, senderId: 'me-1', senderName: 'Me' }]);
+    useGameChatStore.getState().setCurrentUserId('me-1');
+    render(<GameChatPopupOverlay />);
+    expect(
+      screen.getByTestId('chat-message-popup').getAttribute('data-is-own'),
+    ).toBe('true');
+  });
+});

--- a/apps/web/src/widgets/GameChat/ui/types.ts
+++ b/apps/web/src/widgets/GameChat/ui/types.ts
@@ -1,0 +1,10 @@
+export interface ResolvedEquipped {
+  equippedAvatarId: string | null;
+  equippedBadgeId: string | null;
+  equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
+}
+
+export type EquippedResolver = (id?: string | null) => ResolvedEquipped | null;

--- a/docs/superpowers/plans/2026-05-21-chat-popup-inside-widget.md
+++ b/docs/superpowers/plans/2026-05-21-chat-popup-inside-widget.md
@@ -1,0 +1,563 @@
+# Chat Popup Inside Game Widget — Implementation Plan (ARC-735)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the in-game chat message popup inside the `GameWidgetContainer` (anchored top-right of the widget) instead of fixed to the viewport, and suppress it when the chat panel is already open.
+
+**Architecture:** Extend `useGameChatStore` (Zustand) with `currentUserId`, `resolveEquipped`, and `chatPanelOpen` fields. Move popup rendering from `GamePageLayout` into a new `GameChatPopupOverlay` rendered inside `GameWidgetContainer`. Change `ChatMessagePopup` CSS from `position: fixed` to `position: absolute` so it anchors to the widget container (which is already `position: relative`).
+
+**Tech Stack:** Next.js 14 (App Router), React, TypeScript, Zustand, Tamagui, Vitest, Playwright.
+
+**Spec:** [docs/superpowers/specs/2026-05-21-chat-popup-inside-widget-design.md](../specs/2026-05-21-chat-popup-inside-widget-design.md)
+
+---
+
+## File Map
+
+| File                                                                       | Action | Purpose                                                                                    |
+| -------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------ |
+| `apps/web/src/widgets/GameChat/store/gameChatStore.ts`                     | Modify | Add `currentUserId`, `resolveEquipped`, `chatPanelOpen` fields + setters; update `clear()` |
+| `apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts`      | Modify | Add tests for new fields                                                                   |
+| `apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx`                    | Modify | `position: fixed` → `position: absolute`                                                   |
+| `apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx`                | Create | New overlay component that reads store and renders popup                                   |
+| `apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx` | Create | Unit test for overlay (hide when chat open, render when closed)                            |
+| `apps/web/src/widgets/GameChat/index.ts`                                   | Modify | Export `GameChatPopupOverlay`                                                              |
+| `apps/web/src/features/games/ui/GameWidgetContainer.tsx`                   | Modify | Render `<GameChatPopupOverlay />` inside `<Container>`                                     |
+| `apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx` | Modify | Remove popup JSX/`useLatestChatMessage`; add effects to sync store                         |
+| `apps/web/e2e/sea-battle-chat-popup.spec.ts`                               | Modify | Add test: popup hidden when chat panel open                                                |
+
+---
+
+## Task 1: Extend `useGameChatStore` with new fields
+
+**Files:**
+
+- Modify: `apps/web/src/widgets/GameChat/store/gameChatStore.ts`
+- Modify: `apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts`
+
+- [ ] **Step 1: Write failing tests for new store fields**
+
+Append to `gameChatStore.test.ts` inside the existing `describe('gameChatStore', …)` block:
+
+```ts
+it('setCurrentUserId updates currentUserId', () => {
+  useGameChatStore.getState().setCurrentUserId('user-1');
+  expect(useGameChatStore.getState().currentUserId).toBe('user-1');
+});
+
+it('registerResolveEquipped sets resolver', () => {
+  const fn = (id: string | null) =>
+    id === 'u1'
+      ? {
+          equippedAvatarId: 'a1',
+          equippedBadgeId: null,
+          equippedNameColorId: null,
+          equippedFrameId: null,
+          equippedAuraId: null,
+          equippedBannerId: null,
+        }
+      : null;
+  useGameChatStore.getState().registerResolveEquipped(fn);
+  expect(useGameChatStore.getState().resolveEquipped).toBe(fn);
+});
+
+it('setChatPanelOpen updates chatPanelOpen', () => {
+  expect(useGameChatStore.getState().chatPanelOpen).toBe(false);
+  useGameChatStore.getState().setChatPanelOpen(true);
+  expect(useGameChatStore.getState().chatPanelOpen).toBe(true);
+});
+
+it('clear resets new fields', () => {
+  useGameChatStore.getState().setCurrentUserId('user-1');
+  useGameChatStore.getState().registerResolveEquipped(() => null);
+  useGameChatStore.getState().setChatPanelOpen(true);
+  useGameChatStore.getState().clear();
+  const s = useGameChatStore.getState();
+  expect(s.currentUserId).toBeNull();
+  expect(s.resolveEquipped).toBeNull();
+  expect(s.chatPanelOpen).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run the new tests, confirm they fail**
+
+Run: `pnpm --filter @arcadeum/web test src/widgets/GameChat/store/__tests__/gameChatStore.test.ts`
+Expected: 4 new tests fail with messages like "currentUserId is not a function" / `undefined`.
+
+- [ ] **Step 3: Extend store implementation**
+
+Replace the body of `apps/web/src/widgets/GameChat/store/gameChatStore.ts` with:
+
+```ts
+import { create } from 'zustand';
+import type {
+  CriticalLogEntry as ChatLogEntry,
+  ChatScope,
+} from '@/shared/types/games';
+
+export type { CriticalLogEntry as ChatLogEntry } from '@/shared/types/games';
+export type { ChatScope } from '@/shared/types/games';
+
+export type ChatDisplayNameResolver = (
+  id?: string | null,
+  fallback?: string | null,
+) => string | undefined;
+
+export type ChatActorColorResolver = (id?: string | null) => string | undefined;
+
+export interface ChatEquippedItems {
+  equippedAvatarId: string | null;
+  equippedBadgeId: string | null;
+  equippedNameColorId: string | null;
+  equippedFrameId: string | null;
+  equippedAuraId: string | null;
+  equippedBannerId: string | null;
+}
+
+export type ChatEquippedResolver = (
+  id: string | null,
+) => ChatEquippedItems | null;
+
+interface GameChatStore {
+  logs: ChatLogEntry[];
+  sendMessage: ((message: string, scope: ChatScope) => void) | null;
+  resolveDisplayName: ChatDisplayNameResolver | null;
+  resolveActorColor: ChatActorColorResolver | null;
+  resolveEquipped: ChatEquippedResolver | null;
+  currentUserId: string | null;
+  chatPanelOpen: boolean;
+  setLogs: (logs: ChatLogEntry[]) => void;
+  registerSendMessage: (
+    fn: (message: string, scope: ChatScope) => void,
+  ) => void;
+  registerResolveDisplayName: (fn: ChatDisplayNameResolver | null) => void;
+  registerResolveActorColor: (fn: ChatActorColorResolver | null) => void;
+  registerResolveEquipped: (fn: ChatEquippedResolver | null) => void;
+  setCurrentUserId: (id: string | null) => void;
+  setChatPanelOpen: (open: boolean) => void;
+  clear: () => void;
+}
+
+export const useGameChatStore = create<GameChatStore>((set) => ({
+  logs: [],
+  sendMessage: null,
+  resolveDisplayName: null,
+  resolveActorColor: null,
+  resolveEquipped: null,
+  currentUserId: null,
+  chatPanelOpen: false,
+  setLogs: (logs) => set({ logs }),
+  registerSendMessage: (fn) => set({ sendMessage: fn }),
+  registerResolveDisplayName: (fn) => set({ resolveDisplayName: fn }),
+  registerResolveActorColor: (fn) => set({ resolveActorColor: fn }),
+  registerResolveEquipped: (fn) => set({ resolveEquipped: fn }),
+  setCurrentUserId: (id) => set({ currentUserId: id }),
+  setChatPanelOpen: (open) => set({ chatPanelOpen: open }),
+  clear: () =>
+    set({
+      logs: [],
+      sendMessage: null,
+      resolveDisplayName: null,
+      resolveActorColor: null,
+      resolveEquipped: null,
+      currentUserId: null,
+      chatPanelOpen: false,
+    }),
+}));
+
+if (typeof window !== 'undefined') {
+  (
+    window as unknown as { useGameChatStore: typeof useGameChatStore }
+  ).useGameChatStore = useGameChatStore;
+}
+```
+
+- [ ] **Step 4: Run the tests, confirm they pass**
+
+Run: `pnpm --filter @arcadeum/web test src/widgets/GameChat/store/__tests__/gameChatStore.test.ts`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/widgets/GameChat/store/gameChatStore.ts apps/web/src/widgets/GameChat/store/__tests__/gameChatStore.test.ts
+git commit -m "feat(chat): extend chat store with userId, equipped resolver, panelOpen (ARC-735)"
+```
+
+---
+
+## Task 2: Switch `ChatMessagePopup` to `position: absolute`
+
+**Files:**
+
+- Modify: `apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx`
+
+- [ ] **Step 1: Apply CSS change**
+
+In `ChatMessagePopup.tsx`, change the inline `style` object on the wrapper `<div>`:
+
+Old:
+
+```tsx
+position: 'fixed',
+```
+
+New:
+
+```tsx
+position: 'absolute',
+```
+
+Leave `top: 24, right: 24, zIndex: 10000` unchanged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
+git commit -m "refactor(chat): anchor popup to nearest positioned ancestor (ARC-735)"
+```
+
+---
+
+## Task 3: Create `GameChatPopupOverlay`
+
+**Files:**
+
+- Create: `apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx`
+- Create: `apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx`
+- Modify: `apps/web/src/widgets/GameChat/index.ts`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TamaguiProvider, createTamagui } from 'tamagui';
+import { config } from '@arcadeum/ui/tamagui.config';
+import { GameChatPopupOverlay } from '../GameChatPopupOverlay';
+import { useGameChatStore } from '../../store/gameChatStore';
+
+const tamaguiConfig = createTamagui(config);
+
+function renderOverlay() {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <GameChatPopupOverlay />
+    </TamaguiProvider>,
+  );
+}
+
+const baseLog = {
+  id: 'msg-1',
+  type: 'message' as const,
+  senderId: 'opponent-1',
+  senderName: 'Admiral',
+  message: 'Prepare for battle!',
+  createdAt: '2026-05-21T00:00:00Z',
+  scope: 'all' as const,
+};
+
+describe('GameChatPopupOverlay', () => {
+  beforeEach(() => {
+    useGameChatStore.getState().clear();
+  });
+
+  it('renders nothing when there are no messages', () => {
+    renderOverlay();
+    expect(screen.queryByTestId('chat-message-popup')).toBeNull();
+  });
+
+  it('renders the popup for the latest message when chat panel is closed', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    renderOverlay();
+    expect(screen.getByTestId('chat-message-popup')).toBeTruthy();
+    expect(screen.getByText(/Prepare for battle/)).toBeTruthy();
+  });
+
+  it('renders nothing when chat panel is open', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    useGameChatStore.getState().setChatPanelOpen(true);
+    renderOverlay();
+    expect(screen.queryByTestId('chat-message-popup')).toBeNull();
+  });
+
+  it('uses resolveDisplayName when available', () => {
+    useGameChatStore.getState().setLogs([baseLog]);
+    useGameChatStore
+      .getState()
+      .registerResolveDisplayName((id) =>
+        id === 'opponent-1' ? 'Captain Resolved' : undefined,
+      );
+    renderOverlay();
+    expect(screen.getByText(/Captain Resolved/)).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+Run: `pnpm --filter @arcadeum/web test src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx`
+Expected: fails because `GameChatPopupOverlay` doesn't exist yet.
+
+- [ ] **Step 3: Implement `GameChatPopupOverlay`**
+
+Create `apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx`:
+
+```tsx
+'use client';
+
+import { useGameChatStore } from '../store/gameChatStore';
+import { useLatestChatMessage } from '../hooks/useLatestChatMessage';
+import { ChatMessagePopup } from './ChatMessagePopup';
+
+export function GameChatPopupOverlay() {
+  const logs = useGameChatStore((s) => s.logs);
+  const resolveDisplayName = useGameChatStore((s) => s.resolveDisplayName);
+  const resolveEquipped = useGameChatStore((s) => s.resolveEquipped);
+  const currentUserId = useGameChatStore((s) => s.currentUserId);
+  const chatPanelOpen = useGameChatStore((s) => s.chatPanelOpen);
+
+  const { latestMessage, dismiss } = useLatestChatMessage(logs);
+
+  if (chatPanelOpen) return null;
+  if (!latestMessage) return null;
+
+  const senderName =
+    resolveDisplayName?.(latestMessage.senderId, latestMessage.senderName) ??
+    latestMessage.senderName;
+
+  const equipped = resolveEquipped?.(latestMessage.senderId ?? null) ?? null;
+
+  return (
+    <ChatMessagePopup
+      key={latestMessage.id}
+      senderId={latestMessage.senderId ?? null}
+      senderName={senderName}
+      senderEquippedAvatarId={equipped?.equippedAvatarId ?? null}
+      senderEquippedBadgeId={equipped?.equippedBadgeId ?? null}
+      senderEquippedNameColorId={equipped?.equippedNameColorId ?? null}
+      senderEquippedFrameId={equipped?.equippedFrameId ?? null}
+      senderEquippedAuraId={equipped?.equippedAuraId ?? null}
+      senderEquippedBannerId={equipped?.equippedBannerId ?? null}
+      message={latestMessage.message}
+      visible
+      onDismiss={dismiss}
+      isOwn={
+        !!currentUserId &&
+        !!latestMessage.senderId &&
+        latestMessage.senderId === currentUserId
+      }
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Export from widget index**
+
+In `apps/web/src/widgets/GameChat/index.ts`, add:
+
+```ts
+export { GameChatPopupOverlay } from './ui/GameChatPopupOverlay';
+```
+
+- [ ] **Step 5: Run unit tests, confirm they pass**
+
+Run: `pnpm --filter @arcadeum/web test src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx`
+Expected: all 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx apps/web/src/widgets/GameChat/index.ts
+git commit -m "feat(chat): add GameChatPopupOverlay (ARC-735)"
+```
+
+---
+
+## Task 4: Mount overlay inside `GameWidgetContainer`
+
+**Files:**
+
+- Modify: `apps/web/src/features/games/ui/GameWidgetContainer.tsx`
+
+- [ ] **Step 1: Add overlay to container**
+
+In `GameWidgetContainer.tsx`:
+
+1. Add import near the other widget imports at top:
+   ```ts
+   import { GameChatPopupOverlay } from '@/widgets/GameChat';
+   ```
+2. Inside the `<Container>` JSX (the return body), after `{modals}`, add:
+   ```tsx
+   <GameChatPopupOverlay />
+   ```
+
+- [ ] **Step 2: Confirm web build still type-checks**
+
+Run: `pnpm --filter @arcadeum/web type-check`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/features/games/ui/GameWidgetContainer.tsx
+git commit -m "feat(games): mount chat popup overlay inside game widget (ARC-735)"
+```
+
+---
+
+## Task 5: Update `GamePageLayout` to write store + drop local popup
+
+**Files:**
+
+- Modify: `apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx`
+
+- [ ] **Step 1: Remove local popup wiring**
+
+Edit `GamePageLayout.tsx`:
+
+1. In the import from `@/widgets/GameChat`, remove `ChatMessagePopup` and `useLatestChatMessage`:
+   ```tsx
+   import { GameChat, useGameChatStore } from '@/widgets/GameChat';
+   ```
+2. Delete these blocks:
+   - The `useLatestChatMessage(logs)` call (around line 84) — including the `logs` selector on the previous lines if it's only used by the popup. (It is.)
+   - The `registeredResolver` usage that exists only for the popup — keep `resolveDisplayName` and `resolveEquipped` definitions because we'll register them to the store.
+   - The `popupSender`, `popupSenderName` derivations.
+   - The entire `{latestMessage && (<ChatMessagePopup ... />)}` block at the bottom.
+
+After cleanup the imports/state related to the popup are gone. Keep `resolveDisplayName` and `resolveEquipped` functions because they are now registered into the store.
+
+- [ ] **Step 2: Register resolvers + userId + chatOpen into the store via effects**
+
+Inside `GamePageLayout`, after `const handleToggleChat = ...`, add:
+
+```tsx
+const registeredResolver = useGameChatStore((s) => s.resolveDisplayName);
+
+useEffect(() => {
+  useGameChatStore.getState().setCurrentUserId(userId);
+}, [userId]);
+
+useEffect(() => {
+  useGameChatStore.getState().registerResolveEquipped(resolveEquipped);
+}, [resolveEquipped]);
+
+useEffect(() => {
+  useGameChatStore.getState().setChatPanelOpen(showChat);
+}, [showChat]);
+
+useEffect(() => {
+  useGameChatStore.getState().registerResolveDisplayName(resolveDisplayName);
+}, [resolveDisplayName]);
+```
+
+Note: keep the `resolveDisplayName` callback that combines `registeredResolver` (from the game widget via `useGameChatIntegration`) and `fallbackResolver`. Read `registeredResolver` via a separate ref-like pattern to avoid registering and reading the same field simultaneously. Concretely: pull `registeredResolver` from the store _before_ we overwrite it with our combined resolver — store it in `useRef` and update on change.
+
+Replace the `registeredResolver` selector with this ref pattern:
+
+```tsx
+const registeredResolverRef = useRef<ChatDisplayNameResolver | null>(null);
+useEffect(() => {
+  return useGameChatStore.subscribe((state, prev) => {
+    // Track the resolver from the game widget; ignore our own combined writes.
+    if (
+      state.resolveDisplayName !== prev.resolveDisplayName &&
+      state.resolveDisplayName !== combinedResolverRef.current
+    ) {
+      registeredResolverRef.current = state.resolveDisplayName;
+    }
+  });
+}, []);
+```
+
+If that's too involved, simpler alternative: store the game-side resolver in a separate store field (`gameResolveDisplayName`) and have the overlay's resolution call both. Use whichever is cleaner during implementation; the public behavior is what matters.
+
+**Simpler alternative — recommended**: Add a separate store field `gameResolveDisplayName` and have `useGameChatIntegration` write to it. Then `GamePageLayout`'s combined resolver reads from `gameResolveDisplayName` and `resolveDisplayName` registers the combined function. If you take this path, also update `useGameChatIntegration` to call `registerGameResolveDisplayName` instead of `registerResolveDisplayName`. Make sure tests still pass.
+
+**Decision left to executor:** pick whichever approach yields the cleanest diff. Document the choice in the commit message.
+
+- [ ] **Step 3: Manually verify in the dev server**
+
+Run: `pnpm --filter @arcadeum/web dev`
+Open a room with a second tab as another user. Send a chat message from the other tab and confirm:
+
+- Popup appears in the top-right corner _of the game widget_ (not the page).
+- Opening the chat panel suppresses subsequent popups.
+- Entering widget-only fullscreen keeps the popup anchored to the widget.
+
+- [ ] **Step 4: Run web unit tests**
+
+Run: `pnpm --filter @arcadeum/web test`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx apps/web/src/widgets/GameChat/store/gameChatStore.ts apps/web/src/features/games/hooks/useGameChatIntegration.ts apps/web/src/widgets/GameChat/index.ts
+git commit -m "feat(chat): wire GamePageLayout to chat store and remove local popup (ARC-735)"
+```
+
+---
+
+## Task 6: Add e2e test — popup hidden when chat panel open
+
+**Files:**
+
+- Modify: `apps/web/e2e/sea-battle-chat-popup.spec.ts`
+
+- [ ] **Step 1: Add new test case**
+
+Append a new `test(...)` inside the `test.describe('Sea Battle Chat Message Popup', …)` block. Pattern after the existing tests (use the same `mockRoomInfo`, `mockGameSocket`, `waitForRoomReady` setup). The new test:
+
+1. Navigates to a room as in the existing tests.
+2. Before triggering the snapshot, clicks the chat-toggle button (or otherwise sets `showChat=true`). Use the same selector as `GamesControlPanel` exposes — inspect the codebase for `data-testid="toggle-chat"` or similar. If no testid exists, add one in `GamesControlPanel` minimally for testability.
+3. Triggers a snapshot with a new message from the opponent.
+4. Asserts the popup is NOT visible: `await expect(page.getByTestId('chat-message-popup')).not.toBeVisible();`
+5. Asserts the chat panel itself shows the message instead.
+
+- [ ] **Step 2: Run only this test**
+
+Run: `pnpm --filter @arcadeum/web playwright test e2e/sea-battle-chat-popup.spec.ts -g "hidden when chat panel"`
+Expected: pass.
+
+- [ ] **Step 3: Run all e2e chat tests**
+
+Run: `pnpm --filter @arcadeum/web playwright test e2e/sea-battle-chat-popup.spec.ts e2e/chat-interactions.spec.ts e2e/chat.spec.ts`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/sea-battle-chat-popup.spec.ts apps/web/src/widgets/GamesControlPanel
+git commit -m "test(chat): popup hidden when chat panel is open (ARC-735)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Type-check + lint + full test pass**
+
+Run in parallel:
+
+- `pnpm type-check`
+- `pnpm lint`
+- `pnpm --filter @arcadeum/web test`
+
+All must pass.
+
+- [ ] **Step 2: Visual smoke test**
+
+Open a real room with two users. Confirm:
+
+- Popup appears top-right _inside_ the widget.
+- Popup follows the widget into widget-fullscreen.
+- Popup is suppressed when chat panel is open; reopens when chat panel is closed and another message arrives.
+
+- [ ] **Step 3: Final commit / push prep**
+
+No-op if previous tasks were committed cleanly. Otherwise squash WIP commits with `git rebase -i` if explicitly requested by the user (do not rewrite history unilaterally).

--- a/docs/superpowers/specs/2026-05-21-chat-popup-inside-widget-design.md
+++ b/docs/superpowers/specs/2026-05-21-chat-popup-inside-widget-design.md
@@ -1,0 +1,107 @@
+# Chat message popup inside the game widget (ARC-735)
+
+## Problem
+
+When another player sends a chat message during a game, the popup that flashes the message currently anchors to the top-right of the **viewport** (`position: fixed; top: 24; right: 24`). It's rendered in `GamePageLayout` outside the game widget DOM. This makes the popup feel detached from the game and, in widget-only fullscreen mode, the popup ends up far from the player's focus area.
+
+Goal: anchor the popup to the **top-right of the game widget container**, and suppress it when the chat panel is already visible.
+
+## Scope
+
+- Web app only (`apps/web`). Mobile chat already lives in dedicated screens.
+- Sea Battle, Critical, Glimworm, and any future game using `GameWidgetContainer` get the new behavior automatically.
+- No backend or shared `@arcadeum/ui` changes.
+
+## Design
+
+### Architecture
+
+The popup moves from `GamePageLayout` into the widget. A new overlay component lives inside `GameWidgetContainer`'s container element (already `position: relative`). The overlay reads everything it needs from the existing `useGameChatStore`, which is extended with three fields. `GamePageLayout` becomes the writer of those fields.
+
+```
+GamePageLayout
+  ├─ effects: write { currentUserId, resolveEquipped, chatPanelOpen } into store
+  ├─ render children() ── game widget ── GameWidgetContainer
+  │                                        └─ <GameChatPopupOverlay />  ← reads store
+  └─ ChatPanel (GameChat list)
+```
+
+### Components
+
+**Extended `useGameChatStore`** (`apps/web/src/widgets/GameChat/store/gameChatStore.ts`):
+
+```ts
+type EquippedItems = {
+  equippedAvatarId: string | null;
+  equippedBadgeId: string | null;
+  equippedNameColorId: string | null;
+  equippedFrameId: string | null;
+  equippedAuraId: string | null;
+  equippedBannerId: string | null;
+};
+
+type ChatEquippedResolver = (id: string | null) => EquippedItems | null;
+
+// New fields and setters:
+currentUserId: string | null;
+setCurrentUserId: (id: string | null) => void;
+
+resolveEquipped: ChatEquippedResolver | null;
+registerResolveEquipped: (fn: ChatEquippedResolver | null) => void;
+
+chatPanelOpen: boolean;
+setChatPanelOpen: (open: boolean) => void;
+```
+
+The existing `clear()` method must also reset these new fields when a game session ends.
+
+**New `GameChatPopupOverlay`** (`apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx`):
+
+- Reads from store: `logs`, `resolveDisplayName`, `resolveEquipped`, `currentUserId`, `chatPanelOpen`.
+- Calls existing `useLatestChatMessage(logs)`.
+- If `chatPanelOpen` is true → returns `null` (no popup needed; user can see the chat).
+- Otherwise computes `popupSenderName` (via `resolveDisplayName`) and `popupSender` equipped fields (via `resolveEquipped`), then renders `<ChatMessagePopup />`.
+
+**Modified `ChatMessagePopup`** (`apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx`):
+
+- Single line change: `position: 'fixed'` → `position: 'absolute'`.
+- Keeps `top: 24; right: 24; z-index: 10000` — now relative to the nearest positioned ancestor (the widget `Container`).
+
+**Modified `GameWidgetContainer`** (`apps/web/src/features/games/ui/GameWidgetContainer.tsx`):
+
+- Import and render `<GameChatPopupOverlay />` once, inside the existing `<Container>`, after `{modals}`. Always present; the overlay handles its own conditional rendering.
+
+**Modified `GamePageLayout`** (`apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx`):
+
+- Remove `ChatMessagePopup` import, `useLatestChatMessage` call, and the JSX block that renders the popup (currently lines ~82–84, ~121–127, ~181–197).
+- Add three `useEffect`s that push `userId`, `resolveEquipped`, and `showChat` into the store via the new setters. `resolveDisplayName` is already registered via `useGameChatStore` patterns (existing `registeredResolver`).
+
+### Data flow on a new message
+
+1. Backend → game session snapshot → game widget calls `useGameChatIntegration(logs, …)` → store `logs` array updates.
+2. `GameChatPopupOverlay` (rendered inside `GameWidgetContainer`) re-renders because it subscribes to `logs` (and other fields).
+3. `useLatestChatMessage(logs)` returns the newest non-dismissed `type: 'message'` log.
+4. If `chatPanelOpen === true`, overlay returns null.
+5. Otherwise overlay resolves sender name + equipped items from store-registered resolvers and renders `<ChatMessagePopup position: absolute />`.
+6. The popup anchors to the widget's `Container` element. In widget-only fullscreen the container goes `position: fixed; inset: 0` and the popup follows it.
+
+### Error and edge handling
+
+- **Resolver not yet registered**: popup renders with null equipped fields. `ChatMessageBubble` already tolerates this.
+- **`currentUserId` not set**: `isOwn` resolves to false. Acceptable while loading.
+- **Chat panel opened after popup appears**: popup auto-dismisses via existing CSS animation (`popupAutoDismiss`); no extra teardown needed. Overlay will still return null on next render if `chatPanelOpen` flips true mid-flight, which dismisses early. This is desirable.
+- **Multiple new messages while popup visible**: existing behavior — `useLatestChatMessage` re-keys to the latest non-dismissed message; the popup re-animates.
+
+### Testing
+
+- **Existing e2e tests** in `apps/web/e2e/sea-battle-chat-popup.spec.ts` continue to pass unchanged. Selector `[data-testid="chat-message-popup"]` is preserved; popup is still rendered.
+- **New e2e test** in the same file: open the chat panel before triggering a message; assert popup is NOT visible.
+- **Unit test** for `GameChatPopupOverlay`: assert it returns null when `chatPanelOpen` is true and renders a popup with resolved sender info when false.
+- **Visual check (manual)**: confirm popup sits inside the widget at top-right in both normal and fullscreen modes.
+
+## Out of scope
+
+- No change to mobile chat behavior.
+- No change to chat message bubble styling.
+- No change to `useGameChatIntegration` API surface — existing games keep working unchanged.
+- No change to the dismiss/auto-dismiss timing.


### PR DESCRIPTION
## Summary

Two scopes bundled on ARC-735:

1. **Chat popup inside the game widget** — the message popup now anchors to the top-right of the `GameWidgetContainer` (was: fixed to viewport). Suppressed automatically when the chat panel is already open. Naturally follows the widget into widget-only fullscreen.

2. **Premium in-game chat redesign** — applies [`docs/handoffs/INGAME_CHAT_REDESIGN_HANDOFF.md`](docs/handoffs/INGAME_CHAT_REDESIGN_HANDOFF.md) to `apps/web/src/widgets/GameChat`:
   - Two-row header — title dot · *Table Chat* · settings · minimize · close
   - Segmented channel tabs with active pink→amber gradient + per-scope message counts
   - System / action rows render via new `GameChatSystemRow` with kind-tinted left bar (round / combo / elim / join)
   - Composer pill with left channel chip, gradient send button, char counter + kbd hints
   - Quick phrases row above the composer
   - Collapsed pill state (220 × 44) with last-message preview + unread badge, persisted via `localStorage` key `arcadeum.chat.collapsed`

## Changes

- `apps/web/src/widgets/GameChat/store/gameChatStore.ts` — adds `currentUserId`, `resolveEquipped`, `fallbackResolveDisplayName`, `chatPanelOpen` fields + setters
- `apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx` — `position: fixed` → `position: absolute`
- `apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx` (new) — reads store, renders popup, hides when chat panel open
- `apps/web/src/widgets/GameChat/ui/GameChat.tsx` — rewritten per redesign
- `apps/web/src/widgets/GameChat/ui/GameChat.styled.ts` (new) — styled atoms for the panel
- `apps/web/src/widgets/GameChat/ui/GameChatRow.tsx` (new) — extracted row component
- `apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx` (new) — kind-tinted system row
- `apps/web/src/widgets/GameChat/hooks/useChatCollapsed.ts` (new) — localStorage hook
- `apps/web/src/features/games/ui/GameWidgetContainer.tsx` — mounts `GameChatPopupOverlay` inside the widget container
- `apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx` — pushes layout state into the chat store; drops local popup
- `apps/web/e2e/sea-battle-chat-popup-hidden.spec.ts` (new) — popup is hidden while the chat panel is open
- `docs/superpowers/specs/2026-05-21-chat-popup-inside-widget-design.md` (new) — design doc for the popup work
- `docs/superpowers/plans/2026-05-21-chat-popup-inside-widget.md` (new) — implementation plan for the popup work

## Deferred (handoff §9 + items with no current data shape)

- Reactions strip — no `reactions` field in `ChatLogEntry` yet
- Emoji picker — defer until picker library / inventory chosen
- `@you` mention parsing — no roster API surface yet
- Per-player avatar gradients — we keep `EquippedPlayerAvatar` (cosmetics-driven)
- Light theme variant — defer
- Mention autocomplete, "↓ N new" pill, right-click context, voice notes, channel mute toggles — already §9 v2 items

## Test plan

- [x] `pnpm type-check` (web) — passes
- [x] `pnpm lint` (web) — passes
- [x] `pnpm test` (web) — 992 tests pass, including the 9 store tests, 6 popup-overlay tests, and the updated 3 GameChat tests
- [ ] e2e (`pnpm --filter @arcadeum/web test:e2e e2e/sea-battle-chat-popup*.spec.ts`) — run in CI; not run locally (spins up FE+BE webServer)
- [ ] Visual smoke test in a real game room:
  - [ ] Popup appears inside the game widget at top-right when an opponent messages
  - [ ] Popup follows the widget into widget-only fullscreen
  - [ ] Popup is suppressed while the chat panel is open
  - [ ] Chat panel header shows title dot + Table Chat + segmented tabs with active gradient
  - [ ] Channel tabs show per-scope counts; switching scopes filters messages
  - [ ] System / action logs render with kind-tinted left bar
  - [ ] Composer pill shows the active scope's chip (ALL / TEAM / DM) on the left
  - [ ] Quick phrases append into the draft without auto-sending
  - [ ] Char counter increments live; Enter sends, send button disabled when draft is empty
  - [ ] Minimize button collapses to the 220 × 44 pill; click pill to expand
  - [ ] Collapsed pill shows last message preview + unread badge for incoming opponent messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)