### PR TITLE
fix(be): unblock app e2e cold bootstrap (ARC-732)

### DIFF
--- a/apps/be/test/app.e2e-spec.ts
+++ b/apps/be/test/app.e2e-spec.ts
@@ -4,17 +4,23 @@ import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
+// AppModule pulls in every feature module + a live Mongoose connection,
+// so a cold compile + init regularly exceeds Jest's default 5s hook
+// budget on CI runners. Bootstrap once per file and give the hook a
+// generous ceiling.
+const BOOTSTRAP_TIMEOUT_MS = 60_000;
+
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
-  });
+  }, BOOTSTRAP_TIMEOUT_MS);
 
   afterAll(async () => {
     if (app) {


### PR DESCRIPTION
## Summary
The `AppController (e2e)` test failed on CI with a 5002 ms `beforeEach` timeout. `AppModule` imports every feature module plus a live Mongoose connection, so a cold compile + `app.init()` regularly exceeds Jest's default 5s hook budget on CI runners.

## Why
- Discovered while running CI on ARC-729: `pnpm --filter be test:e2e` fails on `develop` (and on every branch cut from it) with `Exceeded timeout of 5000 ms for a hook` in `apps/be/test/app.e2e-spec.ts`.
- Pre-existing — not caused by ARC-729 (which is web-only) — but blocks every PR's CI gate.
- Bootstrapping the full module **once per test** is also unnecessarily wasteful for a single smoke check.

## Changes
- [apps/be/test/app.e2e-spec.ts](apps/be/test/app.e2e-spec.ts): `beforeEach` → `beforeAll`, with a 60s hook timeout. Test logic and assertions unchanged.

## Test plan
- [x] `pnpm --filter be test:e2e` passes locally (was failing before): bootstrap ~21s, request ~30 ms.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)