### PR TITLE
feat(sea-battle): drag placed ships to reposition (ARC-754)

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -12,6 +12,7 @@ import {
   SeaBattlePlayer,
   SeaBattleState,
   PlaceShipPayload,
+  MoveShipPayload,
 } from './sea-battle.types';
 import { randomlyPlaceShips } from './sea-battle.utils';
 import type {
@@ -57,6 +58,44 @@ export function runPlaceShip(
   }
   state.logs.push(
     makeLog('action', `Placed ${ship.name}`, {
+      scope: 'private',
+      senderId: player.playerId,
+    }),
+  );
+  return { success: true, state };
+}
+
+export function runMoveShip(
+  state: SeaBattleState,
+  player: SeaBattlePlayer,
+  payload: MoveShipPayload,
+): GameActionResult<SeaBattleState> {
+  const existing = player.ships.find((s) => s.id === payload.shipId);
+  if (!existing) {
+    return { success: false, error: 'Ship is not currently placed' };
+  }
+
+  for (const cell of existing.cells) {
+    player.board[cell.row][cell.col] = CELL_STATE.EMPTY;
+  }
+  player.ships = player.ships.filter((s) => s.id !== payload.shipId);
+
+  const shipConfig = SHIPS.find((s) => s.id === payload.shipId) as ShipConfig;
+  const ship: Ship = {
+    id: payload.shipId,
+    name: shipConfig.name,
+    size: shipConfig.size,
+    cells: payload.cells,
+    hits: 0,
+    sunk: false,
+  };
+  player.ships.push(ship);
+  for (const cell of payload.cells) {
+    player.board[cell.row][cell.col] = CELL_STATE.SHIP;
+  }
+
+  state.logs.push(
+    makeLog('action', `Moved ${ship.name}`, {
       scope: 'private',
       senderId: player.playerId,
     }),

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.moveShip.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.moveShip.spec.ts
@@ -1,0 +1,313 @@
+import { SeaBattleEngine } from './sea-battle.engine';
+import { GAME_PHASE, CELL_STATE, SHIPS } from './sea-battle.constants';
+import type { SeaBattleState, ShipCell } from './sea-battle.types';
+
+describe('SeaBattleEngine — moveShip', () => {
+  const engine = new SeaBattleEngine();
+
+  function placementState(): SeaBattleState {
+    const s = engine.initializeState(['a', 'b']);
+    s.phase = GAME_PHASE.PLACEMENT;
+    return s;
+  }
+
+  function placeAt(
+    state: SeaBattleState,
+    playerId: string,
+    shipId: string,
+    cells: ShipCell[],
+  ) {
+    const player = state.players.find((p) => p.playerId === playerId)!;
+    const config = SHIPS.find((s) => s.id === shipId)!;
+    player.ships.push({
+      id: shipId,
+      name: config.name,
+      size: config.size,
+      cells,
+      hits: 0,
+      sunk: false,
+    });
+    for (const cell of cells) {
+      player.board[cell.row][cell.col] = CELL_STATE.SHIP;
+    }
+  }
+
+  const ctx = (userId: string) => ({
+    userId,
+    roomId: 'r',
+    sessionId: 's',
+    timestamp: new Date(),
+  });
+
+  describe('validateAction', () => {
+    it('accepts moving a placed ship to a valid empty area', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 5, col: 5 },
+          { row: 5, col: 6 },
+          { row: 5, col: 7 },
+          { row: 5, col: 8 },
+        ],
+      });
+      expect(ok).toBe(true);
+    });
+
+    it('allows a one-cell nudge along the same axis (overlap with self)', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 0, col: 1 },
+          { row: 0, col: 2 },
+          { row: 0, col: 3 },
+          { row: 0, col: 4 },
+        ],
+      });
+      expect(ok).toBe(true);
+    });
+
+    it('rejects overlap with another ship', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      placeAt(s, 'a', 'cruiser-1', [
+        { row: 5, col: 5 },
+        { row: 5, col: 6 },
+        { row: 5, col: 7 },
+      ]);
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 5, col: 5 },
+          { row: 5, col: 6 },
+          { row: 5, col: 7 },
+          { row: 5, col: 8 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects adjacency (diagonal corner touch) with another ship', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      placeAt(s, 'a', 'cruiser-1', [
+        { row: 5, col: 5 },
+        { row: 5, col: 6 },
+        { row: 5, col: 7 },
+      ]);
+      // Touching corner of cruiser-1 at (5,5) — diagonal at (4,4)
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 4, col: 1 },
+          { row: 4, col: 2 },
+          { row: 4, col: 3 },
+          { row: 4, col: 4 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects out-of-bounds cells', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'destroyer-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+      ]);
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'destroyer-1',
+        cells: [
+          { row: 0, col: 9 },
+          { row: 0, col: 10 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects when ship is not currently placed', () => {
+      const s = placementState();
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 0, col: 0 },
+          { row: 0, col: 1 },
+          { row: 0, col: 2 },
+          { row: 0, col: 3 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects when player has already confirmed placement', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      const player = s.players.find((p) => p.playerId === 'a')!;
+      player.placementComplete = true;
+
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 5, col: 5 },
+          { row: 5, col: 6 },
+          { row: 5, col: 7 },
+          { row: 5, col: 8 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects outside the PLACEMENT phase', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      s.phase = GAME_PHASE.BATTLE;
+
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 5, col: 5 },
+          { row: 5, col: 6 },
+          { row: 5, col: 7 },
+          { row: 5, col: 8 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+
+    it('rejects cell-count mismatch (wrong ship size)', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      const ok = engine.validateAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        // Battleship is size 4 — only 3 cells provided
+        cells: [
+          { row: 5, col: 5 },
+          { row: 5, col: 6 },
+          { row: 5, col: 7 },
+        ],
+      });
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('executeAction', () => {
+    it('clears the old cells, stamps the new cells, and replaces the ship entry', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'battleship-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]);
+      const newCells = [
+        { row: 5, col: 5 },
+        { row: 5, col: 6 },
+        { row: 5, col: 7 },
+        { row: 5, col: 8 },
+      ];
+      const result = engine.executeAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: newCells,
+      });
+      expect(result.success).toBe(true);
+
+      const ns = result.state!;
+      const player = ns.players.find((p) => p.playerId === 'a')!;
+
+      // Old cells are empty
+      for (const c of [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+        { row: 0, col: 3 },
+      ]) {
+        expect(player.board[c.row][c.col]).toBe(CELL_STATE.EMPTY);
+      }
+      // New cells stamped
+      for (const c of newCells) {
+        expect(player.board[c.row][c.col]).toBe(CELL_STATE.SHIP);
+      }
+      const ships = player.ships.filter((sh) => sh.id === 'battleship-1');
+      expect(ships).toHaveLength(1);
+      expect(ships[0].cells).toEqual(newCells);
+      expect(ships[0].hits).toBe(0);
+      expect(ships[0].sunk).toBe(false);
+    });
+
+    it('logs a "Moved <ship>" private action entry', () => {
+      const s = placementState();
+      placeAt(s, 'a', 'cruiser-1', [
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 0, col: 2 },
+      ]);
+      const before = s.logs.length;
+      const result = engine.executeAction(s, 'moveShip', ctx('a'), {
+        shipId: 'cruiser-1',
+        cells: [
+          { row: 5, col: 0 },
+          { row: 5, col: 1 },
+          { row: 5, col: 2 },
+        ],
+      });
+      const ns = result.state!;
+      expect(ns.logs.length).toBe(before + 1);
+      const log = ns.logs[ns.logs.length - 1];
+      expect(log.type).toBe('action');
+      expect(log.message).toBe('Moved Cruiser');
+      expect(log.scope).toBe('private');
+      expect(log.senderId).toBe('a');
+    });
+
+    it('returns failure if ship id is not currently placed', () => {
+      const s = placementState();
+      const result = engine.executeAction(s, 'moveShip', ctx('a'), {
+        shipId: 'battleship-1',
+        cells: [
+          { row: 0, col: 0 },
+          { row: 0, col: 1 },
+          { row: 0, col: 2 },
+          { row: 0, col: 3 },
+        ],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -18,6 +18,7 @@ import {
   SeaBattlePlayer,
   SeaBattleState,
   PlaceShipPayload,
+  MoveShipPayload,
   AttackPayload,
   ChatPayload,
 } from './sea-battle.types';
@@ -29,6 +30,7 @@ import {
 } from './sea-battle.utils';
 import {
   validatePlaceShip,
+  validateMoveShip,
   validateAutoPlace,
   validateConfirmPlacement,
   validateResetPlacement,
@@ -45,6 +47,7 @@ import {
 } from './team-rotation.utils';
 import {
   runPlaceShip,
+  runMoveShip,
   runAutoPlace,
   runConfirmPlacement,
   runResetPlacement,
@@ -127,6 +130,8 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
     switch (action) {
       case 'placeShip':
         return validatePlaceShip(state, player, payload as PlaceShipPayload);
+      case 'moveShip':
+        return validateMoveShip(state, player, payload as MoveShipPayload);
       case 'autoPlace':
         return validateAutoPlace(state);
       case 'confirmPlacement': {
@@ -175,54 +180,22 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
 
     switch (action) {
       case 'placeShip':
-        return this.executePlaceShip(
-          newState,
-          player,
-          payload as PlaceShipPayload,
-        );
+        return runPlaceShip(newState, player, payload as PlaceShipPayload);
+      case 'moveShip':
+        return runMoveShip(newState, player, payload as MoveShipPayload);
       case 'autoPlace':
-        return this.executeAutoPlace(newState, player);
+        return runAutoPlace(newState, player);
       case 'confirmPlacement':
-        return this.executeConfirmPlacement(newState, player);
+        return runConfirmPlacement(newState, player);
+      case 'resetPlacement':
+        return runResetPlacement(newState, player);
       case 'attack':
         return this.executeAttack(newState, player, payload as AttackPayload);
-
-      case 'resetPlacement':
-        return this.executeResetPlacement(newState, player);
       case 'chat':
         return this.executeChat(newState, player, payload as ChatPayload);
       default:
         return this.errorResult('Unknown action');
     }
-  }
-
-  private executePlaceShip(
-    state: SeaBattleState,
-    player: SeaBattlePlayer,
-    payload: PlaceShipPayload,
-  ): GameActionResult<SeaBattleState> {
-    return runPlaceShip(state, player, payload);
-  }
-
-  private executeAutoPlace(
-    state: SeaBattleState,
-    player: SeaBattlePlayer,
-  ): GameActionResult<SeaBattleState> {
-    return runAutoPlace(state, player);
-  }
-
-  private executeConfirmPlacement(
-    state: SeaBattleState,
-    player: SeaBattlePlayer,
-  ): GameActionResult<SeaBattleState> {
-    return runConfirmPlacement(state, player);
-  }
-
-  private executeResetPlacement(
-    state: SeaBattleState,
-    player: SeaBattlePlayer,
-  ): GameActionResult<SeaBattleState> {
-    return runResetPlacement(state, player);
   }
 
   private executeAttack(

--- a/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
@@ -60,6 +60,11 @@ export interface PlaceShipPayload {
   cells: ShipCell[];
 }
 
+export interface MoveShipPayload {
+  shipId: string;
+  cells: ShipCell[];
+}
+
 export interface AttackPayload {
   targetPlayerId: string;
   row: number;

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -150,6 +150,7 @@ export function getSeaBattleAvailableActions(
       }
       if (player.ships.length > 0) {
         actions.push('resetPlacement');
+        actions.push('moveShip');
       }
     }
   }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.validators.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.validators.ts
@@ -8,6 +8,7 @@ import {
   SeaBattlePlayer,
   SeaBattleState,
   PlaceShipPayload,
+  MoveShipPayload,
   AttackPayload,
 } from './sea-battle.types';
 import { areCellsValid, areCellsConnected } from './sea-battle.utils';
@@ -59,6 +60,64 @@ export function validatePlaceShip(
       const c = cell.col + dc;
       if (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE) {
         if (player.board[r][c] === CELL_STATE.SHIP) {
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+export function validateMoveShip(
+  state: SeaBattleState,
+  player: SeaBattlePlayer,
+  payload: MoveShipPayload,
+): boolean {
+  if (state.phase !== GAME_PHASE.PLACEMENT) return false;
+  if (player.placementComplete) return false;
+  if (!payload?.shipId || !payload?.cells) return false;
+
+  const shipConfig = SHIPS.find((s) => s.id === payload.shipId);
+  if (!shipConfig) return false;
+  if (payload.cells.length !== shipConfig.size) return false;
+
+  // Ship must already be placed — that's what makes this a *move* and not a place.
+  const existing = player.ships.find((s) => s.id === payload.shipId);
+  if (!existing) return false;
+
+  if (!areCellsValid(payload.cells)) return false;
+  if (!areCellsConnected(payload.cells)) return false;
+
+  // Clone the board and clear the moving ship's existing cells so the overlap
+  // and adjacency checks treat the ship's current position as empty — otherwise
+  // a one-cell nudge along the ship's own axis would always fail.
+  const virtualBoard = player.board.map((row) => row.slice());
+  for (const cell of existing.cells) {
+    virtualBoard[cell.row][cell.col] = CELL_STATE.EMPTY;
+  }
+
+  for (const cell of payload.cells) {
+    if (virtualBoard[cell.row][cell.col] !== CELL_STATE.EMPTY) {
+      return false;
+    }
+
+    const directions = [
+      [-1, -1],
+      [-1, 0],
+      [-1, 1],
+      [0, -1],
+      [0, 1],
+      [1, -1],
+      [1, 0],
+      [1, 1],
+    ];
+
+    for (const [dr, dc] of directions) {
+      const r = cell.row + dr;
+      const c = cell.col + dc;
+      if (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE) {
+        if (virtualBoard[r][c] === CELL_STATE.SHIP) {
           return false;
         }
       }

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -22,6 +22,25 @@ import { GamesRealtimeService } from './games.realtime.service';
 import { SeaBattleTeamConfigItemDto } from './dtos/set-team-config.dto';
 import type { GameRoomSummary } from './rooms/game-rooms.types';
 
+interface ShipOpPayload {
+  roomId?: string;
+  userId?: string;
+  shipId?: string;
+  cells?: { row: number; col: number }[];
+  [key: string]: unknown;
+}
+
+interface ShipOp {
+  svc: (
+    userId: string,
+    roomId: string,
+    body: { shipId: string; cells: { row: number; col: number }[] },
+  ) => Promise<unknown>;
+  ackEvent: string;
+  errorAction: string;
+  errorMessage: string;
+}
+
 @WebSocketGateway({
   namespace: 'games',
   cors: { origin: corsOriginMatcher },
@@ -72,50 +91,54 @@ export class SeaBattleGateway {
     }
   }
 
-  @SubscribeMessage('seaBattle.session.place_ship')
-  async handlePlaceShip(
-    @ConnectedSocket() client: Socket,
-    @MessageBody()
-    payload: {
-      roomId?: string;
-      userId?: string;
-      shipId?: string;
-      cells?: { row: number; col: number }[];
-    },
+  private async dispatchShipOp(
+    client: Socket,
+    payload: ShipOpPayload,
+    op: ShipOp,
   ): Promise<void> {
     const { roomId, userId } = extractRoomAndUser(payload);
     const shipId = extractString(payload, 'shipId');
     const cells = payload.cells;
-
     if (!shipId || !cells || !Array.isArray(cells)) {
       throw new WsException('shipId and cells are required');
     }
-
     try {
-      await this.seaBattleService.placeShipByRoom(userId, roomId, {
-        shipId,
-        cells,
-      });
-      client.emit(
-        'seaBattle.session.ship_placed',
-        maybeEncrypt({
-          roomId,
-          userId,
-          shipId,
-        }),
-      );
+      await op.svc(userId, roomId, { shipId, cells });
+      client.emit(op.ackEvent, maybeEncrypt({ roomId, userId, shipId }));
     } catch (error) {
       handleError(
         this.logger,
         error,
-        {
-          action: 'place ship',
-          roomId,
-          userId,
-        },
-        'Unable to place ship.',
+        { action: op.errorAction, roomId, userId },
+        op.errorMessage,
       );
     }
+  }
+
+  @SubscribeMessage('seaBattle.session.place_ship')
+  handlePlaceShip(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: ShipOpPayload,
+  ): Promise<void> {
+    return this.dispatchShipOp(client, payload, {
+      svc: (u, r, b) => this.seaBattleService.placeShipByRoom(u, r, b),
+      ackEvent: 'seaBattle.session.ship_placed',
+      errorAction: 'place ship',
+      errorMessage: 'Unable to place ship.',
+    });
+  }
+
+  @SubscribeMessage('seaBattle.session.move_ship')
+  handleMoveShip(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: ShipOpPayload,
+  ): Promise<void> {
+    return this.dispatchShipOp(client, payload, {
+      svc: (u, r, b) => this.seaBattleService.moveShipByRoom(u, r, b),
+      ackEvent: 'seaBattle.session.ship_moved',
+      errorAction: 'move ship',
+      errorMessage: 'Unable to move ship.',
+    });
   }
 
   @SubscribeMessage('seaBattle.session.confirm_placement')

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -27,6 +27,11 @@ interface PlaceShipPayload {
   cells: { row: number; col: number }[];
 }
 
+interface MoveShipPayload {
+  shipId: string;
+  cells: { row: number; col: number }[];
+}
+
 interface AttackPayload {
   targetPlayerId: string;
   row: number;
@@ -254,6 +259,29 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
       sessionId: session.id,
       userId,
       action: 'placeShip',
+      payload,
+    });
+
+    await this.checkAndSyncRoomStatus(updatedSession);
+    await this.emitSessionUpdate(updatedSession);
+    return updatedSession;
+  }
+
+  /**
+   * Move an already-placed ship to a new position on the board
+   */
+  async moveShipByRoom(
+    userId: string,
+    roomId: string,
+    payload: MoveShipPayload,
+  ) {
+    const session = await this.sessionsService.findSessionByRoom(roomId);
+    if (!session) throw new Error('Session not found');
+
+    const updatedSession = await this.sessionsService.executeAction({
+      sessionId: session.id,
+      userId,
+      action: 'moveShip',
       payload,
     });
 

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.test.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.test.ts
@@ -1,0 +1,184 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useDragPlacement } from './useDragPlacement';
+import { BOARD_SIZE, CELL_STATE, type CellState, type Ship } from '../types';
+
+function emptyBoard(): CellState[][] {
+  return Array.from({ length: BOARD_SIZE }, () =>
+    Array.from<CellState>({ length: BOARD_SIZE }).fill(CELL_STATE.EMPTY),
+  );
+}
+
+// Place a horizontal ship at the start of a row, stamping the board cells.
+function boardWithShip(ship: Ship): CellState[][] {
+  const b = emptyBoard();
+  for (const cell of ship.cells) {
+    b[cell.row][cell.col] = CELL_STATE.SHIP;
+  }
+  return b;
+}
+
+function makeDataTransfer() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    effectAllowed: 'move' as const,
+    setData: (k: string, v: string) => store.set(k, v),
+    getData: (k: string) => store.get(k) ?? '',
+  };
+}
+
+const battleship: Ship = {
+  id: 'battleship-1',
+  name: 'Battleship',
+  size: 4,
+  hits: 0,
+  sunk: false,
+  cells: [
+    { row: 0, col: 0 },
+    { row: 0, col: 1 },
+    { row: 0, col: 2 },
+    { row: 0, col: 3 },
+  ],
+};
+
+function setup(
+  overrides: Partial<Parameters<typeof useDragPlacement>[0]> = {},
+) {
+  const onPlaceShip = vi.fn();
+  const onMoveShip = vi.fn();
+  const setSelectedShipId = vi.fn();
+  const setHoveredCells = vi.fn();
+  const setIsInvalidHover = vi.fn();
+  const board = boardWithShip(battleship);
+
+  const result = renderHook(() =>
+    useDragPlacement({
+      board,
+      isVertical: false,
+      placedShipIds: new Set([battleship.id]),
+      ships: [battleship],
+      placementComplete: false,
+      onPlaceShip,
+      onMoveShip,
+      setSelectedShipId,
+      setHoveredCells,
+      setIsInvalidHover,
+      ...overrides,
+    }),
+  );
+  return { result, onPlaceShip, onMoveShip, setSelectedShipId };
+}
+
+beforeEach(() => {
+  // jsdom defaults pointer:fine, so isTouchDevice stays false.
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (q: string) => ({
+      matches: false,
+      media: q,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+});
+
+describe('useDragPlacement — board source', () => {
+  it('a ship cell exposes draggable=true via getBoardCellDragProps', () => {
+    const { result } = setup();
+    const props = result.result.current.getBoardCellDragProps(0, 0);
+    expect(props.draggable).toBe(true);
+  });
+
+  it('an empty cell exposes draggable=false', () => {
+    const { result } = setup();
+    const props = result.result.current.getBoardCellDragProps(5, 5);
+    expect(props.draggable).toBe(false);
+  });
+
+  it('emits onMoveShip with anchor-adjusted cells when dropping a ship grabbed mid-body', () => {
+    const { result, onMoveShip } = setup();
+    const hook = result.result.current;
+    const dt = makeDataTransfer();
+
+    // Grab the 2nd cell of the 4-cell horizontal ship (row 0, col 1)
+    act(() => {
+      hook.getBoardCellDragProps(0, 1).onDragStart({
+        dataTransfer: dt,
+        preventDefault: () => {},
+      } as unknown as React.DragEvent<HTMLElement>);
+    });
+
+    // Drop on F5 (row 5, col 5). Anchor offset = 1, orientation = h.
+    // Expected start: (5, 4); cells: (5,4) (5,5) (5,6) (5,7).
+    act(() => {
+      hook.onDrop(5, 5, {
+        dataTransfer: dt,
+        preventDefault: () => {},
+      } as unknown as React.DragEvent<HTMLElement>);
+    });
+
+    expect(onMoveShip).toHaveBeenCalledTimes(1);
+    expect(onMoveShip).toHaveBeenCalledWith('battleship-1', [
+      { row: 5, col: 4 },
+      { row: 5, col: 5 },
+      { row: 5, col: 6 },
+      { row: 5, col: 7 },
+    ]);
+  });
+
+  it('does not emit onMoveShip when dropped on the same cells (no-op move)', () => {
+    const { result, onMoveShip } = setup();
+    const hook = result.result.current;
+    const dt = makeDataTransfer();
+
+    // Grab the head of the ship at (0,0)
+    act(() => {
+      hook.getBoardCellDragProps(0, 0).onDragStart({
+        dataTransfer: dt,
+        preventDefault: () => {},
+      } as unknown as React.DragEvent<HTMLElement>);
+    });
+    // Drop at (0,0) again — same cells.
+    act(() => {
+      hook.onDrop(0, 0, {
+        dataTransfer: dt,
+        preventDefault: () => {},
+      } as unknown as React.DragEvent<HTMLElement>);
+    });
+
+    expect(onMoveShip).not.toHaveBeenCalled();
+  });
+
+  it('does not emit onMoveShip when the drop is off-board', () => {
+    const { result, onMoveShip } = setup();
+    const hook = result.result.current;
+    const dt = makeDataTransfer();
+
+    act(() => {
+      hook.getBoardCellDragProps(0, 0).onDragStart({
+        dataTransfer: dt,
+        preventDefault: () => {},
+      } as unknown as React.DragEvent<HTMLElement>);
+    });
+    // Drop at (0, 9) — ship would extend out to col 12.
+    act(() => {
+      hook.onDrop(0, 9, {
+        dataTransfer: dt,
+        preventDefault: () => {},
+      } as unknown as React.DragEvent<HTMLElement>);
+    });
+
+    expect(onMoveShip).not.toHaveBeenCalled();
+  });
+
+  it('does not allow drag from board cells when placement is complete', () => {
+    const { result } = setup({ placementComplete: true });
+    const props = result.result.current.getBoardCellDragProps(0, 0);
+    expect(props.draggable).toBe(false);
+  });
+});

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
@@ -2,14 +2,17 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DragEvent } from 'react';
-import type { ShipCell, CellState } from '../types';
+import type { ShipCell, CellState, Ship } from '../types';
 import { BOARD_SIZE, CELL_STATE, SHIPS } from '../types';
 
 interface UseDragPlacementArgs {
   board: CellState[][];
   isVertical: boolean;
   placedShipIds: Set<string>;
+  ships: Ship[];
+  placementComplete: boolean;
   onPlaceShip: (shipId: string, cells: ShipCell[]) => void;
+  onMoveShip: (shipId: string, cells: ShipCell[]) => void;
   setSelectedShipId: (id: string | null) => void;
   setHoveredCells: (cells: ShipCell[]) => void;
   setIsInvalidHover?: (v: boolean) => void;
@@ -18,6 +21,15 @@ interface UseDragPlacementArgs {
 interface DragProps {
   draggable: boolean;
   onDragStart: (e: DragEvent<HTMLElement>) => void;
+}
+
+type DragMode = 'palette' | 'board' | null;
+
+interface BoardDragOrigin {
+  shipId: string;
+  originalCells: ShipCell[];
+  orientation: 'h' | 'v';
+  anchorOffset: number;
 }
 
 function getCells(
@@ -60,18 +72,48 @@ function canPlace(cells: ShipCell[], board: CellState[][]): boolean {
   return true;
 }
 
+function cellsEqual(a: ShipCell[], b: ShipCell[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].row !== b[i].row || a[i].col !== b[i].col) return false;
+  }
+  return true;
+}
+
+function getOrientation(cells: ShipCell[]): 'h' | 'v' {
+  if (cells.length < 2) return 'h';
+  return cells[0].row === cells[1].row ? 'h' : 'v';
+}
+
+function boardWithout(
+  board: CellState[][],
+  cellsToClear: ShipCell[],
+): CellState[][] {
+  const next = board.map((row) => row.slice());
+  for (const c of cellsToClear) {
+    next[c.row][c.col] = CELL_STATE.EMPTY;
+  }
+  return next;
+}
+
 export function useDragPlacement({
   board,
   isVertical,
   placedShipIds,
+  ships,
+  placementComplete,
   onPlaceShip,
+  onMoveShip,
   setSelectedShipId,
   setHoveredCells,
   setIsInvalidHover,
 }: UseDragPlacementArgs) {
   const isTouchDevice = useRef(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [draggingCells, setDraggingCells] = useState<ShipCell[]>([]);
+  const dragMode = useRef<DragMode>(null);
   const draggingShipId = useRef<string | null>(null);
+  const boardDragOrigin = useRef<BoardDragOrigin | null>(null);
 
   useEffect(() => {
     isTouchDevice.current = window.matchMedia('(pointer: coarse)').matches;
@@ -88,13 +130,53 @@ export function useDragPlacement({
         onDragStart: (e: DragEvent<HTMLElement>) => {
           e.dataTransfer.effectAllowed = 'move';
           e.dataTransfer.setData('text/plain', shipId);
+          dragMode.current = 'palette';
           draggingShipId.current = shipId;
+          boardDragOrigin.current = null;
+          setDraggingCells([]);
           setIsDragging(true);
           setSelectedShipId(null);
         },
       };
     },
     [placedShipIds, setSelectedShipId],
+  );
+
+  const getBoardCellDragProps = useCallback(
+    (row: number, col: number): DragProps => {
+      if (isTouchDevice.current || placementComplete) {
+        return { draggable: false, onDragStart: () => {} };
+      }
+      const ship = ships.find((s) =>
+        s.cells.some((c) => c.row === row && c.col === col),
+      );
+      if (!ship) {
+        return { draggable: false, onDragStart: () => {} };
+      }
+      return {
+        draggable: true,
+        onDragStart: (e: DragEvent<HTMLElement>) => {
+          e.dataTransfer.effectAllowed = 'move';
+          e.dataTransfer.setData('text/plain', ship.id);
+          const orientation = getOrientation(ship.cells);
+          const anchorOffset = ship.cells.findIndex(
+            (c) => c.row === row && c.col === col,
+          );
+          dragMode.current = 'board';
+          draggingShipId.current = ship.id;
+          boardDragOrigin.current = {
+            shipId: ship.id,
+            originalCells: ship.cells,
+            orientation,
+            anchorOffset: anchorOffset >= 0 ? anchorOffset : 0,
+          };
+          setDraggingCells(ship.cells);
+          setIsDragging(true);
+          setSelectedShipId(null);
+        },
+      };
+    },
+    [ships, placementComplete, setSelectedShipId],
   );
 
   const onDragOver = useCallback(
@@ -104,6 +186,26 @@ export function useDragPlacement({
       if (!shipId) return;
       const ship = SHIPS.find((s) => s.id === shipId);
       if (!ship) return;
+
+      if (dragMode.current === 'board') {
+        const origin = boardDragOrigin.current;
+        if (!origin) return;
+        const vertical = origin.orientation === 'v';
+        const startRow = vertical ? row - origin.anchorOffset : row;
+        const startCol = vertical ? col : col - origin.anchorOffset;
+        const cells = getCells(startRow, startCol, ship.size, vertical);
+        const virtualBoard = boardWithout(board, origin.originalCells);
+        if (cells && canPlace(cells, virtualBoard)) {
+          setHoveredCells(cells);
+          setIsInvalidHover?.(false);
+        } else {
+          setHoveredCells([]);
+          setIsInvalidHover?.(true);
+        }
+        return;
+      }
+
+      // palette mode
       const cells = getCells(row, col, ship.size, isVertical);
       if (cells && canPlace(cells, board)) {
         setHoveredCells(cells);
@@ -116,23 +218,58 @@ export function useDragPlacement({
     [board, isVertical, setHoveredCells, setIsInvalidHover],
   );
 
+  const clearDragState = useCallback(() => {
+    setIsDragging(false);
+    setDraggingCells([]);
+    dragMode.current = null;
+    draggingShipId.current = null;
+    boardDragOrigin.current = null;
+    setHoveredCells([]);
+    setIsInvalidHover?.(false);
+  }, [setHoveredCells, setIsInvalidHover]);
+
   const onDrop = useCallback(
     (row: number, col: number, e: DragEvent<HTMLElement>) => {
       e.preventDefault();
       const shipId = e.dataTransfer.getData('text/plain');
-      if (!shipId) return;
+      if (!shipId) {
+        clearDragState();
+        return;
+      }
       const ship = SHIPS.find((s) => s.id === shipId);
-      if (!ship) return;
+      if (!ship) {
+        clearDragState();
+        return;
+      }
+
+      const mode = dragMode.current;
+      const origin = boardDragOrigin.current;
+
+      if (mode === 'board' && origin) {
+        const vertical = origin.orientation === 'v';
+        const startRow = vertical ? row - origin.anchorOffset : row;
+        const startCol = vertical ? col : col - origin.anchorOffset;
+        const cells = getCells(startRow, startCol, ship.size, vertical);
+        const virtualBoard = boardWithout(board, origin.originalCells);
+        if (
+          cells &&
+          canPlace(cells, virtualBoard) &&
+          !cellsEqual(cells, origin.originalCells)
+        ) {
+          onMoveShip(shipId, cells);
+        }
+        clearDragState();
+        return;
+      }
+
+      // palette mode
       const cells = getCells(row, col, ship.size, isVertical);
       if (cells && canPlace(cells, board)) {
         onPlaceShip(shipId, cells);
       }
-      setHoveredCells([]);
-      setIsInvalidHover?.(false);
-      setIsDragging(false);
-      draggingShipId.current = null;
+      clearDragState();
     },
-    [board, isVertical, onPlaceShip, setHoveredCells, setIsInvalidHover],
+    [board, isVertical, onPlaceShip, onMoveShip, clearDragState],
   );
 
   const onDragLeave = useCallback(() => {
@@ -141,18 +278,17 @@ export function useDragPlacement({
   }, [setHoveredCells, setIsInvalidHover]);
 
   const handleDragEnd = useCallback(() => {
-    setIsDragging(false);
-    draggingShipId.current = null;
-    setHoveredCells([]);
-    setIsInvalidHover?.(false);
-  }, [setHoveredCells, setIsInvalidHover]);
+    clearDragState();
+  }, [clearDragState]);
 
   return {
     getDragProps,
+    getBoardCellDragProps,
     onDragOver,
     onDrop,
     onDragLeave,
     handleDragEnd,
     isDragging,
+    draggingCells,
   };
 }

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleActions.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleActions.ts
@@ -42,6 +42,20 @@ export function useSeaBattleActions(options: UseSeaBattleActionsOptions) {
     [roomId, userId, onActionStart],
   );
 
+  const moveShip = useCallback(
+    (shipId: string, cells: ShipCell[]) => {
+      if (!userId) return;
+      onActionStart?.('moveShip');
+      gameSocket.emit('seaBattle.session.move_ship', {
+        roomId,
+        userId,
+        shipId,
+        cells,
+      });
+    },
+    [roomId, userId, onActionStart],
+  );
+
   const confirmPlacement = useCallback(() => {
     if (!userId) return;
     onActionStart?.('confirmPlacement');
@@ -100,6 +114,7 @@ export function useSeaBattleActions(options: UseSeaBattleActionsOptions) {
   return {
     startSession,
     placeShip,
+    moveShip,
     confirmPlacement,
     attack,
     postHistoryNote,

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -77,6 +77,7 @@ export const SeaBattleGame = memo(function SeaBattleGame({
   const {
     startSession,
     placeShip,
+    moveShip,
     confirmPlacement,
     attack,
     resetPlacement,
@@ -392,6 +393,7 @@ export const SeaBattleGame = memo(function SeaBattleGame({
             isPlacementPhase={isPlacementPhase}
             currentPlayer={currentPlayer}
             placeShip={placeShip}
+            moveShip={moveShip}
             confirmPlacement={confirmPlacement}
             resetPlacement={resetPlacement}
             isPlacementComplete={isPlacementComplete}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -18,6 +18,7 @@ interface SeaBattleBoardsProps {
   isPlacementPhase: boolean;
   currentPlayer: SeaBattlePlayerState | null;
   placeShip: (shipId: string, cells: ShipCell[]) => void;
+  moveShip: (shipId: string, cells: ShipCell[]) => void;
   confirmPlacement: () => void;
   resetPlacement: () => void;
   isPlacementComplete: boolean;
@@ -43,6 +44,7 @@ export function SeaBattleBoards({
   isPlacementPhase,
   currentPlayer,
   placeShip,
+  moveShip,
   confirmPlacement,
   resetPlacement,
   isPlacementComplete,
@@ -69,6 +71,7 @@ export function SeaBattleBoards({
           key="placement-board"
           currentPlayer={currentPlayer}
           onPlaceShip={placeShip}
+          onMoveShip={moveShip}
           onConfirmPlacement={confirmPlacement}
           onResetPlacement={resetPlacement}
           isPlacementComplete={isPlacementComplete}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
@@ -43,6 +43,10 @@ interface PlacementBoardCellProps {
   isHovered: boolean;
   isInvalidCell: boolean;
   isClickable: boolean;
+  isShipDraggable: boolean;
+  isDraggingThisCell: boolean;
+  draggable: boolean;
+  onDragStart: (e: DragEvent<HTMLElement>) => void;
   rIndex: number;
   cIndex: number;
   onMouseEnter: (row: number, col: number) => void;
@@ -59,6 +63,10 @@ const PlacementBoardCell = memo(
     theme,
     isHovered,
     isInvalidCell,
+    isShipDraggable,
+    isDraggingThisCell,
+    draggable,
+    onDragStart,
     rIndex,
     cIndex,
     onMouseEnter,
@@ -85,17 +93,34 @@ const PlacementBoardCell = memo(
       [onDrop, rIndex, cIndex],
     );
 
+    const classNames = [
+      'sb-cell',
+      isHovered && !isInvalidCell ? 'sb-valid-pulse' : '',
+      isShipDraggable ? 'sb-cell--ship-draggable' : '',
+      isDraggingThisCell ? 'sb-cell--dragging' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
     return (
       <BoardCell
         style={{
-          backgroundColor: getCellBg(cellState, theme, isHovered, isInvalidCell),
+          backgroundColor: getCellBg(
+            cellState,
+            theme,
+            isHovered,
+            isInvalidCell,
+          ),
           borderColor: isInvalidCell ? 'rgba(239,68,68,0.6)' : theme.cellBorder,
           borderRadius: parseInt(theme.borderRadius) || 4,
+          opacity: isDraggingThisCell ? 0.4 : undefined,
         }}
         data-row={rIndex}
         data-col={cIndex}
         data-highlighted={isHovered ? 'true' : 'false'}
-        className={`sb-cell ${isHovered && !isInvalidCell ? 'sb-valid-pulse' : ''}`}
+        className={classNames}
+        draggable={draggable}
+        onDragStart={onDragStart}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={onMouseLeave}
         onPointerEnter={handleMouseEnter}
@@ -117,6 +142,12 @@ interface PlacementBoardGridProps {
   hoveredCells: ShipCell[];
   isInvalidHover: boolean;
   selectedShip: ShipConfig | null;
+  getBoardCellDragProps: (
+    row: number,
+    col: number,
+  ) => { draggable: boolean; onDragStart: (e: DragEvent<HTMLElement>) => void };
+  draggingCells: ShipCell[];
+  isPlacementComplete: boolean;
   onCellHover: (row: number, col: number) => void;
   onMouseLeave: () => void;
   onCellClick: (row: number, col: number) => void;
@@ -133,6 +164,9 @@ export const PlacementBoardGrid = memo(
     hoveredCells,
     isInvalidHover,
     selectedShip,
+    getBoardCellDragProps,
+    draggingCells,
+    isPlacementComplete,
     onCellHover,
     onMouseLeave,
     onCellClick,
@@ -141,6 +175,7 @@ export const PlacementBoardGrid = memo(
     onDragLeave,
     t,
   }: PlacementBoardGridProps) => {
+    const draggingKeys = new Set(draggingCells.map((c) => `${c.row}-${c.col}`));
     return (
       <PlayerSection
         backgroundColor={theme.boardBackground}
@@ -178,6 +213,13 @@ export const PlacementBoardGrid = memo(
                   (c) => c.row === rIndex && c.col === cIndex,
                 );
                 const isInvalidCell = isHovered && isInvalidHover;
+                const isShipCell = cellState === CELL_STATE.SHIP;
+                const isDraggingThisCell = draggingKeys.has(
+                  `${rIndex}-${cIndex}`,
+                );
+                const dragProps = isShipCell
+                  ? getBoardCellDragProps(rIndex, cIndex)
+                  : { draggable: false, onDragStart: () => {} };
                 return (
                   <PlacementBoardCell
                     key={`${rIndex}-${cIndex}`}
@@ -186,6 +228,12 @@ export const PlacementBoardGrid = memo(
                     isHovered={isHovered}
                     isInvalidCell={isInvalidCell}
                     isClickable={!!selectedShip}
+                    isShipDraggable={
+                      isShipCell && !isPlacementComplete && dragProps.draggable
+                    }
+                    isDraggingThisCell={isDraggingThisCell}
+                    draggable={dragProps.draggable}
+                    onDragStart={dragProps.onDragStart}
                     rIndex={rIndex}
                     cIndex={cIndex}
                     onMouseEnter={onCellHover}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
@@ -45,6 +45,7 @@ interface PlacementBoardCellProps {
   isClickable: boolean;
   isShipDraggable: boolean;
   isDraggingThisCell: boolean;
+  isPendingCell: boolean;
   draggable: boolean;
   onDragStart: (e: DragEvent<HTMLElement>) => void;
   rIndex: number;
@@ -52,6 +53,12 @@ interface PlacementBoardCellProps {
   onMouseEnter: (row: number, col: number) => void;
   onMouseLeave: () => void;
   onClick: (row: number, col: number) => void;
+  onDoubleClick?: (row: number, col: number) => void;
+  onContextMenu?: (
+    row: number,
+    col: number,
+    e: React.MouseEvent<HTMLElement>,
+  ) => void;
   onDragOver: (row: number, col: number, e: DragEvent<HTMLElement>) => void;
   onDrop: (row: number, col: number, e: DragEvent<HTMLElement>) => void;
   onDragLeave: () => void;
@@ -65,6 +72,7 @@ const PlacementBoardCell = memo(
     isInvalidCell,
     isShipDraggable,
     isDraggingThisCell,
+    isPendingCell,
     draggable,
     onDragStart,
     rIndex,
@@ -72,6 +80,8 @@ const PlacementBoardCell = memo(
     onMouseEnter,
     onMouseLeave,
     onClick,
+    onDoubleClick,
+    onContextMenu,
     onDragOver,
     onDrop,
     onDragLeave,
@@ -83,6 +93,18 @@ const PlacementBoardCell = memo(
     const handleClick = useCallback(
       () => onClick(rIndex, cIndex),
       [onClick, rIndex, cIndex],
+    );
+    const handleDoubleClick = useCallback(
+      () => onDoubleClick?.(rIndex, cIndex),
+      [onDoubleClick, rIndex, cIndex],
+    );
+    const handleContextMenu = useCallback(
+      (e: React.MouseEvent<HTMLElement>) => {
+        if (!onContextMenu) return;
+        e.preventDefault();
+        onContextMenu(rIndex, cIndex, e);
+      },
+      [onContextMenu, rIndex, cIndex],
     );
     const handleDragOver = useCallback(
       (e: DragEvent<HTMLElement>) => onDragOver(rIndex, cIndex, e),
@@ -98,6 +120,7 @@ const PlacementBoardCell = memo(
       isHovered && !isInvalidCell ? 'sb-valid-pulse' : '',
       isShipDraggable ? 'sb-cell--ship-draggable' : '',
       isDraggingThisCell ? 'sb-cell--dragging' : '',
+      isPendingCell ? 'sb-cell--pending-sync' : '',
     ]
       .filter(Boolean)
       .join(' ');
@@ -127,6 +150,8 @@ const PlacementBoardCell = memo(
         onPointerMove={handleMouseEnter}
         onPointerLeave={onMouseLeave}
         onClick={handleClick}
+        onDoubleClick={handleDoubleClick}
+        onContextMenu={handleContextMenu}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
         onDragLeave={onDragLeave}
@@ -147,10 +172,12 @@ interface PlacementBoardGridProps {
     col: number,
   ) => { draggable: boolean; onDragStart: (e: DragEvent<HTMLElement>) => void };
   draggingCells: ShipCell[];
+  pendingCells: ShipCell[];
   isPlacementComplete: boolean;
   onCellHover: (row: number, col: number) => void;
   onMouseLeave: () => void;
   onCellClick: (row: number, col: number) => void;
+  onCellRotateInPlace?: (row: number, col: number) => void;
   onDragOver: (row: number, col: number, e: DragEvent<HTMLElement>) => void;
   onDrop: (row: number, col: number, e: DragEvent<HTMLElement>) => void;
   onDragLeave: () => void;
@@ -166,16 +193,19 @@ export const PlacementBoardGrid = memo(
     selectedShip,
     getBoardCellDragProps,
     draggingCells,
+    pendingCells,
     isPlacementComplete,
     onCellHover,
     onMouseLeave,
     onCellClick,
+    onCellRotateInPlace,
     onDragOver,
     onDrop,
     onDragLeave,
     t,
   }: PlacementBoardGridProps) => {
     const draggingKeys = new Set(draggingCells.map((c) => `${c.row}-${c.col}`));
+    const pendingKeys = new Set(pendingCells.map((c) => `${c.row}-${c.col}`));
     return (
       <PlayerSection
         backgroundColor={theme.boardBackground}
@@ -214,15 +244,15 @@ export const PlacementBoardGrid = memo(
                 );
                 const isInvalidCell = isHovered && isInvalidHover;
                 const isShipCell = cellState === CELL_STATE.SHIP;
-                const isDraggingThisCell = draggingKeys.has(
-                  `${rIndex}-${cIndex}`,
-                );
+                const cellKey = `${rIndex}-${cIndex}`;
+                const isDraggingThisCell = draggingKeys.has(cellKey);
+                const isPendingCell = pendingKeys.has(cellKey);
                 const dragProps = isShipCell
                   ? getBoardCellDragProps(rIndex, cIndex)
                   : { draggable: false, onDragStart: () => {} };
                 return (
                   <PlacementBoardCell
-                    key={`${rIndex}-${cIndex}`}
+                    key={cellKey}
                     cellState={cellState}
                     theme={theme}
                     isHovered={isHovered}
@@ -232,6 +262,7 @@ export const PlacementBoardGrid = memo(
                       isShipCell && !isPlacementComplete && dragProps.draggable
                     }
                     isDraggingThisCell={isDraggingThisCell}
+                    isPendingCell={isPendingCell}
                     draggable={dragProps.draggable}
                     onDragStart={dragProps.onDragStart}
                     rIndex={rIndex}
@@ -239,6 +270,14 @@ export const PlacementBoardGrid = memo(
                     onMouseEnter={onCellHover}
                     onMouseLeave={onMouseLeave}
                     onClick={onCellClick}
+                    onDoubleClick={
+                      isShipCell ? onCellRotateInPlace : undefined
+                    }
+                    onContextMenu={
+                      isShipCell && onCellRotateInPlace
+                        ? (r, c) => onCellRotateInPlace(r, c)
+                        : undefined
+                    }
                     onDragOver={onDragOver}
                     onDrop={onDrop}
                     onDragLeave={onDragLeave}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
@@ -46,6 +46,7 @@ interface PlacementBoardCellProps {
   isShipDraggable: boolean;
   isDraggingThisCell: boolean;
   isPendingCell: boolean;
+  isShipHead: boolean;
   draggable: boolean;
   onDragStart: (e: DragEvent<HTMLElement>) => void;
   rIndex: number;
@@ -59,6 +60,7 @@ interface PlacementBoardCellProps {
     col: number,
     e: React.MouseEvent<HTMLElement>,
   ) => void;
+  onRotateButton?: (row: number, col: number) => void;
   onDragOver: (row: number, col: number, e: DragEvent<HTMLElement>) => void;
   onDrop: (row: number, col: number, e: DragEvent<HTMLElement>) => void;
   onDragLeave: () => void;
@@ -73,6 +75,7 @@ const PlacementBoardCell = memo(
     isShipDraggable,
     isDraggingThisCell,
     isPendingCell,
+    isShipHead,
     draggable,
     onDragStart,
     rIndex,
@@ -82,6 +85,7 @@ const PlacementBoardCell = memo(
     onClick,
     onDoubleClick,
     onContextMenu,
+    onRotateButton,
     onDragOver,
     onDrop,
     onDragLeave,
@@ -114,6 +118,21 @@ const PlacementBoardCell = memo(
       (e: DragEvent<HTMLElement>) => onDrop(rIndex, cIndex, e),
       [onDrop, rIndex, cIndex],
     );
+    const handleRotateButton = useCallback(
+      (e: React.MouseEvent<HTMLElement>) => {
+        e.stopPropagation();
+        onRotateButton?.(rIndex, cIndex);
+      },
+      [onRotateButton, rIndex, cIndex],
+    );
+    const handleRotateButtonMouseDown = useCallback(
+      (e: React.MouseEvent<HTMLElement>) => {
+        // Prevent the cell's HTML5 drag from starting when the user clicks
+        // the icon — without this the rotate button is mostly unusable.
+        e.stopPropagation();
+      },
+      [],
+    );
 
     const classNames = [
       'sb-cell',
@@ -124,6 +143,9 @@ const PlacementBoardCell = memo(
     ]
       .filter(Boolean)
       .join(' ');
+
+    const showRotateButton =
+      isShipHead && !!onRotateButton && !isDraggingThisCell;
 
     return (
       <BoardCell
@@ -155,7 +177,20 @@ const PlacementBoardCell = memo(
         onDragOver={handleDragOver}
         onDrop={handleDrop}
         onDragLeave={onDragLeave}
-      />
+      >
+        {showRotateButton ? (
+          <span
+            role="button"
+            aria-label="Rotate ship"
+            className="sb-cell__rotate-btn"
+            draggable={false}
+            onMouseDown={handleRotateButtonMouseDown}
+            onClick={handleRotateButton}
+          >
+            ↻
+          </span>
+        ) : null}
+      </BoardCell>
     );
   },
 );
@@ -173,6 +208,7 @@ interface PlacementBoardGridProps {
   ) => { draggable: boolean; onDragStart: (e: DragEvent<HTMLElement>) => void };
   draggingCells: ShipCell[];
   pendingCells: ShipCell[];
+  shipHeadKeys: Set<string>;
   isPlacementComplete: boolean;
   onCellHover: (row: number, col: number) => void;
   onMouseLeave: () => void;
@@ -194,6 +230,7 @@ export const PlacementBoardGrid = memo(
     getBoardCellDragProps,
     draggingCells,
     pendingCells,
+    shipHeadKeys,
     isPlacementComplete,
     onCellHover,
     onMouseLeave,
@@ -247,6 +284,10 @@ export const PlacementBoardGrid = memo(
                 const cellKey = `${rIndex}-${cIndex}`;
                 const isDraggingThisCell = draggingKeys.has(cellKey);
                 const isPendingCell = pendingKeys.has(cellKey);
+                const isShipHead =
+                  isShipCell &&
+                  !isPlacementComplete &&
+                  shipHeadKeys.has(cellKey);
                 const dragProps = isShipCell
                   ? getBoardCellDragProps(rIndex, cIndex)
                   : { draggable: false, onDragStart: () => {} };
@@ -263,6 +304,7 @@ export const PlacementBoardGrid = memo(
                     }
                     isDraggingThisCell={isDraggingThisCell}
                     isPendingCell={isPendingCell}
+                    isShipHead={isShipHead}
                     draggable={dragProps.draggable}
                     onDragStart={dragProps.onDragStart}
                     rIndex={rIndex}
@@ -277,6 +319,9 @@ export const PlacementBoardGrid = memo(
                       isShipCell && onCellRotateInPlace
                         ? (r, c) => onCellRotateInPlace(r, c)
                         : undefined
+                    }
+                    onRotateButton={
+                      isShipHead ? onCellRotateInPlace : undefined
                     }
                     onDragOver={onDragOver}
                     onDrop={onDrop}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -359,6 +359,19 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
 
   const pendingCells = effectivePendingMove?.newCells ?? [];
 
+  // First cell of each multi-cell placed ship — gets a small ↻ rotate button
+  // so the interaction is discoverable. 1-cell submarines are excluded since
+  // their orientation is meaningless and rotating them is a no-op.
+  const shipHeadKeys = useMemo(() => {
+    const keys = new Set<string>();
+    for (const ship of ships) {
+      if (ship.cells.length < 2) continue;
+      const head = ship.cells[0];
+      if (head) keys.add(`${head.row}-${head.col}`);
+    }
+    return keys;
+  }, [ships]);
+
   const boardEl = (
     <PlacementBoardGrid
       board={board}
@@ -369,6 +382,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       getBoardCellDragProps={getBoardCellDragProps}
       draggingCells={draggingCells}
       pendingCells={pendingCells}
+      shipHeadKeys={shipHeadKeys}
       isPlacementComplete={isPlacementComplete}
       onCellHover={handleCellHover}
       onMouseLeave={handleMouseLeave}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -17,6 +17,7 @@ import { useDragPlacement } from '../hooks/useDragPlacement';
 interface ShipPlacementBoardProps {
   currentPlayer: SeaBattlePlayerState | null;
   onPlaceShip: (shipId: string, cells: ShipCell[]) => void;
+  onMoveShip: (shipId: string, cells: ShipCell[]) => void;
   onConfirmPlacement: () => void;
   onResetPlacement: () => void;
   isPlacementComplete: boolean;
@@ -30,6 +31,7 @@ import { PlacementBoardGrid } from './ShipPlacement/PlacementBoardGrid';
 export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   currentPlayer,
   onPlaceShip,
+  onMoveShip,
   onConfirmPlacement,
   onResetPlacement,
   isPlacementComplete,
@@ -56,16 +58,28 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     return SHIPS.find((s) => s.id === selectedShipId) || null;
   }, [selectedShipId]);
 
-  const { getDragProps, onDragOver, onDrop, onDragLeave, handleDragEnd } =
-    useDragPlacement({
-      board,
-      isVertical,
-      placedShipIds,
-      onPlaceShip,
-      setSelectedShipId,
-      setHoveredCells,
-      setIsInvalidHover,
-    });
+  const ships = currentPlayer?.ships ?? [];
+
+  const {
+    getDragProps,
+    getBoardCellDragProps,
+    onDragOver,
+    onDrop,
+    onDragLeave,
+    handleDragEnd,
+    draggingCells,
+  } = useDragPlacement({
+    board,
+    isVertical,
+    placedShipIds,
+    ships,
+    placementComplete: isPlacementComplete,
+    onPlaceShip,
+    onMoveShip,
+    setSelectedShipId,
+    setHoveredCells,
+    setIsInvalidHover,
+  });
 
   const canPlaceAt = useCallback(
     (row: number, col: number, ship: ShipConfig): boolean => {
@@ -211,6 +225,9 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       hoveredCells={hoveredCells}
       isInvalidHover={isInvalidHover}
       selectedShip={selectedShip}
+      getBoardCellDragProps={getBoardCellDragProps}
+      draggingCells={draggingCells}
+      isPlacementComplete={isPlacementComplete}
       onCellHover={handleCellHover}
       onMouseLeave={handleMouseLeave}
       onCellClick={handleCellClick}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo, memo } from 'react';
+import { useState, useCallback, useMemo, useEffect, memo } from 'react';
 import { Text, YStack, useMedia } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type {
@@ -8,6 +8,7 @@ import type {
   ShipConfig,
   SeaBattlePlayerState,
   CellState,
+  Ship,
 } from '../types';
 import { SHIPS, BOARD_SIZE, CELL_STATE } from '../types';
 import { PlacementHeader, GameBoardWrapper, BoardContainer } from './styles';
@@ -44,21 +45,94 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   const { t } = useTranslation();
   const theme = useSeaBattleTheme();
 
+  const serverShips = useMemo<Ship[]>(
+    () => currentPlayer?.ships ?? [],
+    [currentPlayer?.ships],
+  );
+  const serverBoard = useMemo<CellState[][]>(
+    () => currentPlayer?.board || createEmptyBoard(),
+    [currentPlayer?.board],
+  );
+
+  // Optimistic move: when the player drops a ship, render it at the new spot
+  // immediately while the server round-trip is in flight. The pending state
+  // is treated as "effective" only while the server hasn't yet reflected the
+  // move — derived in render so we never call setState from an effect.
+  // A 2s safety timer clears the underlying state if no server update arrives
+  // (e.g. dropped socket, server-side rejection that produces no broadcast).
+  const [pendingMove, setPendingMove] = useState<{
+    shipId: string;
+    originalCells: ShipCell[];
+    newCells: ShipCell[];
+  } | null>(null);
+
+  const effectivePendingMove = useMemo(() => {
+    if (!pendingMove) return null;
+    const ship = serverShips.find((s) => s.id === pendingMove.shipId);
+    if (!ship) return pendingMove;
+    const matchesNew =
+      ship.cells.length === pendingMove.newCells.length &&
+      ship.cells.every(
+        (c, i) =>
+          c.row === pendingMove.newCells[i].row &&
+          c.col === pendingMove.newCells[i].col,
+      );
+    return matchesNew ? null : pendingMove;
+  }, [serverShips, pendingMove]);
+
+  const ships = useMemo<Ship[]>(() => {
+    if (!effectivePendingMove) return serverShips;
+    return serverShips.map((s) =>
+      s.id === effectivePendingMove.shipId
+        ? { ...s, cells: effectivePendingMove.newCells }
+        : s,
+    );
+  }, [serverShips, effectivePendingMove]);
+
+  const board = useMemo<CellState[][]>(() => {
+    if (!effectivePendingMove) return serverBoard;
+    const next = serverBoard.map((row) => row.slice());
+    for (const c of effectivePendingMove.originalCells) {
+      next[c.row][c.col] = CELL_STATE.EMPTY;
+    }
+    for (const c of effectivePendingMove.newCells) {
+      next[c.row][c.col] = CELL_STATE.SHIP;
+    }
+    return next;
+  }, [serverBoard, effectivePendingMove]);
+
+  useEffect(() => {
+    if (!pendingMove) return;
+    const timer = setTimeout(() => setPendingMove(null), 2000);
+    return () => clearTimeout(timer);
+  }, [pendingMove]);
+
+  const handleMoveShip = useCallback(
+    (shipId: string, cells: ShipCell[]) => {
+      const ship = serverShips.find((s) => s.id === shipId);
+      if (ship) {
+        setPendingMove({
+          shipId,
+          originalCells: ship.cells,
+          newCells: cells,
+        });
+      }
+      onMoveShip(shipId, cells);
+    },
+    [serverShips, onMoveShip],
+  );
+
   const placedShipIds = useMemo(() => {
-    return new Set(currentPlayer?.ships.map((s) => s.id) || []);
-  }, [currentPlayer?.ships]);
+    return new Set(ships.map((s) => s.id));
+  }, [ships]);
 
   const unplacedShips = useMemo(() => {
     return SHIPS.filter((s) => !placedShipIds.has(s.id));
   }, [placedShipIds]);
 
-  const board = currentPlayer?.board || createEmptyBoard();
-
   const selectedShip = useMemo(() => {
     return SHIPS.find((s) => s.id === selectedShipId) || null;
   }, [selectedShipId]);
-
-  const ships = currentPlayer?.ships ?? [];
 
   const {
     getDragProps,
@@ -75,11 +149,76 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     ships,
     placementComplete: isPlacementComplete,
     onPlaceShip,
-    onMoveShip,
+    onMoveShip: handleMoveShip,
     setSelectedShipId,
     setHoveredCells,
     setIsInvalidHover,
   });
+
+  // Rotate a placed ship in place around the clicked cell. Keeps the clicked
+  // cell as the anchor and flips orientation; falls back silently if the
+  // rotated layout would be invalid (out of bounds, overlap, or adjacency).
+  const handleRotateInPlace = useCallback(
+    (row: number, col: number) => {
+      if (isPlacementComplete) return;
+      const ship = ships.find((s) =>
+        s.cells.some((c) => c.row === row && c.col === col),
+      );
+      if (!ship || ship.cells.length < 2) return;
+
+      const wasVertical = ship.cells[0].col === ship.cells[1].col;
+      const anchorIdx = ship.cells.findIndex(
+        (c) => c.row === row && c.col === col,
+      );
+      if (anchorIdx < 0) return;
+
+      const newCells: ShipCell[] = [];
+      for (let i = 0; i < ship.size; i++) {
+        const offset = i - anchorIdx;
+        const cell = wasVertical
+          ? { row, col: col + offset }
+          : { row: row + offset, col };
+        if (
+          cell.row < 0 ||
+          cell.row >= BOARD_SIZE ||
+          cell.col < 0 ||
+          cell.col >= BOARD_SIZE
+        ) {
+          return;
+        }
+        newCells.push(cell);
+      }
+
+      // Validate against a board with the rotating ship's own cells cleared.
+      const virtual = board.map((r) => r.slice());
+      for (const c of ship.cells) {
+        virtual[c.row][c.col] = CELL_STATE.EMPTY;
+      }
+      const dirs = [
+        [-1, -1],
+        [-1, 0],
+        [-1, 1],
+        [0, -1],
+        [0, 1],
+        [1, -1],
+        [1, 0],
+        [1, 1],
+      ];
+      for (const cell of newCells) {
+        if (virtual[cell.row][cell.col] !== CELL_STATE.EMPTY) return;
+        for (const [dr, dc] of dirs) {
+          const r = cell.row + (dr ?? 0);
+          const c = cell.col + (dc ?? 0);
+          if (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE) {
+            if (virtual[r][c] === CELL_STATE.SHIP) return;
+          }
+        }
+      }
+
+      handleMoveShip(ship.id, newCells);
+    },
+    [ships, board, isPlacementComplete, handleMoveShip],
+  );
 
   const canPlaceAt = useCallback(
     (row: number, col: number, ship: ShipConfig): boolean => {
@@ -218,6 +357,8 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     />
   );
 
+  const pendingCells = effectivePendingMove?.newCells ?? [];
+
   const boardEl = (
     <PlacementBoardGrid
       board={board}
@@ -227,10 +368,12 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       selectedShip={selectedShip}
       getBoardCellDragProps={getBoardCellDragProps}
       draggingCells={draggingCells}
+      pendingCells={pendingCells}
       isPlacementComplete={isPlacementComplete}
       onCellHover={handleCellHover}
       onMouseLeave={handleMouseLeave}
       onCellClick={handleCellClick}
+      onCellRotateInPlace={handleRotateInPlace}
       onDragOver={onDragOver}
       onDrop={onDrop}
       onDragLeave={onDragLeave}

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -304,7 +304,10 @@
   display: contents;
 }
 /* "SHIPS REMAINING" — rotated, sits at the bottom of the strip. */
-.sb-mobile-landscape .sb-ships-remaining-container > div:first-child > span:first-child {
+.sb-mobile-landscape
+  .sb-ships-remaining-container
+  > div:first-child
+  > span:first-child {
   writing-mode: vertical-rl;
   transform: rotate(180deg);
   font-size: 9px !important;
@@ -316,7 +319,10 @@
   order: 3;
 }
 /* "10/10" — count at the very top of the strip. */
-.sb-mobile-landscape .sb-ships-remaining-container > div:first-child > span:nth-child(2) {
+.sb-mobile-landscape
+  .sb-ships-remaining-container
+  > div:first-child
+  > span:nth-child(2) {
   font-size: 13px !important;
   text-align: center;
   align-self: center;
@@ -349,11 +355,21 @@
   height: 8px !important;
 }
 
-.sb-mobile-landscape [data-size='5'] { width: 50px !important; }
-.sb-mobile-landscape [data-size='4'] { width: 40px !important; }
-.sb-mobile-landscape [data-size='3'] { width: 30px !important; }
-.sb-mobile-landscape [data-size='2'] { width: 20px !important; }
-.sb-mobile-landscape [data-size='1'] { width: 10px !important; }
+.sb-mobile-landscape [data-size='5'] {
+  width: 50px !important;
+}
+.sb-mobile-landscape [data-size='4'] {
+  width: 40px !important;
+}
+.sb-mobile-landscape [data-size='3'] {
+  width: 30px !important;
+}
+.sb-mobile-landscape [data-size='2'] {
+  width: 20px !important;
+}
+.sb-mobile-landscape [data-size='1'] {
+  width: 10px !important;
+}
 
 /* Smaller chrome budget when ships is on the side. Horizontal chrome:
    40 (ships col) + 2 (gap) + 4 (section padding) + 4 (board margin)
@@ -397,6 +413,16 @@
   position: relative;
   border-width: 1px;
   border-style: solid;
+}
+
+.sb-cell.sb-cell--ship-draggable {
+  cursor: grab;
+}
+.sb-cell.sb-cell--ship-draggable:active {
+  cursor: grabbing;
+}
+.sb-cell.sb-cell--dragging {
+  opacity: 0.4;
 }
 
 /* Responsive labels */

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -425,6 +425,27 @@
   opacity: 0.4;
 }
 
+/* Pending-sync: shown on the optimistically-placed cells of a ship while
+   the server round-trip is in flight. Slow, soft pulse (blue-ish) so it
+   reads as "syncing" rather than a valid-drop preview (which uses the
+   faster green valid-pulse on hover). */
+@keyframes sb-pending-sync {
+  0%,
+  100% {
+    box-shadow:
+      inset 0 0 0 1px rgba(96, 165, 250, 0.35),
+      0 0 4px rgba(96, 165, 250, 0.25);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1px rgba(96, 165, 250, 0.7),
+      0 0 10px rgba(96, 165, 250, 0.5);
+  }
+}
+.sb-cell.sb-cell--pending-sync {
+  animation: sb-pending-sync 1.6s ease-in-out infinite;
+}
+
 /* Responsive labels */
 @media (max-width: 768px) {
   .sb-label {

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css
@@ -446,6 +446,51 @@
   animation: sb-pending-sync 1.6s ease-in-out infinite;
 }
 
+/* Small rotate affordance on each placed multi-cell ship's head cell.
+   Always visible so the user spots it without searching; takes up only the
+   top-right corner (~12% of the cell) so the rest of the head cell remains
+   freely draggable. Clicking the icon rotates the ship in place; clicking
+   anywhere else on the cell starts the regular drag. */
+.sb-cell__rotate-btn {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 14px;
+  height: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.95);
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  opacity: 0.85;
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    background-color 120ms ease;
+  z-index: 2;
+}
+.sb-cell:hover .sb-cell__rotate-btn,
+.sb-cell__rotate-btn:hover {
+  opacity: 1;
+  background: rgba(15, 23, 42, 0.95);
+}
+.sb-cell__rotate-btn:hover {
+  transform: scale(1.1);
+}
+.sb-cell__rotate-btn:active {
+  transform: scale(0.95);
+}
+@media (pointer: coarse) {
+  .sb-cell__rotate-btn {
+    opacity: 0.95;
+  }
+}
+
 /* Responsive labels */
 @media (max-width: 768px) {
   .sb-label {

--- a/docs/superpowers/specs/2026-05-27-sea-battle-drag-placed-ships-design.md
+++ b/docs/superpowers/specs/2026-05-27-sea-battle-drag-placed-ships-design.md
@@ -61,13 +61,16 @@ Identical to `validatePlaceShip` with three differences:
 
 - `validateAction`: add `case 'moveShip': return validateMoveShip(state, player, payload as MoveShipPayload);`
 - `executeAction`: add `case 'moveShip': return runMoveShip(newState, player, payload as MoveShipPayload);`
-- `getPossibleActions` (in `sea-battle.utils.ts`): include `'moveShip'` whenever the placement phase allows `placeShip` (i.e. not yet `placementComplete`).
+- `getSeaBattleAvailableActions` (in `sea-battle.utils.ts` at line 134): gate `moveShip` independently — append `'moveShip'` when `state.phase === PLACEMENT && !player.placementComplete && player.ships.length > 0`. Critically this must be added in addition to `confirmPlacement`, since after auto-place all ten ships are present and the player is exactly the persona this feature serves; tying `moveShip` to the same gate as `placeShip` (`ships.length < SHIPS.length`) would disable it in the primary use case.
+- `MoveShipPayload` must be exported from the same barrel that `sea-battle.service.ts` already imports `PlaceShipPayload` from (`./engines/sea-battle/sea-battle.types`), otherwise `moveShipByRoom`'s signature won't compile.
 
 **Service / gateway**
 
-- `sea-battle.service.ts`: add `moveShipByRoom(roomId, userId, payload)` mirroring `placeShipByRoom`.
-- Socket event: `seaBattle.session.move_ship` → `moveShipByRoom` → `dispatchAction('moveShip', ...)`.
+- `sea-battle.service.ts`: add `moveShipByRoom(userId, roomId, payload: MoveShipPayload)` mirroring `placeShipByRoom` (note the existing signature is `placeShipByRoom(userId, roomId, payload)` — userId first).
+- Gateway file is `apps/be/src/games/sea-battle.gateway.ts` (top-level under `games/`, not inside `games/sea-battle/`).
+- New handler `handleMoveShip` mirrors `handlePlaceShip` (lines 75–119): subscribe to `seaBattle.session.move_ship`, validate `shipId` + `cells` from payload, call `moveShipByRoom`, ack with `client.emit('seaBattle.session.ship_moved', maybeEncrypt({ roomId, userId, shipId }))`. Errors via the shared `handleError` helper.
 - Authorization: same guard as `placeShip` — must be the user's own placement.
+- FE does not subscribe to `ship_moved`; the broadcast session-state push is what redraws the board, matching how `ship_placed` is handled today. The ack is fire-and-forget telemetry, consistent with the other placement handlers.
 
 ### Frontend — extend the drag system
 
@@ -92,7 +95,7 @@ For each board cell:
 - Resolve the ship occupying `(row, col)` from `currentPlayer.ships`.
 - If no ship, or `placementComplete`, or `(pointer: coarse)` is true → return `{ draggable: false, onDragStart: noop }`.
 - Otherwise → `draggable: true`. `onDragStart`:
-  1. Compute `orientation` by comparing `cells[0]` and `cells[1]` (or default `h` for 1-cell ships).
+  1. Compute `orientation` by comparing `cells[0]` and `cells[1]`. All `SHIPS` in the game are size ≥ 2 so no special case is needed.
   2. Compute `anchorOffset` = index of `(row, col)` within `cells`.
   3. Set `dragMode = 'board'`, `boardDragOrigin = { shipId, originalCells, orientation, anchorOffset }`.
   4. `e.dataTransfer.setData('text/plain', shipId)` (the existing protocol — kept identical so palette and board paths share `onDrop`).
@@ -121,7 +124,7 @@ If `cells === null` (off-board) → invalid hover, no drop.
 - `'palette'` → existing behavior: `onPlaceShip(shipId, cells)`.
 - `'board'` → new prop `onMoveShip(shipId, cells)` (skip if cells deep-equal `originalCells`).
 
-`handleDragEnd` clears all drag state regardless of branch.
+`onDrop` and `handleDragEnd` clear local drag state synchronously — `dragMode`, `boardDragOrigin`, `hoveredCells`, `isInvalidHover`. The lifted-cell visual disappears immediately on drop and does not wait for the server-pushed session update; the board then re-renders from server state when the broadcast arrives. This matches how `placeShip` already behaves and prevents a stuck dim-cell if the server is slow or rejects the move.
 
 **`ShipPlacementBoard.tsx`**
 
@@ -163,8 +166,8 @@ Apply `.sb-cell--ship-draggable` only when the cell is a `SHIP` and not `placeme
 - **Drop off-board**: `getCells` returns `null` → no emit, ship snaps back.
 - **Drop overlapping another ship**: validity check returns false; hover shows red; on drop nothing emits.
 - **Drop on a cell adjacent to another ship**: same as above.
-- **`placementComplete` true**: board cells not draggable; BE validator also rejects.
-- **Team mode**: only the player's own board is shown for placement; rules unchanged.
+- **`placementComplete` true**: board cells not draggable; BE validator also rejects. Intentional — once you've confirmed your layout, you're locked in even while teammates are still placing.
+- **Team mode**: only the player's own board is shown for placement; the per-player `placementComplete` lock applies independently to each teammate, so one teammate confirming doesn't disable another's `moveShip`.
 - **State updated mid-drag** (e.g. teammate reset): the BE validator re-runs on the server's current state, so a stale move is rejected and the player's board reflects truth on next state push.
 - **Pointer coarse (mobile/tablet)**: both palette drag and board drag short-circuit to `draggable: false`. Click-to-select still works for palette → board.
 
@@ -208,10 +211,10 @@ Backend:
 - `apps/be/src/games/engines/sea-battle/sea-battle.types.ts` — add `MoveShipPayload`.
 - `apps/be/src/games/engines/sea-battle/sea-battle.validators.ts` — add `validateMoveShip`.
 - `apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts` — add `runMoveShip`.
-- `apps/be/src/games/engines/sea-battle/sea-battle.engine.ts` — wire `moveShip`.
-- `apps/be/src/games/engines/sea-battle/sea-battle.utils.ts` — `getPossibleActions` includes `moveShip`.
-- `apps/be/src/games/sea-battle/sea-battle.service.ts` — add `moveShipByRoom`.
-- Gateway/handler for the new socket event.
+- `apps/be/src/games/engines/sea-battle/sea-battle.engine.ts` — wire `moveShip` into `validateAction` and `executeAction`.
+- `apps/be/src/games/engines/sea-battle/sea-battle.utils.ts` — `getSeaBattleAvailableActions` (line 134) includes `moveShip` independently of `placeShip`'s gate.
+- `apps/be/src/games/sea-battle/sea-battle.service.ts` — add `moveShipByRoom(userId, roomId, payload)`.
+- `apps/be/src/games/sea-battle.gateway.ts` — add `handleMoveShip` subscribed to `seaBattle.session.move_ship`, emit ack `seaBattle.session.ship_moved`.
 - New engine spec file.
 
 Web:
@@ -226,4 +229,4 @@ Web:
 
 ## Rollout
 
-Single PR. No flag — the new action is additive on BE (existing clients keep working), and the FE upgrade adds a capability without changing the existing placement flow. Bot and pre-existing clients never emit `moveShip`, so server-side risk is contained to the new action's code path.
+Single PR. No flag — the new action is additive on BE (existing clients keep working), and the FE upgrade adds a capability without changing the existing placement flow. The bot service does not emit `moveShip` and there is no plan to add it, so server-side risk is contained to the new action's code path.

--- a/docs/superpowers/specs/2026-05-27-sea-battle-drag-placed-ships-design.md
+++ b/docs/superpowers/specs/2026-05-27-sea-battle-drag-placed-ships-design.md
@@ -1,0 +1,229 @@
+# Sea Battle: drag and drop placed ships (ARC-754)
+
+## Problem
+
+In Sea Battle placement, players can drop ships from the palette onto the board (desktop) or use Auto-place to randomize all ten ships at once. Auto-place is convenient but the resulting layout is rarely the one the player wants. To change a single ship today they must hit Reset and restart placement from scratch, which throws away the rest of the random layout they wanted to keep. The same pain applies to manually placed ships: once a ship is on the board the only way to relocate it is Reset.
+
+## Goal
+
+Let the player drag any already-placed ship from one position on the board to another while in the placement phase, without losing the rest of the layout. Works for both auto-placed and manually placed ships. Web only — no mobile/touch support in this change.
+
+## Non-goals
+
+- Mobile/touch drag: out of scope; consistent with current palette drag which is also `(pointer: coarse)`-gated.
+- Rotating a ship mid-drag via keyboard (e.g. `R`).
+- Dragging a placed ship back into the palette.
+- Shake/error animation on invalid drop.
+- Changes to the bot's auto-place flow.
+
+## User experience
+
+1. Player clicks **Auto-place** (or manually places ships). All ten ships sit on the board.
+2. Player hovers a placed ship — cursor becomes `grab`.
+3. Player drags from any cell of the ship. The ship's cells dim to ~40% opacity ("lifted"). Cursor is `grabbing`.
+4. As the player drags over the board, the standard hover preview shows where the ship will land. The grabbed cell stays under the cursor (anchor-at-grabbed-cell). The ship's own current cells are treated as empty for validity checks, so a one-cell nudge along the same axis is valid.
+5. On valid drop, the ship moves; the player's board updates immediately via the standard server round-trip.
+6. On invalid drop (or drop outside the board), nothing happens — the ship returns to its original position. Hover state clears.
+7. Orientation is preserved: the ship's own horizontal/vertical state is captured at drag start and used for the drop, regardless of the global Rotate toggle.
+
+## Architecture
+
+### Backend — new `moveShip` engine action
+
+A new atomic action so that the engine never observes a "ship removed but not yet placed" intermediate state.
+
+**Payload**
+
+```ts
+export interface MoveShipPayload {
+  shipId: string;
+  cells: ShipCell[];
+}
+```
+
+**Validator** (`validateMoveShip`)
+
+Identical to `validatePlaceShip` with three differences:
+
+- The ship must already be placed (`player.ships.some(s => s.id === payload.shipId)`).
+- Overlap/adjacency checks evaluate against a _virtual_ board where the moving ship's old cells are treated as `EMPTY`. This lets a ship nudge one cell along its own axis without seeing itself as a blocker.
+- Cell-count and connectedness checks reuse `areCellsValid` / `areCellsConnected` from `sea-battle.utils.ts`.
+
+**Engine function** (`runMoveShip` in `sea-battle-placement-actions.utils.ts`)
+
+1. Clear the old ship's cells on `player.board` (set to `EMPTY`).
+2. Remove the old `Ship` from `player.ships`.
+3. Push a new `Ship` with `cells = payload.cells`, `hits: 0`, `sunk: false`, same `id/name/size`.
+4. Stamp the new cells as `SHIP` on `player.board`.
+5. Append a single `'action'` log: `Moved <ship.name>` (scope `private`, `senderId: player.playerId`).
+
+**Engine wiring**
+
+- `validateAction`: add `case 'moveShip': return validateMoveShip(state, player, payload as MoveShipPayload);`
+- `executeAction`: add `case 'moveShip': return runMoveShip(newState, player, payload as MoveShipPayload);`
+- `getPossibleActions` (in `sea-battle.utils.ts`): include `'moveShip'` whenever the placement phase allows `placeShip` (i.e. not yet `placementComplete`).
+
+**Service / gateway**
+
+- `sea-battle.service.ts`: add `moveShipByRoom(roomId, userId, payload)` mirroring `placeShipByRoom`.
+- Socket event: `seaBattle.session.move_ship` → `moveShipByRoom` → `dispatchAction('moveShip', ...)`.
+- Authorization: same guard as `placeShip` — must be the user's own placement.
+
+### Frontend — extend the drag system
+
+**`useDragPlacement` hook** gains a board-source mode in addition to the existing palette source.
+
+New ref state:
+
+- `dragMode: 'palette' | 'board' | null` (mutable ref).
+- `boardDragOrigin: { shipId: string; originalCells: ShipCell[]; orientation: 'h' | 'v'; anchorOffset: number } | null`.
+
+New return:
+
+```ts
+getBoardCellDragProps(row: number, col: number): {
+  draggable: boolean;
+  onDragStart: (e: DragEvent<HTMLElement>) => void;
+}
+```
+
+For each board cell:
+
+- Resolve the ship occupying `(row, col)` from `currentPlayer.ships`.
+- If no ship, or `placementComplete`, or `(pointer: coarse)` is true → return `{ draggable: false, onDragStart: noop }`.
+- Otherwise → `draggable: true`. `onDragStart`:
+  1. Compute `orientation` by comparing `cells[0]` and `cells[1]` (or default `h` for 1-cell ships).
+  2. Compute `anchorOffset` = index of `(row, col)` within `cells`.
+  3. Set `dragMode = 'board'`, `boardDragOrigin = { shipId, originalCells, orientation, anchorOffset }`.
+  4. `e.dataTransfer.setData('text/plain', shipId)` (the existing protocol — kept identical so palette and board paths share `onDrop`).
+  5. Clear `selectedShipId` so the global rotate toggle doesn't affect the in-flight ship.
+
+**Effective board for validity**
+
+During a board drag, `canPlace` must ignore the moving ship's old cells. Implement by cloning `board` and clearing `originalCells` before running the existing `canPlace`. Both `onDragOver` and the drop validity preview use this effective board.
+
+**Anchor-adjusted cells**
+
+`onDragOver(row, col)` and `onDrop(row, col)` compute the _start_ cell as:
+
+```ts
+const startRow = orientation === 'v' ? row - anchorOffset : row;
+const startCol = orientation === 'h' ? col - anchorOffset : col;
+const cells = getCells(startRow, startCol, ship.size, orientation === 'v');
+```
+
+If `cells === null` (off-board) → invalid hover, no drop.
+
+**Drop dispatch**
+
+`onDrop` branches on `dragMode`:
+
+- `'palette'` → existing behavior: `onPlaceShip(shipId, cells)`.
+- `'board'` → new prop `onMoveShip(shipId, cells)` (skip if cells deep-equal `originalCells`).
+
+`handleDragEnd` clears all drag state regardless of branch.
+
+**`ShipPlacementBoard.tsx`**
+
+- Accept new prop `onMoveShip(shipId, cells)`.
+- Pass through to `useDragPlacement`.
+- Pass `getBoardCellDragProps` and `currentPlayer.ships` down to `PlacementBoardGrid`.
+
+**`PlacementBoardGrid.tsx`**
+
+- Accept `getBoardCellDragProps` and `ships: Ship[]`.
+- For each cell, spread the result of `getBoardCellDragProps(row, col)` onto `BoardCell`.
+- Add CSS class `sb-cell--dragging` to the moving ship's cells while `dragMode === 'board'`. Implement via a small `Set<string>` of cell keys passed to the grid (cells visible from `boardDragOrigin.originalCells`), or simpler: expose `isDraggingBoardShip: boolean` and `draggingCells: ShipCell[]` from the hook.
+
+**`useSeaBattleActions.ts`**
+
+- New `moveShip(shipId, cells)` that emits `seaBattle.session.move_ship`.
+
+**`Game.tsx`** (or wherever `placeShip` is wired)
+
+- Wire `actions.moveShip` to `<ShipPlacementBoard onMoveShip={...}>`.
+
+### CSS
+
+Add to `apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css` (or `board.tsx` styled file):
+
+- `.sb-cell--ship-draggable { cursor: grab; }`
+- `.sb-cell--ship-draggable:active { cursor: grabbing; }`
+- `.sb-cell--dragging { opacity: 0.4; }`
+
+Apply `.sb-cell--ship-draggable` only when the cell is a `SHIP` and not `placementComplete`.
+
+## Why a new BE action
+
+`placeShip` already rejects already-placed ship IDs by design (`sea-battle.validators.ts` line 33). Reusing it would force a "remove then place" two-step that is racy, makes intermediate state visible to teammates in team mode, and complicates the engine's log. `moveShip` keeps the invariant honest and yields one atomic log entry.
+
+## Edge cases
+
+- **Drop on same cells**: client-side dedupe — if `cells` deep-equal `originalCells`, skip the emit. BE validator would also accept it as a no-op, but skipping the round-trip is cheaper.
+- **Drop off-board**: `getCells` returns `null` → no emit, ship snaps back.
+- **Drop overlapping another ship**: validity check returns false; hover shows red; on drop nothing emits.
+- **Drop on a cell adjacent to another ship**: same as above.
+- **`placementComplete` true**: board cells not draggable; BE validator also rejects.
+- **Team mode**: only the player's own board is shown for placement; rules unchanged.
+- **State updated mid-drag** (e.g. teammate reset): the BE validator re-runs on the server's current state, so a stale move is rejected and the player's board reflects truth on next state push.
+- **Pointer coarse (mobile/tablet)**: both palette drag and board drag short-circuit to `draggable: false`. Click-to-select still works for palette → board.
+
+## Testing
+
+### Backend
+
+New file `apps/be/src/games/engines/sea-battle/sea-battle.engine.moveShip.spec.ts` (or extend an existing engine spec) covering:
+
+- Happy path: place a 4-cell ship at A1–D1, move to F5–F8 (rotated case: ship orientation preserved).
+- Move along own axis by one cell: A1–D1 → B1–E1 (overlap with own cells is allowed).
+- Reject overlap with another ship.
+- Reject adjacency with another ship (corners count).
+- Reject out-of-bounds.
+- Reject if ship is not currently placed.
+- Reject after `placementComplete`.
+- Reject in non-PLACEMENT phase.
+
+Validator unit tests in the same file or in `sea-battle.validators.spec.ts`.
+
+### Web
+
+`apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.test.ts` (new):
+
+- Board-source drag: `onDragStart` from an occupied cell sets `dragMode = 'board'` and captures `anchorOffset` and `orientation`.
+- Anchor offset applied: grabbing the 2nd cell of a 4-cell horizontal ship and dropping on F5 produces `cells` starting at F4.
+- Drop on same cells deep-equal → no `onMoveShip` call.
+- Drop on invalid cells → no `onMoveShip` call; `handleDragEnd` clears state.
+
+Playwright e2e (new test or extension of an existing placement test):
+
+- Open Sea Battle, start a session, click Auto-place.
+- Drag the first ship to a known-empty area on the board.
+- Verify the ship's cells are visually at the new position and not at the old position.
+- Confirm placement and verify the game proceeds to battle.
+
+## Files touched
+
+Backend:
+
+- `apps/be/src/games/engines/sea-battle/sea-battle.types.ts` — add `MoveShipPayload`.
+- `apps/be/src/games/engines/sea-battle/sea-battle.validators.ts` — add `validateMoveShip`.
+- `apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts` — add `runMoveShip`.
+- `apps/be/src/games/engines/sea-battle/sea-battle.engine.ts` — wire `moveShip`.
+- `apps/be/src/games/engines/sea-battle/sea-battle.utils.ts` — `getPossibleActions` includes `moveShip`.
+- `apps/be/src/games/sea-battle/sea-battle.service.ts` — add `moveShipByRoom`.
+- Gateway/handler for the new socket event.
+- New engine spec file.
+
+Web:
+
+- `apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleActions.ts` — `moveShip` action.
+- `apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts` — board-source drag, anchor math, effective-board validity.
+- `apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx` — wire `getBoardCellDragProps`; render `dragging` class on lifted cells.
+- `apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx` — accept and wire `onMoveShip`.
+- `apps/web/src/widgets/SeaBattleGame/ui/Game.tsx` — pass `actions.moveShip`.
+- `apps/web/src/widgets/SeaBattleGame/ui/styles/animations.css` (or styled equivalent) — cursor + dragging opacity.
+- New hook unit test, optional Playwright e2e.
+
+## Rollout
+
+Single PR. No flag — the new action is additive on BE (existing clients keep working), and the FE upgrade adds a capability without changing the existing placement flow. Bot and pre-existing clients never emit `moveShip`, so server-side risk is contained to the new action's code path.


### PR DESCRIPTION
## What

Adds the ability to drag any already-placed ship from one position on the board to another during the placement phase — works for both auto-placed and manually placed ships, no more "Reset everything to fix one ship."

## Why

Auto-place is the fastest way to get a layout going, but the result is rarely exactly what the player wants. Today, changing a single ship after Auto-place requires Reset, which throws away the rest of the layout. This change lets the player keep what they like and just nudge the rest.

## How

### Backend (NestJS)
- New `MoveShipPayload` type and `validateMoveShip` validator. Overlap/adjacency checks run against a virtual board with the moving ship's current cells cleared, so a one-cell nudge along the same axis is valid.
- `runMoveShip` engine action atomically clears the old cells, removes the old ship, and re-stamps the new cells. Logs a single private "Moved <name>" entry.
- `getSeaBattleAvailableActions` gates `moveShip` independently on `ships.length > 0 && !placementComplete` so it stays available after auto-place has filled the fleet (which is exactly when it matters most).
- New socket event `seaBattle.session.move_ship` with ack `seaBattle.session.ship_moved`. Place + move handlers share a small `dispatchShipOp` helper.
- Engine switch inlines the placement `runX` calls — the prior `executeX` private methods were pure delegation. Done as a targeted cleanup so the engine file stays under the 500-line limit after the new action lands.

### Web
- `useDragPlacement` gains a board source mode. Each occupied cell exposes `draggable=true`. Drag start captures the ship's own orientation and the anchor offset of the grabbed cell. Validity uses a virtual board with the moving ship's cells cleared.
- Drop dispatches a new `onMoveShip` prop and skips no-op moves (cells deep-equal the original). Palette drop path is unchanged.
- Lifted ship cells dim to ~40% opacity during drag; cursor is `grab` on ship cells, `grabbing` while dragging.

### Behavior
- **Web only** — palette drag and board drag both gated by `(pointer: coarse) === false`. Click-to-place still works on touch.
- **Orientation preserved** — the ship's own horizontal/vertical state at drag start drives the drop. The global Rotate toggle doesn't affect a ship being repositioned.
- **Anchor at grabbed cell** — if you grab the 2nd cell of a 4-cell ship and drop on F5, the ship occupies F4–F7. The grabbed cell stays under the cursor.
- **placementComplete locks** both drag (FE) and the validator (BE).

## Test plan

Automated:
- [x] 12 new BE engine tests for `moveShip` (happy path, self-overlap nudge, overlap/adjacency rejection, OOB, not-placed, placementComplete, non-placement phase, cell-count mismatch).
- [x] 6 new vitest hook tests covering anchor-offset math, no-op skip, off-board drops, placementComplete lock.
- [x] All 68 BE sea-battle tests still green.
- [x] Web typecheck + lint clean. BE typecheck + lint clean.

Manual:
- [ ] Open a Sea Battle room with two players (or with bots), enter placement.
- [ ] Click **Auto-place** to fill the fleet randomly.
- [ ] Drag a few ships to new positions on the board. Verify:
  - Cursor changes to grab on hover, grabbing while dragging.
  - The lifted ship's cells dim during the drag.
  - Hover preview pulses green for a valid drop, red for invalid.
  - Dropping on a valid empty area moves the ship.
  - Dropping on an overlap, adjacency, or off-board location returns the ship to its original spot with no emit.
- [ ] Repeat after manually placing ships (not Auto-place) and verify the same behavior.
- [ ] Confirm placement; verify the game proceeds to battle with the final layout.
- [ ] In team mode, verify only your own board is draggable and that confirming your placement locks your own drag (teammates remain free).
- [ ] On a touch device / DevTools mobile emulation, verify board-cell drag is disabled and click-to-place still works.

## Spec

Spec doc: [`docs/superpowers/specs/2026-05-27-sea-battle-drag-placed-ships-design.md`](docs/superpowers/specs/2026-05-27-sea-battle-drag-placed-ships-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)