### PR TITLE
feat(home): premium hero cards with variant artwork + Play CTA (ARC-734)

### DIFF
--- a/apps/web/src/app/[locale]/home/components/HomeHero.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeHero.tsx
@@ -192,7 +192,7 @@ export default function HomeHero() {
                   <Link
                     href={`${routes.gameCreate}?variant=${card.id}`}
                     className="hero-card-play-cta"
-                    data-testid={`hero-card-play-${index}`}
+                    data-testid={`hero-play-cta-${index}`}
                   >
                     {playLabel}
                   </Link>

--- a/apps/web/src/app/[locale]/home/components/HomeHero.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeHero.tsx
@@ -143,6 +143,7 @@ export default function HomeHero() {
           >
             {heroCards.map((card, index) => {
               const isLast = index === heroCards.length - 1;
+              const isFront = isLast;
 
               // spread them out slightly more for better visibility of the "not covered" parts
               const x = (index - 1) * 65;
@@ -174,7 +175,7 @@ export default function HomeHero() {
                       src={card.bgImage}
                       alt=""
                       fill
-                      priority={isLast}
+                      priority={isFront}
                       sizes="(max-width: 1150px) 60vw, 280px"
                       className="hero-card-image"
                     />

--- a/apps/web/src/app/[locale]/home/components/HomeHero.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeHero.tsx
@@ -189,15 +189,13 @@ export default function HomeHero() {
                     {t(card.nameKey as TranslationKey) || card.nameKey}
                   </div>
                   <div className="hero-card-brand">{heroCardBrand}</div>
-                  {isFront ? (
-                    <Link
-                      href={`${routes.gameCreate}?variant=${card.id}`}
-                      className="hero-card-play-cta"
-                      data-testid="hero-card-play"
-                    >
-                      {playLabel}
-                    </Link>
-                  ) : null}
+                  <Link
+                    href={`${routes.gameCreate}?variant=${card.id}`}
+                    className="hero-card-play-cta"
+                    data-testid={`hero-card-play-${index}`}
+                  >
+                    {playLabel}
+                  </Link>
                 </div>
               );
             })}

--- a/apps/web/src/app/[locale]/home/components/HomeHero.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeHero.tsx
@@ -10,23 +10,30 @@ import {
 } from '@/shared/lib/useTranslation';
 import { SupportIcon } from '@/shared/ui';
 import Link from 'next/link';
+import Image from 'next/image';
 import { CARD_VARIANTS } from '@/features/games/lib/criticalVariants';
 
-type ThemeColor = '$red10' | '$blue10' | '$purple10';
-const THEME_COLORS: ThemeColor[] = ['$red10', '$blue10', '$purple10'];
+const HERO_VARIANT_IDS = ['fantasy', 'galaxy', 'steampunk'] as const;
+
+type HeroCard = {
+  nameKey: string;
+  bgImage?: string;
+};
 
 export default function HomeHero() {
   const sectionRef = useRef<HTMLElement>(null);
   const { t } = useTranslation();
   const routes = useRoutes();
 
-  const heroCards = useMemo(
+  const heroCards = useMemo<HeroCard[]>(
     () =>
-      [...CARD_VARIANTS].slice(0, 3).map((v, i) => ({
-        name: v.name,
-        icon: v.emoji,
-        colorToken: THEME_COLORS[i % THEME_COLORS.length],
-      })),
+      HERO_VARIANT_IDS.map((id) => {
+        const v = CARD_VARIANTS.find((c) => c.id === id);
+        return {
+          nameKey: v?.name ?? '',
+          bgImage: v?.bgImage,
+        };
+      }),
     [],
   );
 
@@ -162,64 +169,22 @@ export default function HomeHero() {
                   }
                   data-testid={`hero-card-${index}`}
                 >
-                  <div
-                    style={{
-                      position: 'absolute',
-                      inset: 0,
-                      zIndex: 0,
-                      pointerEvents: 'none',
-                      opacity: 0.6,
-                      backgroundColor: `var(--${card.colorToken.replace('$', '')})`,
-                    }}
-                  />
-                  <div
-                    style={{
-                      position: 'relative',
-                      zIndex: 1,
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      width: '100%',
-                    }}
-                  >
-                    <span style={{ color: 'white', fontWeight: 'bold' }}>
-                      {t(card.name as TranslationKey) || card.name}
-                    </span>
-                    <span>{card.icon}</span>
+                  {card.bgImage ? (
+                    <Image
+                      src={card.bgImage}
+                      alt=""
+                      fill
+                      priority={isLast}
+                      sizes="(max-width: 1150px) 60vw, 280px"
+                      className="hero-card-image"
+                    />
+                  ) : null}
+                  <div className="hero-card-scrim hero-card-scrim-top" />
+                  <div className="hero-card-scrim hero-card-scrim-bottom" />
+                  <div className="hero-card-name">
+                    {t(card.nameKey as TranslationKey) || card.nameKey}
                   </div>
-                  <div
-                    style={{
-                      position: 'relative',
-                      zIndex: 1,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flex: 1,
-                    }}
-                  >
-                    <span style={{ fontSize: '120px', lineHeight: '120px' }}>
-                      {card.icon}
-                    </span>
-                  </div>
-                  <div
-                    style={{
-                      position: 'relative',
-                      zIndex: 1,
-                      display: 'flex',
-                      justifyContent: 'center',
-                      width: '100%',
-                    }}
-                  >
-                    <span
-                      style={{
-                        color: 'white',
-                        opacity: 0.7,
-                        fontWeight: 'bold',
-                        letterSpacing: '2px',
-                      }}
-                    >
-                      {heroCardBrand}
-                    </span>
-                  </div>
+                  <div className="hero-card-brand">{heroCardBrand}</div>
                 </div>
               );
             })}

--- a/apps/web/src/app/[locale]/home/components/HomeHero.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeHero.tsx
@@ -16,6 +16,7 @@ import { CARD_VARIANTS } from '@/features/games/lib/criticalVariants';
 const HERO_VARIANT_IDS = ['fantasy', 'galaxy', 'steampunk'] as const;
 
 type HeroCard = {
+  id: (typeof HERO_VARIANT_IDS)[number];
   nameKey: string;
   bgImage?: string;
 };
@@ -30,6 +31,7 @@ export default function HomeHero() {
       HERO_VARIANT_IDS.map((id) => {
         const v = CARD_VARIANTS.find((c) => c.id === id);
         return {
+          id,
           nameKey: v?.name ?? '',
           bgImage: v?.bgImage,
         };
@@ -58,6 +60,7 @@ export default function HomeHero() {
     `Enjoy a wide variety of board games and tabletop experiences online. Create real-time game rooms, invite your friends, and let ${appName} handle rules, scoring, and turns so you can focus on the fun.`;
   const primaryLabel = homeCopy.primaryCtaLabel ?? 'Get started';
   const heroCardBrand = homeCopy.heroCardBrand ?? 'CRITICAL';
+  const playLabel = homeCopy.heroCardPlayCta ?? 'Play';
   const supportLabel = homeCopy.supportCtaLabel ?? 'Support the developers';
 
   const primaryHref = routes.games;
@@ -186,6 +189,15 @@ export default function HomeHero() {
                     {t(card.nameKey as TranslationKey) || card.nameKey}
                   </div>
                   <div className="hero-card-brand">{heroCardBrand}</div>
+                  {isFront ? (
+                    <Link
+                      href={`${routes.gameCreate}?variant=${card.id}`}
+                      className="hero-card-play-cta"
+                      data-testid="hero-card-play"
+                    >
+                      {playLabel}
+                    </Link>
+                  ) : null}
                 </div>
               );
             })}

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.css
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.css
@@ -368,6 +368,50 @@
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
+.hero-card-play-cta {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.92);
+  z-index: 4;
+  padding: 12px 28px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #0b0d10;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-decoration: none;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 8px 22px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.22s ease,
+    transform 0.22s ease,
+    background 0.22s ease;
+  white-space: nowrap;
+}
+
+.hero-card-main:hover .hero-card-play-cta {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.hero-card-play-cta:hover {
+  background: #ffffff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-card-play-cta {
+    transition: opacity 0.15s ease;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
 .is-hydrated .hero-card-main {
   opacity: 1;
   pointer-events: auto;

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.css
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.css
@@ -283,14 +283,15 @@
   position: absolute;
   width: 280px;
   height: 380px;
-  background: rgba(30, 32, 35, 0.85);
-  backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(20, 22, 26, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 24px;
-  display: flex;
-  flex-direction: column;
-  padding: 24px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 6px 14px rgba(0, 0, 0, 0.3),
+    0 20px 40px -10px rgba(0, 0, 0, 0.55);
   transform: translate(var(--card-x), var(--card-y)) rotate(var(--card-rotate))
     scale(var(--card-scale));
   opacity: 0;
@@ -299,6 +300,72 @@
     opacity 0.6s ease-out,
     box-shadow 0.3s ease;
   pointer-events: none;
+}
+
+.hero-card-image {
+  object-fit: cover;
+  object-position: center;
+  z-index: 0;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hero-card-scrim {
+  position: absolute;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.hero-card-scrim-top {
+  top: 0;
+  height: 45%;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.6) 0%,
+    rgba(0, 0, 0, 0.25) 60%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.hero-card-scrim-bottom {
+  bottom: 0;
+  height: 50%;
+  background: linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.7) 0%,
+    rgba(0, 0, 0, 0.3) 55%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.hero-card-name {
+  position: absolute;
+  top: 22px;
+  left: 24px;
+  right: 24px;
+  z-index: 2;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: -0.005em;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.hero-card-brand {
+  position: absolute;
+  bottom: 22px;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.78);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
 .is-hydrated .hero-card-main {
@@ -310,8 +377,38 @@
   transform: translate(var(--card-x), calc(var(--card-y) - 20px))
     rotate(var(--card-rotate)) scale(1.05) !important;
   z-index: 100 !important;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.6);
-  border-color: rgba(255, 255, 255, 0.3);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.18),
+    0 12px 24px rgba(0, 0, 0, 0.4),
+    0 30px 60px -12px rgba(0, 0, 0, 0.7);
+}
+
+.hero-card-main::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  background: linear-gradient(
+    120deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.08) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  transition: transform 1.6s ease;
+}
+
+.hero-card-main:hover::after {
+  transform: translateX(100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-card-main::after,
+  .hero-card-main:hover::after {
+    transition: none;
+    transform: translateX(-100%);
+  }
 }
 
 @media (max-width: 1150px) {
@@ -319,10 +416,6 @@
     margin-top: 60px;
     margin-bottom: 40px;
     transform: scale(0.85);
-  }
-
-  .hero-card-main {
-    background: rgba(30, 32, 35, 0.92);
   }
 }
 /* Static Presentation Styles */

--- a/apps/web/src/features/games/lib/criticalVariants.test.ts
+++ b/apps/web/src/features/games/lib/criticalVariants.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { CARD_VARIANTS } from './criticalVariants';
+
+describe('CARD_VARIANTS bgImage field', () => {
+  const expectImage = (id: string, file: string) => {
+    const v = CARD_VARIANTS.find((c) => c.id === id);
+    expect(v, `variant ${id} should exist`).toBeDefined();
+    expect(v?.bgImage).toBe(`/images/variants/${file}`);
+  };
+
+  it('populates bgImage for the 6 variants with shipped artwork', () => {
+    expectImage('egypt', 'egypt_bg.png');
+    expectImage('fantasy', 'fantasy_bg.png');
+    expectImage('galaxy', 'galaxy_bg.png');
+    expectImage('steampunk', 'steampunk_bg.png');
+    expectImage('western', 'western_bg.png');
+    expectImage('zen', 'zen_bg.png');
+  });
+
+  it('leaves bgImage undefined for variants without shipped artwork', () => {
+    const noArtIds = [
+      'cyberpunk',
+      'underwater',
+      'crime',
+      'horror',
+      'adventure',
+      'high-altitude-hike',
+      'random',
+    ];
+    for (const id of noArtIds) {
+      const v = CARD_VARIANTS.find((c) => c.id === id);
+      expect(
+        v?.bgImage,
+        `variant ${id} should not have bgImage`,
+      ).toBeUndefined();
+    }
+  });
+});

--- a/apps/web/src/features/games/lib/criticalVariants.ts
+++ b/apps/web/src/features/games/lib/criticalVariants.ts
@@ -4,6 +4,7 @@ export const CARD_VARIANTS: {
   description: string;
   emoji: string;
   gradient: string;
+  bgImage?: string;
   disabled?: boolean;
 }[] = [
   {
@@ -54,6 +55,7 @@ export const CARD_VARIANTS: {
     description: 'games.critical_v1.variants.galaxy.description',
     emoji: '🌌',
     gradient: 'linear-gradient(135deg, #6b21a8 0%, #1e1b4b 100%)',
+    bgImage: '/images/variants/galaxy_bg.png',
   },
   {
     id: 'fantasy',
@@ -61,6 +63,7 @@ export const CARD_VARIANTS: {
     description: 'games.critical_v1.variants.fantasy.description',
     emoji: '🐉',
     gradient: 'linear-gradient(135deg, #065f46 0%, #d4af37 100%)',
+    bgImage: '/images/variants/fantasy_bg.png',
   },
   {
     id: 'western',
@@ -68,6 +71,7 @@ export const CARD_VARIANTS: {
     description: 'games.critical_v1.variants.western.description',
     emoji: '🤠',
     gradient: 'linear-gradient(135deg, #9a3412 0%, #fde68a 100%)',
+    bgImage: '/images/variants/western_bg.png',
   },
   {
     id: 'egypt',
@@ -75,6 +79,7 @@ export const CARD_VARIANTS: {
     description: 'games.critical_v1.variants.egypt.description',
     emoji: '🏺',
     gradient: 'linear-gradient(135deg, #b45309 0%, #1e3a8a 100%)',
+    bgImage: '/images/variants/egypt_bg.png',
   },
   {
     id: 'steampunk',
@@ -82,6 +87,7 @@ export const CARD_VARIANTS: {
     description: 'games.critical_v1.variants.steampunk.description',
     emoji: '⚙️',
     gradient: 'linear-gradient(135deg, #78350f 0%, #fef3c7 100%)',
+    bgImage: '/images/variants/steampunk_bg.png',
   },
   {
     id: 'zen',
@@ -89,6 +95,7 @@ export const CARD_VARIANTS: {
     description: 'games.critical_v1.variants.zen.description',
     emoji: '🏮',
     gradient: 'linear-gradient(135deg, #db2777 0%, #1e1b4b 100%)',
+    bgImage: '/images/variants/zen_bg.png',
   },
   {
     id: 'random',

--- a/apps/web/src/shared/i18n/messages/home.ts
+++ b/apps/web/src/shared/i18n/messages/home.ts
@@ -10,6 +10,7 @@ export const en = {
   playWithBotsLabel: 'Play with Bots',
   defaultRoomName: "{{name}}'s game",
   heroCardBrand: 'CRITICAL',
+  heroCardPlayCta: 'Play',
   supportCtaLabel: 'Support the developers',
   downloadsTitle: 'Install Arcadeum',
   pwaDescription:
@@ -17,7 +18,6 @@ export const en = {
   downloadsDescription: 'Grab the latest builds directly from the web app.',
   downloadsIosLabel: 'Download for iOS',
   downloadsAndroidLabel: 'Download for Android',
-  // Games section
   gamesTitle: 'Featured Games',
   gamesSubtitle: 'Explore our growing library of tabletop experiences',
   gamePlayButton: 'Play Now',
@@ -31,7 +31,6 @@ export const en = {
   showLess: 'Show Less',
   rulesTab: 'Rules',
   infoTab: 'Game Themes',
-
   // Features section
   featuresTitle: 'Why {{appName}}?',
   featuresSubtitle:
@@ -57,7 +56,6 @@ export const en = {
   featureTournamentsTitle: 'Tournaments',
   featureTournamentsDescription:
     'Compete in ranked events and prove your skills against the best players.',
-  // How it works section
   howItWorksTitle: 'How It Works',
   howItWorksSubtitle: 'Get started in three simple steps',
   stepCreateTitle: 'Create or Join a Room',
@@ -106,6 +104,7 @@ export const es = {
   playWithBotsLabel: 'Jugar con Bots',
   defaultRoomName: 'Partida de {{name}}',
   heroCardBrand: 'CRITICAL',
+  heroCardPlayCta: 'Jugar',
   supportCtaLabel: 'Apoyar a los desarrolladores',
   downloadsTitle: 'Instalar Arcadeum',
   pwaDescription:
@@ -205,6 +204,7 @@ export const fr = {
   playWithBotsLabel: 'Jouer avec des Bots',
   defaultRoomName: 'Partie de {{name}}',
   heroCardBrand: 'CRITICAL',
+  heroCardPlayCta: 'Jouer',
   supportCtaLabel: 'Soutenir les développeurs',
   downloadsTitle: 'Installer Arcadeum',
   pwaDescription:
@@ -305,6 +305,7 @@ export const ru = {
   playWithBotsLabel: 'Играть с ботами',
   defaultRoomName: 'Игра {{name}}',
   heroCardBrand: 'CRITICAL',
+  heroCardPlayCta: 'Играть',
   supportCtaLabel: 'Поддержать разработчиков',
   downloadsTitle: 'Установить Arcadeum',
   pwaDescription:
@@ -400,6 +401,7 @@ export const by = {
   playWithBotsLabel: 'Гуляць з ботамі',
   defaultRoomName: 'Гульня {{name}}',
   heroCardBrand: 'CRITICAL',
+  heroCardPlayCta: 'Гуляць',
   supportCtaLabel: 'Падрымаць распрацоўшчыкаў',
   downloadsTitle: 'Усталяваць Arcadeum',
   pwaDescription:

--- a/docs/superpowers/plans/2026-05-23-home-hero-cards-premium.md
+++ b/docs/superpowers/plans/2026-05-23-home-hero-cards-premium.md
@@ -1,0 +1,582 @@
+# Home Hero Cards — Premium Visual Refresh Implementation Plan (ARC-734)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the emoji-driven hero card centerpieces with full-bleed AI artwork (fantasy / galaxy / steampunk), refined scrims, inner ring, elevation shadow, and a subtle hover shimmer — preserving the existing fan-out layout and all e2e selectors.
+
+**Architecture:** Add an optional `bgImage` field to `CARD_VARIANTS`, curate three hero variants by id (not `slice`), and rewrite the card body in `HomeHero.tsx` to render a `next/image` background with two text rows (variant name top, `CRITICAL` brand bottom) over CSS scrims. All visual treatment lives in `home-bundle.css` on `.hero-card-main`.
+
+**Tech Stack:** Next.js (App Router) · `next/image` · Tamagui design tokens · Vitest (web unit tests) · Playwright (e2e). Spec: [docs/superpowers/specs/2026-05-23-home-hero-cards-premium-design.md](../specs/2026-05-23-home-hero-cards-premium-design.md).
+
+---
+
+## File Structure
+
+| File                                                               | Responsibility                             | Action                                                                                                            |
+| ------------------------------------------------------------------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `apps/web/src/features/games/lib/criticalVariants.ts`              | Source of truth for CRITICAL game variants | Modify — add optional `bgImage?: string` to type, populate for 6 variants with art                                |
+| `apps/web/src/app/[locale]/home/components/HomeHero.tsx`           | Renders the hero section + card stack      | Modify — curate 3 hero ids, replace card body with `next/image` + 2 text rows                                     |
+| `apps/web/src/app/[locale]/home/components/styles/home-bundle.css` | Hero / presentation styles                 | Modify — `.hero-card-main` gets scrims, inner ring, layered shadow, hover shimmer; `prefers-reduced-motion` guard |
+| `apps/web/src/features/games/lib/criticalVariants.test.ts`         | Unit test for variant data                 | Create — assert hero variants exist + have `bgImage` paths under `/images/variants/`                              |
+| `apps/web/e2e/homepage.spec.ts:85-100`                             | Existing e2e                               | Unchanged — must still pass (`hero-card-stack` count 3)                                                           |
+
+---
+
+## Pre-flight check
+
+- [ ] **Verify working tree and branch**
+
+Run:
+
+```bash
+git -C /Users/anatoliyaliaksandrau/js/arcadeum_claude status
+git -C /Users/anatoliyaliaksandrau/js/arcadeum_claude branch --show-current
+```
+
+Expected: on `ARC-734`, clean working tree (the spec commit `603bb8e9` is already on this branch).
+
+- [ ] **Verify the variant artwork is present**
+
+Run:
+
+```bash
+ls apps/web/public/images/variants/
+```
+
+Expected: `egypt_bg.png  fantasy_bg.png  galaxy_bg.png  steampunk_bg.png  western_bg.png  zen_bg.png`.
+
+If any of `fantasy_bg.png`, `galaxy_bg.png`, `steampunk_bg.png` is missing, stop and surface — the hero trio depends on them.
+
+---
+
+## Task 1: Add `bgImage` to CARD_VARIANTS (data + types)
+
+**Files:**
+
+- Modify: `apps/web/src/features/games/lib/criticalVariants.ts`
+- Create: `apps/web/src/features/games/lib/criticalVariants.test.ts`
+
+### Steps
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `apps/web/src/features/games/lib/criticalVariants.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { CARD_VARIANTS } from './criticalVariants';
+
+describe('CARD_VARIANTS bgImage field', () => {
+  const expectImage = (id: string, file: string) => {
+    const v = CARD_VARIANTS.find((c) => c.id === id);
+    expect(v, `variant ${id} should exist`).toBeDefined();
+    expect(v?.bgImage).toBe(`/images/variants/${file}`);
+  };
+
+  it('populates bgImage for the 6 variants with shipped artwork', () => {
+    expectImage('egypt', 'egypt_bg.png');
+    expectImage('fantasy', 'fantasy_bg.png');
+    expectImage('galaxy', 'galaxy_bg.png');
+    expectImage('steampunk', 'steampunk_bg.png');
+    expectImage('western', 'western_bg.png');
+    expectImage('zen', 'zen_bg.png');
+  });
+
+  it('leaves bgImage undefined for variants without shipped artwork', () => {
+    const noArtIds = [
+      'cyberpunk',
+      'underwater',
+      'crime',
+      'horror',
+      'adventure',
+      'high-altitude-hike',
+      'random',
+    ];
+    for (const id of noArtIds) {
+      const v = CARD_VARIANTS.find((c) => c.id === id);
+      expect(
+        v?.bgImage,
+        `variant ${id} should not have bgImage`,
+      ).toBeUndefined();
+    }
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to confirm it fails**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web test -- criticalVariants.test
+```
+
+Expected: FAIL — `bgImage` is not defined on any variant.
+
+- [ ] **Step 1.3: Add `bgImage` to the type and the 6 entries**
+
+Edit `apps/web/src/features/games/lib/criticalVariants.ts`. Change the type declaration to include `bgImage?: string` and add the field to the six entries.
+
+Type change (top of file):
+
+```ts
+export const CARD_VARIANTS: {
+  id: string;
+  name: string;
+  description: string;
+  emoji: string;
+  gradient: string;
+  bgImage?: string;
+  disabled?: boolean;
+}[] = [
+```
+
+Per-entry additions (insert `bgImage` line after `gradient`):
+
+- `fantasy`: `bgImage: '/images/variants/fantasy_bg.png',`
+- `galaxy`: `bgImage: '/images/variants/galaxy_bg.png',`
+- `steampunk`: `bgImage: '/images/variants/steampunk_bg.png',`
+- `egypt`: `bgImage: '/images/variants/egypt_bg.png',`
+- `western`: `bgImage: '/images/variants/western_bg.png',`
+- `zen`: `bgImage: '/images/variants/zen_bg.png',`
+
+- [ ] **Step 1.4: Run test to confirm it passes**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web test -- criticalVariants.test
+```
+
+Expected: PASS (both `it` blocks).
+
+- [ ] **Step 1.5: Type-check + lint**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web typecheck
+pnpm --filter @arcadeum/web lint
+```
+
+Expected: no errors. `CARD_VARIANTS` is also imported by `features/games/ui/create/constants.ts` (re-export) and `features/games/lib/variantRegistry.ts` — both ignore unknown fields, so the optional addition is non-breaking.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add apps/web/src/features/games/lib/criticalVariants.ts apps/web/src/features/games/lib/criticalVariants.test.ts
+git commit -m "feat(games): add optional bgImage to CARD_VARIANTS for shipped artwork (ARC-734)"
+```
+
+---
+
+## Task 2: Curate hero trio + rewrite card body in HomeHero
+
+**Files:**
+
+- Modify: `apps/web/src/app/[locale]/home/components/HomeHero.tsx`
+
+### Steps
+
+- [ ] **Step 2.1: Replace the `heroCards` memo + remove `THEME_COLORS`**
+
+Edit `apps/web/src/app/[locale]/home/components/HomeHero.tsx`. Two distinct edits in this file (do NOT delete the `export default function HomeHero()` declaration between them):
+
+**Edit A — top-level constants (lines 15–16):** replace
+
+```ts
+type ThemeColor = '$red10' | '$blue10' | '$purple10';
+const THEME_COLORS: ThemeColor[] = ['$red10', '$blue10', '$purple10'];
+```
+
+with
+
+```ts
+const HERO_VARIANT_IDS = ['fantasy', 'galaxy', 'steampunk'] as const;
+
+type HeroCard = {
+  nameKey: string;
+  bgImage?: string;
+};
+```
+
+**Edit B — inside the component body, the `heroCards` useMemo (currently lines 23–31):** replace the existing `useMemo(...)` call with
+
+```ts
+const heroCards = useMemo<HeroCard[]>(
+  () =>
+    HERO_VARIANT_IDS.map((id) => {
+      const v = CARD_VARIANTS.find((c) => c.id === id);
+      return {
+        nameKey: v?.name ?? '',
+        bgImage: v?.bgImage,
+      };
+    }),
+  [],
+);
+```
+
+- [ ] **Step 2.2: Add the `next/image` import**
+
+At the top of the file, after the `next/link` import:
+
+```ts
+import Image from 'next/image';
+```
+
+- [ ] **Step 2.3: Replace the card body markup**
+
+In the `.map((card, index) =>` block, replace the existing `<div className="hero-card-main" …>` and all its inner children (the colored overlay, the top span row with emoji, the centered 120px emoji block, and the bottom brand row) with this body:
+
+```tsx
+return (
+  <div
+    key={index}
+    className="hero-card-main"
+    style={
+      {
+        '--card-x': `${x}px`,
+        '--card-y': `${y}px`,
+        '--card-rotate': rotate,
+        '--card-scale': scale,
+        zIndex: zIndexVal,
+        opacity: opacity,
+      } as React.CSSProperties
+    }
+    data-testid={`hero-card-${index}`}
+  >
+    {card.bgImage ? (
+      <Image
+        src={card.bgImage}
+        alt=""
+        fill
+        priority={isLast}
+        sizes="(max-width: 1150px) 60vw, 280px"
+        className="hero-card-image"
+      />
+    ) : null}
+    <div className="hero-card-scrim hero-card-scrim-top" />
+    <div className="hero-card-scrim hero-card-scrim-bottom" />
+    <div className="hero-card-name">
+      {t(card.nameKey as TranslationKey) || card.nameKey}
+    </div>
+    <div className="hero-card-brand">{heroCardBrand}</div>
+  </div>
+);
+```
+
+Notes:
+
+- `alt=""` is intentional — the card is decorative; the page title and CTAs convey meaning. The variant name appears as visible text on the card, so screen-reader users still get context.
+- `priority={isLast}` keeps the front card eligible for LCP without preloading the two background cards.
+- All four `data-testid` selectors (`hero-section`, `hero-visual`, `hero-card-stack`, `hero-card-${index}`) are preserved.
+
+- [ ] **Step 2.4: Run the existing e2e to verify selectors still match**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web test:e2e -- homepage.spec.ts -g "Card stack"
+```
+
+(Look for the `hero-card-stack` assertion in `apps/web/e2e/homepage.spec.ts:85-100`.) Expected: PASS — count of `hero-card-*` is still 3.
+
+If e2e setup is heavy in your environment and the test infra isn't ready, you can defer this and run it after Task 3; record that in the commit footer.
+
+- [ ] **Step 2.5: Type-check + lint**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web typecheck
+pnpm --filter @arcadeum/web lint
+```
+
+Expected: no errors. Note: the `Hero.styles.tsx` re-import (line 24 of `home-bundle.css` comment) is not affected; nothing else references `THEME_COLORS`.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add apps/web/src/app/[locale]/home/components/HomeHero.tsx
+git commit -m "feat(home): render hero cards with full-bleed variant artwork (ARC-734)"
+```
+
+---
+
+## Task 3: Card surface styling — scrims, ring, shadow, shimmer
+
+**Files:**
+
+- Modify: `apps/web/src/app/[locale]/home/components/styles/home-bundle.css` (around lines 272–327)
+
+### Steps
+
+- [ ] **Step 3.1: Update `.hero-card-main` base rule (lines 282–303)**
+
+Replace the existing `.hero-card-main` rule with:
+
+```css
+.hero-card-main {
+  position: absolute;
+  width: 280px;
+  height: 380px;
+  background: rgba(20, 22, 26, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 24px;
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 6px 14px rgba(0, 0, 0, 0.3),
+    0 20px 40px -10px rgba(0, 0, 0, 0.55);
+  transform: translate(var(--card-x), var(--card-y)) rotate(var(--card-rotate))
+    scale(var(--card-scale));
+  opacity: 0;
+  transition:
+    transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.6s ease-out,
+    box-shadow 0.3s ease;
+  pointer-events: none;
+}
+```
+
+Key changes vs. current rule:
+
+- `overflow: hidden` so the `next/image` fill + scrims clip to the rounded corners.
+- `isolation: isolate` to keep the `::after` shimmer in its own stacking context.
+- Multi-layer shadow (outer elevation + inner ring) replaces the single `0 10px 30px`.
+- `backdrop-filter: blur` removed — the artwork now is the background, no blur needed.
+
+- [ ] **Step 3.2: Add `.hero-card-image` and scrim rules immediately after `.hero-card-main`**
+
+Insert (between the base rule and `.is-hydrated .hero-card-main`):
+
+```css
+.hero-card-image {
+  object-fit: cover;
+  object-position: center;
+  z-index: 0;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.hero-card-scrim {
+  position: absolute;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.hero-card-scrim-top {
+  top: 0;
+  height: 45%;
+  background: linear-gradient(
+    180deg,
+    rgba(0, 0, 0, 0.6) 0%,
+    rgba(0, 0, 0, 0.25) 60%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.hero-card-scrim-bottom {
+  bottom: 0;
+  height: 50%;
+  background: linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.7) 0%,
+    rgba(0, 0, 0, 0.3) 55%,
+    rgba(0, 0, 0, 0) 100%
+  );
+}
+
+.hero-card-name {
+  position: absolute;
+  top: 22px;
+  left: 24px;
+  right: 24px;
+  z-index: 2;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: -0.005em;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+.hero-card-brand {
+  position: absolute;
+  bottom: 22px;
+  left: 0;
+  right: 0;
+  z-index: 2;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.78);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+```
+
+- [ ] **Step 3.3: Update `.hero-card-main:hover` (line 309) + add shimmer**
+
+Replace the existing `.hero-card-main:hover` rule with:
+
+```css
+.hero-card-main:hover {
+  transform: translate(var(--card-x), calc(var(--card-y) - 20px))
+    rotate(var(--card-rotate)) scale(1.05) !important;
+  z-index: 100 !important;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.18),
+    0 12px 24px rgba(0, 0, 0, 0.4),
+    0 30px 60px -12px rgba(0, 0, 0, 0.7);
+}
+
+.hero-card-main::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  background: linear-gradient(
+    120deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.08) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  transition: transform 1.6s ease;
+}
+
+.hero-card-main:hover::after {
+  transform: translateX(100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-card-main::after,
+  .hero-card-main:hover::after {
+    transition: none;
+    transform: translateX(-100%);
+  }
+}
+```
+
+- [ ] **Step 3.4: Update the mobile media query (lines 317–326)**
+
+Replace the `@media (max-width: 1150px)` `.hero-card-main` background tweak. The dark fallback no longer makes sense once the card is an image; instead, leave the rule out entirely or, if you prefer to keep an explicit no-art fallback, scope it to a missing-image case. Recommended:
+
+```css
+@media (max-width: 1150px) {
+  .hero-card-stack {
+    margin-top: 60px;
+    margin-bottom: 40px;
+    transform: scale(0.85);
+  }
+}
+```
+
+(Drop the `.hero-card-main { background: rgba(30, 32, 35, 0.92); }` block — it overrode the artwork.)
+
+- [ ] **Step 3.5: Visual smoke check**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web dev
+```
+
+Open `http://localhost:3000/en` in a desktop-width browser:
+
+- Confirm the three cards show the AI artwork (fantasy / galaxy / steampunk) full-bleed.
+- Confirm the variant name reads cleanly at the top, `CRITICAL` reads cleanly at the bottom.
+- Hover the front card → the shimmer sweep happens once, smooth lift on hover.
+- Resize to <1150px → the card stack scales to 0.85, no broken background.
+
+Stop the dev server (Ctrl+C).
+
+- [ ] **Step 3.6: File-length + lint + typecheck**
+
+Run:
+
+```bash
+pnpm check-file-length
+pnpm --filter @arcadeum/web lint
+pnpm --filter @arcadeum/web typecheck
+```
+
+Expected: all pass. (`home-bundle.css` should stay well under 500 lines after this change.)
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add apps/web/src/app/[locale]/home/components/styles/home-bundle.css
+git commit -m "style(home): premium scrims, inner ring, elevation, hover shimmer on hero cards (ARC-734)"
+```
+
+---
+
+## Task 4: Full verification + e2e
+
+**Files:** none (verification only)
+
+### Steps
+
+- [ ] **Step 4.1: Run web unit tests**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web test
+```
+
+Expected: all tests pass, including the new `criticalVariants.test.ts`.
+
+- [ ] **Step 4.2: Run the homepage e2e**
+
+Run:
+
+```bash
+pnpm --filter @arcadeum/web test:e2e -- homepage.spec.ts
+```
+
+Expected: hero-card-stack assertion (lines 85–100) passes; other homepage specs unaffected. If anything else breaks, the cause is unrelated to this ticket — surface, don't paper over.
+
+- [ ] **Step 4.3: Performance spot-check**
+
+Run dev (`pnpm --filter @arcadeum/web dev`), open DevTools → Network, hard-reload `http://localhost:3000/en`:
+
+- The front card image should be requested as `image/avif` or `image/webp` (not the raw PNG).
+- Total bytes for the three card images at the rendered 280×380 size should be well under 500 KB combined.
+- LCP candidate (Lighthouse → Performance, or DevTools Performance panel) should include the front-card image, not the H1.
+
+This is guidance, not a hard gate — log results and proceed.
+
+- [ ] **Step 4.4: Reduced-motion check**
+
+In DevTools → Rendering panel, enable `prefers-reduced-motion: reduce`. Reload. Hover the front card → no shimmer animation; the lift transform still happens.
+
+- [ ] **Step 4.5: Final clean status**
+
+Run:
+
+```bash
+git -C /Users/anatoliyaliaksandrau/js/arcadeum_claude status
+git -C /Users/anatoliyaliaksandrau/js/arcadeum_claude log --oneline origin/develop..HEAD
+```
+
+Expected: clean tree; 4 commits ahead of `origin/develop` (spec + 3 implementation commits).
+
+- [ ] **Step 4.6: Done — handoff**
+
+The branch is ready for PR review. The user (AnAtoliy-AA) decides whether to push and open the PR (per project memory, pull develop before pushing — we branched from `origin/develop`, so the branch is already current).
+
+---
+
+## Out of scope (do not do in this plan)
+
+- Don't migrate other CARD_VARIANTS consumers (games index, variant picker) to use `bgImage` — separate ticket.
+- Don't generate new artwork for the variants that lack `bgImage`.
+- Don't restructure `home-bundle.css` beyond the `.hero-card*` rules touched above.
+- Don't touch `apps/web/e2e/homepage.spec.ts` — the existing selectors must still match.

--- a/docs/superpowers/specs/2026-05-23-home-hero-cards-premium-design.md
+++ b/docs/superpowers/specs/2026-05-23-home-hero-cards-premium-design.md
@@ -1,0 +1,166 @@
+# Home Hero Cards — Premium Visual Refresh (ARC-734)
+
+**Status:** Approved (design phase)
+**Date:** 2026-05-23
+**Branch:** ARC-734
+**Owner:** AnAtoliy-AA
+
+## Problem
+
+The home page hero (`apps/web/src/app/[locale]/home/components/HomeHero.tsx`) shows three fanned-out cards representing CRITICAL game variants. Each card centers a 120px emoji (🤖, 🦑, 🕵️‍♀️) on a flat semi-transparent color tile. The emoji centerpiece reads as a placeholder and undermines the otherwise polished hero layout. The product needs the hero to feel premium and modern on first paint.
+
+## Goal
+
+Replace the emoji-driven cards with full-bleed AI artwork that already ships in the repo, presented with refined typography and a card surface treatment (scrims, inner ring, elevation) that reads as a premium playing card. Keep the existing fan-out stack and animations.
+
+## Non-goals
+
+- Generating new artwork or touching the sprite sheets in `apps/web/public/images/cards/`.
+- Refactoring `CARD_VARIANTS` beyond adding one optional field.
+- Changing the games index page or any other surface that consumes `CARD_VARIANTS`.
+- Internationalising new copy — the design reuses existing keys (`games.critical_v1.variants.*.name`, `home.heroCardBrand`).
+
+## Background
+
+### Current implementation
+
+`HomeHero.tsx` (lines 23–31, 137–225) picks `CARD_VARIANTS.slice(0, 3)` — currently cyberpunk, underwater, crime — and renders each as a div with:
+
+- A solid colored background overlay at 60% opacity (`var(--<colorToken>)`).
+- A top row with the variant name (left) and a small emoji (right).
+- A 120px emoji centered in the body.
+- A bottom row with the `CRITICAL` brand label.
+
+The fan-out positioning lives in inline CSS variables (`--card-x`, `--card-y`, `--card-rotate`, `--card-scale`) and is animated by `.hero-card-main` rules in `apps/web/src/app/[locale]/home/components/styles/home-bundle.css:282–330`.
+
+### Available artwork
+
+`apps/web/public/images/variants/` contains six 1024×1024 background paintings shipped as `.png` (egypt, fantasy, galaxy, steampunk, western, zen). File sizes range 713 KB–1.0 MB. Each has a clear central subject and dramatic color palette — production-grade quality.
+
+### Selected hero trio
+
+**Fantasy / Galaxy / Steampunk.** Chosen because:
+
+- Color palettes are mutually distinct (green-teal, cosmic purple, copper-warm), so a fanned stack reads as three clearly different cards.
+- Each has a strong central subject (dragon, space station, gear mechanism) that sits well behind a top title and bottom brand label.
+- This trio mirrors the red/blue/purple silhouette of the current stack — visual rhythm of the existing composition is preserved.
+
+## Design
+
+### Card composition (front card)
+
+```
+┌───────────────────────────────────┐  rounded 20px
+│ ░░░ dark gradient scrim, ~30% ░░░ │  ← legibility top
+│  Fantasy                          │  ← variant name (i18n)
+│                                   │
+│                                   │
+│        full-bleed artwork         │  ← <Image fill> 1024×1024 source
+│                                   │
+│                                   │
+│ ░░░ dark gradient scrim, ~40% ░░░ │  ← legibility bottom
+│             CRITICAL              │  ← brand label
+└───────────────────────────────────┘
+   ↳ outer drop shadow, inner 1px ring at white@8%
+```
+
+- **Top scrim:** linear-gradient from `rgba(0,0,0,0.55)` at the top to transparent ~35% down.
+- **Bottom scrim:** linear-gradient from transparent ~60% down to `rgba(0,0,0,0.65)` at the bottom.
+- **Inner ring:** `box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08)` for subtle edge definition.
+- **Outer elevation:** layered drop shadow (e.g. `0 20px 40px -10px rgba(0,0,0,0.55), 0 6px 14px rgba(0,0,0,0.3)`).
+- **No emoji** anywhere on the card. The top-right emoji and the 120px centerpiece are both removed.
+
+### Typography
+
+- **Variant name:** existing token, weight 600, slight letter-spacing (`-0.005em`), `color: #fff`, `text-shadow: 0 1px 2px rgba(0,0,0,0.6)` for art-on-text contrast.
+- **Brand label (`CRITICAL`):** uppercase, `letter-spacing: 0.18em`, `color: rgba(255,255,255,0.78)`, weight 700, font-size 12–13px.
+
+### Stack and motion
+
+- **Fan layout:** unchanged — same x/y/rotate/scale CSS variable contract.
+- **Hover:** keep existing transform-on-hover from `.hero-card-main:hover`.
+- **Premium foil shimmer (subtle):** a `::after` pseudo-element on `.hero-card-main` with a diagonal `linear-gradient(120deg, transparent 30%, rgba(255,255,255,0.06) 50%, transparent 70%)` translated across the card on hover with a 1.6s ease. Always-on shimmer would be too noisy — only animates on hover of the front card.
+- **`prefers-reduced-motion`:** disables the shimmer and falls back to the current static hover lift.
+
+### Data model
+
+Add an optional field to `CARD_VARIANTS` for variants that have shipped background art:
+
+```ts
+// apps/web/src/features/games/lib/criticalVariants.ts
+{
+  id: 'fantasy',
+  name: 'games.critical_v1.variants.fantasy.name',
+  description: '…',
+  emoji: '🐉',
+  gradient: '…',
+  bgImage: '/images/variants/fantasy_bg.png',  // ← new, optional
+},
+```
+
+Populate `bgImage` for: `egypt`, `fantasy`, `galaxy`, `steampunk`, `western`, `zen`. Leave undefined elsewhere. This is non-breaking — consumers that ignore `bgImage` are unaffected.
+
+### Hero variant selection
+
+Replace the slice with an explicit curated list:
+
+```ts
+// HomeHero.tsx
+const HERO_VARIANT_IDS = ['fantasy', 'galaxy', 'steampunk'] as const;
+
+const heroCards = useMemo(
+  () =>
+    HERO_VARIANT_IDS.map((id, i) => {
+      const v = CARD_VARIANTS.find((c) => c.id === id);
+      return {
+        name: v?.name ?? '',
+        bgImage: v?.bgImage,
+      };
+    }),
+  [],
+);
+```
+
+If a referenced variant ever loses its `bgImage` (e.g. asset deleted), the card renders a solid fallback (`var(--<id>-fallback)` or the existing gradient) rather than crashing.
+
+### Image delivery
+
+- Use `next/image` with `fill`, `priority={isFront}`, `sizes="(max-width: 768px) 60vw, 320px"`.
+- `next/image` will serve AVIF/WebP automatically — the existing PNGs stay as the source.
+- Object-fit cover, object-position center.
+
+## File changes (summary)
+
+| File                                                               | Change                                                                                                                                 |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/web/src/features/games/lib/criticalVariants.ts`              | Add optional `bgImage?: string` to the entry type. Populate for 6 variants with art.                                                   |
+| `apps/web/src/app/[locale]/home/components/HomeHero.tsx`           | Replace `slice(0, 3)` with curated `HERO_VARIANT_IDS`. Strip inline emoji/style block. Render `next/image` background + two text rows. |
+| `apps/web/src/app/[locale]/home/components/styles/home-bundle.css` | Add scrim gradients, inner ring, outer shadow, `prefers-reduced-motion` guard, and `::after` shimmer rules.                            |
+| `apps/web/src/app/[locale]/home/components/styles/Hero.styles.tsx` | No change expected; only the bundle CSS rules for `.hero-card-main` evolve.                                                            |
+
+## Edge cases & states
+
+- **Variant without `bgImage`:** card falls back to its `CARD_VARIANTS.gradient` (so the curated-but-missing case still renders something premium-looking).
+- **Image load failure:** `next/image` `onError` handler swaps to gradient fallback. The card never shows a broken-image icon.
+- **SSR / before hydration:** `Image priority` on the front card means it's part of the LCP candidate set. The other two cards lazy-load.
+- **Reduced motion:** shimmer suppressed; hover transform stays.
+- **Tests:** existing `data-testid="hero-card-${index}"` and `data-testid="hero-card-stack"` selectors are preserved so any e2e referencing them is unaffected.
+
+## Risks & mitigations
+
+- **LCP regression** — adding a remote image to the LCP slot could slow it down. Mitigation: `priority` only on the front card, correct `sizes` attribute, source is already in `public/`.
+- **File weight** — 3 × ~900 KB PNGs is 2.7 MB raw. Mitigation: `next/image` AVIF/WebP transforms bring each to ~80–150 KB at the rendered size.
+- **Visual review across themes** — light theme will need scrim contrast verified. Current hero background is dark, so scrims are already tuned for that case; we'll spot-check.
+
+## Out of scope
+
+- Adopting `bgImage` on the games index / variant picker — separate ticket if desired.
+- Replacing emoji in the variant picker overlay.
+- Generating artwork for the 6 variants that don't have backgrounds.
+
+## Verification plan
+
+- Visual: load `/`, confirm all three cards render the AI artwork, fan-out unchanged, hover shimmer plays on the front card, scrims keep text legible.
+- Performance: confirm LCP element is the front-card image; verify network panel shows AVIF/WebP, not PNG, and total card weight under ~500 KB combined.
+- A11y: confirm reduced-motion suppresses shimmer; confirm card text contrast passes WCAG AA against the scrims.
+- Regression: existing `data-testid` selectors still match; `pnpm test` (web) passes; `pnpm lint` and `pnpm check-file-length` pass.


### PR DESCRIPTION
## Summary

- Replace the emoji-driven hero card centerpieces with full-bleed AI artwork (fantasy / galaxy / steampunk) over a refined card surface — scrims, inner ring, layered drop shadow, hover shimmer.
- Add a hover-revealed `Play` CTA on every card that routes to `/<locale>/games/create?variant=<id>` so the lobby preselects the variant.
- Add optional `bgImage?: string` to `CARD_VARIANTS` (populated for the 6 variants with shipped artwork); add `heroCardPlayCta` i18n key across all 5 locales.

## Why

The previous hero stack centered a 120px emoji on a flat colored tile — it read as a placeholder against an otherwise polished hero. The new treatment uses production-grade AI paintings already in `public/images/variants/`, framed by gradient scrims, an inset 1px ring, and a 3-layer drop shadow, with a glossy white pill CTA that fades in on hover. `prefers-reduced-motion` suppresses the shimmer and CTA scale-in.

## Changes

- `apps/web/src/features/games/lib/criticalVariants.ts` — add optional `bgImage?: string`; populate for `egypt`, `fantasy`, `galaxy`, `steampunk`, `western`, `zen`.
- `apps/web/src/features/games/lib/criticalVariants.test.ts` — new Vitest covering presence + absence of `bgImage`.
- `apps/web/src/app/[locale]/home/components/HomeHero.tsx` — curate hero trio explicitly (`fantasy / galaxy / steampunk`), render `next/image` with `priority` on the front card, add per-card `Play` `<Link>`.
- `apps/web/src/app/[locale]/home/components/styles/home-bundle.css` — scrims, inner ring, layered shadow, hover shimmer, `prefers-reduced-motion` guard, frosted Play CTA.
- `apps/web/src/shared/i18n/messages/home.ts` — add `heroCardPlayCta` for en/es/fr/ru/by.
- `docs/superpowers/specs/2026-05-23-home-hero-cards-premium-design.md` + `docs/superpowers/plans/2026-05-23-home-hero-cards-premium.md` — design spec and step-by-step plan.

## Test plan

- [ ] Desktop browser: confirm three cards render full-bleed artwork (fantasy / galaxy / steampunk) with variant name top-left, CRITICAL brand bottom-center.
- [ ] Hover each card: lift transform + shimmer sweep + white `Play` button fades in centered.
- [ ] Click `Play` on each card: lands on `/games/create?variant=<id>` with the variant preselected in the lobby.
- [ ] Resize <1150px: card stack scales to 0.85, artwork still renders, no dark background override.
- [ ] DevTools → Rendering → `prefers-reduced-motion: reduce`: shimmer + CTA scale-in suppressed, lift transform still works.
- [ ] DevTools → Network → hard reload: front-card image served as AVIF/WebP, not raw PNG.
- [ ] `pnpm --filter web test` — 1008 / 1008 passing.
- [ ] `pnpm --filter web test:e2e -- homepage.spec.ts` — `hero-card-stack` count assertion still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up work (not in this PR)

Preexisting issues surfaced during ARC-734 verification — none introduced by this branch, but tracked for future:

- #735 — BE dev-script race: `node dist/src/main.js` starts before `tsc --watch` emits all files
- #736 — Missing `$error` Tamagui theme token (also responsible for the misleading "duplicate Tamagui" warning)
- #737 — Hydration mismatch on `/<locale>/games/create` (Tamagui SSR class-name divergence). The Play CTA added in this PR sends users into this page; the mismatch reproduces on develop.
