### PR TITLE
fix(gems): redirect unauthorized users to sign-in when buying gems (ARC-742)

### DIFF
--- a/apps/web/src/features/gems/server/gems.actions.test.ts
+++ b/apps/web/src/features/gems/server/gems.actions.test.ts
@@ -92,6 +92,18 @@ describe('buyGemsAction', () => {
     const result = await buyGemsAction({ packageId: 'pkg-1' });
     expect(result).toEqual({ ok: false, error: 'generic' });
   });
+
+  it('returns unauthorized error on 401', async () => {
+    fetchMock.mockResolvedValue(makeErrorResponse(401));
+    const result = await buyGemsAction({ packageId: 'pkg-1' });
+    expect(result).toEqual({ ok: false, error: 'unauthorized' });
+  });
+
+  it('returns unauthorized error on 403', async () => {
+    fetchMock.mockResolvedValue(makeErrorResponse(403));
+    const result = await buyGemsAction({ packageId: 'pkg-1' });
+    expect(result).toEqual({ ok: false, error: 'unauthorized' });
+  });
 });
 
 // ─── finalizeGemPurchaseAction ────────────────────────────────────────────────

--- a/apps/web/src/features/gems/server/gems.actions.ts
+++ b/apps/web/src/features/gems/server/gems.actions.ts
@@ -9,7 +9,15 @@ import type { ConversionResult } from './gems.types';
 
 export type BuyGemsResult =
   | { ok: true; approveUrl: string; paypalOrderId: string }
-  | { ok: false; error: 'not_found' | 'inactive' | 'unavailable' | 'generic' };
+  | {
+      ok: false;
+      error:
+        | 'not_found'
+        | 'inactive'
+        | 'unavailable'
+        | 'unauthorized'
+        | 'generic';
+    };
 
 export type FinalizeGemPurchaseResult =
   | {
@@ -66,6 +74,9 @@ export async function buyGemsAction(input: {
     body: JSON.stringify({ packageId: input.packageId }),
   });
 
+  if (res.status === 401 || res.status === 403) {
+    return { ok: false, error: 'unauthorized' };
+  }
   if (res.status === 404) return { ok: false, error: 'not_found' };
   if (res.status === 400) {
     const body = await res.json().catch(() => ({}));

--- a/apps/web/src/features/gems/ui/BuyGemsButton.test.tsx
+++ b/apps/web/src/features/gems/ui/BuyGemsButton.test.tsx
@@ -95,4 +95,26 @@ describe('BuyGemsButton', () => {
       expect(alertMock).toHaveBeenCalledWith('Package not found.');
     });
   });
+
+  it('redirects to /auth when not authenticated, without calling the action', async () => {
+    render(<BuyGemsButton packageId="pkg-1" isAuthenticated={false} />);
+    fireEvent.click(screen.getByTestId('buy-gems-btn-pkg-1'));
+
+    await waitFor(() => {
+      expect(locationMock.href).toBe('/auth');
+    });
+    expect(mockBuyGemsAction).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /auth when the action returns unauthorized', async () => {
+    mockBuyGemsAction.mockResolvedValue({ ok: false, error: 'unauthorized' });
+
+    render(<BuyGemsButton packageId="pkg-1" />);
+    fireEvent.click(screen.getByTestId('buy-gems-btn-pkg-1'));
+
+    await waitFor(() => {
+      expect(locationMock.href).toBe('/auth');
+    });
+    expect(alertMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/features/gems/ui/BuyGemsButton.tsx
+++ b/apps/web/src/features/gems/ui/BuyGemsButton.tsx
@@ -6,20 +6,32 @@ import { buyGemsAction } from '../server/gems.actions';
 interface BuyGemsButtonProps {
   packageId: string;
   label?: string;
+  isAuthenticated?: boolean;
 }
 
 export function BuyGemsButton({
   packageId,
   label = 'Buy with PayPal',
+  isAuthenticated = true,
 }: BuyGemsButtonProps) {
   const [isPending, startTransition] = useTransition();
 
   const handleClick = () => {
+    if (!isAuthenticated) {
+      window.location.href = '/auth';
+      return;
+    }
+
     startTransition(async () => {
       const result = await buyGemsAction({ packageId });
 
       if (result.ok) {
         window.location.href = result.approveUrl;
+        return;
+      }
+
+      if (result.error === 'unauthorized') {
+        window.location.href = '/auth';
         return;
       }
 

--- a/apps/web/src/features/gems/ui/GemPackageCard.tsx
+++ b/apps/web/src/features/gems/ui/GemPackageCard.tsx
@@ -6,11 +6,13 @@ import { BuyGemsButton } from './BuyGemsButton';
 interface GemPackageCardProps {
   pkg: GemPackagePublic;
   locale?: Locale;
+  isAuthenticated?: boolean;
 }
 
 export function GemPackageCard({
   pkg,
   locale = DEFAULT_LOCALE,
+  isAuthenticated = true,
 }: GemPackageCardProps) {
   const priceDisplay = formatCurrency(pkg.priceUsdCents / 100, locale, 'USD');
   const totalGems = pkg['gems'] + pkg['bonusGems'];
@@ -88,7 +90,7 @@ export function GemPackageCard({
         >
           {priceDisplay}
         </div>
-        <BuyGemsButton packageId={pkg.id} />
+        <BuyGemsButton packageId={pkg.id} isAuthenticated={isAuthenticated} />
       </div>
     </div>
   );

--- a/apps/web/src/features/gems/ui/GemStore.tsx
+++ b/apps/web/src/features/gems/ui/GemStore.tsx
@@ -1,12 +1,15 @@
 import { getServerLocale } from '@/shared/i18n/server';
+import { getServerAccessToken } from '@/entities/session/api/serverTokens';
 import { getActivePackages } from '../server/gems.server';
 import { GemPackageCard } from './GemPackageCard';
 
 export async function GemStore() {
-  const [packages, locale] = await Promise.all([
+  const [packages, locale, accessToken] = await Promise.all([
     getActivePackages(),
     getServerLocale(),
+    getServerAccessToken(),
   ]);
+  const isAuthenticated = Boolean(accessToken);
 
   if (packages.length === 0) {
     return (
@@ -51,7 +54,12 @@ export async function GemStore() {
         }}
       >
         {packages.map((pkg) => (
-          <GemPackageCard key={pkg.id} pkg={pkg} locale={locale} />
+          <GemPackageCard
+            key={pkg.id}
+            pkg={pkg}
+            locale={locale}
+            isAuthenticated={isAuthenticated}
+          />
         ))}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Unauthenticated visitors clicking **Buy with PayPal** in the gem store were hitting `POST /payments/gems/orders` without a token and seeing a generic *"Something went wrong"* alert.
- The button now redirects to `/auth` immediately when no session is present, and the server action normalizes `401`/`403` into an `unauthorized` result so the button can also redirect on stale tokens.
- `GemStore` (server component) reads `getServerAccessToken()` and threads `isAuthenticated` down through `GemPackageCard` → `BuyGemsButton`.

## Why
ARC-742: unauthorized users trying to buy gems should land on the sign-in page instead of a confusing error toast.

## Changes
- `apps/web/src/features/gems/ui/BuyGemsButton.tsx` — new optional `isAuthenticated` prop; short-circuits to `/auth` before calling the action and on `unauthorized` result.
- `apps/web/src/features/gems/ui/GemPackageCard.tsx` — forwards `isAuthenticated`.
- `apps/web/src/features/gems/ui/GemStore.tsx` — server-side reads access token and passes `isAuthenticated` to each card.
- `apps/web/src/features/gems/server/gems.actions.ts` — `buyGemsAction` returns `{ error: 'unauthorized' }` on `401`/`403`.
- Vitest specs updated to cover both paths (no-token short-circuit and `unauthorized` from the action).

## Test plan
- [x] `pnpm vitest run` — gems unit tests (button, package card, action) all green
- [x] `pnpm type-check` — clean
- [x] `pnpm lint src/features/gems` — clean
- [ ] Manual: sign out, open `/wallet`, click **Buy with PayPal** → lands on `/auth`
- [ ] Manual: sign in, click **Buy with PayPal** → PayPal redirect still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)