### PR TITLE
refactor(wallet): move Buy Gems above history and anchor Next link (ARC-756)

### DIFF
--- a/apps/web/e2e/wallet/socket-update.spec.ts
+++ b/apps/web/e2e/wallet/socket-update.spec.ts
@@ -162,8 +162,8 @@ test.describe('/wallet socket-driven refresh (mocked socket)', () => {
 
     // The page renders — check that the balance section HTML is present
     const body = await res.text();
-    // The WalletPageView renders a [data-testid="balance-coins"] and
-    // [data-testid="balance-gems"] div. If those are not present the server
+    // WalletBalanceSummary renders [data-testid="balance-coins"] and
+    // [data-testid="balance-gems"] divs. If those are not present the server
     // component is broken (regression guard).
     //
     // Note: The page may redirect to /login for unauthenticated users. In that

--- a/apps/web/e2e/wallet/wallet-page.spec.ts
+++ b/apps/web/e2e/wallet/wallet-page.spec.ts
@@ -152,7 +152,7 @@ test.describe('/wallet filters and pagination (mocked)', () => {
   });
 });
 
-// ── WalletPageView DOM assertions (mocked server props via route intercept) ───
+// ── Wallet page DOM assertions (mocked server props via route intercept) ───
 
 test.describe('/wallet page — UI data-testid assertions (mocked)', () => {
   /**

--- a/apps/web/src/app/[locale]/wallet/page.tsx
+++ b/apps/web/src/app/[locale]/wallet/page.tsx
@@ -5,7 +5,8 @@ import {
   getWalletBalance,
   getWalletTransactions,
 } from '@/features/wallet/server/wallet.server';
-import { WalletPageView } from '@/features/wallet/ui/WalletPageView';
+import { WalletBalanceSummary } from '@/features/wallet/ui/WalletBalanceSummary';
+import { WalletHistory } from '@/features/wallet/ui/WalletHistory';
 import type {
   PaginatedWalletTransactions,
   WalletBalance,
@@ -18,7 +19,7 @@ import { getConversionRate } from '@/features/gems/server/gems.server';
 import { DailyRewardCard } from '@/features/daily-rewards/ui/DailyRewardCard';
 import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
 import { PageBreadcrumb } from '@/shared/seo/PageBreadcrumb';
-import { isLocale } from '@/shared/i18n';
+import { isLocale, type Locale } from '@/shared/i18n';
 
 // <WalletLiveBridge /> is mounted once in apps/web/src/app/layout.tsx — no
 // need to render it here.
@@ -44,6 +45,12 @@ function parseCurrency(input?: string): WalletCurrency | undefined {
 const EMPTY_BALANCE: WalletBalance = { coins: 0, gems: 0 };
 const EMPTY_PAGE: PaginatedWalletTransactions = { items: [], nextCursor: null };
 
+const GEM_SECTIONS_STYLE: React.CSSProperties = {
+  maxWidth: '900px',
+  margin: '0 auto',
+  padding: '0 16px 32px',
+};
+
 export default async function WalletPage({
   params,
   searchParams,
@@ -55,6 +62,7 @@ export default async function WalletPage({
   const sp = await searchParams;
   const currency = parseCurrency(sp.currency);
   const cursor = sp.cursor;
+  const typedLocale: Locale | undefined = isLocale(locale) ? locale : undefined;
 
   // Fetch the conversion rate server-side (no auth needed — public endpoint).
   let conversionRate = 100;
@@ -74,25 +82,17 @@ export default async function WalletPage({
     return (
       <div>
         <PageBreadcrumb locale={locale} page="wallet" />
-        <WalletPageView
-          balance={EMPTY_BALANCE}
-          page={EMPTY_PAGE}
-          currency={currency}
-          locale={isLocale(locale) ? locale : undefined}
-        />
-        <div
-          style={{
-            maxWidth: '900px',
-            margin: '0 auto',
-            padding: '0 16px 32px',
-          }}
-          data-testid="gem-sections"
-        >
-          {/* GemStore is always shown — no auth required for browsing */}
-          <div id="gem-store" style={{ marginBottom: '32px' }}>
+        <WalletBalanceSummary balance={EMPTY_BALANCE} locale={typedLocale} />
+        <div style={GEM_SECTIONS_STYLE} data-testid="gem-sections">
+          <div id="gem-store" style={{ marginTop: '32px' }}>
             <GemStore />
           </div>
         </div>
+        <WalletHistory
+          page={EMPTY_PAGE}
+          currency={currency}
+          locale={typedLocale}
+        />
       </div>
     );
   }
@@ -124,29 +124,20 @@ export default async function WalletPage({
           BalanceChip — so it never blocks the page from rendering. */}
       <DailyRewardCard />
 
-      <WalletPageView
-        balance={balance}
-        page={page}
-        currency={currency}
-        locale={isLocale(locale) ? locale : undefined}
-      />
+      <WalletBalanceSummary balance={balance} locale={typedLocale} />
 
       {/* Gem sections: pending purchases banner, gem store, and conversion form */}
-      <div
-        style={{ maxWidth: '900px', margin: '0 auto', padding: '0 16px 48px' }}
-        data-testid="gem-sections"
-      >
-        {/* Pending purchases banner — renders nothing if no pending purchases */}
+      <div style={GEM_SECTIONS_STYLE} data-testid="gem-sections">
         <PendingGemPurchases />
 
-        {/* Gem store — lists purchasable packages */}
-        <div id="gem-store" style={{ marginBottom: '32px' }}>
+        <div id="gem-store" style={{ marginTop: '32px', marginBottom: '32px' }}>
           <GemStore />
         </div>
 
-        {/* Convert gems to coins form */}
         <ConvertGemsForm rate={conversionRate} currentGems={currentGems} />
       </div>
+
+      <WalletHistory page={page} currency={currency} locale={typedLocale} />
     </div>
   );
 }

--- a/apps/web/src/features/wallet/ui/WalletBalanceSummary.test.tsx
+++ b/apps/web/src/features/wallet/ui/WalletBalanceSummary.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WalletBalanceSummary } from './WalletBalanceSummary';
+import type { WalletBalance } from '../server/wallet.types';
+
+describe('WalletBalanceSummary', () => {
+  it('renders coin and gem balances', () => {
+    const balance: WalletBalance = { coins: 1_250, gems: 30 };
+    render(<WalletBalanceSummary balance={balance} />);
+    expect(screen.getByTestId('balance-coins-value').textContent).toContain(
+      '1,250',
+    );
+    expect(screen.getByTestId('balance-gems-value').textContent).toContain(
+      '30',
+    );
+  });
+
+  it('renders zero balances for an empty wallet', () => {
+    render(<WalletBalanceSummary balance={{ coins: 0, gems: 0 }} />);
+    expect(screen.getByTestId('balance-coins-value').textContent).toContain(
+      '0',
+    );
+    expect(screen.getByTestId('balance-gems-value').textContent).toContain('0');
+  });
+});

--- a/apps/web/src/features/wallet/ui/WalletBalanceSummary.tsx
+++ b/apps/web/src/features/wallet/ui/WalletBalanceSummary.tsx
@@ -1,0 +1,98 @@
+import { formatNumber } from '@/shared/i18n/formatters';
+import { DEFAULT_LOCALE, type Locale } from '@/shared/config/locale-slugs';
+import type { WalletBalance } from '../server/wallet.types';
+
+interface Props {
+  balance: WalletBalance;
+  locale?: Locale;
+}
+
+export function WalletBalanceSummary({
+  balance,
+  locale = DEFAULT_LOCALE,
+}: Props) {
+  const { coins, gems } = balance;
+  const fmt = (n: number) => formatNumber(n, locale);
+
+  return (
+    <section
+      aria-label="Wallet balance"
+      style={{ maxWidth: '900px', margin: '0 auto', padding: '32px 16px 0' }}
+    >
+      <h1
+        style={{
+          fontSize: '24px',
+          fontWeight: 700,
+          marginBottom: '4px',
+          color: 'var(--color-text, #e4e4e7)',
+        }}
+      >
+        Your Wallet
+      </h1>
+      <p
+        style={{
+          fontSize: '14px',
+          color: 'var(--color-text-secondary, #71717a)',
+          marginBottom: '32px',
+        }}
+      >
+        Coins are earned through play. Gems are purchased.
+      </p>
+
+      <div
+        aria-label="Balance summary"
+        style={{
+          display: 'flex',
+          gap: '16px',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div
+          data-testid="balance-coins"
+          style={{
+            flex: '1 1 160px',
+            padding: '20px 24px',
+            borderRadius: '12px',
+            background: 'rgba(251,191,36,0.08)',
+            border: '1px solid rgba(251,191,36,0.2)',
+          }}
+        >
+          <div
+            style={{ fontSize: '12px', color: '#a1a1aa', marginBottom: '6px' }}
+          >
+            🪙 Coins
+          </div>
+          <div
+            style={{ fontSize: '28px', fontWeight: 700, color: '#fbbf24' }}
+            data-testid="balance-coins-value"
+          >
+            {fmt(coins)}
+          </div>
+        </div>
+
+        <div
+          data-testid="balance-gems"
+          style={{
+            flex: '1 1 160px',
+            padding: '20px 24px',
+            borderRadius: '12px',
+            background: 'rgba(167,139,250,0.08)',
+            border: '1px solid rgba(167,139,250,0.2)',
+          }}
+        >
+          <div
+            style={{ fontSize: '12px', color: '#a1a1aa', marginBottom: '6px' }}
+          >
+            💎 Gems
+          </div>
+          <div
+            style={{ fontSize: '28px', fontWeight: 700, color: '#a78bfa' }}
+            data-testid="balance-gems-value"
+          >
+            {fmt(gems)}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/wallet/ui/WalletHistory.test.tsx
+++ b/apps/web/src/features/wallet/ui/WalletHistory.test.tsx
@@ -1,15 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { WalletPageView } from './WalletPageView';
-import type {
-  WalletBalance,
-  PaginatedWalletTransactions,
-} from '../server/wallet.types';
-
-// WalletPageView is a pure presentational Server Component — no async I/O —
-// so Vitest + jsdom can render it directly without any special setup.
-
-const balance: WalletBalance = { coins: 1_250, gems: 30 };
+import { WalletHistory } from './WalletHistory';
+import type { PaginatedWalletTransactions } from '../server/wallet.types';
 
 const singlePage: PaginatedWalletTransactions = {
   items: [
@@ -40,31 +32,21 @@ const pagedResult: PaginatedWalletTransactions = {
   nextCursor: 'cursor-abc123',
 };
 
-describe('WalletPageView', () => {
-  it('renders coin and gem balances', () => {
-    render(<WalletPageView balance={balance} page={singlePage} />);
-    expect(screen.getByTestId('balance-coins-value').textContent).toContain(
-      '1,250',
-    );
-    expect(screen.getByTestId('balance-gems-value').textContent).toContain(
-      '30',
-    );
-  });
-
+describe('WalletHistory', () => {
   it('renders a row for each transaction', () => {
-    render(<WalletPageView balance={balance} page={singlePage} />);
+    render(<WalletHistory page={singlePage} />);
     const rows = screen.getAllByTestId('transaction-row');
     expect(rows).toHaveLength(2);
   });
 
   it('shows empty state when there are no transactions', () => {
-    render(<WalletPageView balance={balance} page={emptyPage} />);
+    render(<WalletHistory page={emptyPage} />);
     expect(screen.getByTestId('wallet-empty')).toBeTruthy();
     expect(screen.queryByTestId('transactions-table')).toBeNull();
   });
 
   it('shows Next link when nextCursor is present', () => {
-    render(<WalletPageView balance={balance} page={pagedResult} />);
+    render(<WalletHistory page={pagedResult} />);
     const nextLink = screen.getByTestId('next-page');
     expect(nextLink).toBeTruthy();
     expect((nextLink as HTMLAnchorElement).href).toContain(
@@ -72,32 +54,33 @@ describe('WalletPageView', () => {
     );
   });
 
+  it('anchors Next link to the history section so the browser does not scroll to the top of the page', () => {
+    render(<WalletHistory page={pagedResult} />);
+    const nextLink = screen.getByTestId('next-page') as HTMLAnchorElement;
+    expect(nextLink.href).toContain('#wallet-history');
+  });
+
   it('does not show Next link when nextCursor is null', () => {
-    render(<WalletPageView balance={balance} page={singlePage} />);
+    render(<WalletHistory page={singlePage} />);
     expect(screen.queryByTestId('next-page')).toBeNull();
   });
 
   it('preserves currency filter in Next link', () => {
-    render(
-      <WalletPageView balance={balance} page={pagedResult} currency="coins" />,
-    );
+    render(<WalletHistory page={pagedResult} currency="coins" />);
     const nextLink = screen.getByTestId('next-page') as HTMLAnchorElement;
     expect(nextLink.href).toContain('currency=coins');
     expect(nextLink.href).toContain('cursor=cursor-abc123');
   });
 
   it('marks the "All" filter active when no currency is set', () => {
-    render(<WalletPageView balance={balance} page={singlePage} />);
+    render(<WalletHistory page={singlePage} />);
     const allLink = screen.getByTestId('filter-all') as HTMLAnchorElement;
-    // Active filter has a lighter border colour (checked via href = /wallet)
     expect(allLink.href).toContain('/wallet');
     expect(allLink.href).not.toContain('currency=');
   });
 
   it('marks the coins filter active when currency=coins', () => {
-    render(
-      <WalletPageView balance={balance} page={singlePage} currency="coins" />,
-    );
+    render(<WalletHistory page={singlePage} currency="coins" />);
     const coinsLink = screen.getByTestId('filter-coins') as HTMLAnchorElement;
     expect(coinsLink.href).toContain('currency=coins');
   });

--- a/apps/web/src/features/wallet/ui/WalletHistory.tsx
+++ b/apps/web/src/features/wallet/ui/WalletHistory.tsx
@@ -1,15 +1,12 @@
 import Link from 'next/link';
-import { formatNumber } from '@/shared/i18n/formatters';
 import { DEFAULT_LOCALE, type Locale } from '@/shared/config/locale-slugs';
 import type {
-  WalletBalance,
   WalletCurrency,
   PaginatedWalletTransactions,
 } from '../server/wallet.types';
 import { TransactionRow } from './TransactionRow';
 
 interface Props {
-  balance: WalletBalance;
   page: PaginatedWalletTransactions;
   currency?: WalletCurrency;
   locale?: Locale;
@@ -43,19 +40,13 @@ const FILTER_INACTIVE: React.CSSProperties = {
   color: '#a1a1aa',
 };
 
-export function WalletPageView({
-  balance,
+export function WalletHistory({
   page,
   currency,
   locale = DEFAULT_LOCALE,
 }: Props) {
-  // Destructure to avoid the no-restricted-syntax member-access rule for
-  // .coins / .gems.
-  const { coins, gems } = balance;
-  const fmt = (n: number) => formatNumber(n, locale);
   const { items, nextCursor } = page;
 
-  // Currency filter links reset the cursor when changing filter.
   const allHref = '/wallet';
   const coinsHref = '/wallet?currency=coins';
   const gemsHref = '/wallet?currency=gems';
@@ -65,86 +56,16 @@ export function WalletPageView({
   const isGems = currency === 'gems';
 
   return (
-    <main style={{ maxWidth: '900px', margin: '0 auto', padding: '32px 16px' }}>
-      {/* Page title */}
-      <h1
-        style={{
-          fontSize: '24px',
-          fontWeight: 700,
-          marginBottom: '4px',
-          color: 'var(--color-text, #e4e4e7)',
-        }}
-      >
-        Your Wallet
-      </h1>
-      <p
-        style={{
-          fontSize: '14px',
-          color: 'var(--color-text-secondary, #71717a)',
-          marginBottom: '32px',
-        }}
-      >
-        Coins are earned through play. Gems are purchased.
-      </p>
-
-      {/* Balance summary */}
-      <section
-        aria-label="Balance summary"
-        style={{
-          display: 'flex',
-          gap: '16px',
-          marginBottom: '32px',
-          flexWrap: 'wrap',
-        }}
-      >
-        <div
-          data-testid="balance-coins"
-          style={{
-            flex: '1 1 160px',
-            padding: '20px 24px',
-            borderRadius: '12px',
-            background: 'rgba(251,191,36,0.08)',
-            border: '1px solid rgba(251,191,36,0.2)',
-          }}
-        >
-          <div
-            style={{ fontSize: '12px', color: '#a1a1aa', marginBottom: '6px' }}
-          >
-            🪙 Coins
-          </div>
-          <div
-            style={{ fontSize: '28px', fontWeight: 700, color: '#fbbf24' }}
-            data-testid="balance-coins-value"
-          >
-            {fmt(coins)}
-          </div>
-        </div>
-
-        <div
-          data-testid="balance-gems"
-          style={{
-            flex: '1 1 160px',
-            padding: '20px 24px',
-            borderRadius: '12px',
-            background: 'rgba(167,139,250,0.08)',
-            border: '1px solid rgba(167,139,250,0.2)',
-          }}
-        >
-          <div
-            style={{ fontSize: '12px', color: '#a1a1aa', marginBottom: '6px' }}
-          >
-            💎 Gems
-          </div>
-          <div
-            style={{ fontSize: '28px', fontWeight: 700, color: '#a78bfa' }}
-            data-testid="balance-gems-value"
-          >
-            {fmt(gems)}
-          </div>
-        </div>
-      </section>
-
-      {/* Currency filters */}
+    <section
+      id="wallet-history"
+      aria-label="Transaction history"
+      style={{
+        maxWidth: '900px',
+        margin: '0 auto',
+        padding: '0 16px 32px',
+        scrollMarginTop: '16px',
+      }}
+    >
       <nav
         aria-label="Transaction filters"
         style={{
@@ -177,7 +98,6 @@ export function WalletPageView({
         </Link>
       </nav>
 
-      {/* Transaction list */}
       {items.length === 0 ? (
         <div
           data-testid="wallet-empty"
@@ -250,11 +170,10 @@ export function WalletPageView({
         </div>
       )}
 
-      {/* Pagination */}
       {nextCursor && (
         <div style={{ marginTop: '24px', textAlign: 'right' }}>
           <Link
-            href={`/wallet?${currency ? `currency=${currency}&` : ''}cursor=${nextCursor}`}
+            href={`/wallet?${currency ? `currency=${currency}&` : ''}cursor=${nextCursor}#wallet-history`}
             data-testid="next-page"
             style={{
               display: 'inline-flex',
@@ -274,6 +193,6 @@ export function WalletPageView({
           </Link>
         </div>
       )}
-    </main>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

- Hoist the **Buy Gems** block above transaction history on the wallet page so top-up is the first thing players see.
- Split `WalletPageView` into `WalletBalanceSummary` (top) and `WalletHistory` (bottom); `GemStore` + `ConvertGemsForm` sit between them.
- Anchor the Next pagination link to `#wallet-history` so paginating no longer scrolls the page to the top of the gem store.

## Why

Reordering the layout dropped the history below the gem store, which broke the perceived behavior of the **Next** button — Next.js `<Link>` defaults to scrolling to top, so clicking Next dumped the user at Buy Gems and the new transactions rendered invisibly below the fold. The anchor fix is part of the same change because it's a consequence of the reorder.

## Changes

- New: `apps/web/src/features/wallet/ui/WalletBalanceSummary.tsx` (+ test)
- Renamed: `WalletPageView.tsx` → `WalletHistory.tsx` (balance section stripped; filters/table/pagination remain) + test renamed and trimmed
- `apps/web/src/app/[locale]/wallet/page.tsx` — both auth and unauth branches reordered: Balance → (Pending/GemStore/Convert) → History
- E2E spec comments updated to drop the stale `WalletPageView` reference

## Test plan

- [x] `pnpm vitest run` for the two new test files (10/10 passing)
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean on touched files
- [ ] Manual: click **Next** in transaction history → browser scrolls to top of history section, not page top
- [ ] Manual: visit `/wallet` unauthenticated → balance pills (0/0) and Buy Gems render; no history error
- [ ] Manual: visit `/wallet` authenticated → balance, pending purchases, Buy Gems, Convert form, history all render in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)