### PR TITLE
fix(games): sea battle lobby crash when gameOptions.teams is not an array (ARC-752)

### DIFF
--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -103,9 +103,15 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
   // Team mode state derived from room game options
   const teamOpts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
   const teamMode = !!teamOpts.teamMode;
-  // Memoized so the `?? []` fallback doesn't return a fresh array reference
-  // each render and bust downstream useMemo deps.
-  const teams = React.useMemo(() => teamOpts.teams ?? [], [teamOpts.teams]);
+  // gameOptions is `Record<string, unknown>` over the wire (Mongoose Mixed), so
+  // the cast above doesn't validate the runtime shape. Guard with isArray to
+  // tolerate stale/corrupted server data — without it, `.reduce` below crashes
+  // the entire lobby render the moment `teams` is anything other than nullish
+  // or an array.
+  const teams = React.useMemo(
+    () => (Array.isArray(teamOpts.teams) ? teamOpts.teams : []),
+    [teamOpts.teams],
+  );
   const hideShipsFromTeammates = !!teamOpts.hideShipsFromTeammates;
 
   // In team mode, the lobby cap is the sum of team target sizes (up to 8).


### PR DESCRIPTION
## What
Stop the Sea Battle lobby from crashing with `teams.reduce is not a function` when `room.gameOptions.teams` arrives as anything other than nullish or an array.

## Why
`room.gameOptions` is persisted as Mongoose Mixed (`Record<string, unknown>`) on the BE, so the FE cast to `SeaBattleGameOptions` doesn't actually validate runtime shape. The previous `teamOpts.teams ?? []` only guarded against nullish, leaving any stale/corrupted document free to crash the entire `SeaBattleLobby` render via `teams.reduce` in the `teamCap` `useMemo`. `TicTacToeTeamPanel` already does the same `Array.isArray` guard on the same field.

## Changes
- `apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx`: derive `teams` with `Array.isArray(teamOpts.teams) ? teamOpts.teams : []` and replace the comment with the actual reason for the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)