### PR TITLE
fix(chat): render sender (and target) on system/action rows (ARC-736)

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -114,7 +114,7 @@ export function runConfirmPlacement(
 ): GameActionResult<SeaBattleState> {
   player.placementComplete = true;
   state.logs.push(
-    makeLog('system', 'A player has finished placing ships', {
+    makeLog('system', 'finished placing ships', {
       senderId: player.playerId,
     }),
   );

--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -113,7 +113,11 @@ export function runConfirmPlacement(
   player: SeaBattlePlayer,
 ): GameActionResult<SeaBattleState> {
   player.placementComplete = true;
-  state.logs.push(makeLog('system', 'A player has finished placing ships'));
+  state.logs.push(
+    makeLog('system', 'A player has finished placing ships', {
+      senderId: player.playerId,
+    }),
+  );
   const allReady = state.players.every((p) => p.placementComplete);
   if (allReady) {
     state.phase = GAME_PHASE.BATTLE;

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -272,7 +272,9 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
       if (target.shipsRemaining === 0) {
         target.alive = false;
         state.logs.push(
-          this.createLogEntry('system', 'A player has been eliminated!'),
+          this.createLogEntry('system', 'A player has been eliminated!', {
+            senderId: target.playerId,
+          }),
         );
         // In team mode, make sure the eliminated player isn't left as their
         // team's active shooter — otherwise their team's next turn deadlocks
@@ -413,7 +415,9 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
 
     player.alive = false;
     newState.logs.push(
-      this.createLogEntry('system', 'A player has left the game'),
+      this.createLogEntry('system', 'A player has left the game', {
+        senderId: playerId,
+      }),
     );
 
     if (newState.teams) {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -272,7 +272,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
       if (target.shipsRemaining === 0) {
         target.alive = false;
         state.logs.push(
-          this.createLogEntry('system', 'A player has been eliminated!', {
+          this.createLogEntry('system', 'has been eliminated!', {
             senderId: target.playerId,
           }),
         );
@@ -415,7 +415,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
 
     player.alive = false;
     newState.logs.push(
-      this.createLogEntry('system', 'A player has left the game', {
+      this.createLogEntry('system', 'left the game', {
         senderId: playerId,
       }),
     );

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -157,8 +157,7 @@ export function GameChat({
   const sendMessage = useGameChatStore((s) => s.sendMessage);
   const resolveActorColor = useGameChatStore((s) => s.resolveActorColor);
   const theme = useTheme();
-  const inputColor =
-    (theme.color?.get?.() as string | undefined) ?? '#ecefee';
+  const inputColor = (theme.color?.get?.() as string | undefined) ?? '#ecefee';
 
   const scopes = teamMode ? TEAM_SCOPES : FFA_SCOPES;
   const [draft, setDraft] = useState('');
@@ -354,34 +353,41 @@ export function GameChat({
                 />
               </Divider>
               {visibleLogs.map((log) => {
+                const senderName = log.senderId
+                  ? resolveDisplayName
+                    ? resolveDisplayName(
+                        log.senderId ?? undefined,
+                        log.senderName ?? undefined,
+                      )
+                    : (log.senderName ?? undefined)
+                  : undefined;
+                const senderColor = log.senderId
+                  ? (resolveActorColor?.(log.senderId) ??
+                    getPlayerColor(log.senderId))
+                  : undefined;
+                const targetId = log.targetId;
+                const targetName = targetId
+                  ? resolveDisplayName
+                    ? resolveDisplayName(targetId, undefined)
+                    : targetId
+                  : undefined;
+                const targetColor = targetId
+                  ? (resolveActorColor?.(targetId) ?? getPlayerColor(targetId))
+                  : undefined;
                 if (log.type === 'system' || log.type === 'action') {
                   return (
                     <GameChatSystemRow
                       key={log.id}
                       kind={inferSysKind(log)}
                       content={renderResultHighlights(log.message)}
+                      senderName={senderName}
+                      senderColor={senderColor}
+                      targetName={targetName}
+                      targetColor={targetColor}
                     />
                   );
                 }
                 const isOwn = !!currentUserId && log.senderId === currentUserId;
-                const senderName = resolveDisplayName
-                  ? resolveDisplayName(
-                      log.senderId ?? undefined,
-                      log.senderName ?? undefined,
-                    )
-                  : (log.senderName ?? undefined);
-                const senderColor = log.senderId
-                  ? (resolveActorColor?.(log.senderId) ??
-                    getPlayerColor(log.senderId))
-                  : undefined;
-                const targetId = log.targetId;
-                const targetName =
-                  targetId && resolveDisplayName
-                    ? resolveDisplayName(targetId, undefined)
-                    : (targetId ?? undefined);
-                const targetColor = targetId
-                  ? (resolveActorColor?.(targetId) ?? getPlayerColor(targetId))
-                  : undefined;
                 return (
                   <GameChatRow
                     key={log.id}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -123,7 +123,8 @@ function inferSysKind(log: ChatLogEntry): SystemRowKind {
   const msg = log.message?.toLowerCase() ?? '';
   if (msg.includes('round')) return 'round';
   if (msg.includes('combo')) return 'combo';
-  if (msg.includes('join')) return 'join';
+  if (msg.includes('join') || msg.includes('placing') || msg.includes('left '))
+    return 'join';
   return log.type === 'action' ? 'combo' : 'elim';
 }
 

--- a/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
@@ -38,7 +38,7 @@ export function GameChatSystemRow({
       backgroundColor={`color-mix(in srgb, ${color} 12%, transparent)`}
       data-testid="game-chat-system-row"
     >
-      <SysText color={color} fontWeight="700">
+      <SysText flex={0} color={color} fontWeight="700">
         {GLYPHS[kind]}
       </SysText>
       <SysText>

--- a/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
@@ -8,6 +8,10 @@ export type SystemRowKind = 'elim' | 'round' | 'combo' | 'join';
 interface Props {
   kind: SystemRowKind;
   content: ReactNode;
+  senderName?: string;
+  senderColor?: string;
+  targetName?: string;
+  targetColor?: string;
   time?: string;
 }
 
@@ -18,17 +22,51 @@ const GLYPHS: Record<SystemRowKind, string> = {
   join: '⇢',
 };
 
-export function GameChatSystemRow({ kind, content, time }: Props) {
+export function GameChatSystemRow({
+  kind,
+  content,
+  senderName,
+  senderColor,
+  targetName,
+  targetColor,
+  time,
+}: Props) {
   const color = SYS_COLOR[kind];
   return (
     <SysWrap
       borderLeftColor={color}
       backgroundColor={`color-mix(in srgb, ${color} 12%, transparent)`}
+      data-testid="game-chat-system-row"
     >
       <SysText color={color} fontWeight="700">
         {GLYPHS[kind]}
       </SysText>
-      <SysText>{content}</SysText>
+      <SysText>
+        {senderName ? (
+          <>
+            <SysText
+              color={senderColor ?? color}
+              fontWeight="700"
+              data-testid="system-row-sender"
+            >
+              {senderName}
+            </SysText>
+            {targetName ? (
+              <>
+                {' → '}
+                <SysText
+                  color={targetColor ?? color}
+                  fontWeight="700"
+                  data-testid="system-row-target"
+                >
+                  {targetName}
+                </SysText>
+              </>
+            ) : null}{' '}
+          </>
+        ) : null}
+        {content}
+      </SysText>
       {time ? <SysTime>{time}</SysTime> : null}
     </SysWrap>
   );

--- a/apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx
@@ -109,23 +109,21 @@ describe('GameChat', () => {
   });
 
   it('renders system and action logs separately from chat messages', () => {
-    useGameChatStore
-      .getState()
-      .setLogs([
-        makeLog({
-          id: 'a',
-          type: 'action',
-          senderId: 'p1',
-          message: 'Drew a card',
-        }),
-        makeLog({
-          id: 'b',
-          type: 'system',
-          senderId: 'p2',
-          message: 'exploded!',
-        }),
-        makeLog({ id: 'c', type: 'message', senderId: 'p1', message: 'hi' }),
-      ]);
+    useGameChatStore.getState().setLogs([
+      makeLog({
+        id: 'a',
+        type: 'action',
+        senderId: 'p1',
+        message: 'Drew a card',
+      }),
+      makeLog({
+        id: 'b',
+        type: 'system',
+        senderId: 'p2',
+        message: 'exploded!',
+      }),
+      makeLog({ id: 'c', type: 'message', senderId: 'p1', message: 'hi' }),
+    ]);
 
     renderChat(
       <GameChat
@@ -143,8 +141,41 @@ describe('GameChat', () => {
     expect(chatRendered[0]?.getAttribute('data-sender-color')).toMatch(/^#/);
 
     // System / action messages still appear somewhere in the rendered tree.
-    expect(screen.getByText('Drew a card')).toBeTruthy();
-    expect(screen.getByText('exploded!')).toBeTruthy();
+    expect(screen.getByText(/Drew a card/)).toBeTruthy();
+    expect(screen.getByText(/exploded!/)).toBeTruthy();
+  });
+
+  it('renders sender (and optional target) on system and action rows', () => {
+    useGameChatStore.getState().setLogs([
+      makeLog({
+        id: 'sa',
+        type: 'action',
+        senderId: 'p1',
+        targetId: 'p2',
+        message: 'attacked H10 — MISS!',
+      }),
+      makeLog({
+        id: 'ss',
+        type: 'system',
+        senderId: 'p1',
+        message: 'A player has finished placing ships',
+      }),
+    ]);
+
+    renderChat(
+      <GameChat
+        currentUserId="p1"
+        resolveDisplayName={(id) =>
+          id === 'p1' ? 'Alice' : id === 'p2' ? 'Bob' : id
+        }
+      />,
+    );
+
+    const senders = screen.getAllByTestId('system-row-sender');
+    expect(senders.map((n) => n.textContent)).toEqual(['Alice', 'Alice']);
+
+    const targets = screen.getAllByTestId('system-row-target');
+    expect(targets.map((n) => n.textContent)).toEqual(['Bob']);
   });
 
   it('treats messages as not-own when currentUserId is missing', () => {


### PR DESCRIPTION
## What
Game chat now attributes system and action events to the player who triggered them, with their player-color name (and optional target) shown before the message.

## Why
The chat panel renders three log kinds: user messages, system events, and player actions. System and action rows previously dropped the `senderId`/`senderName`/`targetId` that BE already attaches to entries like sea-battle attacks, so messages such as "attacked H10 — MISS!" appeared unattributed. A few sea-battle BE log entries also omitted `senderId` despite having the actor in hand, and the system-row layout reserved half the row for the single-character glyph.

## Changes
- `apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx`: accept `senderName`/`senderColor`/`targetName`/`targetColor` and render them (in player color) before the message, matching the `→ target` pattern from `@arcadeum/ui` `ChatMessage`. Pin the glyph cell to `flex={0}` so the icon doesn't claim 50% of the row width.
- `apps/web/src/widgets/GameChat/ui/GameChat.tsx`: resolve display name + player color for system/action logs and pass them through. Route `placing` / `left ` messages to the `join` glyph instead of the elim skull.
- `apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts`: attach `senderId` to the placement-complete log and trim "A player has " so the rendered output reads `<name> finished placing ships`.
- `apps/be/src/games/engines/sea-battle/sea-battle.engine.ts`: attach `senderId` to the eliminated and left-the-game logs and trim "A player has " for the same reason.
- `apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx`: add a test verifying sender + target render on system/action rows; loosen existing assertions to allow the new sender prefix.

## Test plan
- [ ] Start a sea-battle game; verify "Game started! Place your ships." has no sender (genuine system event)
- [ ] Confirm placement; verify the chat shows `<your name> finished placing ships` with the join (⇢) glyph in your player color
- [ ] Attack opponent cells; verify each action row shows `<attacker> → <target> attacked <cell> — HIT/MISS/SUNK!`
- [ ] Eliminate / leave a player; verify chat shows `<name> has been eliminated!` / `<name> left the game`
- [ ] Open chat collapsed view; verify nothing regresses for user messages with the equipped-avatar bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)