### PR TITLE
fix(ui,be): silence Tamagui $error warning + fix BE dev-script race (ARC-737, ARC-738, ARC-739)

### DIFF
--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "dev": "nest start --watch",
+    "dev": "rm -rf dist && nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/packages/ui/src/tamagui.config.ts
+++ b/packages/ui/src/tamagui.config.ts
@@ -112,6 +112,17 @@ const themeBase = {
   primaryText: '#ffffff',
   secondary: '#4338ca',
   danger: '#b91c1c',
+  // Alias the danger palette under the `$error*` namespace so components
+  // that follow the standard form-validation naming (Input, FormGroup,
+  // TextArea, Select, admin/tournaments error banners) resolve their
+  // tokens at SSR. A missing token here causes Tamagui to emit inline
+  // style fallbacks server-side and atomic classes client-side, which
+  // triggers hydration mismatches on any page using these components.
+  error: '#b91c1c',
+  errorText: '#ffffff',
+  errorBg: 'rgba(220, 38, 38, 0.15)',
+  errorBgSoft: 'rgba(185, 28, 28, 0.1)',
+  errorBorder: 'rgba(185, 28, 28, 0.4)',
   success: '#047857',
   warning: '#92400e',
   info: '#2563eb',


### PR DESCRIPTION
## Summary

- **(ARC-737) Web hydration mismatch on `/<locale>/games/create`** — addressed via the `$error` token fix below. The mismatch came from missing theme tokens that caused Tamagui to emit inline styles server-side and atomic classes client-side. With the tokens defined, the SSR/CSR output converges.
- **(ARC-738) Missing `$error` Tamagui theme tokens** — added `$error`, `$errorText`, `$errorBg`, `$errorBgSoft`, `$errorBorder` to `themeBase` in `packages/ui/src/tamagui.config.ts`. Values mirror the existing danger palette so visuals stay consistent.
- **(ARC-739) BE dev-script race** — `apps/be/package.json` `dev` script now does `rm -rf dist && nest start --watch` so node never boots against a partial compiled tree.

## Why

These were all surfaced during the ARC-734 (#731) dev session. None are regressions from that ticket, but together they corrupt the dev experience: the BE crashes intermittently on cold start, the home page logs a misleading Tamagui warning that has been sending debugging down the wrong path (it suggests duplicated Tamagui — verified there is only one), and the create-game-room page hydrates with className/style divergence.

## Changes

- `apps/be/package.json` — prefix `dev` with `rm -rf dist`.
- `packages/ui/src/tamagui.config.ts` — add 5 `$error*` theme entries in `themeBase` (inherited by every theme).

## Verification

- `pnpm --filter web type-check` ✅
- `pnpm --filter @arcadeum/ui type-check` ✅
- `pnpm --filter web lint` ✅
- `pnpm --filter web test` ✅ (1008 / 1008 passing)
- Preexisting `@arcadeum/ui` test failures (Button, CollapsibleSection, ErrorState, Modal, ServerLoadingNotice — 13 total) reproduce on clean develop and are unrelated to this PR.

## Test plan

- [ ] After merge: `pkill -f "next dev"; rm -rf apps/web/.next apps/be/dist; pnpm dev`.
- [ ] Confirm BE boots cleanly (no `Cannot find module './app.controller'`).
- [ ] Confirm no `[tamagui] Warning: missing token color in category color - $error` line in web logs on first render.
- [ ] Visit `/en/games/create?gameId=critical_v1&variant=cyberpunk` — confirm no React hydration warnings in the console for FormGroup / Input. (Other hydration warnings unrelated to `$error` — Container/Button/h1 — are tracked separately under the Tamagui SSR class-name divergence on Turbopack and not in scope here.)

Closes #735
Closes #736
Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)