### PR TITLE
fix(games): join any room via invite code (ARC-745)

### DIFF
--- a/apps/be/src/games/games.controller.ts
+++ b/apps/be/src/games/games.controller.ts
@@ -171,6 +171,20 @@ export class GamesController {
   }
 
   @UseGuards(JwtOptionalAuthGuard)
+  @Get('rooms/by-code/:code')
+  async findRoomByInviteCode(
+    @Req() req: Request,
+    @Param('code') code: string,
+  ): Promise<{ room: Awaited<ReturnType<GamesService['getRoom']>> }> {
+    const user = req.user as AuthenticatedUser | undefined | null;
+    const room = await this.gamesService.findRoomByInviteCode(
+      code,
+      user?.userId,
+    );
+    return { room };
+  }
+
+  @UseGuards(JwtOptionalAuthGuard)
   @Post('room-info')
   async getRoomInfoBody(
     @Req() req: Request,

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -89,9 +89,10 @@ export class GamesService {
     return this.roomsService.getRoom(roomId, userId);
   }
 
-  /**
-   * Get room with session
-   */
+  async findRoomByInviteCode(code: string, viewerId?: string) {
+    return this.roomsService.findByInviteCode(code, viewerId);
+  }
+
   async getRoomSession(roomId: string, userId?: string) {
     const room = await this.roomsService.getRoom(roomId, userId);
     let session = await this.sessionsService.findSessionByRoom(roomId);

--- a/apps/be/src/games/rooms/game-rooms.service.ts
+++ b/apps/be/src/games/rooms/game-rooms.service.ts
@@ -109,9 +109,21 @@ export class GameRoomsService {
     };
   }
 
-  /**
-   * Get a specific room by ID
-   */
+  // Bypasses canViewRoom so non-participants can discover a private room they
+  // were invited to. Joining still validates the code in joinRoom.
+  async findByInviteCode(
+    code: string,
+    viewerId?: string,
+  ): Promise<GameRoomSummary> {
+    const normalized = code.trim().toUpperCase();
+    if (!normalized) throw new NotFoundException('Room not found');
+    const room = await this.gameRoomModel
+      .findOne({ inviteCode: normalized })
+      .exec();
+    if (!room) throw new NotFoundException('Room not found');
+    return this.gameRoomsMapper.prepareRoomSummary(room, viewerId);
+  }
+
   async getRoom(roomId: string, userId?: string): Promise<GameRoomSummary> {
     if (!Types.ObjectId.isValid(roomId)) {
       throw new NotFoundException(`Invalid room ID format: ${roomId}`);
@@ -432,12 +444,6 @@ export class GameRoomsService {
     return false;
   }
 
-  /**
-   * Decline a rematch invitation
-   */
-  /**
-   * Decline a rematch invitation
-   */
   async declineRematchInvitation(
     roomId: string,
     userId: string,

--- a/apps/be/src/games/rooms/game-rooms.service.ts
+++ b/apps/be/src/games/rooms/game-rooms.service.ts
@@ -48,10 +48,7 @@ export class GameRoomsService {
     userId: string,
     dto: CreateGameRoomDto,
   ): Promise<GameRoomSummary> {
-    const inviteCode =
-      dto.visibility === 'private'
-        ? await this.generateInviteCode()
-        : undefined;
+    const inviteCode = await this.generateInviteCode();
 
     const room = await this.gameRoomModel.create({
       gameId: dto.gameId,

--- a/apps/web/src/app/[locale]/games/components/InviteCodeModal.tsx
+++ b/apps/web/src/app/[locale]/games/components/InviteCodeModal.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import { useMutation } from '@/shared/hooks/useMutation';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useRoutes } from '@/shared/config/useRoutes';
+import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import {
   Modal,
   ModalContent,
@@ -15,6 +16,7 @@ import {
   FormGroup,
 } from '@/shared/ui';
 import { gamesApi } from '@/features/games/api';
+import { HttpStatus } from '@/shared/lib/http-status';
 
 interface InviteCodeModalProps {
   open: boolean;
@@ -25,34 +27,37 @@ export function InviteCodeModal({ open, onClose }: InviteCodeModalProps) {
   const { t } = useTranslation();
   const router = useRouter();
   const routes = useRoutes();
+  const { snapshot } = useSessionTokens();
   const [code, setCode] = useState('');
 
   const { mutate, isLoading, error, reset } = useMutation({
     mutationFn: async (inviteCode: string) => {
-      // Search for room by invite code
-      const response = await gamesApi.getRooms({
-        search: inviteCode,
-        limit: 50,
-      });
-
-      // Find the exact room with this invite code
-      const room =
-        response.rooms.find((r) => r.inviteCode === inviteCode) ||
-        response.rooms[0];
-
-      if (!room) {
-        throw new Error(
-          t('games.inviteCode.errors.notFound') || 'Room not found',
-        );
+      const normalized = inviteCode.trim().toUpperCase();
+      try {
+        return await gamesApi.getRoomByCode(normalized, {
+          token: snapshot.accessToken || undefined,
+        });
+      } catch (err: unknown) {
+        const status =
+          err && typeof err === 'object'
+            ? ((err as { status?: number; statusCode?: number }).status ??
+              (err as { statusCode?: number }).statusCode)
+            : undefined;
+        if (status === HttpStatus.NOT_FOUND) {
+          throw new Error(
+            t('games.inviteCode.errors.notFound') || 'Room not found',
+          );
+        }
+        throw err;
       }
-
-      return room;
     },
-    onSuccess: (room, inviteCode) => {
+    onSuccess: (room) => {
       onClose();
       // Pass invite code in URL so GameRoomPage auto-joins without re-entering
       router.push(
-        `${routes.gameRoom(room.id)}?inviteCode=${encodeURIComponent(inviteCode)}`,
+        `${routes.gameRoom(room.id)}?inviteCode=${encodeURIComponent(
+          code.trim().toUpperCase(),
+        )}`,
       );
     },
   });

--- a/apps/web/src/features/games/api.ts
+++ b/apps/web/src/features/games/api.ts
@@ -153,6 +153,18 @@ export const gamesApi = {
     }
   },
 
+  getRoomByCode: async (
+    code: string,
+    options?: ApiClientOptions,
+  ): Promise<GameRoomSummary> => {
+    const normalized = code.trim().toUpperCase();
+    const data = await apiClient.get<{ room: GameRoomSummary }>(
+      `/games/rooms/by-code/${encodeURIComponent(normalized)}`,
+      options,
+    );
+    return data.room;
+  },
+
   getRoomInfo: async (
     roomId: string,
     options?: ApiClientOptions,


### PR DESCRIPTION
## Summary
- Every room now gets an invite code on creation (not only private rooms), so the code can be shared as a join shortcut for public games too.
- New backend lookup `GET /games/rooms/by-code/:code` (case-insensitive, anon-host friendly, bypasses the private-room visibility gate so non-participants can resolve the room from a shared code).
- `InviteCodeModal` switched to the new endpoint with normalized input (trim + uppercase) and the brittle "first matching room" fallback removed.

## Why
The "Join a Private Game" modal previously called `/games/rooms?search=CODE`, which always applies `hostId: { $not: /^anon_/ }` to suppress guest-created rooms from public listings. A guest-hosted room could never be joined via code — the modal returned "Room not found or invite code invalid". Generating a code for every room and routing the lookup through a dedicated endpoint fixes both halves of the problem.

Joining still validates the code in `joinRoom` for `visibility === 'private'` rooms — public rooms treat the code purely as a share shortcut.

## Test plan
- [ ] As a logged-in user, create a public room → confirm the lobby sidebar now shows the invite code with copy.
- [ ] As a logged-in user, create a private room → existing behavior unchanged.
- [ ] In another session, open `/games`, click the invite-code modal, paste the code (mixed case, leading whitespace) → joins the room.
- [ ] As a guest (no login), create a room, share the URL — second guest joins via the invite-code modal using the code from the lobby.
- [ ] Wrong code → modal shows "Room not found or invite code invalid".
- [ ] Direct URL `/games/rooms/:id?inviteCode=CODE` still auto-joins private rooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)