### PR TITLE
feat(games): in-game player avatars for critical + sea-battle (ARC-728)

### DIFF
--- a/apps/web/src/features/games/ui/InGameAvatar.test.tsx
+++ b/apps/web/src/features/games/ui/InGameAvatar.test.tsx
@@ -1,0 +1,126 @@
+import { render as rtlRender, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import config from '@/shared/config/tamagui.config';
+import { InGameAvatar } from './InGameAvatar';
+import * as cosmeticsHook from '@/features/shop/hooks/useEquippedCosmetics';
+import { useGameStore } from '@/features/games/store/gameStore';
+import type { GameRoomSummary } from '@/shared/types/games';
+
+vi.mock('@/features/shop/hooks/useEquippedCosmetics');
+
+const render = (ui: React.ReactElement) =>
+  rtlRender(
+    <TamaguiProvider config={config} defaultTheme="dark">
+      {ui}
+    </TamaguiProvider>,
+  );
+
+const allNulls = {
+  avatarUrl: null,
+  avatarItem: null,
+  badgeUrl: null,
+  badgeItem: null,
+  nameColor: null,
+  nameColorItem: null,
+  frameColor: null,
+  frameItem: null,
+  auraColor: null,
+  auraItem: null,
+  bannerColor: null,
+  bannerItem: null,
+};
+
+function seedRoom(members: GameRoomSummary['members']) {
+  useGameStore.setState({
+    room: {
+      id: 'room-1',
+      gameId: 'critical',
+      name: 'r',
+      hostId: 'u-1',
+      visibility: 'public',
+      playerCount: members?.length ?? 0,
+      maxPlayers: 4,
+      createdAt: new Date().toISOString(),
+      status: 'in_progress',
+      members,
+    } as GameRoomSummary,
+  });
+}
+
+describe('InGameAvatar', () => {
+  beforeEach(() => {
+    vi.mocked(cosmeticsHook.useEquippedCosmetics).mockReset();
+    useGameStore.setState({ room: null });
+  });
+
+  it('resolves equipped ids from the room store and passes them to the resolver', () => {
+    const spy = vi
+      .mocked(cosmeticsHook.useEquippedCosmetics)
+      .mockReturnValue({ ...allNulls, avatarUrl: '/jane.png' });
+    seedRoom([
+      {
+        id: 'u-1',
+        displayName: 'Jane',
+        isHost: true,
+        equippedAvatarId: 'av-1',
+        equippedBadgeId: 'bd-1',
+      },
+    ]);
+
+    render(<InGameAvatar playerId="u-1" name="Jane" data-testid="iga" />);
+
+    expect(spy).toHaveBeenCalledWith({
+      equippedAvatarId: 'av-1',
+      equippedBadgeId: 'bd-1',
+    });
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/jane.png');
+  });
+
+  it('passes nulls for unknown players (bots, missing member)', () => {
+    const spy = vi
+      .mocked(cosmeticsHook.useEquippedCosmetics)
+      .mockReturnValue(allNulls);
+    seedRoom([]);
+
+    render(<InGameAvatar playerId="bot-7" name="Bot 7" />);
+
+    expect(spy).toHaveBeenCalledWith({
+      equippedAvatarId: null,
+      equippedBadgeId: null,
+    });
+  });
+
+  it('suppresses cosmetic frame/aura/banner so game state rings stay authoritative', () => {
+    vi.mocked(cosmeticsHook.useEquippedCosmetics).mockReturnValue({
+      ...allNulls,
+      avatarUrl: '/x.png',
+      frameColor: '#ff0',
+      auraColor: '#0ff',
+      bannerColor: '#f0f',
+    });
+    seedRoom([
+      {
+        id: 'u-1',
+        displayName: 'Jane',
+        isHost: true,
+        equippedAvatarId: 'av-1',
+        equippedBadgeId: null,
+        equippedFrameId: 'fr-1',
+        equippedAuraId: 'au-1',
+        equippedBannerId: 'bn-1',
+      },
+    ]);
+
+    render(
+      <InGameAvatar playerId="u-1" name="Jane" size="md" data-testid="iga" />,
+    );
+
+    // PlayerAvatar only paints frame / aura when those props are truthy. Since
+    // InGameAvatar passes null for all three, none of those decorations
+    // appear in the DOM.
+    expect(screen.queryByTestId('iga-frame')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('iga-aura')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('iga-banner')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/games/ui/InGameAvatar.tsx
+++ b/apps/web/src/features/games/ui/InGameAvatar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { memo } from 'react';
+import { PlayerAvatar, type PlayerAvatarSize } from '@arcadeum/ui';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+import { useGameStore, type GameState } from '@/features/games/store/gameStore';
+
+export interface InGameAvatarProps {
+  playerId: string;
+  name: string;
+  size?: PlayerAvatarSize;
+  priority?: boolean;
+  'data-testid'?: string;
+}
+
+// In-field avatars deliberately suppress cosmetic frame/aura/banner/name-color
+// so they don't compete with the game's own state rings (turn, seat color,
+// eliminated). Only the avatar image and equipped badge are shown.
+export const InGameAvatar = memo(function InGameAvatar({
+  playerId,
+  name,
+  size = 'icon',
+  priority,
+  'data-testid': testId,
+}: InGameAvatarProps) {
+  const room = useGameStore((s: GameState) => s.room);
+  const member = room?.members?.find((m) => m.id === playerId);
+  const cosmetics = useEquippedCosmetics({
+    equippedAvatarId: member?.equippedAvatarId ?? null,
+    equippedBadgeId: member?.equippedBadgeId ?? null,
+  });
+
+  return (
+    <PlayerAvatar
+      name={name}
+      size={size}
+      avatarUrl={cosmetics.avatarUrl}
+      badgeUrl={cosmetics.badgeUrl}
+      frameColor={null}
+      auraColor={null}
+      bannerColor={null}
+      nameColor={null}
+      priority={priority}
+      data-testid={testId}
+    />
+  );
+});

--- a/apps/web/src/features/games/ui/index.ts
+++ b/apps/web/src/features/games/ui/index.ts
@@ -10,3 +10,4 @@ export { GameResultModal } from './GameResultModal';
 export { RematchModal } from './RematchModal';
 export { RematchInvitationModal } from './RematchInvitationModal';
 export { GameVariantSelector } from './GameVariantSelector';
+export { InGameAvatar, type InGameAvatarProps } from './InGameAvatar';

--- a/apps/web/src/widgets/CriticalGame/ui/TablePlayer.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/TablePlayer.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import {
   PlayerPositionWrapper,
   PlayerCard,
-  PlayerAvatar,
   PlayerName,
   PlayerCardCount,
   TurnIndicator,
@@ -13,8 +12,9 @@ import { SeaBattlePopup } from '@/widgets/SeaBattleGame/ui/SeaBattlePopup';
 import type { CriticalLogEntry, CriticalPlayerTableState } from '../types';
 import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { IdleBadge } from '@/shared/ui';
-import { useMedia, Text } from 'tamagui';
+import { useMedia, Text, YStack } from 'tamagui';
 import type { GameVariant } from '@arcadeum/ui';
+import { InGameAvatar } from '@/features/games/ui';
 import { useScenePalette } from './ScenePaletteContext';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { getPlayerColor } from '@/shared/lib/playerColors';
@@ -74,13 +74,6 @@ export function TablePlayer({
   const showEliminatedRing = !player.alive;
 
   const playerColor = getPlayerColor(playerId);
-
-  const initials = displayName
-    .split(' ')
-    .map((part) => part[0])
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
 
   // Circular Positioning Logic (from table.ts)
   const positionStyle = useMemo(() => {
@@ -208,32 +201,33 @@ export function TablePlayer({
               }}
             />
           )}
-          <PlayerAvatar
-            $isCurrentTurn={isCurrent}
-            $isAlive={player.alive}
-            $variant={cardVariant as GameVariant}
+          <YStack
             width={avatarInnerSize}
             height={avatarInnerSize}
             borderRadius={9999}
             alignItems="center"
             justifyContent="center"
             overflow="hidden"
+            opacity={player.alive ? 1 : 0.4}
           >
-            <Text
-              fontSize={15}
-              fontWeight="800"
-              letterSpacing={0.5}
-              color={
-                player.alive
-                  ? isCurrent
-                    ? '#1a1a1a'
-                    : '$colorSubtle'
-                  : 'rgba(255,255,255,0.3)'
-              }
-            >
-              {player.alive ? initials : '💀'}
-            </Text>
-          </PlayerAvatar>
+            {player.alive ? (
+              <InGameAvatar
+                playerId={playerId}
+                name={displayName}
+                size={isMobile ? 'icon' : 'sm'}
+                data-testid={`player-avatar-${playerId}`}
+              />
+            ) : (
+              <Text
+                fontSize={15}
+                fontWeight="800"
+                letterSpacing={0.5}
+                color="rgba(255,255,255,0.3)"
+              >
+                💀
+              </Text>
+            )}
+          </YStack>
         </div>
 
         <PlayerName

--- a/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx
@@ -8,6 +8,7 @@ import type { CriticalPlayerTableState, CriticalLogEntry } from '../../types';
 import { getPlayerColor } from '@/shared/lib/playerColors';
 import { ChatBubble } from '../ChatBubble';
 import { SeaBattlePopup } from '@/widgets/SeaBattleGame/ui/SeaBattlePopup';
+import { InGameAvatar } from '@/features/games/ui';
 
 interface OpponentTileProps {
   player: CriticalPlayerTableState;
@@ -51,16 +52,6 @@ interface OpponentTileProps {
 const TURN_RING = '#34d399';
 const ELIMINATED_RING = 'rgba(239, 68, 68, 0.85)';
 const TARGET_RING = '#f472b6';
-
-function initialsOf(name: string): string {
-  return name
-    .split(' ')
-    .map((part) => part[0])
-    .filter(Boolean)
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
-}
 
 function findLastMessage(logs: CriticalLogEntry[], playerId: string) {
   return logs.findLast(
@@ -238,11 +229,15 @@ export function OpponentTile({
         borderColor={avatarBorderColor}
         alignItems="center"
         justifyContent="center"
+        overflow="hidden"
       >
         {alive ? (
-          <Text fontSize={14} fontWeight="800" letterSpacing={0.5}>
-            {initialsOf(displayName)}
-          </Text>
+          <InGameAvatar
+            playerId={player.playerId}
+            name={displayName}
+            size={finalAvatarSize >= 64 ? 'sm' : 'icon'}
+            data-testid={`player-avatar-${player.playerId}`}
+          />
         ) : (
           <SkullIcon size={Math.round(finalAvatarSize * 0.55)} />
         )}

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { memo, useCallback, useState } from 'react';
-import { Text, XStack } from 'tamagui';
+import { Text, XStack, YStack } from 'tamagui';
 import type { SeaBattlePlayerState, SeaBattleTeam } from '../../types';
 import { CELL_STATE, COL_LABELS, ROW_LABELS } from '../../types';
 import { ShipsLeft } from '../ShipsLeft';
@@ -22,6 +22,7 @@ import type { SeaBattleTheme } from '../../lib/theme';
 import { AttackBoardCell } from './AttackBoardCell';
 import { BadgePill, TeamPill } from './Pills';
 import { getPlayerColor } from '@/shared/lib/playerColors';
+import { InGameAvatar } from '@/features/games/ui';
 
 interface AttackPlayerBoardProps {
   player: SeaBattlePlayerState;
@@ -60,9 +61,10 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   // Optimistic "shot fired" state: instantly mark the clicked cell as pending
   // so the player sees feedback without waiting for the server round-trip,
   // and can't spam-click the same cell.
-  const [pendingCell, setPendingCell] = useState<{ r: number; c: number } | null>(
-    null,
-  );
+  const [pendingCell, setPendingCell] = useState<{
+    r: number;
+    c: number;
+  } | null>(null);
 
   // Derived: only treat the stored pending cell as "still pending" if it's
   // my turn and the server hasn't yet resolved the cell to HIT/MISS.
@@ -77,9 +79,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   const handleGridClick = useCallback(
     (e: React.MouseEvent) => {
       if (!isMyTurn || isAttackDisabled || !onAttack) return;
-      const cell = (e.target as HTMLElement).closest(
-        '.sb-cell.sb-attackable',
-      );
+      const cell = (e.target as HTMLElement).closest('.sb-cell.sb-attackable');
       if (!cell) return;
       const row = cell.getAttribute('data-row');
       const col = cell.getAttribute('data-col');
@@ -145,11 +145,34 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
     </BoardGrid>
   );
 
+  const cornerAvatar = (
+    <YStack
+      position="absolute"
+      top={-4}
+      left={-4}
+      zIndex={11}
+      pointerEvents="none"
+      borderRadius={9999}
+      borderWidth={2}
+      borderColor={team?.color ?? theme.cellBorder}
+      backgroundColor={theme.boardBackground}
+      padding={2}
+    >
+      <InGameAvatar
+        playerId={player.playerId}
+        name={resolveDisplayName(player.playerId, isMe ? 'You' : 'Unknown')}
+        size="icon"
+        data-testid={`sb-corner-avatar-${player.playerId}`}
+      />
+    </YStack>
+  );
+
   if (isMe) {
     const isDefending = !isMyTurn && player.alive;
     const showBadge = player.alive;
     return (
       <PlayerSectionWrapper>
+        {cornerAvatar}
         <BadgeWrapper
           backgroundColor={theme.boardBackground}
           borderRadius={8}
@@ -167,12 +190,8 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
               backgroundColor={
                 isCurrentTurn ? '$dangerBgSoft' : '$warningBgSoft'
               }
-              borderColor={
-                isCurrentTurn ? '$dangerBorder' : '$warningBorder'
-              }
-              className={
-                isCurrentTurn ? 'sb-badge-danger-breathe' : undefined
-              }
+              borderColor={isCurrentTurn ? '$dangerBorder' : '$warningBorder'}
+              className={isCurrentTurn ? 'sb-badge-danger-breathe' : undefined}
             >
               <Text fontSize={10}>{isCurrentTurn ? '🎯' : '🛡️'}</Text>
               <Text
@@ -195,11 +214,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
         <PlayerSection
           backgroundColor={theme.boardBackground}
           borderColor={
-            team
-              ? team.color
-              : isDefending
-                ? theme.hitColor
-                : theme.cellBorder
+            team ? team.color : isDefending ? theme.hitColor : theme.cellBorder
           }
           borderWidth={team ? 2 : undefined}
           className={isDefending ? 'sb-section-danger-breathe' : undefined}
@@ -242,6 +257,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
 
   return (
     <PlayerSectionWrapper>
+      {cornerAvatar}
       <BadgeWrapper
         backgroundColor={theme.boardBackground}
         borderRadius={8}
@@ -286,11 +302,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
         isTargetable={isMyTurn}
         backgroundColor={theme.boardBackground}
         borderColor={
-          team
-            ? team.color
-            : isMyTurn
-              ? theme.accentColor
-              : theme.cellBorder
+          team ? team.color : isMyTurn ? theme.accentColor : theme.cellBorder
         }
         borderWidth={team ? 2 : undefined}
         className={isMyTurn && !team ? 'sb-breathe' : undefined}

--- a/docs/superpowers/specs/2026-05-21-ingame-avatars-design.md
+++ b/docs/superpowers/specs/2026-05-21-ingame-avatars-design.md
@@ -1,0 +1,70 @@
+# ARC-728 — In-Game Player Avatars
+
+## Goal
+
+Show each player's avatar **inside an active game**, not only in the lobby:
+
+- **Critical** (multiplayer card game): real avatar on every player's table card (desktop ring + mobile opponent strip), replacing the current initials/skull bubble.
+- **Sea-Battle**: a small avatar disc anchored to the **top-left corner of each player's grid**, so the corner of the field identifies whose board the viewer is looking at.
+
+The avatars must come from each player's equipped cosmetics (`equippedAvatarId`, `equippedBadgeId`) — the same source already used in the lobby, leaderboards, and chat.
+
+## Non-Goals
+
+- No new server payload. `GameRoomSummary.members[]` already carries every `equipped*` id; we only need to read it client-side.
+- No avatar editor inside the field.
+- No cosmetic frame / aura / banner inside the field — those compete visually with the game's own state rings (turn / seat color / eliminated). They keep working everywhere else.
+
+## Approach
+
+### Shared component
+
+Add `apps/web/src/features/games/ui/InGameAvatar.tsx`:
+
+```tsx
+interface InGameAvatarProps {
+  playerId: string;
+  name: string;
+  size?: PlayerAvatarSize; // 'icon' | 'sm' | 'md' | 'lg' | 'card'
+  priority?: boolean;
+  'data-testid'?: string;
+}
+```
+
+Behavior:
+
+1. Reads `room` from `useGameStore` (already the source of truth across both widgets).
+2. Looks up `room.members.find(m => m.id === playerId)` to get `equippedAvatarId` and `equippedBadgeId`.
+3. Pipes those through `useEquippedCosmetics` (existing hook, module-cached catalog).
+4. Renders `<PlayerAvatar />` from `@arcadeum/ui` with `avatarUrl` + `badgeUrl` resolved, and `frameColor`/`auraColor`/`bannerColor`/`nameColor` explicitly `null` so the in-field rendering doesn't fight the game's state rings.
+5. Bots (`bot-*`) and unknown ids → no member, no cosmetics → `PlayerAvatar` falls back to `Avatar` initials. Zero special-casing needed.
+
+This keeps a single seam for both games and makes future tweaks (e.g. lazy avatar reveal, animation on turn change) a one-file change.
+
+### Critical wiring
+
+- `apps/web/src/widgets/CriticalGame/ui/TablePlayer.tsx` — replace the `<PlayerAvatar>{initials}</PlayerAvatar>` block inside the decoration `<div>` (which hosts the turn / seat / eliminated rings) with `<InGameAvatar size={isMobile ? 'icon' : 'sm'} />`. Existing rings stay on the outer `<div>` and remain the state cue.
+- `apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx` — replace the `initialsOf(displayName)` bubble (the alive branch) with `<InGameAvatar size="icon" />`. The skull on the eliminated branch is unchanged.
+
+### Sea-Battle wiring
+
+`apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx` — overlay an `<InGameAvatar size="icon" />` absolutely-positioned at the **top-left** of the `PlayerSection`, for both the `isMe` branch and the opponent branch.
+
+The corner is the natural identification anchor: the existing badge (`🎯 ATTACKING`, `🛡️ DEFENDING`, `🤝 TEAMMATE`) already lives at top-center, so top-left keeps the two pieces of state from overlapping. Avatar gets `pointer-events: none` so it never blocks board clicks.
+
+## Test plan
+
+- Unit (Vitest): `InGameAvatar.test.tsx` — resolves member from store, suppresses cosmetic frame/aura, returns initials fallback for bots and missing members.
+- Adjust existing critical/sea-battle tests if (and only if) they assert on the initials text that the avatar replaces; the assertion becomes the new `data-testid` on the avatar.
+- Manual: lobby → start critical → see real avatars on the table; lobby → start sea-battle → see avatars at the corner of every grid; bots still render as initials.
+
+## File map
+
+| Action | Path                                                                      |
+| ------ | ------------------------------------------------------------------------- |
+| add    | `apps/web/src/features/games/ui/InGameAvatar.tsx`                         |
+| add    | `apps/web/src/features/games/ui/InGameAvatar.test.tsx`                    |
+| edit   | `apps/web/src/features/games/ui/index.ts` (export)                        |
+| edit   | `apps/web/src/widgets/CriticalGame/ui/TablePlayer.tsx`                    |
+| edit   | `apps/web/src/widgets/CriticalGame/ui/opponents/OpponentTile.tsx`         |
+| edit   | `apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx` |


### PR DESCRIPTION
## Summary

- Show each player's **equipped avatar inside active games**, not just in the lobby.
- **Critical**: the desktop `TablePlayer` ring and the mobile `OpponentTile` strip now render the real avatar in place of the initials bubble. Turn / seat-color / eliminated rings are unchanged — the avatar slots into the existing decoration.
- **Sea-Battle**: each `AttackPlayerBoard` gets a small avatar disc anchored to the **top-left corner** of the field so the corner of every grid identifies whose board the viewer is looking at.

A shared `InGameAvatar` component (`apps/web/src/features/games/ui/InGameAvatar.tsx`) reads `room.members` from `useGameStore`, resolves the equipped cosmetics through the existing `useEquippedCosmetics` hook, and renders `PlayerAvatar` with cosmetic frame/aura/banner/name-color **suppressed** — those would otherwise compete with the game's own state rings. Bots (`bot-*`) and unknown ids fall back to initials via the existing `Avatar` component, no special-casing.

Design doc: `docs/superpowers/specs/2026-05-21-ingame-avatars-design.md`.

## Test plan

- [x] `pnpm vitest run` — full web unit suite (997/997 pass), incl. new `InGameAvatar.test.tsx` (3 tests: resolves cosmetics, bot/missing-member fallback, suppresses frame/aura/banner).
- [x] `pnpm exec tsc --noEmit` for `apps/web` — clean.
- [x] `pnpm lint` (web) — clean.
- [x] `pnpm check-file-length` — clean.
- [x] `pnpm build` (turbo) — clean.
- [ ] Manual: lobby → start critical → real avatars appear on the table (desktop ring + mobile strip).
- [ ] Manual: lobby → start sea-battle → small avatar disc visible at top-left of every grid.
- [ ] Manual: bot players continue to render as initials in both games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)