### PR TITLE
feat(sea-battle): adaptive board sizing — fill space, no scroll, 2-board landscape minimum (ARC-729)

### DIFF
--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -213,9 +213,12 @@ export const SharedGameBoard = styled(BaseGameBoard, {
   flexDirection: 'column',
   position: 'relative',
   width: '100%',
-  flexGrow: 0,
-  flexShrink: 0,
-  flexBasis: 'auto',
+  // Fill the remaining height of the widget container after the sticky
+  // header so the boards inside can use 1fr-row CSS to fit vertically
+  // without scroll. Inner content opts in via flex propagation.
+  flex: 1,
+  minHeight: 0,
+  minWidth: 0,
   overflow: 'visible',
 });
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -217,7 +217,9 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
             team ? team.color : isDefending ? theme.hitColor : theme.cellBorder
           }
           borderWidth={team ? 2 : undefined}
-          className={isDefending ? 'sb-section-danger-breathe' : undefined}
+          className={`sb-player-section-fit ${
+            isDefending ? 'sb-section-danger-breathe' : ''
+          }`}
           backdropFilter="blur(8px)"
         >
           <PlayerName
@@ -305,7 +307,9 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
           team ? team.color : isMyTurn ? theme.accentColor : theme.cellBorder
         }
         borderWidth={team ? 2 : undefined}
-        className={isMyTurn && !team ? 'sb-breathe' : undefined}
+        className={`sb-player-section-fit ${
+          isMyTurn && !team ? 'sb-breathe' : ''
+        }`}
         backdropFilter="blur(8px)"
       >
         <PlayerName

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.md
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.md
@@ -1,0 +1,101 @@
+# SeaBattleGrids — board grid layout contract
+
+Co-located with [SeaBattleGrids.tsx](./SeaBattleGrids.tsx). Defines how
+the multi-board grid sizes itself across viewport, orientation, and
+fullscreen state.
+
+## Fullscreen states
+
+There are **three** distinct states. They produce different layouts and
+must not be conflated.
+
+| State                  | How it's set                                                                                                                                         | Detection                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Widget fullscreen      | "Expand" button on the widget header (`useFullscreen` on `GameWidgetContainer`)                                                                      | Ancestor matches `.game-widget-container.is-fullscreen`                                       |
+| Page (game) fullscreen | Global `f` shortcut or expand button on the page layout (`useFullscreen` on `GamePageLayout`) — expands the [control panel + widget + chat] tri-pane | Ancestor matches `.games-room-container.is-fullscreen` OR `document.fullscreenElement` is set |
+| Not fullscreen         | default                                                                                                                                              | neither of the above                                                                          |
+
+Both fullscreen variants are CSS-class based (not the real Fullscreen
+API) so body-portaled modals (Dialog.Portal, GameResultModal, etc.)
+remain reachable.
+
+## Sizing matrix
+
+Every cell describes what **the rows** of the grid look like. Columns
+are decided separately (see "Column count" below).
+
+| Context                     | Rows behavior                                                                                                                                                                                                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Mobile portrait             | 1 col only; each board capped at `100dvh − 200px` via CSS (`.sb-grids-container-mobile`). First board fully visible; 2nd peeks; page scrolls.                                                                                                                               |
+| Mobile landscape, non-fs    | Natural `squareRow` height. Cells prioritized over fitting. Widget scrolls if rows don't fit.                                                                                                                                                                               |
+| Mobile landscape, page-fs   | Same as non-fs. Boards never shrink below their non-fs size.                                                                                                                                                                                                                |
+| Mobile landscape, widget-fs | **Same sizing as non-fs** — natural `squareRow`. Cells are never smaller than non-fs per spec ("not less than without fullscreen"). Widget-fs's benefit is the recovered viewport (no app header above), so more of each row is visible at once. Scrolls if rows don't fit. |
+| Desktop normal              | Natural `squareRow`. Widget scrolls between rows if needed.                                                                                                                                                                                                                 |
+| Desktop page-fs             | Same as normal. Boards never shrink below their normal size.                                                                                                                                                                                                                |
+| Desktop widget-fs           | `minmax(SAFETY_MIN, squareRow)` per row. All boards visible at once; cells shrink to fit (with a 160px floor to stay playable). Only state where cells may be shrunk to satisfy a fit goal.                                                                                 |
+
+## Universal invariants
+
+1. **Visible boards are never clipped.** A row that is "in view" must
+   render fully top-to-bottom (modulo the deliberate mobile-portrait
+   peek-in of the 2nd board, which is a scroll affordance).
+2. **Cells in any fullscreen state are never smaller than non-fs.**
+   Page-fs and mobile widget-fs both keep natural `squareRow` for this
+   reason. The only place cells shrink is desktop widget-fs, where the
+   user explicitly opted in to "fit every board on one screen".
+3. **Page-fs is about screen real estate, not packing more on screen.**
+   Going page-fs expands the play area; cells stay the same size, and
+   the recovered space just shows more of each board without scrolling.
+4. **Widget-fs is the user opting in to "fit everything I can see"**,
+   but only on desktop does this translate into a shrink. On mobile,
+   widget-fs keeps cells at non-fs size — the win is the recovered
+   viewport (no app header), so more of each row is visible at once.
+
+## Column count
+
+Set in [SeaBattleGrids.tsx](./SeaBattleGrids.tsx) before the row math
+runs (`cols` variable). Independent of row sizing:
+
+- `count <= 1` or mobile portrait → 1 column (early return, mobile CSS path).
+- `media.short` (very-short landscape) → cap at 2.
+- Small-tablet / narrow landscape (`isCompact && isLandscape`) → at
+  least 2, balanced via `idealCols`.
+- Desktop → `idealCols(count)` (1/2/3/4) bounded by `containerWidth`.
+- Mobile/tablet held sideways OR mobile/tablet in widget-fs → cap at 2
+  cols so each board stays playable.
+
+## Layout modes (top vs side)
+
+A separate orthogonal choice in [SeaBattleGrids.tsx](./SeaBattleGrids.tsx):
+
+- **Top layout** (default): ships-remaining strip above the board.
+  Chrome above board ≈ 115px; below ≈ 0.
+- **Side layout** (`.sb-mobile-landscape`): ships-remaining strip on
+  the LEFT of the board. Chrome reduces to ~42px vertical, board grows
+  ~30% taller in the same cell.
+
+Side layout activates when:
+
+- Mobile landscape (always), OR
+- Widget-fs with height-tight cells (each row would otherwise be
+  taller-than-wide).
+
+## Tunables
+
+In [SeaBattleGrids.tsx](./SeaBattleGrids.tsx):
+
+| Constant                           | Meaning                                                                                      | Default |
+| ---------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
+| `SAFETY_MIN_ROW_PX`                | Lowest row height accepted in desktop widget-fs shrink. Below this cells become unplayable.  | 160     |
+| `MIN_BOARD_WIDTH_MOBILE_LANDSCAPE` | Minimum cell width before reducing column count in narrow landscape.                         | 200     |
+| Mobile portrait CSS chrome         | `100dvh − 200px` cap on board height. The 200 covers app header + widget chrome + safe area. | 200     |
+
+## Tests
+
+E2e specs that assert this layout contract:
+
+- [sea-battle-6-players.spec.ts](../../../../../e2e/sea-battle-6-players.spec.ts) — desktop 1920×1080, mobile portrait 375×812, mobile landscape 844×390.
+- [sea-battle-tablet.spec.ts](../../../../../e2e/sea-battle-tablet.spec.ts) — tablet landscape 1024×768 and portrait 768×1024.
+
+These assert column count and display mode, but **not** row sizing or
+peek behavior — those need manual verification when changed.

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -181,12 +181,12 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   );
   // Chrome budget = the section's non-board axis (above + below the board).
   // In mobile landscape we move ships to the side, so vertical chrome
-  // drops from ~115 (above) to ~42 (compact name + col labels + gaps).
-  // The board also loses ~65px horizontally to the ships column +
+  // drops from ~115 (above) to ~38 (compact name + col labels + gaps).
+  // The board also loses ~55px horizontally to the ships column +
   // padding, so the square-cell row works out to
-  // `cellWidth - 65 + 42 = cellWidth - 23`.
+  // `cellWidth - 55 + 38 = cellWidth - 17`.
   const squareRowHeightPx = Math.round(
-    isMobileLandscape ? approxCellWidthPx - 23 : approxCellWidthPx + 115,
+    isMobileLandscape ? approxCellWidthPx - 17 : approxCellWidthPx + 115,
   );
   // clamp(floor, square-row, 78dvh viewport-cap):
   // - floor keeps the board playable on very narrow columns (would

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -129,11 +129,13 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = Math.min(ideal, count, fits || ideal);
   }
 
-  // Fullscreen override: when the widget (or page) is expanded to fill the
-  // viewport, cap at 2 cols so two full boards are visible at once and
-  // remaining boards scroll vertically. This trades horizontal density
-  // for per-board readability — the user's choice for the expanded view.
-  if (isAncestorFullscreen && cols > 2) {
+  // Cap at 2 cols whenever there isn't real desktop-wide room: in widget
+  // / page fullscreen (any size), or in any non-desktop landscape
+  // (mobile / tablet held sideways). The player sees two full boards at
+  // once and scrolls vertically for the rest, instead of tiling 4 cols
+  // worth of small boards into a short viewport.
+  const wantsTwoColCap = isAncestorFullscreen || (isLandscape && !media.gtMd);
+  if (wantsTwoColCap && cols > 2) {
     cols = 2;
   }
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -164,24 +164,25 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const rows = Math.ceil(count / cols);
   const rowGap = media.short ? 10 : media.sm ? 12 : 16;
   const gridPadding = media.short ? 4 : media.sm ? 4 : 8;
-  // In 2-col cap mode we want one pair filling the visible viewport,
-  // but we should also cap the row at "exactly a square cell" so the
-  // section doesn't render a tall empty void below a width-limited
-  // board. Approximate cell width from the JS-tracked container width.
+  // Cap every row at "exactly a square cell + chrome". The board is sized
+  // to the SHORTER of width/height inside its section, so a row taller
+  // than (cellWidth + chrome) just leaves a void below the last cell —
+  // the cells can't grow into it because they're width-limited. Sizing
+  // rows directly (no `1fr` stretch) tightens each section around its
+  // board.
   const approxCellWidthPx = Math.max(
     0,
     (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
   );
   const squareRowHeightPx = Math.round(approxCellWidthPx + 115);
-  // Row floor = clamp(320 structural-min, square-row, 78dvh viewport-cap).
-  // - 320px = chrome (~115) + min playable board (~205). Below this the
-  //   board would shrink below playability, so we overflow + scroll.
-  // - 78dvh keeps things from pushing past one screen on tall viewports.
-  // - In the middle, the row tightens around an exactly-square cell so
-  //   there's no empty space below the board.
-  const minRowHeight = wantsTwoColCap
-    ? `clamp(320px, ${squareRowHeightPx}px, 78dvh)`
-    : `${media.short ? 220 : isCompact ? 260 : 300}px`;
+  // clamp(floor, square-row, 78dvh viewport-cap):
+  // - floor keeps the board playable on very narrow columns (would
+  //   otherwise crush below ~205px usable board).
+  // - 78dvh keeps a single row from pushing past one screen.
+  // - middle term tightens the row around an exact square cell so the
+  //   section never renders a void below a width-limited board.
+  const rowFloorPx = wantsTwoColCap ? 320 : media.short ? 220 : isCompact ? 260 : 300;
+  const rowHeight = `clamp(${rowFloorPx}px, ${squareRowHeightPx}px, 78dvh)`;
 
   return (
     <div
@@ -191,7 +192,7 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       style={{
         display: 'grid',
         gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-        gridTemplateRows: `repeat(${rows}, minmax(${minRowHeight}, 1fr))`,
+        gridTemplateRows: `repeat(${rows}, ${rowHeight})`,
         gap: rowGap,
         width: '100%',
         height: '100%',
@@ -200,8 +201,8 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
         padding: media.short ? 4 : media.sm ? 4 : 8,
         boxSizing: 'border-box',
         // Anchor tracks to the top. We previously used `place-content:
-        // center` here, but when content (rows × minRowHeight) exceeds
-        // the grid container, centering pushes the first row ABOVE the
+        // center` here, but when content (rows × rowHeight) exceeds the
+        // grid container, centering pushes the first row ABOVE the
         // container top — where the widget's sticky header crops it.
         // Top-aligned: extras live below and scroll into view naturally.
         // Horizontally, `center` keeps the boards centered when they

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -1,5 +1,12 @@
 'use client';
-import { Children, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  Children,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useMedia } from 'tamagui';
 
 interface SeaBattleGridsProps {
@@ -13,16 +20,15 @@ const MIN_BOARD_WIDTH_MOBILE_LANDSCAPE = 200;
 // Upper bound for a single board's width. Generous on purpose so on tall /
 // fullscreen displays the boards can grow into the available space — the
 // actual width is still constrained per-row by the height-driven cap below.
-const MAX_BOARD_WIDTH = 560;
+const MAX_BOARD_WIDTH = 720;
 // Non-grid chrome inside each PlayerSection (name, ships left strip, column
 // labels, paddings, badge wrapper). Used to convert "available height per row"
 // into "max board side" so two rows of boards fit without scroll.
-const BOARD_SECTION_CHROME_DESKTOP = 140;
-const BOARD_SECTION_CHROME_COMPACT = 100;
-// Chrome outside the boards section but inside the visible viewport
-// (app top bar, game widget header, control panel, paddings).
-const VIEWPORT_CHROME_DESKTOP = 220;
-const VIEWPORT_CHROME_COMPACT = 170;
+const BOARD_SECTION_CHROME_DESKTOP = 130;
+const BOARD_SECTION_CHROME_COMPACT = 90;
+// Bottom breathing room left under the boards so they don't kiss the
+// container edge.
+const BOTTOM_BREATHING_PX = 12;
 // Hard floor so the board never shrinks below something playable when the
 // viewport math gets aggressive (very short viewports, many rows).
 const MIN_PLAYABLE_BOARD_SIDE = 200;
@@ -40,14 +46,20 @@ function idealCols(count: number): number {
  *   - any landscape on phones / small tablets: at least 2 columns, sized to
  *     fit the viewport vertically so the layout doesn't scroll
  *   - tablet+ desktop: balanced layout from idealCols(), boards expand into
- *     available space but are capped by viewport height so 2 rows still fit
+ *     the actual remaining vertical space (measured from the DOM) so 2 rows
+ *     still fit while reclaiming every spare pixel
  */
 export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const media = useMedia();
   const count = Children.count(children);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
-  const [viewport, setViewport] = useState({ w: 0, h: 0 });
+  // Vertical space available below the grid's top edge within the visible
+  // viewport. Measured from the DOM (rather than guessed via a chrome
+  // constant) so the boards fill whatever room the rest of the layout
+  // happens to leave them.
+  const [availableHeight, setAvailableHeight] = useState(0);
+  const [isLandscape, setIsLandscape] = useState(false);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -61,23 +73,32 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     return () => ro.disconnect();
   }, []);
 
-  useEffect(() => {
-    const update = () =>
-      setViewport({ w: window.innerWidth, h: window.innerHeight });
-    update();
-    window.addEventListener('resize', update);
-    window.addEventListener('orientationchange', update);
+  useLayoutEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const measure = () => {
+      const rect = node.getBoundingClientRect();
+      setAvailableHeight(
+        Math.max(0, window.innerHeight - rect.top - BOTTOM_BREATHING_PX),
+      );
+      setIsLandscape(window.innerWidth > window.innerHeight);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(node);
+    window.addEventListener('resize', measure);
+    window.addEventListener('orientationchange', measure);
+    // Capture-phase listener so scrolling any ancestor (which can shift our
+    // top) re-runs the measurement.
+    document.addEventListener('scroll', measure, true);
     return () => {
-      window.removeEventListener('resize', update);
-      window.removeEventListener('orientationchange', update);
+      ro.disconnect();
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('orientationchange', measure);
+      document.removeEventListener('scroll', measure, true);
     };
   }, []);
 
-  // Treat anything wider than it is tall as landscape. The "short" media query
-  // only catches very short viewports (≤480px); this also catches a tablet
-  // turned sideways at e.g. 900×600 where height isn't tiny but orientation
-  // is clearly landscape.
-  const isLandscape = viewport.w > 0 && viewport.w > viewport.h;
   const isCompact = !media.gtSm; // phone / small-tablet widths
   const isMobilePortrait = isCompact && !media.short && !isLandscape;
 
@@ -135,24 +156,21 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     );
   }
 
-  // Height-driven board size cap — keeps two-row layouts (and tall single-row
-  // layouts on landscape phones) inside the viewport so the widget doesn't
-  // need to scroll vertically.
+  // Compute the height-driven cap. `availableHeight` is the actual room left
+  // in the viewport below the grid's top; we divide it across however many
+  // rows the layout needs and subtract per-section chrome to get the maximum
+  // board side that won't trigger vertical scroll.
   const rows = Math.ceil(count / cols);
   const rowGap = media.short ? 10 : media.sm ? 12 : 16;
   const sectionChrome =
     media.short || isCompact
       ? BOARD_SECTION_CHROME_COMPACT
       : BOARD_SECTION_CHROME_DESKTOP;
-  const viewportChrome =
-    media.short || isCompact
-      ? VIEWPORT_CHROME_COMPACT
-      : VIEWPORT_CHROME_DESKTOP;
-  const availableHeight = Math.max(
-    MIN_PLAYABLE_BOARD_SIDE * rows,
-    viewport.h - viewportChrome,
+  const usableHeight = Math.max(
+    MIN_PLAYABLE_BOARD_SIDE * rows + rowGap * (rows - 1),
+    availableHeight,
   );
-  const perRowBudget = (availableHeight - rowGap * (rows - 1)) / rows;
+  const perRowBudget = (usableHeight - rowGap * (rows - 1)) / rows;
   const heightCappedBoardSide = Math.max(
     MIN_PLAYABLE_BOARD_SIDE,
     perRowBudget - sectionChrome,

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -6,7 +6,7 @@ interface SeaBattleGridsProps {
   children: ReactNode;
 }
 
-const MIN_BOARD_WIDTH_DESKTOP = 240;
+const MIN_BOARD_WIDTH_DESKTOP = 200;
 // Slightly tighter than desktop so phones / small tablets in landscape can
 // still guarantee two boards side by side even on the narrower viewports.
 const MIN_BOARD_WIDTH_MOBILE_LANDSCAPE = 200;
@@ -42,6 +42,7 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const count = Children.toArray(children).length;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [containerHeight, setContainerHeight] = useState(0);
   const [isLandscape, setIsLandscape] = useState(false);
   // Watches for an ancestor with `.is-fullscreen` (added by the page-level
   // or widget-level useFullscreen hook). When set, the grid caps cols at 2
@@ -52,10 +53,15 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   useEffect(() => {
     const node = containerRef.current;
     if (!node) return;
-    setContainerWidth(node.getBoundingClientRect().width);
+    const rect = node.getBoundingClientRect();
+    setContainerWidth(rect.width);
+    setContainerHeight(rect.height);
     const ro = new ResizeObserver((entries) => {
       const entry = entries[0];
-      if (entry) setContainerWidth(entry.contentRect.width);
+      if (entry) {
+        setContainerWidth(entry.contentRect.width);
+        setContainerHeight(entry.contentRect.height);
+      }
     });
     ro.observe(node);
     return () => ro.disconnect();
@@ -98,10 +104,14 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
 
   const isCompact = !media.gtSm; // phone / small-tablet widths
   const isMobilePortrait = isCompact && !media.short && !isLandscape;
-  // Mobile / small-tablet held sideways (matches `wantsTwoColCap`'s
-  // breakpoint so the two layouts move together). CSS uses this hook to
-  // switch each section to "ships on the side" — vertical chrome above
-  // the board shrinks, board grows ~30% taller.
+  // Side-layout (ships on the LEFT of the board) is enabled when:
+  //   • mobile / small-tablet in landscape — the original case, where
+  //     vertical space is scarce.
+  //   • OR the grid is "height-tight": each cell ends up taller than
+  //     wide enough that side-layout would give a bigger board (less
+  //     vertical chrome 42 vs 115 outweighs the 47px horizontal cost
+  //     of the ships column). Common in widget-fullscreen with many
+  //     boards on a wide-but-not-tall desktop viewport.
   const isMobileLandscape = !media.gtMd && isLandscape;
 
   let cols: number;
@@ -179,30 +189,55 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     0,
     (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
   );
-  // Chrome budget = the section's non-board axis (above + below the board).
-  // In mobile landscape we move ships to the side, so vertical chrome
-  // drops from ~115 (above) to ~42 (compact name + team pill + col
-  // labels + gaps). The board also loses ~55px horizontally to the
-  // ships column + padding, so the square-cell row works out to
-  // `cellWidth - 55 + 42 = cellWidth - 13`.
+  // Fit-cap = (containerHeight - row gaps) / rows. Shrinks the row
+  // just enough so every row fits in the grid container without
+  // forcing a scroll (e.g. desktop fullscreen with 8 boards in 4×2).
+  const SAFETY_MIN_ROW_PX = 160;
+  const fitCapPx = containerHeight > 0
+    ? Math.max(
+        SAFETY_MIN_ROW_PX,
+        Math.floor((containerHeight - rowGap * (rows - 1)) / rows),
+      )
+    : 0;
+  // Side layout wins when the row is short enough that top-layout's
+  // 115px vertical chrome would crush the board below what side-
+  // layout's smaller 42px chrome + 55px horizontal cost can offer.
+  // Algebra: side wins iff (cqi - 55, cqh - 42) is bigger than
+  // (cqi - 8, cqh - 115); under height-limited (cqh small) cases,
+  // that reduces to `cqh < cqi + 18`. Approximate with row & cell width.
+  const isHeightTight =
+    fitCapPx > 0 && approxCellWidthPx > 0 && fitCapPx < approxCellWidthPx + 18;
+  const useSideLayout = isMobileLandscape || isHeightTight;
+  // Chrome budget = the section's non-board axis. Side layout: 42v + 55h.
+  // Top layout: 115v + 8h. The square-cell row works out to
+  //  top:  cellWidth + 115
+  //  side: cellWidth - 13   (= cellWidth - 55 + 42)
   const squareRowHeightPx = Math.round(
-    isMobileLandscape ? approxCellWidthPx - 13 : approxCellWidthPx + 115,
+    useSideLayout ? approxCellWidthPx - 13 : approxCellWidthPx + 115,
   );
-  // clamp(floor, square-row, 78dvh viewport-cap):
-  // - floor keeps the board playable on very narrow columns (would
-  //   otherwise crush below ~205px usable board).
-  // - 78dvh keeps a single row from pushing past one screen.
+  // clamp(floor, square-row, fit-cap):
   // - middle term tightens the row around an exact square cell so the
   //   section never renders a void below a width-limited board.
-  const rowFloorPx = wantsTwoColCap ? 320 : media.short ? 220 : isCompact ? 260 : 300;
-  const rowHeight = `clamp(${rowFloorPx}px, ${squareRowHeightPx}px, 78dvh)`;
+  // - floor keeps cells playable on roomy viewports; when the
+  //   container is genuinely short, we let the floor drop to fit-cap
+  //   (down to a safety minimum) so all rows stay visible.
+  const idealFloorPx = wantsTwoColCap
+    ? 320
+    : media.short
+      ? 220
+      : isCompact
+        ? 260
+        : 300;
+  const rowFloorPx = fitCapPx > 0 ? Math.min(idealFloorPx, fitCapPx) : idealFloorPx;
+  const fitCap = fitCapPx > 0 ? `${fitCapPx}px` : '78dvh';
+  const rowHeight = `clamp(${rowFloorPx}px, ${squareRowHeightPx}px, ${fitCap})`;
 
   return (
     <div
       ref={containerRef}
       data-testid="sea-battle-grids-container"
       className={`sb-grids-container sb-fit-grid${
-        isMobileLandscape ? ' sb-mobile-landscape' : ''
+        useSideLayout ? ' sb-mobile-landscape' : ''
       }`}
       style={{
         display: 'grid',

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -7,11 +7,25 @@ interface SeaBattleGridsProps {
 }
 
 const MIN_BOARD_WIDTH_DESKTOP = 280;
-const MIN_BOARD_WIDTH_MOBILE_LANDSCAPE = 220;
-// Cap so boards don't blow up on very wide viewports (e.g. fullscreen on a
-// 1080p+ screen with 4 columns), where a single 10×10 board would otherwise
-// take ~480px and two rows wouldn't fit vertically.
-const MAX_BOARD_WIDTH_DESKTOP = 360;
+// Slightly tighter than desktop so phones / small tablets in landscape can still
+// guarantee two boards side by side even on the narrower viewports.
+const MIN_BOARD_WIDTH_MOBILE_LANDSCAPE = 200;
+// Upper bound for a single board's width. Generous on purpose so on tall /
+// fullscreen displays the boards can grow into the available space — the
+// actual width is still constrained per-row by the height-driven cap below.
+const MAX_BOARD_WIDTH = 560;
+// Non-grid chrome inside each PlayerSection (name, ships left strip, column
+// labels, paddings, badge wrapper). Used to convert "available height per row"
+// into "max board side" so two rows of boards fit without scroll.
+const BOARD_SECTION_CHROME_DESKTOP = 140;
+const BOARD_SECTION_CHROME_COMPACT = 100;
+// Chrome outside the boards section but inside the visible viewport
+// (app top bar, game widget header, control panel, paddings).
+const VIEWPORT_CHROME_DESKTOP = 220;
+const VIEWPORT_CHROME_COMPACT = 170;
+// Hard floor so the board never shrinks below something playable when the
+// viewport math gets aggressive (very short viewports, many rows).
+const MIN_PLAYABLE_BOARD_SIDE = 200;
 
 function idealCols(count: number): number {
   if (count <= 1) return 1;
@@ -21,21 +35,19 @@ function idealCols(count: number): number {
 }
 
 /**
- * Picks the column count for the boards grid:
- *   - mobile portrait (narrow & not "short"): 1 column
- *   - mobile landscape ("short" viewport): up to 2 columns, but no
- *     narrower than MIN_BOARD_WIDTH_MOBILE_LANDSCAPE per board
- *   - tablet+: prefer the balanced layout from idealCols(), but cap by
- *     how many MIN_BOARD_WIDTH_DESKTOP-wide boards fit in the actual
- *     container width so boards never overlap when the chat panel
- *     is open or the viewport is otherwise narrow
+ * Picks the column count and per-board size for the boards grid:
+ *   - mobile portrait (narrow & not landscape): 1 column, full-width boards
+ *   - any landscape on phones / small tablets: at least 2 columns, sized to
+ *     fit the viewport vertically so the layout doesn't scroll
+ *   - tablet+ desktop: balanced layout from idealCols(), boards expand into
+ *     available space but are capped by viewport height so 2 rows still fit
  */
 export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const media = useMedia();
-  const isMobilePortrait = !media.gtSm && !media.short;
   const count = Children.count(children);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [viewport, setViewport] = useState({ w: 0, h: 0 });
 
   useEffect(() => {
     const node = containerRef.current;
@@ -49,16 +61,50 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     return () => ro.disconnect();
   }, []);
 
+  useEffect(() => {
+    const update = () =>
+      setViewport({ w: window.innerWidth, h: window.innerHeight });
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
+    };
+  }, []);
+
+  // Treat anything wider than it is tall as landscape. The "short" media query
+  // only catches very short viewports (≤480px); this also catches a tablet
+  // turned sideways at e.g. 900×600 where height isn't tiny but orientation
+  // is clearly landscape.
+  const isLandscape = viewport.w > 0 && viewport.w > viewport.h;
+  const isCompact = !media.gtSm; // phone / small-tablet widths
+  const isMobilePortrait = isCompact && !media.short && !isLandscape;
+
+  // Column count
   let cols: number;
   if (count <= 1 || isMobilePortrait) {
     cols = 1;
   } else if (media.short) {
+    // Phone-sized landscape (very short viewport): cap at 2 cols so boards
+    // stay playable when there are many players.
     const fits = Math.max(
       1,
       Math.floor(containerWidth / MIN_BOARD_WIDTH_MOBILE_LANDSCAPE),
     );
-    cols = Math.min(2, count, fits);
+    cols = Math.min(2, count, fits || 2);
+  } else if (isCompact && isLandscape) {
+    // Small-tablet / narrow landscape that isn't "short" (e.g. 800×600).
+    // Always at least 2 boards in a row, but otherwise use the balanced
+    // desktop layout.
+    const ideal = idealCols(count);
+    const fits = Math.max(
+      1,
+      Math.floor(containerWidth / MIN_BOARD_WIDTH_MOBILE_LANDSCAPE),
+    );
+    cols = Math.max(2, Math.min(ideal, count, fits || 2));
   } else {
+    // Tablet landscape and desktop.
     const ideal = idealCols(count);
     const fits = Math.max(
       1,
@@ -89,14 +135,37 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     );
   }
 
-  // On desktop layouts, clamp each column's max width so two-row arrangements
-  // (5–8 players) keep both rows visible without vertical scroll, even in
-  // fullscreen on wide displays. Mobile / short viewports keep their 1fr
-  // behaviour since the cap is bigger than they have width for anyway.
-  const desktopColumnTemplate = `repeat(${cols}, minmax(0, ${MAX_BOARD_WIDTH_DESKTOP}px))`;
-  const flexColumnTemplate = `repeat(${cols}, minmax(0, 1fr))`;
-  const gridTemplateColumns =
-    !isMobilePortrait && !media.short ? desktopColumnTemplate : flexColumnTemplate;
+  // Height-driven board size cap — keeps two-row layouts (and tall single-row
+  // layouts on landscape phones) inside the viewport so the widget doesn't
+  // need to scroll vertically.
+  const rows = Math.ceil(count / cols);
+  const rowGap = media.short ? 10 : media.sm ? 12 : 16;
+  const sectionChrome =
+    media.short || isCompact
+      ? BOARD_SECTION_CHROME_COMPACT
+      : BOARD_SECTION_CHROME_DESKTOP;
+  const viewportChrome =
+    media.short || isCompact
+      ? VIEWPORT_CHROME_COMPACT
+      : VIEWPORT_CHROME_DESKTOP;
+  const availableHeight = Math.max(
+    MIN_PLAYABLE_BOARD_SIDE * rows,
+    viewport.h - viewportChrome,
+  );
+  const perRowBudget = (availableHeight - rowGap * (rows - 1)) / rows;
+  const heightCappedBoardSide = Math.max(
+    MIN_PLAYABLE_BOARD_SIDE,
+    perRowBudget - sectionChrome,
+  );
+  const maxBoardWidth = Math.min(MAX_BOARD_WIDTH, heightCappedBoardSide);
+
+  // Only apply the explicit pixel cap on layouts with room to grow. On
+  // phone-landscape (very short viewports) we keep 1fr tracks so boards
+  // always fill the narrow viewport width.
+  const useCap = !media.short;
+  const gridTemplateColumns = useCap
+    ? `repeat(${cols}, minmax(0, ${Math.round(maxBoardWidth)}px))`
+    : `repeat(${cols}, minmax(0, 1fr))`;
 
   return (
     <div
@@ -107,7 +176,7 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
         display: 'grid',
         gridTemplateColumns,
         gridAutoRows: 'min-content',
-        gap: media.short ? 10 : media.sm ? 12 : 16,
+        gap: rowGap,
         width: '100%',
         minWidth: 0,
         marginLeft: 'auto',
@@ -117,10 +186,9 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
         alignItems: 'stretch',
         justifyItems: 'stretch',
         alignContent: 'start',
-        // Tracks are capped at MAX_BOARD_WIDTH_DESKTOP so on wide / fullscreen
-        // displays the row would otherwise leave a large blank strip on the
-        // right of the rightmost board. Use space-evenly to redistribute that
-        // slack as extra inter-board gaps, so the layout fills the row.
+        // With a per-track cap, wide viewports would leave slack on the right
+        // of the rightmost board. Distribute it as extra inter-board gaps so
+        // the row still feels balanced.
         justifyContent: 'space-evenly',
         flexGrow: 1,
       }}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -181,11 +181,12 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   );
   // Chrome budget = the section's non-board axis (above + below the board).
   // In mobile landscape we move ships to the side, so vertical chrome
-  // drops from ~115 (above) to ~54 (name + col labels + gaps). The board
-  // also loses ~80px horizontally to the ships column, so the square-cell
-  // row works out to `cellWidth - 80 + 54 = cellWidth - 26`.
+  // drops from ~115 (above) to ~42 (compact name + col labels + gaps).
+  // The board also loses ~65px horizontally to the ships column +
+  // padding, so the square-cell row works out to
+  // `cellWidth - 65 + 42 = cellWidth - 23`.
   const squareRowHeightPx = Math.round(
-    isMobileLandscape ? approxCellWidthPx - 26 : approxCellWidthPx + 115,
+    isMobileLandscape ? approxCellWidthPx - 23 : approxCellWidthPx + 115,
   );
   // clamp(floor, square-row, 78dvh viewport-cap):
   // - floor keeps the board playable on very narrow columns (would

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -43,6 +43,11 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [isLandscape, setIsLandscape] = useState(false);
+  // Watches for an ancestor with `.is-fullscreen` (added by the page-level
+  // or widget-level useFullscreen hook). When set, the grid caps cols at 2
+  // so the player can see two full boards at once and scroll through the
+  // rest vertically — the preferred interaction in the expanded view.
+  const [isAncestorFullscreen, setIsAncestorFullscreen] = useState(false);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -65,6 +70,30 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       window.removeEventListener('resize', update);
       window.removeEventListener('orientationchange', update);
     };
+  }, []);
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const check = () => {
+      let el: HTMLElement | null = node.parentElement;
+      while (el) {
+        if (el.classList.contains('is-fullscreen')) {
+          setIsAncestorFullscreen(true);
+          return;
+        }
+        el = el.parentElement;
+      }
+      setIsAncestorFullscreen(false);
+    };
+    check();
+    const observer = new MutationObserver(check);
+    let el: HTMLElement | null = node.parentElement;
+    while (el) {
+      observer.observe(el, { attributes: true, attributeFilter: ['class'] });
+      el = el.parentElement;
+    }
+    return () => observer.disconnect();
   }, []);
 
   const isCompact = !media.gtSm; // phone / small-tablet widths
@@ -98,6 +127,14 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       Math.floor(containerWidth / MIN_BOARD_WIDTH_DESKTOP),
     );
     cols = Math.min(ideal, count, fits || ideal);
+  }
+
+  // Fullscreen override: when the widget (or page) is expanded to fill the
+  // viewport, cap at 2 cols so two full boards are visible at once and
+  // remaining boards scroll vertically. This trades horizontal density
+  // for per-board readability — the user's choice for the expanded view.
+  if (isAncestorFullscreen && cols > 2) {
+    cols = 2;
   }
 
   if (cols === 1) {

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -6,9 +6,8 @@ interface SeaBattleGridsProps {
   children: ReactNode;
 }
 
-const MIN_BOARD_WIDTH_DESKTOP = 200;
-// Slightly tighter than desktop so phones / small tablets in landscape can
-// still guarantee two boards side by side even on the narrower viewports.
+// Min board width for the mobile/tablet landscape sizing path. Desktop's
+// minimum is decided inline based on fit-mode state.
 const MIN_BOARD_WIDTH_MOBILE_LANDSCAPE = 200;
 
 function idealCols(count: number): number {
@@ -49,6 +48,10 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   // so the player can see two full boards at once and scroll through the
   // rest vertically — the preferred interaction in the expanded view.
   const [isAncestorFullscreen, setIsAncestorFullscreen] = useState(false);
+  // Mirrors `document.fullscreenElement` — the page-level browser
+  // fullscreen state. Triggers the same "fit all boards in viewport"
+  // mode as widget fullscreen.
+  const [isDocumentFullscreen, setIsDocumentFullscreen] = useState(false);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -76,6 +79,13 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       window.removeEventListener('resize', update);
       window.removeEventListener('orientationchange', update);
     };
+  }, []);
+
+  useEffect(() => {
+    const update = () => setIsDocumentFullscreen(!!document.fullscreenElement);
+    update();
+    document.addEventListener('fullscreenchange', update);
+    return () => document.removeEventListener('fullscreenchange', update);
   }, []);
 
   useEffect(() => {
@@ -137,10 +147,15 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = Math.max(2, Math.min(ideal, count, fits || 2));
   } else {
     const ideal = idealCols(count);
-    const fits = Math.max(
-      1,
-      Math.floor(containerWidth / MIN_BOARD_WIDTH_DESKTOP),
-    );
+    // In fit mode (widget or page fullscreen) we want to pack more
+    // boards per row to avoid scrolling, so accept narrower cells.
+    // In normal mode we prefer fewer, bigger cells (the user is fine
+    // scrolling between rows of larger boards).
+    const inFitMode =
+      isAncestorFullscreen ||
+      (typeof document !== 'undefined' && !!document.fullscreenElement);
+    const minBoardWidth = inFitMode ? 200 : 240;
+    const fits = Math.max(1, Math.floor(containerWidth / minBoardWidth));
     cols = Math.min(ideal, count, fits || ideal);
   }
 
@@ -189,20 +204,20 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     0,
     (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
   );
-  // Side-layout heuristic — we want to know if the available row will
-  // be short enough that top-layout's 115px vertical chrome would crush
-  // the board below what side-layout (42v + 55h) can offer. Use the
-  // measured container height when available; otherwise fall back to
-  // an approximation of the visible viewport minus widget chrome.
+  // "Fit-in-viewport" mode: the player explicitly chose an expanded
+  // view (widget or browser fullscreen) and expects to see every board
+  // at once. Outside that, we prefer bigger cells with scroll over
+  // small cells that fit.
+  const isFitMode = isAncestorFullscreen || isDocumentFullscreen;
+  // Side-layout heuristic — only meaningful in fit mode, where rows
+  // are forced down to fit the container. Outside fit mode the row is
+  // always `squareRow` so top-layout is always at least as good.
   const probableRowPx =
     containerHeight > 0
       ? Math.floor((containerHeight - rowGap * (rows - 1)) / rows)
-      : Math.max(
-          0,
-          (typeof window !== 'undefined' ? window.innerHeight - 220 : 0)
-            - rowGap * (rows - 1),
-        ) / rows;
+      : 0;
   const isHeightTight =
+    isFitMode &&
     probableRowPx > 0 &&
     approxCellWidthPx > 0 &&
     probableRowPx < approxCellWidthPx + 18;
@@ -214,16 +229,16 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const squareRowHeightPx = Math.round(
     useSideLayout ? approxCellWidthPx - 13 : approxCellWidthPx + 115,
   );
-  // Row sizing: `minmax(safety, squareRow)`. Each track tries to be
-  // `squareRow` (the size that exactly fits a square board + chrome),
-  // but the CSS grid auto-shrinks tracks when the container is shorter
-  // than `rows × squareRow`. The `safety` minimum keeps cells big
-  // enough to be clickable; below that, content overflows and scrolls.
-  // This is intentionally CSS-only so it works on the first paint
-  // before any ResizeObserver fires (the JS measurement above is only
-  // used for the side-layout heuristic, where being wrong by a frame
-  // is harmless).
+  // Row sizing differs by mode:
+  // - fit mode: `minmax(safety, squareRow)` — tracks auto-shrink so
+  //   every row fits in the container without scroll.
+  // - normal: just `squareRow` — let the row be its natural size; if
+  //   that doesn't fit, scroll. The user explicitly asked to keep
+  //   bigger cells over fitting in non-fullscreen.
   const SAFETY_MIN_ROW_PX = 160;
+  const rowTemplate = isFitMode
+    ? `minmax(${SAFETY_MIN_ROW_PX}px, ${squareRowHeightPx}px)`
+    : `${squareRowHeightPx}px`;
 
   return (
     <div
@@ -235,7 +250,7 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       style={{
         display: 'grid',
         gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-        gridTemplateRows: `repeat(${rows}, minmax(${SAFETY_MIN_ROW_PX}px, ${squareRowHeightPx}px))`,
+        gridTemplateRows: `repeat(${rows}, ${rowTemplate})`,
         gap: rowGap,
         width: '100%',
         height: '100%',

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -1,37 +1,15 @@
 'use client';
-import {
-  Children,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import { Children, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useMedia } from 'tamagui';
 
 interface SeaBattleGridsProps {
   children: ReactNode;
 }
 
-const MIN_BOARD_WIDTH_DESKTOP = 280;
-// Slightly tighter than desktop so phones / small tablets in landscape can still
-// guarantee two boards side by side even on the narrower viewports.
+const MIN_BOARD_WIDTH_DESKTOP = 240;
+// Slightly tighter than desktop so phones / small tablets in landscape can
+// still guarantee two boards side by side even on the narrower viewports.
 const MIN_BOARD_WIDTH_MOBILE_LANDSCAPE = 200;
-// Upper bound for a single board's width. Generous on purpose so on tall /
-// fullscreen displays the boards can grow into the available space — the
-// actual width is still constrained per-row by the height-driven cap below.
-const MAX_BOARD_WIDTH = 720;
-// Non-grid chrome inside each PlayerSection (name, ships left strip, column
-// labels, paddings, badge wrapper). Used to convert "available height per row"
-// into "max board side" so two rows of boards fit without scroll.
-const BOARD_SECTION_CHROME_DESKTOP = 130;
-const BOARD_SECTION_CHROME_COMPACT = 90;
-// Bottom breathing room left under the boards so they don't kiss the
-// container edge.
-const BOTTOM_BREATHING_PX = 12;
-// Hard floor so the board never shrinks below something playable when the
-// viewport math gets aggressive (very short viewports, many rows).
-const MIN_PLAYABLE_BOARD_SIDE = 200;
 
 function idealCols(count: number): number {
   if (count <= 1) return 1;
@@ -41,24 +19,29 @@ function idealCols(count: number): number {
 }
 
 /**
- * Picks the column count and per-board size for the boards grid:
+ * Picks the column count for the boards grid and lets pure CSS handle
+ * sizing each board:
  *   - mobile portrait (narrow & not landscape): 1 column, full-width boards
- *   - any landscape on phones / small tablets: at least 2 columns, sized to
- *     fit the viewport vertically so the layout doesn't scroll
- *   - tablet+ desktop: balanced layout from idealCols(), boards expand into
- *     the actual remaining vertical space (measured from the DOM) so 2 rows
- *     still fit while reclaiming every spare pixel
+ *     stacked vertically (page scrolls naturally if there are many).
+ *   - any landscape on phones / small tablets: at least 2 columns.
+ *   - tablet+ desktop: balanced layout from idealCols().
+ *
+ * For >1 column layouts, the grid uses `repeat(M, minmax(0, 1fr))` rows
+ * + `repeat(N, minmax(0, 1fr))` cols, the ancestor flex chain provides a
+ * definite height (SharedGameBoard / MainGameArea are flex:1 minHeight:0),
+ * and the BoardGrid inside uses `aspect-ratio: 1` + `width: min(100%,
+ * 100cqh - chrome)` to be the largest square that fits its cell. The
+ * effect is "boards grow to fill the available space without scroll" —
+ * no JS measurement needed.
  */
 export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const media = useMedia();
-  const count = Children.count(children);
+  // `Children.count` includes booleans / nulls from `{cond && ...}`
+  // expressions, which inflates the row count when callers conditionally
+  // render the current-player board. `Children.toArray` drops those.
+  const count = Children.toArray(children).length;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
-  // Vertical space available below the grid's top edge within the visible
-  // viewport. Measured from the DOM (rather than guessed via a chrome
-  // constant) so the boards fill whatever room the rest of the layout
-  // happens to leave them.
-  const [availableHeight, setAvailableHeight] = useState(0);
   const [isLandscape, setIsLandscape] = useState(false);
 
   useEffect(() => {
@@ -73,36 +56,20 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     return () => ro.disconnect();
   }, []);
 
-  useLayoutEffect(() => {
-    const node = containerRef.current;
-    if (!node) return;
-    const measure = () => {
-      const rect = node.getBoundingClientRect();
-      setAvailableHeight(
-        Math.max(0, window.innerHeight - rect.top - BOTTOM_BREATHING_PX),
-      );
-      setIsLandscape(window.innerWidth > window.innerHeight);
-    };
-    measure();
-    const ro = new ResizeObserver(measure);
-    ro.observe(node);
-    window.addEventListener('resize', measure);
-    window.addEventListener('orientationchange', measure);
-    // Capture-phase listener so scrolling any ancestor (which can shift our
-    // top) re-runs the measurement.
-    document.addEventListener('scroll', measure, true);
+  useEffect(() => {
+    const update = () => setIsLandscape(window.innerWidth > window.innerHeight);
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('orientationchange', update);
     return () => {
-      ro.disconnect();
-      window.removeEventListener('resize', measure);
-      window.removeEventListener('orientationchange', measure);
-      document.removeEventListener('scroll', measure, true);
+      window.removeEventListener('resize', update);
+      window.removeEventListener('orientationchange', update);
     };
   }, []);
 
   const isCompact = !media.gtSm; // phone / small-tablet widths
   const isMobilePortrait = isCompact && !media.short && !isLandscape;
 
-  // Column count
   let cols: number;
   if (count <= 1 || isMobilePortrait) {
     cols = 1;
@@ -125,7 +92,6 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     );
     cols = Math.max(2, Math.min(ideal, count, fits || 2));
   } else {
-    // Tablet landscape and desktop.
     const ideal = idealCols(count);
     const fits = Math.max(
       1,
@@ -156,59 +122,33 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     );
   }
 
-  // Compute the height-driven cap. `availableHeight` is the actual room left
-  // in the viewport below the grid's top; we divide it across however many
-  // rows the layout needs and subtract per-section chrome to get the maximum
-  // board side that won't trigger vertical scroll.
   const rows = Math.ceil(count / cols);
   const rowGap = media.short ? 10 : media.sm ? 12 : 16;
-  const sectionChrome =
-    media.short || isCompact
-      ? BOARD_SECTION_CHROME_COMPACT
-      : BOARD_SECTION_CHROME_DESKTOP;
-  const usableHeight = Math.max(
-    MIN_PLAYABLE_BOARD_SIDE * rows + rowGap * (rows - 1),
-    availableHeight,
-  );
-  const perRowBudget = (usableHeight - rowGap * (rows - 1)) / rows;
-  const heightCappedBoardSide = Math.max(
-    MIN_PLAYABLE_BOARD_SIDE,
-    perRowBudget - sectionChrome,
-  );
-  const maxBoardWidth = Math.min(MAX_BOARD_WIDTH, heightCappedBoardSide);
-
-  // Only apply the explicit pixel cap on layouts with room to grow. On
-  // phone-landscape (very short viewports) we keep 1fr tracks so boards
-  // always fill the narrow viewport width.
-  const useCap = !media.short;
-  const gridTemplateColumns = useCap
-    ? `repeat(${cols}, minmax(0, ${Math.round(maxBoardWidth)}px))`
-    : `repeat(${cols}, minmax(0, 1fr))`;
+  // Floor each row at a playable section height. If the viewport can give
+  // each row 1fr ≥ this floor, the layout fits without scroll; below it,
+  // the grid overflows and the widget scrolls — which is the right
+  // behavior when too many players + too short a viewport.
+  const minRowHeight = media.short ? 220 : isCompact ? 260 : 300;
 
   return (
     <div
       ref={containerRef}
       data-testid="sea-battle-grids-container"
-      className="sb-grids-container"
+      className="sb-grids-container sb-fit-grid"
       style={{
         display: 'grid',
-        gridTemplateColumns,
-        gridAutoRows: 'min-content',
+        gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+        gridTemplateRows: `repeat(${rows}, minmax(${minRowHeight}px, 1fr))`,
         gap: rowGap,
         width: '100%',
+        height: '100%',
         minWidth: 0,
-        marginLeft: 'auto',
-        marginRight: 'auto',
+        minHeight: 0,
         padding: media.short ? 4 : media.sm ? 4 : 8,
         boxSizing: 'border-box',
         alignItems: 'stretch',
         justifyItems: 'stretch',
-        alignContent: 'start',
-        // With a per-track cap, wide viewports would leave slack on the right
-        // of the rightmost board. Distribute it as extra inter-board gaps so
-        // the row still feels balanced.
-        justifyContent: 'space-evenly',
-        flexGrow: 1,
+        flex: 1,
       }}
     >
       {children}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -129,12 +129,12 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = Math.min(ideal, count, fits || ideal);
   }
 
-  // Cap at 2 cols whenever there isn't real desktop-wide room: in widget
-  // / page fullscreen (any size), or in any non-desktop landscape
-  // (mobile / tablet held sideways). The player sees two full boards at
-  // once and scrolls vertically for the rest, instead of tiling 4 cols
-  // worth of small boards into a short viewport.
-  const wantsTwoColCap = isAncestorFullscreen || (isLandscape && !media.gtMd);
+  // Cap at 2 cols whenever there isn't real desktop-wide room: mobile
+  // / tablet held sideways (any width ≤1150px in landscape) OR a
+  // mobile / tablet fullscreen. On desktop (>1150px) fullscreen, we
+  // keep the balanced idealCols layout so all boards stay visible at
+  // once — the player explicitly expanded to see *more*, not pages.
+  const wantsTwoColCap = !media.gtMd && (isAncestorFullscreen || isLandscape);
   if (wantsTwoColCap && cols > 2) {
     cols = 2;
   }
@@ -163,24 +163,24 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
 
   const rows = Math.ceil(count / cols);
   const rowGap = media.short ? 10 : media.sm ? 12 : 16;
-  // Floor each row at a playable section height. If the viewport can give
-  // each row 1fr ≥ this floor, the layout fits without scroll; below it,
-  // the grid overflows and the widget scrolls — which is the right
-  // behavior when too many players + too short a viewport.
-  //
-  // When the 2-col cap kicks in (fullscreen or mobile/tablet landscape)
-  // we *want* exactly one pair of boards per visible page — so the row
-  // floor becomes "almost the whole visible viewport". `dvh` adapts to
-  // the dynamic viewport so mobile UI chrome (address bar) doesn't push
-  // the next pair into view.
-  //
-  // On very short landscape phones (390-tall viewport: 78dvh ≈ 304)
-  // the row also has to fit the section's chrome + a playable board.
-  // 320px = section chrome (~115) + board side (~205) — anything below
-  // that would force the board to shrink below playability, so we
-  // overflow the widget (which scrolls) instead.
+  const gridPadding = media.short ? 4 : media.sm ? 4 : 8;
+  // In 2-col cap mode we want one pair filling the visible viewport,
+  // but we should also cap the row at "exactly a square cell" so the
+  // section doesn't render a tall empty void below a width-limited
+  // board. Approximate cell width from the JS-tracked container width.
+  const approxCellWidthPx = Math.max(
+    0,
+    (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
+  );
+  const squareRowHeightPx = Math.round(approxCellWidthPx + 115);
+  // Row floor = clamp(320 structural-min, square-row, 78dvh viewport-cap).
+  // - 320px = chrome (~115) + min playable board (~205). Below this the
+  //   board would shrink below playability, so we overflow + scroll.
+  // - 78dvh keeps things from pushing past one screen on tall viewports.
+  // - In the middle, the row tightens around an exactly-square cell so
+  //   there's no empty space below the board.
   const minRowHeight = wantsTwoColCap
-    ? 'max(78dvh, 320px)'
+    ? `clamp(320px, ${squareRowHeightPx}px, 78dvh)`
     : `${media.short ? 220 : isCompact ? 260 : 300}px`;
 
   return (

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -98,6 +98,11 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
 
   const isCompact = !media.gtSm; // phone / small-tablet widths
   const isMobilePortrait = isCompact && !media.short && !isLandscape;
+  // Mobile / small-tablet held sideways (matches `wantsTwoColCap`'s
+  // breakpoint so the two layouts move together). CSS uses this hook to
+  // switch each section to "ships on the side" — vertical chrome above
+  // the board shrinks, board grows ~30% taller.
+  const isMobileLandscape = !media.gtMd && isLandscape;
 
   let cols: number;
   if (count <= 1 || isMobilePortrait) {
@@ -174,7 +179,14 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     0,
     (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
   );
-  const squareRowHeightPx = Math.round(approxCellWidthPx + 115);
+  // Chrome budget = the section's non-board axis (above + below the board).
+  // In mobile landscape we move ships to the side, so vertical chrome
+  // drops from ~115 (above) to ~54 (name + col labels + gaps). The board
+  // also loses ~80px horizontally to the ships column, so the square-cell
+  // row works out to `cellWidth - 80 + 54 = cellWidth - 26`.
+  const squareRowHeightPx = Math.round(
+    isMobileLandscape ? approxCellWidthPx - 26 : approxCellWidthPx + 115,
+  );
   // clamp(floor, square-row, 78dvh viewport-cap):
   // - floor keeps the board playable on very narrow columns (would
   //   otherwise crush below ~205px usable board).
@@ -188,7 +200,9 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     <div
       ref={containerRef}
       data-testid="sea-battle-grids-container"
-      className="sb-grids-container sb-fit-grid"
+      className={`sb-grids-container sb-fit-grid${
+        isMobileLandscape ? ' sb-mobile-landscape' : ''
+      }`}
       style={{
         display: 'grid',
         gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -181,12 +181,12 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   );
   // Chrome budget = the section's non-board axis (above + below the board).
   // In mobile landscape we move ships to the side, so vertical chrome
-  // drops from ~115 (above) to ~38 (compact name + col labels + gaps).
-  // The board also loses ~55px horizontally to the ships column +
-  // padding, so the square-cell row works out to
-  // `cellWidth - 55 + 38 = cellWidth - 17`.
+  // drops from ~115 (above) to ~42 (compact name + team pill + col
+  // labels + gaps). The board also loses ~55px horizontally to the
+  // ships column + padding, so the square-cell row works out to
+  // `cellWidth - 55 + 42 = cellWidth - 13`.
   const squareRowHeightPx = Math.round(
-    isMobileLandscape ? approxCellWidthPx - 17 : approxCellWidthPx + 115,
+    isMobileLandscape ? approxCellWidthPx - 13 : approxCellWidthPx + 115,
   );
   // clamp(floor, square-row, 78dvh viewport-cap):
   // - floor keeps the board playable on very narrow columns (would

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -174,14 +174,13 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   // the dynamic viewport so mobile UI chrome (address bar) doesn't push
   // the next pair into view.
   //
-  // But on very short landscape phones (390-tall viewport: 78dvh ≈ 304)
-  // a row shorter than `min-board + chrome` would clip the board via
-  // PlayerSection's `overflow: hidden`. So we also floor at the
-  // structural minimum (200 board + 140 chrome = 340px); on small
-  // viewports the grid overflows and the widget scrolls, but the
-  // board itself stays whole.
+  // On very short landscape phones (390-tall viewport: 78dvh ≈ 304)
+  // the row also has to fit the section's chrome + a playable board.
+  // 320px = section chrome (~115) + board side (~205) — anything below
+  // that would force the board to shrink below playability, so we
+  // overflow the widget (which scrolls) instead.
   const minRowHeight = wantsTwoColCap
-    ? 'max(78dvh, 340px)'
+    ? 'max(78dvh, 320px)'
     : `${media.short ? 220 : isCompact ? 260 : 300}px`;
 
   return (
@@ -200,11 +199,15 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
         minHeight: 0,
         padding: media.short ? 4 : media.sm ? 4 : 8,
         boxSizing: 'border-box',
-        // `place-content: center` packs the rows / columns toward the
-        // center when each cell's natural size (square boards) doesn't
-        // fill the container — so a 2-board landscape doesn't leave the
-        // boards floating in the top corners with empty space below.
-        placeContent: 'center',
+        // Anchor tracks to the top. We previously used `place-content:
+        // center` here, but when content (rows × minRowHeight) exceeds
+        // the grid container, centering pushes the first row ABOVE the
+        // container top — where the widget's sticky header crops it.
+        // Top-aligned: extras live below and scroll into view naturally.
+        // Horizontally, `center` keeps the boards centered when they
+        // don't fill the row.
+        alignContent: 'start',
+        justifyContent: 'center',
         flex: 1,
       }}
     >

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -146,8 +146,11 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
         minHeight: 0,
         padding: media.short ? 4 : media.sm ? 4 : 8,
         boxSizing: 'border-box',
-        alignItems: 'stretch',
-        justifyItems: 'stretch',
+        // `place-content: center` packs the rows / columns toward the
+        // center when each cell's natural size (square boards) doesn't
+        // fill the container — so a 2-board landscape doesn't leave the
+        // boards floating in the top corners with empty space below.
+        placeContent: 'center',
         flex: 1,
       }}
     >

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -167,7 +167,16 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   // each row 1fr ≥ this floor, the layout fits without scroll; below it,
   // the grid overflows and the widget scrolls — which is the right
   // behavior when too many players + too short a viewport.
-  const minRowHeight = media.short ? 220 : isCompact ? 260 : 300;
+  //
+  // When the 2-col cap kicks in (fullscreen or mobile/tablet landscape)
+  // we *want* exactly one pair of boards per visible page — so the row
+  // floor becomes "almost the whole visible viewport". That makes the
+  // boards fill the screen and additional rows live below, reached by
+  // scrolling. `dvh` adapts to the dynamic viewport so mobile UI
+  // chrome (address bar) doesn't push the next pair into view.
+  const minRowHeight = wantsTwoColCap
+    ? '78dvh'
+    : `${media.short ? 220 : isCompact ? 260 : 300}px`;
 
   return (
     <div
@@ -177,7 +186,7 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       style={{
         display: 'grid',
         gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-        gridTemplateRows: `repeat(${rows}, minmax(${minRowHeight}px, 1fr))`,
+        gridTemplateRows: `repeat(${rows}, minmax(${minRowHeight}, 1fr))`,
         gap: rowGap,
         width: '100%',
         height: '100%',

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -43,15 +43,17 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
   const [isLandscape, setIsLandscape] = useState(false);
-  // Watches for an ancestor with `.is-fullscreen` (added by the page-level
-  // or widget-level useFullscreen hook). When set, the grid caps cols at 2
-  // so the player can see two full boards at once and scroll through the
-  // rest vertically — the preferred interaction in the expanded view.
-  const [isAncestorFullscreen, setIsAncestorFullscreen] = useState(false);
-  // Mirrors `document.fullscreenElement` — the page-level browser
-  // fullscreen state. Triggers the same "fit all boards in viewport"
-  // mode as widget fullscreen.
-  const [isDocumentFullscreen, setIsDocumentFullscreen] = useState(false);
+  // Widget-level fullscreen: ancestor matches `.game-widget-container.is-fullscreen`
+  // (the expand button on the widget header). This is the "fit every
+  // board on one screen" state and is the only state where the grid is
+  // allowed to shrink cells — and only on desktop (mobile widget-fs
+  // keeps cells at non-fs size per spec; scrolls if rows don't fit).
+  //
+  // Page-level fullscreen (games-room-container, browser F11) is
+  // deliberately not tracked: cells in page-fs must not differ from
+  // non-fs (page-fs is about screen real estate, not shrinking), so
+  // there's nothing to react to.
+  const [isWidgetFullscreen, setIsWidgetFullscreen] = useState(false);
 
   useEffect(() => {
     const node = containerRef.current;
@@ -82,25 +84,22 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   }, []);
 
   useEffect(() => {
-    const update = () => setIsDocumentFullscreen(!!document.fullscreenElement);
-    update();
-    document.addEventListener('fullscreenchange', update);
-    return () => document.removeEventListener('fullscreenchange', update);
-  }, []);
-
-  useEffect(() => {
     const node = containerRef.current;
     if (!node) return;
     const check = () => {
+      let widgetFs = false;
       let el: HTMLElement | null = node.parentElement;
       while (el) {
-        if (el.classList.contains('is-fullscreen')) {
-          setIsAncestorFullscreen(true);
-          return;
+        if (
+          el.classList.contains('is-fullscreen') &&
+          el.classList.contains('game-widget-container')
+        ) {
+          widgetFs = true;
+          break;
         }
         el = el.parentElement;
       }
-      setIsAncestorFullscreen(false);
+      setIsWidgetFullscreen(widgetFs);
     };
     check();
     const observer = new MutationObserver(check);
@@ -147,24 +146,21 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = Math.max(2, Math.min(ideal, count, fits || 2));
   } else {
     const ideal = idealCols(count);
-    // In fit mode (widget or page fullscreen) we want to pack more
-    // boards per row to avoid scrolling, so accept narrower cells.
-    // In normal mode we prefer fewer, bigger cells (the user is fine
-    // scrolling between rows of larger boards).
-    const inFitMode =
-      isAncestorFullscreen ||
-      (typeof document !== 'undefined' && !!document.fullscreenElement);
-    const minBoardWidth = inFitMode ? 200 : 240;
+    // Widget-fs packs more boards per row (accept narrower cells) so the
+    // user can see every board at once — that's what widget-fs is for.
+    // Page-fs and normal both prefer fewer, bigger cells; page-fs is
+    // about more screen real estate, not about shrinking boards.
+    const minBoardWidth = isWidgetFullscreen ? 200 : 240;
     const fits = Math.max(1, Math.floor(containerWidth / minBoardWidth));
     cols = Math.min(ideal, count, fits || ideal);
   }
 
   // Cap at 2 cols whenever there isn't real desktop-wide room: mobile
   // / tablet held sideways (any width ≤1150px in landscape) OR a
-  // mobile / tablet fullscreen. On desktop (>1150px) fullscreen, we
-  // keep the balanced idealCols layout so all boards stay visible at
-  // once — the player explicitly expanded to see *more*, not pages.
-  const wantsTwoColCap = !media.gtMd && (isAncestorFullscreen || isLandscape);
+  // mobile / tablet WIDGET-fullscreen (where the spec asks for 2 boards
+  // fully visible). Page-fs doesn't trip the cap — its goal is more
+  // room, not a different column count.
+  const wantsTwoColCap = !media.gtMd && (isWidgetFullscreen || isLandscape);
   if (wantsTwoColCap && cols > 2) {
     cols = 2;
   }
@@ -204,11 +200,15 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     0,
     (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
   );
-  // "Fit-in-viewport" mode: the player explicitly chose an expanded
-  // view (widget or browser fullscreen) and expects to see every board
-  // at once. Outside that, we prefer bigger cells with scroll over
-  // small cells that fit.
-  const isFitMode = isAncestorFullscreen || isDocumentFullscreen;
+  // "Fit-in-viewport" mode: ONLY widget-fullscreen. The user explicitly
+  // chose the widget-expand button to see every board at once, so this
+  // is the only state where the grid is allowed to shrink cells.
+  //
+  // Page-fullscreen and non-fullscreen both keep cells at natural size
+  // and let the widget scroll between rows — page-fs is about more
+  // screen real estate, not about fitting more on screen. See
+  // SeaBattleGrids.md for the full contract.
+  const isFitMode = isWidgetFullscreen;
   // Side-layout heuristic — only meaningful in fit mode, where rows
   // are forced down to fit the container. Outside fit mode the row is
   // always `squareRow` so top-layout is always at least as good.
@@ -229,14 +229,18 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const squareRowHeightPx = Math.round(
     useSideLayout ? approxCellWidthPx - 13 : approxCellWidthPx + 115,
   );
-  // Row sizing differs by mode:
-  // - fit mode: `minmax(safety, squareRow)` — tracks auto-shrink so
-  //   every row fits in the container without scroll.
-  // - normal: just `squareRow` — let the row be its natural size; if
-  //   that doesn't fit, scroll. The user explicitly asked to keep
-  //   bigger cells over fitting in non-fullscreen.
+  // Row sizing rules (see SeaBattleGrids.md):
+  // - Desktop widget-fs: minmax shrinks rows so every board fits on
+  //   one screen — the explicit ask of the widget-expand button.
+  // - Everything else (mobile any, desktop normal, desktop page-fs):
+  //   natural squareRow. Widget scrolls if rows don't fit. Mobile
+  //   widget-fs deliberately uses the same sizing as mobile non-fs
+  //   per spec ("cells not less than non-fs"); widget-fs's win is the
+  //   recovered viewport (no app header), so more of each row is
+  //   visible at once without changing the cell size.
   const SAFETY_MIN_ROW_PX = 160;
-  const rowTemplate = isFitMode
+  const shouldShrinkToFit = isFitMode && media.gtMd;
+  const rowTemplate = shouldShrinkToFit
     ? `minmax(${SAFETY_MIN_ROW_PX}px, ${squareRowHeightPx}px)`
     : `${squareRowHeightPx}px`;
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -189,24 +189,23 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     0,
     (containerWidth - gridPadding * 2 - rowGap * (cols - 1)) / cols,
   );
-  // Fit-cap = (containerHeight - row gaps) / rows. Shrinks the row
-  // just enough so every row fits in the grid container without
-  // forcing a scroll (e.g. desktop fullscreen with 8 boards in 4×2).
-  const SAFETY_MIN_ROW_PX = 160;
-  const fitCapPx = containerHeight > 0
-    ? Math.max(
-        SAFETY_MIN_ROW_PX,
-        Math.floor((containerHeight - rowGap * (rows - 1)) / rows),
-      )
-    : 0;
-  // Side layout wins when the row is short enough that top-layout's
-  // 115px vertical chrome would crush the board below what side-
-  // layout's smaller 42px chrome + 55px horizontal cost can offer.
-  // Algebra: side wins iff (cqi - 55, cqh - 42) is bigger than
-  // (cqi - 8, cqh - 115); under height-limited (cqh small) cases,
-  // that reduces to `cqh < cqi + 18`. Approximate with row & cell width.
+  // Side-layout heuristic — we want to know if the available row will
+  // be short enough that top-layout's 115px vertical chrome would crush
+  // the board below what side-layout (42v + 55h) can offer. Use the
+  // measured container height when available; otherwise fall back to
+  // an approximation of the visible viewport minus widget chrome.
+  const probableRowPx =
+    containerHeight > 0
+      ? Math.floor((containerHeight - rowGap * (rows - 1)) / rows)
+      : Math.max(
+          0,
+          (typeof window !== 'undefined' ? window.innerHeight - 220 : 0)
+            - rowGap * (rows - 1),
+        ) / rows;
   const isHeightTight =
-    fitCapPx > 0 && approxCellWidthPx > 0 && fitCapPx < approxCellWidthPx + 18;
+    probableRowPx > 0 &&
+    approxCellWidthPx > 0 &&
+    probableRowPx < approxCellWidthPx + 18;
   const useSideLayout = isMobileLandscape || isHeightTight;
   // Chrome budget = the section's non-board axis. Side layout: 42v + 55h.
   // Top layout: 115v + 8h. The square-cell row works out to
@@ -215,22 +214,16 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const squareRowHeightPx = Math.round(
     useSideLayout ? approxCellWidthPx - 13 : approxCellWidthPx + 115,
   );
-  // clamp(floor, square-row, fit-cap):
-  // - middle term tightens the row around an exact square cell so the
-  //   section never renders a void below a width-limited board.
-  // - floor keeps cells playable on roomy viewports; when the
-  //   container is genuinely short, we let the floor drop to fit-cap
-  //   (down to a safety minimum) so all rows stay visible.
-  const idealFloorPx = wantsTwoColCap
-    ? 320
-    : media.short
-      ? 220
-      : isCompact
-        ? 260
-        : 300;
-  const rowFloorPx = fitCapPx > 0 ? Math.min(idealFloorPx, fitCapPx) : idealFloorPx;
-  const fitCap = fitCapPx > 0 ? `${fitCapPx}px` : '78dvh';
-  const rowHeight = `clamp(${rowFloorPx}px, ${squareRowHeightPx}px, ${fitCap})`;
+  // Row sizing: `minmax(safety, squareRow)`. Each track tries to be
+  // `squareRow` (the size that exactly fits a square board + chrome),
+  // but the CSS grid auto-shrinks tracks when the container is shorter
+  // than `rows × squareRow`. The `safety` minimum keeps cells big
+  // enough to be clickable; below that, content overflows and scrolls.
+  // This is intentionally CSS-only so it works on the first paint
+  // before any ResizeObserver fires (the JS measurement above is only
+  // used for the side-layout heuristic, where being wrong by a frame
+  // is harmless).
+  const SAFETY_MIN_ROW_PX = 160;
 
   return (
     <div
@@ -242,7 +235,7 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
       style={{
         display: 'grid',
         gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-        gridTemplateRows: `repeat(${rows}, ${rowHeight})`,
+        gridTemplateRows: `repeat(${rows}, minmax(${SAFETY_MIN_ROW_PX}px, ${squareRowHeightPx}px))`,
         gap: rowGap,
         width: '100%',
         height: '100%',

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -170,12 +170,18 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   //
   // When the 2-col cap kicks in (fullscreen or mobile/tablet landscape)
   // we *want* exactly one pair of boards per visible page — so the row
-  // floor becomes "almost the whole visible viewport". That makes the
-  // boards fill the screen and additional rows live below, reached by
-  // scrolling. `dvh` adapts to the dynamic viewport so mobile UI
-  // chrome (address bar) doesn't push the next pair into view.
+  // floor becomes "almost the whole visible viewport". `dvh` adapts to
+  // the dynamic viewport so mobile UI chrome (address bar) doesn't push
+  // the next pair into view.
+  //
+  // But on very short landscape phones (390-tall viewport: 78dvh ≈ 304)
+  // a row shorter than `min-board + chrome` would clip the board via
+  // PlayerSection's `overflow: hidden`. So we also floor at the
+  // structural minimum (200 board + 140 chrome = 340px); on small
+  // viewports the grid overflows and the widget scrolls, but the
+  // board itself stays whole.
   const minRowHeight = wantsTwoColCap
-    ? '78dvh'
+    ? 'max(78dvh, 340px)'
     : `${media.short ? 220 : isCompact ? 260 : 300}px`;
 
   return (

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipsLeft.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipsLeft.tsx
@@ -88,6 +88,7 @@ export function ShipsLeft({ ships, isMe }: ShipsLeftProps) {
               height={isMobile ? 10 : 14}
               position="relative"
               data-title={config.name}
+              data-size={config.size}
               data-sunk={isSunk.toString()}
             >
               {Array.from({ length: config.size }).map((_, i) => (

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -183,10 +183,20 @@
 }
 
 /* Inside the wrapper, PlayerSection (which carries the visible card
-   border) also needs to stretch so its border traces the full cell. */
+   border) needs to stretch vertically so its border traces the full
+   cell height. Horizontally, we let it shrink to its content (board +
+   chrome) so the border doesn't trace a wide empty rectangle around a
+   height-limited board — the leftover slack moves outside the section,
+   centered in the grid cell, instead of inside it. */
 .sb-fit-grid .sb-player-section-fit {
   height: 100%;
   min-height: 0;
+  /* Tamagui's `width: 100%` rule from PlayerSection is at higher
+     specificity (`:root ._w-...`), so override needs !important. */
+  width: fit-content !important;
+  max-width: 100% !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 .sb-fit-grid .sb-board-with-labels-layout {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -243,17 +243,18 @@
    compact line so the board can use as much of the cell as possible. */
 .sb-fit-grid.sb-mobile-landscape .sb-player-section-fit {
   display: grid !important;
-  grid-template-columns: 48px minmax(0, 1fr);
+  grid-template-columns: 40px minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
     'name name'
     'ships board';
-  gap: 3px;
-  padding: 4px !important;
+  gap: 2px;
+  padding: 2px !important;
 }
 .sb-mobile-landscape .sb-player-section-fit > .is_PlayerName {
-  font-size: 11px !important;
+  font-size: 10px !important;
   line-height: 1.1 !important;
+  max-height: 14px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -352,11 +353,11 @@
 .sb-mobile-landscape [data-size='1'] { width: 10px !important; }
 
 /* Smaller chrome budget when ships is on the side. Horizontal chrome:
-   48 (ships col) + 3 (gap) + 8 (section padding) + 4 (board margin)
-   ≈ 63. Vertical chrome: 15 (compact name) + 3 (gap) + 8 (section
-   padding) + 16 (col labels) ≈ 42. */
+   40 (ships col) + 2 (gap) + 4 (section padding) + 4 (board margin)
+   ≈ 50. Vertical chrome: 14 (name max) + 2 (gap) + 4 (section padding)
+   + 16 (col labels) ≈ 36. */
 .sb-fit-grid.sb-mobile-landscape .sb-board-with-labels-layout {
-  --sb-board-side: min(calc(100cqi - 65px), max(60px, calc(100cqh - 42px)));
+  --sb-board-side: min(calc(100cqi - 55px), max(60px, calc(100cqh - 38px)));
 }
 
 .sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -238,16 +238,26 @@
    LEFT side of the board instead of above it. The board picks up the
    reclaimed vertical chrome (~75px), growing ~30% taller in the same
    viewport. PlayerSection switches to a 2×2 CSS grid; ShipsContainer
-   flips to a vertical bar with the segments stacked. */
+   flips to a vertical bar with the segments stacked. The ships column
+   is narrow (48px) and the player name row is clamped to a single
+   compact line so the board can use as much of the cell as possible. */
 .sb-fit-grid.sb-mobile-landscape .sb-player-section-fit {
   display: grid !important;
-  grid-template-columns: 60px minmax(0, 1fr);
+  grid-template-columns: 48px minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
   grid-template-areas:
     'name name'
     'ships board';
-  gap: 4px;
-  padding: 6px !important;
+  gap: 3px;
+  padding: 4px !important;
+}
+.sb-mobile-landscape .sb-player-section-fit > .is_PlayerName {
+  font-size: 11px !important;
+  line-height: 1.1 !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 0 4px;
 }
 
 .sb-mobile-landscape .sb-player-section-fit > .is_PlayerName {
@@ -342,11 +352,11 @@
 .sb-mobile-landscape [data-size='1'] { width: 10px !important; }
 
 /* Smaller chrome budget when ships is on the side. Horizontal chrome:
-   60 (ships col) + 4 (gap) + 12 (section padding) + 4 (board padding)
-   ≈ 80. Vertical chrome: 22 (name) + 4 (gap) + 12 (section padding)
-   + 16 (col labels) ≈ 54. */
+   48 (ships col) + 3 (gap) + 8 (section padding) + 4 (board margin)
+   ≈ 63. Vertical chrome: 15 (compact name) + 3 (gap) + 8 (section
+   padding) + 16 (col labels) ≈ 42. */
 .sb-fit-grid.sb-mobile-landscape .sb-board-with-labels-layout {
-  --sb-board-side: min(calc(100cqi - 80px), max(60px, calc(100cqh - 54px)));
+  --sb-board-side: min(calc(100cqi - 65px), max(60px, calc(100cqh - 42px)));
 }
 
 .sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -263,14 +263,16 @@
 }
 
 /* The ShipsLeft container is a YStack (column) wrapping a label row and
-   a bars row (XStack). In side-layout mode the OUTER container fills
-   its narrow column, the bars row becomes vertical (column), and each
-   ship bar inside also stacks its segments vertically. */
+   a bars row. In side-layout mode we reverse the column order so ship
+   silhouettes sit at the TOP of the strip and the "SHIPS REMAINING"
+   label + "10/10" count sit underneath them. */
 .sb-mobile-landscape .sb-ships-remaining-container {
   height: 100%;
   width: 100%;
   padding: 4px !important;
   gap: 4px !important;
+  flex-direction: column-reverse !important;
+  justify-content: flex-end !important;
 }
 
 /* Label row: stack vertically. "SHIPS REMAINING" text rotated -90deg

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -234,6 +234,83 @@
   height: 100% !important;
 }
 
+/* Mobile / small-tablet landscape: put the ships-remaining strip on the
+   LEFT side of the board instead of above it. The board picks up the
+   reclaimed vertical chrome (~75px), growing ~30% taller in the same
+   viewport. PlayerSection switches to a 2×2 CSS grid; ShipsContainer
+   flips to a vertical bar with the segments stacked. */
+.sb-fit-grid.sb-mobile-landscape .sb-player-section-fit {
+  display: grid !important;
+  grid-template-columns: 60px minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-areas:
+    'name name'
+    'ships board';
+  gap: 4px;
+  padding: 6px !important;
+}
+
+.sb-mobile-landscape .sb-player-section-fit > .is_PlayerName {
+  grid-area: name;
+}
+.sb-mobile-landscape .sb-player-section-fit > .is_PlayerStats {
+  grid-area: ships;
+  min-height: 0;
+  height: 100%;
+}
+.sb-mobile-landscape .sb-player-section-fit > .sb-board-with-labels-layout {
+  grid-area: board;
+}
+
+/* The ShipsLeft container is a YStack (column) wrapping a label row and
+   a bars row (XStack). In side-layout mode the OUTER container fills
+   its narrow column, the bars row becomes vertical (column), and each
+   ship bar inside also stacks its segments vertically. */
+.sb-mobile-landscape .sb-ships-remaining-container {
+  height: 100%;
+  width: 100%;
+  padding: 4px !important;
+  gap: 4px !important;
+}
+
+/* Label row: keep the "10/10" count visible; tighten the label text so
+   it fits the narrow column. */
+.sb-mobile-landscape .sb-ships-remaining-container > div:first-child {
+  flex-direction: column !important;
+  gap: 2px;
+}
+.sb-mobile-landscape .sb-ships-remaining-container > div:first-child > div:first-child {
+  font-size: 8px !important;
+  letter-spacing: 0.5px !important;
+  text-align: center;
+}
+
+/* Bars row: stack ships vertically, fill remaining column height. */
+.sb-mobile-landscape .sb-ships-remaining-container > div:nth-child(2) {
+  flex-direction: column !important;
+  flex: 1;
+  height: auto;
+  align-items: stretch !important;
+  gap: 4px !important;
+}
+
+/* Each ship bar: stack its segments vertically, fill width. The
+   `flex: <size>` (set inline by ShipsLeft for the row layout) keeps
+   ships of different sizes proportional in this column-stack too. */
+.sb-mobile-landscape .sb-ships-remaining-container > div:nth-child(2) > div {
+  flex-direction: column !important;
+  width: 100% !important;
+  height: auto !important;
+}
+
+/* Smaller chrome budget when ships is on the side. Horizontal chrome:
+   60 (ships col) + 4 (gap) + 12 (section padding) + 4 (board padding)
+   ≈ 80. Vertical chrome: 22 (name) + 4 (gap) + 12 (section padding)
+   + 16 (col labels) ≈ 54. */
+.sb-fit-grid.sb-mobile-landscape .sb-board-with-labels-layout {
+  --sb-board-side: min(calc(100cqi - 80px), max(60px, calc(100cqh - 54px)));
+}
+
 .sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {
   width: 100% !important;
   height: 100% !important;

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -169,29 +169,34 @@
 
 /* In multi-board grid mode the ancestor flex chain hands down a definite
    height. The grids container is a CSS grid; each direct child is a
-   PlayerSectionWrapper that we stretch to fill its cell, and inside,
-   PlayerSection acts as a size container so the board grid (further
-   inside) can pick its side from cqi/cqh. In mobile vertical (1-col
-   flex column) neither rule applies, so wrappers and sections size to
-   content and the page scrolls naturally between boards. */
+   PlayerSectionWrapper that we stretch to fill its cell AND make a
+   size container — so anything deeper can read the wrapper's box via
+   cqi/cqh without depending on Tamagui className passthrough on the
+   styled components inside. In mobile vertical (1-col flex column) the
+   `.sb-fit-grid` class is absent, so neither rule applies and the
+   page scrolls naturally between boards. */
 .sb-fit-grid > * {
   height: 100%;
   min-height: 0;
-}
-
-.sb-fit-grid .sb-player-section-fit {
-  height: 100%;
-  min-height: 0;
+  min-width: 0;
   container-type: size;
 }
 
+/* Inside the wrapper, PlayerSection (which carries the visible card
+   border) also needs to stretch so its border traces the full cell. */
+.sb-fit-grid .sb-player-section-fit {
+  height: 100%;
+  min-height: 0;
+}
+
 .sb-fit-grid .sb-board-with-labels-layout {
-  /* Reserve ~90px of vertical chrome for name + stats + paddings above
-     the board within the PlayerSection — gives the board square room to
-     grow. The actual chrome is ~80-115 depending on breakpoint, so this
-     is a slightly generous estimate that prevents the layout from
-     pushing the board past the section bottom. */
-  --sb-board-side: min(100cqi, max(120px, calc(100cqh - 105px)));
+  /* Side = min(width-of-cell, height-of-cell - chrome). The chrome
+     budget (~140px) covers PlayerSectionWrapper's paddingTop, the
+     PlayerSection paddings + border, the player name row, the ships-
+     remaining strip and the gaps between them. Bigger than strictly
+     needed so the layout doesn't push the board past the section
+     bottom on viewports where the chrome rounds up. */
+  --sb-board-side: min(calc(100cqi - 8px), max(140px, calc(100cqh - 140px)));
   width: var(--sb-board-side);
   height: var(--sb-board-side);
   align-self: center;

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -167,16 +167,21 @@
   min-width: 0;
 }
 
-/* In multi-board grid mode each PlayerSection becomes a size container.
-   BoardWithLabels (labels + grid) is then sized to the *largest square*
-   that fits the section after the name / stats chrome above it — using
-   container query units so we don't depend on `aspect-ratio + max-*`
-   recomputation (which some browsers don't honor when both axes are
-   constrained by the flex chain). The inner `auto 1fr / auto 1fr` grid
-   guarantees ColLabels (cell 1/2), RowLabels (cell 2/1) and BoardGrid
-   (cell 2/2) share the same column-2 width and row-2 height, so labels
-   sit directly above / beside their cells. */
+/* In multi-board grid mode the ancestor flex chain hands down a definite
+   height. The grids container is a CSS grid; each direct child is a
+   PlayerSectionWrapper that we stretch to fill its cell, and inside,
+   PlayerSection acts as a size container so the board grid (further
+   inside) can pick its side from cqi/cqh. In mobile vertical (1-col
+   flex column) neither rule applies, so wrappers and sections size to
+   content and the page scrolls naturally between boards. */
+.sb-fit-grid > * {
+  height: 100%;
+  min-height: 0;
+}
+
 .sb-fit-grid .sb-player-section-fit {
+  height: 100%;
+  min-height: 0;
   container-type: size;
 }
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -253,12 +253,15 @@
 }
 .sb-mobile-landscape .sb-player-section-fit > .is_PlayerName {
   font-size: 10px !important;
-  line-height: 1.1 !important;
-  max-height: 14px;
+  line-height: 1.2 !important;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 0 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
 }
 
 .sb-mobile-landscape .sb-player-section-fit > .is_PlayerName {
@@ -354,10 +357,10 @@
 
 /* Smaller chrome budget when ships is on the side. Horizontal chrome:
    40 (ships col) + 2 (gap) + 4 (section padding) + 4 (board margin)
-   ≈ 50. Vertical chrome: 14 (name max) + 2 (gap) + 4 (section padding)
-   + 16 (col labels) ≈ 36. */
+   ≈ 50. Vertical chrome: 18 (name + team pill) + 2 (gap) + 4 (section
+   padding) + 16 (col labels) ≈ 40. */
 .sb-fit-grid.sb-mobile-landscape .sb-board-with-labels-layout {
-  --sb-board-side: min(calc(100cqi - 55px), max(60px, calc(100cqh - 38px)));
+  --sb-board-side: min(calc(100cqi - 55px), max(60px, calc(100cqh - 42px)));
 }
 
 .sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -273,35 +273,57 @@
   gap: 4px !important;
 }
 
-/* Label row: keep the "10/10" count visible; tighten the label text so
-   it fits the narrow column. */
+/* Label row: stack vertically. "SHIPS REMAINING" text rotated -90deg
+   so it reads bottom-to-top on the left of the strip; "10/10" count
+   sits horizontally below it. We give the rotated label a reserved
+   slot via height + display:flex so it doesn't overflow into the
+   board area. */
 .sb-mobile-landscape .sb-ships-remaining-container > div:first-child {
   flex-direction: column !important;
-  gap: 2px;
+  align-items: center !important;
+  gap: 6px !important;
+  width: 100%;
 }
-.sb-mobile-landscape .sb-ships-remaining-container > div:first-child > div:first-child {
-  font-size: 8px !important;
-  letter-spacing: 0.5px !important;
+.sb-mobile-landscape .sb-ships-remaining-container > div:first-child > span:first-child {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 9px !important;
+  letter-spacing: 1px !important;
+  line-height: 1 !important;
+  white-space: nowrap;
   text-align: center;
 }
+.sb-mobile-landscape .sb-ships-remaining-container > div:first-child > span:nth-child(2) {
+  font-size: 12px !important;
+}
 
-/* Bars row: stack ships vertically, fill remaining column height. */
+/* Bars row: stack ships vertically as a list. Each ship stays as a
+   HORIZONTAL row of cells (its natural orientation), just rendered
+   smaller. Left-aligned so a 1-cell patrol doesn't stretch to 60px. */
 .sb-mobile-landscape .sb-ships-remaining-container > div:nth-child(2) {
   flex-direction: column !important;
   flex: 1;
   height: auto;
-  align-items: stretch !important;
-  gap: 4px !important;
+  align-items: flex-start !important;
+  justify-content: flex-start !important;
+  gap: 3px !important;
 }
 
-/* Each ship bar: stack its segments vertically, fill width. The
-   `flex: <size>` (set inline by ShipsLeft for the row layout) keeps
-   ships of different sizes proportional in this column-stack too. */
+/* Each ship: keep horizontal cell row (no flex-direction override).
+   Override Tamagui's `flex: size` (which would grow vertically in a
+   column parent) and the inline `height: 10` so ships sit at a fixed
+   compact height. Width is set by data-size below — proportional to
+   ship length so the silhouette is recognizable. */
 .sb-mobile-landscape .sb-ships-remaining-container > div:nth-child(2) > div {
-  flex-direction: column !important;
-  width: 100% !important;
-  height: auto !important;
+  flex: 0 0 auto !important;
+  height: 8px !important;
 }
+
+.sb-mobile-landscape [data-size='5'] { width: 50px !important; }
+.sb-mobile-landscape [data-size='4'] { width: 40px !important; }
+.sb-mobile-landscape [data-size='3'] { width: 30px !important; }
+.sb-mobile-landscape [data-size='2'] { width: 20px !important; }
+.sb-mobile-landscape [data-size='1'] { width: 10px !important; }
 
 /* Smaller chrome budget when ships is on the side. Horizontal chrome:
    60 (ships col) + 4 (gap) + 12 (section padding) + 4 (board padding)

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -190,14 +190,15 @@
 }
 
 .sb-fit-grid .sb-board-with-labels-layout {
-  /* Side = min(width-of-cell, height-of-cell - chrome). The chrome
-     budget (~140px) covers PlayerSectionWrapper's paddingTop, the
-     PlayerSection paddings + border, the player name row, the ships-
-     remaining strip and the gaps between them. The 200px floor inside
-     max() prevents the board from shrinking below something playable
-     on tight viewports — if it doesn't fit, the layout overflows and
-     the widget scrolls rather than cropping the cells. */
-  --sb-board-side: min(calc(100cqi - 8px), max(200px, calc(100cqh - 140px)));
+  /* Side = min(width-of-cell, height-of-cell - chrome). The 115px chrome
+     budget matches what PlayerSectionWrapper's paddingTop + PlayerSection
+     paddings + border + player name row + ships-remaining strip + gaps
+     actually consume above the board grid — keeps the board strictly
+     inside its section so `overflow: hidden` never crops cells.
+     The 60px floor inside max() is a safety net for absurdly tight
+     cells; layout responsibility is on the row-floor math to keep cells
+     large enough that the board stays playable. */
+  --sb-board-side: min(calc(100cqi - 8px), max(60px, calc(100cqh - 115px)));
   width: var(--sb-board-side);
   height: var(--sb-board-side);
   align-self: center;
@@ -206,11 +207,12 @@
 }
 
 /* Mobile vertical (1-col flex column container). Each board fills the
-   column width and we cap its side by the dynamic viewport height so a
-   single full board is visible at a time — scroll moves through the
-   list of boards rather than within a single tall board. */
+   column width and we cap its side by the dynamic viewport height
+   minus app + widget chrome (~180px) and the in-section chrome (~115)
+   so a single full board fits without clipping, even when the column
+   is wider than the viewport height allows. */
 .sb-grids-container-mobile .sb-board-with-labels-layout {
-  --sb-board-side: min(100%, max(220px, calc(100dvh - 180px)));
+  --sb-board-side: min(100%, max(200px, calc(100dvh - 200px)));
   width: var(--sb-board-side);
   height: var(--sb-board-side);
   align-self: center;

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -166,38 +166,31 @@
   min-height: 0;
   min-width: 0;
   flex: 1;
-  /* Center the BoardGrid in cell (2,2) when it's smaller than the cell. */
-  place-items: center;
-}
-
-/* The `.sb-board-cell` wrapper occupies grid cell (2,2) of BoardWithLabels
-   and acts as the query container in fit-grid mode. The base style (used
-   in placement / unconstrained contexts) just lets the BoardGrid fill
-   its width naturally. */
-.sb-board-cell {
-  width: 100%;
-  display: contents;
 }
 
 /* In multi-board grid mode the ancestor flex chain hands down a definite
-   height. The cell becomes a size container; the BoardGrid inside picks
-   `min(100cqi, 100cqh)` as its side, then `aspect-ratio: 1` makes it
-   square. This is pure CSS — no JS measurement — and produces the
-   largest square that fits both cell width and cell height. */
-.sb-fit-grid .sb-board-cell {
-  display: grid;
-  place-items: center;
+   height. We make the whole BoardWithLabels (labels + grid) the largest
+   square that fits its cell:
+     - aspect-ratio: 1 forces a square shape
+     - width: 100% + max-height: 100% lets the browser pick the smaller
+       axis; the other dimension is recomputed via aspect-ratio.
+   The inner grid template (auto 1fr / auto 1fr) then guarantees that
+   ColLabels (cell 1/2), RowLabels (cell 2/1) and BoardGrid (cell 2/2)
+   share the same column-2 width and row-2 height — so the numbers and
+   letters land directly above / beside the corresponding cells. */
+.sb-fit-grid .sb-board-with-labels-layout {
+  aspect-ratio: 1;
   width: 100%;
-  height: 100%;
-  min-width: 0;
-  min-height: 0;
-  container-type: size;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+  align-self: center;
+  margin: 0 auto;
 }
 
-.sb-fit-grid .sb-board-cell .sb-board-grid-layout {
-  width: min(100cqi, 100cqh) !important;
-  height: auto !important;
-  margin: 0 auto;
+.sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .sb-row-labels {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -165,27 +165,33 @@
   max-width: 100%;
   min-height: 0;
   min-width: 0;
-  flex: 1;
 }
 
-/* In multi-board grid mode the ancestor flex chain hands down a definite
-   height. We make the whole BoardWithLabels (labels + grid) the largest
-   square that fits its cell:
-     - aspect-ratio: 1 forces a square shape
-     - width: 100% + max-height: 100% lets the browser pick the smaller
-       axis; the other dimension is recomputed via aspect-ratio.
-   The inner grid template (auto 1fr / auto 1fr) then guarantees that
-   ColLabels (cell 1/2), RowLabels (cell 2/1) and BoardGrid (cell 2/2)
-   share the same column-2 width and row-2 height — so the numbers and
-   letters land directly above / beside the corresponding cells. */
+/* In multi-board grid mode each PlayerSection becomes a size container.
+   BoardWithLabels (labels + grid) is then sized to the *largest square*
+   that fits the section after the name / stats chrome above it — using
+   container query units so we don't depend on `aspect-ratio + max-*`
+   recomputation (which some browsers don't honor when both axes are
+   constrained by the flex chain). The inner `auto 1fr / auto 1fr` grid
+   guarantees ColLabels (cell 1/2), RowLabels (cell 2/1) and BoardGrid
+   (cell 2/2) share the same column-2 width and row-2 height, so labels
+   sit directly above / beside their cells. */
+.sb-fit-grid .sb-player-section-fit {
+  container-type: size;
+}
+
 .sb-fit-grid .sb-board-with-labels-layout {
-  aspect-ratio: 1;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-  max-height: 100%;
+  /* Reserve ~90px of vertical chrome for name + stats + paddings above
+     the board within the PlayerSection — gives the board square room to
+     grow. The actual chrome is ~80-115 depending on breakpoint, so this
+     is a slightly generous estimate that prevents the layout from
+     pushing the board past the section bottom. */
+  --sb-board-side: min(100cqi, max(120px, calc(100cqh - 105px)));
+  width: var(--sb-board-side);
+  height: var(--sb-board-side);
   align-self: center;
   margin: 0 auto;
+  flex: 0 0 auto;
 }
 
 .sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -155,11 +155,49 @@
 
 .sb-board-with-labels-layout {
   display: grid !important;
-  grid-template-columns: auto 1fr !important;
-  grid-template-rows: auto auto !important;
+  grid-template-columns: auto minmax(0, 1fr) !important;
+  /* `auto minmax(0, 1fr)` so the board row stretches to fill the parent's
+     remaining height. In unconstrained parents (placement screen), 1fr
+     collapses to content size, preserving prior behavior. */
+  grid-template-rows: auto minmax(0, 1fr) !important;
   gap: 2px;
   width: 100%;
   max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+  /* Center the BoardGrid in cell (2,2) when it's smaller than the cell. */
+  place-items: center;
+}
+
+/* The `.sb-board-cell` wrapper occupies grid cell (2,2) of BoardWithLabels
+   and acts as the query container in fit-grid mode. The base style (used
+   in placement / unconstrained contexts) just lets the BoardGrid fill
+   its width naturally. */
+.sb-board-cell {
+  width: 100%;
+  display: contents;
+}
+
+/* In multi-board grid mode the ancestor flex chain hands down a definite
+   height. The cell becomes a size container; the BoardGrid inside picks
+   `min(100cqi, 100cqh)` as its side, then `aspect-ratio: 1` makes it
+   square. This is pure CSS — no JS measurement — and produces the
+   largest square that fits both cell width and cell height. */
+.sb-fit-grid .sb-board-cell {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  container-type: size;
+}
+
+.sb-fit-grid .sb-board-cell .sb-board-grid-layout {
+  width: min(100cqi, 100cqh) !important;
+  height: auto !important;
+  margin: 0 auto;
 }
 
 .sb-row-labels {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -263,16 +263,19 @@
 }
 
 /* The ShipsLeft container is a YStack (column) wrapping a label row and
-   a bars row. In side-layout mode we reverse the column order so ship
-   silhouettes sit at the TOP of the strip and the "SHIPS REMAINING"
-   label + "10/10" count sit underneath them. */
+   a bars row. In side-layout mode we want the visual order:
+     1. "10/10" count at the top (the most useful glanceable stat)
+     2. Ship silhouettes in the middle
+     3. "SHIPS REMAINING" rotated label at the bottom
+   The count and label are siblings inside one row, so we promote that
+   row to `display: contents` (its children become direct children of
+   the container) and then use `order` to position each part. */
 .sb-mobile-landscape .sb-ships-remaining-container {
   height: 100%;
   width: 100%;
   padding: 4px !important;
   gap: 4px !important;
-  flex-direction: column-reverse !important;
-  justify-content: flex-end !important;
+  flex-direction: column !important;
 }
 
 /* Label row: stack vertically. "SHIPS REMAINING" text rotated -90deg
@@ -280,12 +283,13 @@
    sits horizontally below it. We give the rotated label a reserved
    slot via height + display:flex so it doesn't overflow into the
    board area. */
+/* Promote the label-row contents into the container so we can order
+   "10/10" and "SHIPS REMAINING" independently of each other AND the
+   bars row below. */
 .sb-mobile-landscape .sb-ships-remaining-container > div:first-child {
-  flex-direction: column !important;
-  align-items: center !important;
-  gap: 6px !important;
-  width: 100%;
+  display: contents;
 }
+/* "SHIPS REMAINING" — rotated, sits at the bottom of the strip. */
 .sb-mobile-landscape .sb-ships-remaining-container > div:first-child > span:first-child {
   writing-mode: vertical-rl;
   transform: rotate(180deg);
@@ -294,9 +298,19 @@
   line-height: 1 !important;
   white-space: nowrap;
   text-align: center;
+  align-self: center;
+  order: 3;
 }
+/* "10/10" — count at the very top of the strip. */
 .sb-mobile-landscape .sb-ships-remaining-container > div:first-child > span:nth-child(2) {
-  font-size: 12px !important;
+  font-size: 13px !important;
+  text-align: center;
+  align-self: center;
+  order: 1;
+}
+/* Bars row stays in the middle (default order: 2). */
+.sb-mobile-landscape .sb-ships-remaining-container > div:nth-child(2) {
+  order: 2;
 }
 
 /* Bars row: stack ships vertically as a list. Each ship stays as a

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -193,15 +193,33 @@
   /* Side = min(width-of-cell, height-of-cell - chrome). The chrome
      budget (~140px) covers PlayerSectionWrapper's paddingTop, the
      PlayerSection paddings + border, the player name row, the ships-
-     remaining strip and the gaps between them. Bigger than strictly
-     needed so the layout doesn't push the board past the section
-     bottom on viewports where the chrome rounds up. */
-  --sb-board-side: min(calc(100cqi - 8px), max(140px, calc(100cqh - 140px)));
+     remaining strip and the gaps between them. The 200px floor inside
+     max() prevents the board from shrinking below something playable
+     on tight viewports — if it doesn't fit, the layout overflows and
+     the widget scrolls rather than cropping the cells. */
+  --sb-board-side: min(calc(100cqi - 8px), max(200px, calc(100cqh - 140px)));
   width: var(--sb-board-side);
   height: var(--sb-board-side);
   align-self: center;
   margin: 0 auto;
   flex: 0 0 auto;
+}
+
+/* Mobile vertical (1-col flex column container). Each board fills the
+   column width and we cap its side by the dynamic viewport height so a
+   single full board is visible at a time — scroll moves through the
+   list of boards rather than within a single tall board. */
+.sb-grids-container-mobile .sb-board-with-labels-layout {
+  --sb-board-side: min(100%, max(220px, calc(100dvh - 180px)));
+  width: var(--sb-board-side);
+  height: var(--sb-board-side);
+  align-self: center;
+  margin: 0 auto;
+}
+
+.sb-grids-container-mobile .sb-board-with-labels-layout .sb-board-grid-layout {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .sb-fit-grid .sb-board-with-labels-layout .sb-board-grid-layout {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/board.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/board.tsx
@@ -10,19 +10,42 @@ interface BoardComponentProps extends HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 }
 
-export const BoardGrid = ({ className = '', ...props }: BoardComponentProps) => (
-  <div className={`sb-board-grid-layout ${className}`} {...props} />
+// Wraps the 10×10 grid in a `.sb-board-cell` so the multi-board layout
+// can drive it as a query container: in fit-grid mode the cell is sized
+// by its grid track, and the BoardGrid inside picks the larger of cqi/cqh
+// (clamped to the smaller) so it stays square and fits both dimensions.
+// In single-board contexts (placement) the cell stays width:100% and the
+// BoardGrid fills it naturally.
+export const BoardGrid = ({
+  className = '',
+  children,
+  ...props
+}: BoardComponentProps) => (
+  <div className="sb-board-cell">
+    <div className={`sb-board-grid-layout ${className}`} {...props}>
+      {children}
+    </div>
+  </div>
 );
 
-export const BoardWithLabels = ({ className = '', ...props }: BoardComponentProps) => (
+export const BoardWithLabels = ({
+  className = '',
+  ...props
+}: BoardComponentProps) => (
   <div className={`sb-board-with-labels-layout ${className}`} {...props} />
 );
 
-export const RowLabels = ({ className = '', ...props }: BoardComponentProps) => (
+export const RowLabels = ({
+  className = '',
+  ...props
+}: BoardComponentProps) => (
   <div className={`sb-row-labels ${className}`} {...props} />
 );
 
-export const ColLabels = ({ className = '', ...props }: BoardComponentProps) => (
+export const ColLabels = ({
+  className = '',
+  ...props
+}: BoardComponentProps) => (
   <div className={`sb-col-labels ${className}`} {...props} />
 );
 
@@ -30,6 +53,9 @@ export const Label = ({ className = '', ...props }: BoardComponentProps) => (
   <div className={`sb-label ${className}`} {...props} />
 );
 
-export const BoardCell = ({ className = '', ...props }: BoardComponentProps) => (
+export const BoardCell = ({
+  className = '',
+  ...props
+}: BoardComponentProps) => (
   <div className={`sb-cell ${className}`} {...props} />
 );

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/board.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/board.tsx
@@ -10,22 +10,11 @@ interface BoardComponentProps extends HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
 }
 
-// Wraps the 10×10 grid in a `.sb-board-cell` so the multi-board layout
-// can drive it as a query container: in fit-grid mode the cell is sized
-// by its grid track, and the BoardGrid inside picks the larger of cqi/cqh
-// (clamped to the smaller) so it stays square and fits both dimensions.
-// In single-board contexts (placement) the cell stays width:100% and the
-// BoardGrid fills it naturally.
 export const BoardGrid = ({
   className = '',
-  children,
   ...props
 }: BoardComponentProps) => (
-  <div className="sb-board-cell">
-    <div className={`sb-board-grid-layout ${className}`} {...props}>
-      {children}
-    </div>
-  </div>
+  <div className={`sb-board-grid-layout ${className}`} {...props} />
 );
 
 export const BoardWithLabels = ({

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/layout.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/layout.tsx
@@ -4,9 +4,9 @@ export const MainGameArea = styled(YStack, {
   name: 'MainGameArea',
   gap: '$4',
   width: '100%',
-  flexGrow: 1,
-  flexShrink: 0,
+  flex: 1,
   minHeight: 0,
+  minWidth: 0,
   padding: '$2',
 
   $md: {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/player.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/player.tsx
@@ -8,7 +8,13 @@ export const PlayerSection = styled(YStack, {
   borderWidth: 2,
   borderRadius: 12,
   minWidth: 0,
+  minHeight: 0,
   width: '100%',
+  // When the wrapper provides a definite height (multi-board grid mode),
+  // fill it so the BoardWithLabels child can take the remaining space via
+  // its grid 1fr row. In single-board / unconstrained contexts (placement
+  // screen), height:100% collapses to auto, preserving prior behavior.
+  height: '100%',
   overflow: 'hidden',
 
   variants: {
@@ -40,32 +46,24 @@ export const PlayerSection = styled(YStack, {
   },
 });
 
-// Narrow (≤1150px): full-width block, stacked vertically by parent column layout.
-// Wide (>1150px): flex:1 side-by-side row, capped at 440px.
+// Fills its parent grid cell so the contained board can fit-to-height via
+// CSS (1fr rows on the grid + aspect-ratio on the board). Width-cap is
+// dropped — the grid template now governs per-column width.
 export const PlayerSectionWrapper = styled(YStack, {
   name: 'PlayerSectionWrapper',
   position: 'relative',
   overflow: 'visible',
   paddingTop: 8,
   width: '100%',
-  maxWidth: 520,
-  alignSelf: 'center',
+  height: '100%',
+  minHeight: 0,
+  minWidth: 0,
 
-  $gtMd: {
-    paddingTop: 10,
-    width: 'auto',
-    alignSelf: 'auto',
-    flex: 1,
-    maxWidth: 'min(580px, calc(100vh - 240px))',
-    minWidth: 260,
-  },
   $sm: {
     paddingTop: 6,
-    maxWidth: 'none',
   },
   $short: {
     paddingTop: 4,
-    maxWidth: 'min(420px, calc(100vh - 120px))',
   },
 });
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/player.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/player.tsx
@@ -10,11 +10,6 @@ export const PlayerSection = styled(YStack, {
   minWidth: 0,
   minHeight: 0,
   width: '100%',
-  // When the wrapper provides a definite height (multi-board grid mode),
-  // fill it so the BoardWithLabels child can take the remaining space via
-  // its grid 1fr row. In single-board / unconstrained contexts (placement
-  // screen), height:100% collapses to auto, preserving prior behavior.
-  height: '100%',
   overflow: 'hidden',
 
   variants: {
@@ -46,17 +41,16 @@ export const PlayerSection = styled(YStack, {
   },
 });
 
-// Fills its parent grid cell so the contained board can fit-to-height via
-// CSS (1fr rows on the grid + aspect-ratio on the board). Width-cap is
-// dropped — the grid template now governs per-column width.
+// Natural-height wrapper. In fit-grid mode the `.sb-fit-grid > *` CSS
+// rule stretches it to fill its grid cell; in mobile vertical (1-col flex
+// column) we leave it at content height so the page scrolls naturally
+// between boards instead of each board taking the full viewport height.
 export const PlayerSectionWrapper = styled(YStack, {
   name: 'PlayerSectionWrapper',
   position: 'relative',
   overflow: 'visible',
   paddingTop: 8,
   width: '100%',
-  height: '100%',
-  minHeight: 0,
   minWidth: 0,
 
   $sm: {


### PR DESCRIPTION
## Summary
- Sea Battle boards now grow to fill the available vertical space under the game header without forcing scroll when there's room.
- Mobile / tablet in landscape (and widget-fullscreen up to ≤1150px) is capped at 2 columns so users always see at least two playable boards side-by-side.
- Mobile vertical stacks one full board at a time; desktop fullscreen keeps the balanced `idealCols` layout so all boards stay visible.
- Row/col labels (1–10, A–J) sized to match cell widths/heights so they read like real coordinates.

## Why
Boards used to be JS-sized off a measured viewport remainder, which left them small in plenty of room and clipped at the bottom in others. Players asked for "fields fill all available place, avoid scroll if possible, never less than 2 in a row in horizontal on mobile/tablet."

## How
- Pure-CSS sizing: `SeaBattleGrids` picks a column count, then a container-query block on each `PlayerSectionWrapper` (`container-type: size`) lets the inner board compute its side as `min(100cqi - 8, max(60, 100cqh - 115))` — largest square that fits its cell with real chrome subtracted.
- Fullscreen detection via `MutationObserver` walking ancestors for `.is-fullscreen` so the layout can swap modes when the player toggles the widget.
- 2-col cap row floor uses `clamp(320px, cellWidth + 115px chrome, 78dvh)` so width-limited boards don't leave a huge empty void below them.
- Top-anchored tracks (`alignContent: 'start'`) so overflowed rows don't push the first row above the widget's sticky header.

## Changes
- [apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx](apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx) — col-count + row-height logic, fullscreen MutationObserver, landscape detection.
- [apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css](apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css) — `.sb-fit-grid` container-query sizing, mobile-vertical sizing, label grid rules.
- [apps/web/src/widgets/SeaBattleGame/ui/styles/player.tsx](apps/web/src/widgets/SeaBattleGame/ui/styles/player.tsx) — drop default `height: 100%` from `PlayerSection`/`PlayerSectionWrapper`; the gated CSS rules apply it only in fit-grid mode.
- [apps/web/src/widgets/SeaBattleGame/ui/styles/layout.tsx](apps/web/src/widgets/SeaBattleGame/ui/styles/layout.tsx) — `MainGameArea` becomes `flex: 1; minHeight: 0; minWidth: 0` so children get a definite height.
- [apps/web/src/widgets/SeaBattleGame/ui/styles/board.tsx](apps/web/src/widgets/SeaBattleGame/ui/styles/board.tsx) — board layout components.
- [apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx](apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx) — add `sb-player-section-fit` class so the visible card border stretches with its cell.
- [apps/web/src/features/games/ui/GameWidgetContainer.tsx](apps/web/src/features/games/ui/GameWidgetContainer.tsx) — `SharedGameBoard` becomes `flex: 1; minHeight: 0` so the height handoff reaches the grids container.

## Test plan
- [x] Desktop 1440×900 (chat open): 2-player board fills section, no empty void below
- [x] Desktop widget-fullscreen 1294×1200, 8 boards: 4×2 grid, all boards visible at once
- [x] Mobile landscape 844×390: 2-col cap, ~201×201 boards, scroll between pairs
- [x] Mobile vertical: 1 full board at a time, page scrolls between
- [x] All 8 sea-battle e2e tests pass on chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)