### PR TITLE
feat(games): auto-exit fullscreen after a game finishes (ARC-757)

### DIFF
--- a/apps/web/e2e/fullscreen-auto-exit.spec.ts
+++ b/apps/web/e2e/fullscreen-auto-exit.spec.ts
@@ -52,18 +52,19 @@ test.describe('Fullscreen auto-exit on game finish', () => {
     });
   });
 
-  test('leaves fullscreen shortly after the room status becomes completed', async ({
+  test('leaves fullscreen shortly after the session status becomes completed', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto(`/games/rooms/${roomId}`);
     await waitForRoomReady(page);
 
-    // Wait for the store's room-update listener to be registered.
+    // The real "game finished" signal is a session snapshot — wait for its
+    // listener to be registered.
     await page.waitForFunction(
       () =>
         !!window.gameSocket?.connected &&
-        !!window.gameSocket?._mockListeners?.['games.room.update'],
+        !!window.gameSocket?._mockListeners?.['games.session.snapshot'],
       { timeout: 60000 },
     );
 
@@ -73,19 +74,31 @@ test.describe('Fullscreen auto-exit on game finish', () => {
     await page.getByTestId('fullscreen-button').click();
     await expect(container).toHaveClass(/is-fullscreen/);
 
-    // Backend marks the game finished.
+    // Backend marks the game finished — this is the only event clients receive
+    // on completion (room.status is NOT pushed to the client).
     await page.evaluate(
-      ({ roomId, members }) => {
-        window.gameSocket?.trigger('games.room.update', {
-          room: {
-            id: roomId,
-            gameId: 'critical_v1',
+      ({ roomId, userId, opponentId }) => {
+        window.gameSocket?.trigger('games.session.snapshot', {
+          roomId,
+          session: {
+            id: 'session-1',
             status: 'completed',
-            members,
+            state: {
+              players: [
+                { playerId: userId, alive: true, hand: [], stash: [] },
+                { playerId: opponentId, alive: false, hand: [], stash: [] },
+              ],
+              playerOrder: [userId, opponentId],
+              currentTurnIndex: 0,
+              deck: [],
+              discardPile: [],
+              logs: [],
+              winnerId: userId,
+            },
           },
         });
       },
-      { roomId, members },
+      { roomId, userId, opponentId },
     );
 
     // Auto-exit fires after the delay (~1.5s) — allow generous slack.

--- a/apps/web/e2e/fullscreen-auto-exit.spec.ts
+++ b/apps/web/e2e/fullscreen-auto-exit.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, mockGameSocket } from './fixtures/test-utils';
+import { mockSession } from './fixtures/utils/auth';
+import { mockRoomInfo, waitForRoomReady } from './fixtures/utils/room';
+
+/**
+ * ARC-757 — after a game finishes, the page should automatically leave
+ * fullscreen a short moment later so the player returns to the normal chrome.
+ */
+test.describe('Fullscreen auto-exit on game finish', () => {
+  const roomId = '507f191e810c19729de860ea';
+  const userId = '507f191e810c19729de860ea';
+
+  const opponentId = '507f191e810c19729de860e2';
+
+  const members = [
+    { id: userId, userId, displayName: 'Me', isHost: true },
+    { id: opponentId, userId: opponentId, displayName: 'Rival', isHost: false },
+  ];
+
+  // A live (un-finished) Critical game state so the widget renders instead of
+  // crashing on missing fields.
+  const activeState = {
+    players: [
+      { playerId: userId, alive: true, hand: [], stash: [] },
+      { playerId: opponentId, alive: true, hand: [], stash: [] },
+    ],
+    playerOrder: [userId, opponentId],
+    currentTurnIndex: 0,
+    deck: [],
+    discardPile: [],
+    logs: [],
+  };
+
+  test.beforeEach(async ({ page }) => {
+    await mockSession(page);
+    await mockRoomInfo(page, {
+      room: {
+        id: roomId,
+        name: 'Auto-exit Room',
+        gameId: 'critical_v1',
+        status: 'active',
+        members,
+      },
+      session: { id: 'session-1', status: 'active', state: activeState },
+    });
+    await mockGameSocket(page, roomId, userId, {
+      roomJoinedPayload: {
+        status: 'active',
+        members,
+        session: { id: 'session-1', status: 'active', state: activeState },
+      },
+    });
+  });
+
+  test('leaves fullscreen shortly after the room status becomes completed', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(`/games/rooms/${roomId}`);
+    await waitForRoomReady(page);
+
+    // Wait for the store's room-update listener to be registered.
+    await page.waitForFunction(
+      () =>
+        !!window.gameSocket?.connected &&
+        !!window.gameSocket?._mockListeners?.['games.room.update'],
+      { timeout: 60000 },
+    );
+
+    const container = page.locator('.games-room-container');
+
+    // Enter fullscreen.
+    await page.getByTestId('fullscreen-button').click();
+    await expect(container).toHaveClass(/is-fullscreen/);
+
+    // Backend marks the game finished.
+    await page.evaluate(
+      ({ roomId, members }) => {
+        window.gameSocket?.trigger('games.room.update', {
+          room: {
+            id: roomId,
+            gameId: 'critical_v1',
+            status: 'completed',
+            members,
+          },
+        });
+      },
+      { roomId, members },
+    );
+
+    // Auto-exit fires after the delay (~1.5s) — allow generous slack.
+    await expect(container).not.toHaveClass(/is-fullscreen/, { timeout: 5000 });
+  });
+});

--- a/apps/web/e2e/sea-battle-fullscreen-auto-exit.spec.ts
+++ b/apps/web/e2e/sea-battle-fullscreen-auto-exit.spec.ts
@@ -1,0 +1,99 @@
+import { expect } from '@playwright/test';
+import {
+  test,
+  mockSession,
+  mockRoomInfo,
+  MOCK_OBJECT_ID,
+  mockGameSocket,
+  waitForRoomReady,
+} from './fixtures/test-utils';
+import {
+  createSeaBattleState,
+  TestWindow,
+} from './fixtures/sea-battle-chat-utils';
+
+/**
+ * ARC-757 — Sea Battle uses the widget-level fullscreen (the button inside the
+ * game widget header, distinct from the page-level control-panel toggle). It
+ * must also auto-exit shortly after the game finishes.
+ */
+test.describe('Sea Battle widget fullscreen auto-exit on finish', () => {
+  const roomId = '507f1f77bcf86cd799439011';
+  const userId = MOCK_OBJECT_ID;
+  const otherUserId = 'opponent-user-id';
+
+  test('leaves widget fullscreen shortly after the session completes', async ({
+    page,
+  }) => {
+    const initialState = createSeaBattleState(userId, otherUserId);
+
+    await mockSession(page);
+    await mockRoomInfo(page, {
+      room: {
+        id: roomId,
+        name: 'Sea Battle Fullscreen',
+        gameId: 'sea_battle_v1',
+        status: 'active',
+        members: [
+          { id: userId, userId, displayName: 'Me', isHost: true },
+          {
+            id: otherUserId,
+            userId: otherUserId,
+            displayName: 'Captain',
+            isHost: false,
+          },
+        ],
+      },
+      session: { id: 'session-1', status: 'active', state: initialState },
+    });
+    await mockGameSocket(page, roomId, userId, {
+      gameId: 'sea_battle_v1',
+      roomJoinedPayload: {
+        status: 'active',
+        session: { id: 'session-1', status: 'active', state: initialState },
+      },
+    });
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(`/games/rooms/${roomId}`);
+    await waitForRoomReady(page);
+
+    await page.waitForFunction(
+      () => {
+        const socket = (window as unknown as TestWindow).gameSocket;
+        return (
+          socket?.connected &&
+          !!socket._mockListeners?.['games.session.snapshot']
+        );
+      },
+      { timeout: 60000 },
+    );
+
+    const widget = page.locator('.game-widget-container');
+
+    // Enter the widget-level fullscreen.
+    await page.getByTestId('widget-fullscreen-button').click();
+    await expect(widget).toHaveClass(/is-fullscreen/);
+
+    // Game finishes — real completion signal.
+    await page.evaluate(
+      ({ roomId, userId, state }) => {
+        (window as unknown as TestWindow).gameSocket?.trigger(
+          'games.session.snapshot',
+          {
+            roomId,
+            session: {
+              id: 'session-1',
+              status: 'completed',
+              state: { ...state, phase: 'game_over', winnerId: userId },
+            },
+          },
+        );
+      },
+      { roomId, userId, state: initialState },
+    );
+
+    // Auto-exit fires after the delay (~1.5s).
+    await expect(widget).not.toHaveClass(/is-fullscreen/, { timeout: 5000 });
+  });
+});

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/AutoExitFullscreenOnFinish.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/AutoExitFullscreenOnFinish.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useGameSession } from '@/features/games/hooks/useGameSession';
+import { useAutoExitFullscreen } from '@/features/games/hooks/useAutoExitFullscreen';
+import type { GameSessionSummary } from '@/shared/types/games';
+
+interface AutoExitFullscreenOnFinishProps {
+  roomId: string;
+  isFullscreen: boolean;
+  exitFullscreen: () => void;
+  /** Baseline session so an already-finished room never auto-exits on mount. */
+  initialSession?: GameSessionSummary | null;
+}
+
+/**
+ * Renders nothing — it exists only to drive the auto-exit-on-finish behaviour.
+ *
+ * The reliable client-side "game finished" signal is `session.status`
+ * (delivered via `games.session.snapshot`); the room status is NOT pushed to
+ * clients on completion. We subscribe to the live session here, isolated in its
+ * own component so per-move snapshots don't re-render the whole GamePageLayout
+ * (and the game widget) on every turn.
+ */
+export function AutoExitFullscreenOnFinish({
+  roomId,
+  isFullscreen,
+  exitFullscreen,
+  initialSession,
+}: AutoExitFullscreenOnFinishProps) {
+  const { session } = useGameSession({ roomId, initialSession });
+
+  useAutoExitFullscreen({
+    status: session?.status,
+    isFullscreen,
+    exitFullscreen,
+  });
+
+  return null;
+}

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -5,6 +5,7 @@ import React, { useRef, useState, useCallback, useEffect } from 'react';
 import { useMedia } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useFullscreen } from '@/features/games/hooks/useFullscreen';
+import { useAutoExitFullscreen } from '@/features/games/hooks/useAutoExitFullscreen';
 import { ConnectionOverlay } from '@arcadeum/ui/components/ConnectionOverlay/ConnectionOverlay';
 import { GamesControlPanel } from '@/widgets/GamesControlPanel';
 import { GameChat, useGameChatStore } from '@/widgets/GameChat';
@@ -59,8 +60,19 @@ export function GamePageLayout(props: GamePageLayoutProps) {
   const media = useMedia();
   const roomFlexDirection = media.gtMd ? 'row' : 'column';
   const gameContainerRef = useRef<HTMLDivElement>(null);
-  const { isFullscreen, toggleFullscreen } = useFullscreen(gameContainerRef, {
-    enableKeyboard: true,
+  const { isFullscreen, toggleFullscreen, exitFullscreen } = useFullscreen(
+    gameContainerRef,
+    {
+      enableKeyboard: true,
+    },
+  );
+
+  // Drop out of fullscreen shortly after the game finishes so the player
+  // returns to the normal page chrome (header, rematch, navigation).
+  useAutoExitFullscreen({
+    status: room.status,
+    isFullscreen,
+    exitFullscreen,
   });
 
   // Chat visibility — wide screens default visible, narrow hidden

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -5,18 +5,19 @@ import React, { useRef, useState, useCallback, useEffect } from 'react';
 import { useMedia } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useFullscreen } from '@/features/games/hooks/useFullscreen';
-import { useAutoExitFullscreen } from '@/features/games/hooks/useAutoExitFullscreen';
 import { ConnectionOverlay } from '@arcadeum/ui/components/ConnectionOverlay/ConnectionOverlay';
 import { GamesControlPanel } from '@/widgets/GamesControlPanel';
 import { GameChat, useGameChatStore } from '@/widgets/GameChat';
-import type { GameRoomSummary } from '@/shared/types/games';
+import type { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
+import { AutoExitFullscreenOnFinish } from './AutoExitFullscreenOnFinish';
 import { Container, fullscreenStyles } from './styles';
 import { GameRow, ChatPanel } from './layoutStyles';
 
 interface GamePageLayoutProps {
   roomId: string;
   room: GameRoomSummary;
+  session?: GameSessionSummary | null;
   inviteCode?: string;
   userId: string | null;
 
@@ -42,6 +43,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
   const {
     roomId,
     room,
+    session,
     inviteCode,
     userId,
     isDisconnected,
@@ -66,14 +68,6 @@ export function GamePageLayout(props: GamePageLayoutProps) {
       enableKeyboard: true,
     },
   );
-
-  // Drop out of fullscreen shortly after the game finishes so the player
-  // returns to the normal page chrome (header, rematch, navigation).
-  useAutoExitFullscreen({
-    status: room.status,
-    isFullscreen,
-    exitFullscreen,
-  });
 
   // Chat visibility — wide screens default visible, narrow hidden
   const [showChat, setShowChat] = useState(false);
@@ -148,6 +142,15 @@ export function GamePageLayout(props: GamePageLayoutProps) {
         ref={gameContainerRef as React.RefObject<never>}
         className="games-room-container"
       >
+        {/* Drops out of fullscreen shortly after the game finishes so the
+            player returns to the normal page chrome (header, rematch, nav). */}
+        <AutoExitFullscreenOnFinish
+          roomId={roomId}
+          isFullscreen={isFullscreen}
+          exitFullscreen={exitFullscreen}
+          initialSession={session}
+        />
+
         <ConnectionOverlay
           visible={isDisconnected}
           reconnecting={isReconnecting}

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
@@ -399,6 +399,7 @@ export default function GameRoomPage({
       <GamePageLayout
         roomId={roomId}
         room={room}
+        session={initialSession as GameSessionSummary | null}
         userId={snapshot.userId}
         inviteCode={room?.inviteCode}
         isDisconnected={isDisconnected}

--- a/apps/web/src/features/games/hooks/index.ts
+++ b/apps/web/src/features/games/hooks/index.ts
@@ -5,3 +5,4 @@ export type { GameType } from './useGameActions';
 export { useRematch } from './useRematch';
 export { useGameChatIntegration } from './useGameChatIntegration';
 export { useFullscreen } from './useFullscreen';
+export { useAutoExitFullscreen } from './useAutoExitFullscreen';

--- a/apps/web/src/features/games/hooks/useAutoExitFullscreen.test.ts
+++ b/apps/web/src/features/games/hooks/useAutoExitFullscreen.test.ts
@@ -1,0 +1,96 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  useAutoExitFullscreen,
+  AUTO_EXIT_FULLSCREEN_DELAY_MS,
+} from './useAutoExitFullscreen';
+
+interface Props {
+  status: string | undefined;
+  isFullscreen: boolean;
+}
+
+describe('useAutoExitFullscreen', () => {
+  let exitFullscreen: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    exitFullscreen = vi.fn<() => void>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup(initial: Props) {
+    return renderHook(
+      ({ status, isFullscreen }: Props) =>
+        useAutoExitFullscreen({ status, isFullscreen, exitFullscreen }),
+      { initialProps: initial },
+    );
+  }
+
+  it('exits fullscreen after the delay when status transitions to completed', () => {
+    const { rerender } = setup({ status: 'in_progress', isFullscreen: true });
+
+    rerender({ status: 'completed', isFullscreen: true });
+    expect(exitFullscreen).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('does not exit when not in fullscreen at the moment of finish', () => {
+    const { rerender } = setup({ status: 'in_progress', isFullscreen: false });
+
+    rerender({ status: 'completed', isFullscreen: false });
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('does not exit when mounted with an already-completed status', () => {
+    setup({ status: 'completed', isFullscreen: true });
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+
+  it('fires once per game — re-entering fullscreen after exit does not re-trigger', () => {
+    const { rerender } = setup({ status: 'in_progress', isFullscreen: true });
+
+    rerender({ status: 'completed', isFullscreen: true });
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).toHaveBeenCalledOnce();
+
+    // Player manually re-enters fullscreen while still on the finished game
+    rerender({ status: 'completed', isFullscreen: false });
+    rerender({ status: 'completed', isFullscreen: true });
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).toHaveBeenCalledOnce();
+  });
+
+  it('re-arms for a rematch (completed -> lobby -> completed fires again)', () => {
+    const { rerender } = setup({ status: 'in_progress', isFullscreen: true });
+
+    rerender({ status: 'completed', isFullscreen: true });
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+
+    rerender({ status: 'lobby', isFullscreen: true });
+    rerender({ status: 'in_progress', isFullscreen: true });
+    rerender({ status: 'completed', isFullscreen: true });
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels the pending timer on unmount', () => {
+    const { rerender, unmount } = setup({
+      status: 'in_progress',
+      isFullscreen: true,
+    });
+
+    rerender({ status: 'completed', isFullscreen: true });
+    unmount();
+    vi.advanceTimersByTime(AUTO_EXIT_FULLSCREEN_DELAY_MS);
+    expect(exitFullscreen).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/games/hooks/useAutoExitFullscreen.ts
+++ b/apps/web/src/features/games/hooks/useAutoExitFullscreen.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Delay between a game finishing and the page leaving fullscreen. Gives the
+ * player a brief moment to see the final board before the view collapses back
+ * to the normal page chrome (the game-over result modal still shows).
+ */
+export const AUTO_EXIT_FULLSCREEN_DELAY_MS = 1500;
+
+interface UseAutoExitFullscreenOptions {
+  /** Current room status — `'completed'` marks the game as finished. */
+  status: string | undefined;
+  /** Whether the page is currently in the CSS fullscreen mode. */
+  isFullscreen: boolean;
+  /** Leaves fullscreen. Should be a stable callback (e.g. from useFullscreen). */
+  exitFullscreen: () => void;
+  /** Override the auto-exit delay (primarily for tests). */
+  delayMs?: number;
+}
+
+/**
+ * Auto-exits fullscreen a short moment after a game finishes.
+ *
+ * Fires only on the transition into `'completed'` (not on the steady completed
+ * state), so it triggers once per game: re-entering fullscreen afterward stays,
+ * joining an already-finished room never triggers it, and a rematch
+ * (completed -> lobby -> completed) naturally re-arms. Only exits if the page
+ * was actually in fullscreen when the game finished.
+ */
+export function useAutoExitFullscreen({
+  status,
+  isFullscreen,
+  exitFullscreen,
+  delayMs = AUTO_EXIT_FULLSCREEN_DELAY_MS,
+}: UseAutoExitFullscreenOptions): void {
+  const prevStatusRef = useRef(status);
+
+  useEffect(() => {
+    const prevStatus = prevStatusRef.current;
+    prevStatusRef.current = status;
+
+    const justFinished = prevStatus !== 'completed' && status === 'completed';
+    if (!justFinished || !isFullscreen) return;
+
+    const timer = setTimeout(exitFullscreen, delayMs);
+    return () => clearTimeout(timer);
+  }, [status, isFullscreen, exitFullscreen, delayMs]);
+}

--- a/apps/web/src/features/games/hooks/useFullscreen.test.ts
+++ b/apps/web/src/features/games/hooks/useFullscreen.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRef } from 'react';
+import { useFullscreen } from './useFullscreen';
+
+describe('useFullscreen', () => {
+  let node: HTMLDivElement;
+
+  beforeEach(() => {
+    node = document.createElement('div');
+    document.body.appendChild(node);
+  });
+
+  afterEach(() => {
+    node.parentNode?.removeChild(node);
+  });
+
+  function setup() {
+    const ref = createRef<HTMLDivElement>();
+    // jsdom refs are plain objects; assign current manually
+    (ref as { current: HTMLDivElement }).current = node;
+    return renderHook(() => useFullscreen(ref));
+  }
+
+  it('toggles the is-fullscreen class on and off', () => {
+    const { result } = setup();
+
+    expect(node.classList.contains('is-fullscreen')).toBe(false);
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(true);
+    expect(node.classList.contains('is-fullscreen')).toBe(true);
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(false);
+    expect(node.classList.contains('is-fullscreen')).toBe(false);
+  });
+
+  it('exitFullscreen removes the class when in fullscreen', () => {
+    const { result } = setup();
+
+    act(() => result.current.toggleFullscreen());
+    expect(result.current.isFullscreen).toBe(true);
+
+    act(() => result.current.exitFullscreen());
+    expect(result.current.isFullscreen).toBe(false);
+    expect(node.classList.contains('is-fullscreen')).toBe(false);
+  });
+
+  it('exitFullscreen is idempotent when already exited', () => {
+    const { result } = setup();
+
+    expect(result.current.isFullscreen).toBe(false);
+    act(() => result.current.exitFullscreen());
+    expect(result.current.isFullscreen).toBe(false);
+    expect(node.classList.contains('is-fullscreen')).toBe(false);
+  });
+
+  it('keeps a stable exitFullscreen identity across renders', () => {
+    const { result, rerender } = setup();
+    const first = result.current.exitFullscreen;
+    rerender();
+    expect(result.current.exitFullscreen).toBe(first);
+  });
+});

--- a/apps/web/src/features/games/hooks/useFullscreen.ts
+++ b/apps/web/src/features/games/hooks/useFullscreen.ts
@@ -28,6 +28,13 @@ export function useFullscreen(
     setIsFullscreen((prev) => !prev);
   }, []);
 
+  // Unconditionally leave fullscreen. No-op when already exited, so callers
+  // (e.g. the auto-exit-on-game-finish effect) can fire it safely without a
+  // risk of toggling fullscreen back on.
+  const exitFullscreen = useCallback(() => {
+    setIsFullscreen((prev) => (prev ? false : prev));
+  }, []);
+
   useEffect(() => {
     const node = containerRef.current;
     if (!node) return;
@@ -63,5 +70,6 @@ export function useFullscreen(
   return {
     isFullscreen,
     toggleFullscreen,
+    exitFullscreen,
   };
 }

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -10,6 +10,7 @@ import {
 } from '@arcadeum/ui';
 import { MaximizeIcon, MinimizeIcon } from '@/shared/ui';
 import { useFullscreen } from '../hooks/useFullscreen';
+import { useAutoExitFullscreen } from '../hooks/useAutoExitFullscreen';
 import { scrollbarStyles } from '@/shared/lib/styles';
 import { GameChatPopupOverlay } from '@/widgets/GameChat';
 
@@ -286,6 +287,8 @@ interface GameWidgetContainerProps {
   modals?: React.ReactNode;
   variant?: string;
   isMyTurn?: boolean;
+  /** When true, the widget auto-exits its fullscreen shortly after finish. */
+  isGameOver?: boolean;
 }
 
 const gameWidgetGlobalStyles = `
@@ -314,13 +317,23 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   modals,
   variant,
   isMyTurn,
+  isGameOver,
 }: GameWidgetContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Widget-only fullscreen — independent of the page-level toggle in
   // `GamePageLayout`. Page level expands [control panel + widget + chat];
   // this expands only the widget. Keyboard disabled so the global `f`
   // shortcut owned by the page-level instance doesn't toggle both at once.
-  const { isFullscreen, toggleFullscreen } = useFullscreen(containerRef);
+  const { isFullscreen, toggleFullscreen, exitFullscreen } =
+    useFullscreen(containerRef);
+
+  // Leave this widget's fullscreen shortly after the game finishes. Mapped to
+  // the status the auto-exit hook expects so it fires once on the transition.
+  useAutoExitFullscreen({
+    status: isGameOver ? 'completed' : 'active',
+    isFullscreen,
+    exitFullscreen,
+  });
 
   const renderedHeader =
     header ??
@@ -376,6 +389,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
 
           <FullscreenButton
             onClick={toggleFullscreen}
+            data-testid="widget-fullscreen-button"
             title={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
           >
             {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -255,6 +255,7 @@ function CascadeGameImpl({
         modals={modals}
         variant={options.variant}
         isMyTurn={myTurn}
+        isGameOver={isGameOver}
         headerProps={{
           variantEmoji: variantTokens.emoji,
           title: 'Cascade',

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -404,6 +404,7 @@ export const SeaBattleGame = memo(function SeaBattleGame({
     <SeaBattleThemeProvider variant={cardVariant}>
       <GameWidgetContainer
         headerProps={headerProps}
+        isGameOver={isGameOver}
         board={
           <SeaBattleBoards
             isPlacementPhase={isPlacementPhase}

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -235,6 +235,7 @@ function TicTacToeGameImpl({
         modals={modals}
         variant={options.variant}
         isMyTurn={myTurn}
+        isGameOver={isGameOver}
         headerProps={{
           variantEmoji: variantTokens.emoji,
           title: 'Tic-Tac-Toe',


### PR DESCRIPTION
## What

After a game finishes, the page automatically leaves fullscreen mode after a short delay (~1.5s), returning the player to the normal page chrome (header, rematch controls, navigation). The game-over result modal still appears over the page.

This covers **both** fullscreen mechanisms in the games UI:
- **Page-level** fullscreen (the control-panel toggle in `GamePageLayout`) — used by Critical.
- **Widget-level** fullscreen (the button in the game widget header, `GameWidgetContainer`) — used by Sea Battle, Tic-Tac-Toe, Cascade. These are independent of the page-level toggle, which is why the first pass missed them.

## Why

In fullscreen the page chrome is hidden. Once a match ends, players need the surrounding UI (rematch, back-to-home, navigation), so we drop them back out automatically. The brief delay lets them glance at the final board first.

## How it detects "finished"

The reliable client-side signal is `session.status === 'completed'` (delivered via `games.session.snapshot`), **not** `room.status` — the room status is updated in the DB on completion but is not pushed to clients (no `games.room.update`). The widget-level path uses each game's existing `isGameOver` flag (which is itself derived from session status).

## Changes

- **`useFullscreen`** — added an idempotent `exitFullscreen()` (no-op when already exited).
- **`useAutoExitFullscreen`** (new hook) — fires **once per game**, only on the transition into the finished state while in fullscreen. Joining an already-finished room never triggers it, re-entering fullscreen afterward stays, and a rematch naturally re-arms. Delay: `AUTO_EXIT_FULLSCREEN_DELAY_MS = 1500`.
- **`AutoExitFullscreenOnFinish`** (new component) — null-rendering child that subscribes to the live session and drives the page-level auto-exit off `session.status`. Isolated so per-move snapshots don't re-render the whole layout / widget.
- **`GamePageLayout`** — renders the component; takes a `session` prop threaded from `GameRoomPage` as the baseline.
- **`GameWidgetContainer`** — auto-exits its own (widget-level) fullscreen when `isGameOver` flips; consumers (Sea Battle, Tic-Tac-Toe, Cascade) pass their `isGameOver`. Added `data-testid="widget-fullscreen-button"`.

## Tests

- Unit (Vitest): `useFullscreen.exitFullscreen` + `useAutoExitFullscreen` (delay, not-in-fullscreen, already-completed-on-mount, fire-once, rematch re-arm, unmount cleanup) — 10 tests.
- e2e (Playwright): page-level (Critical) and widget-level (Sea Battle) flows, each emitting the real `games.session.snapshot` completion event and asserting the `is-fullscreen` class is removed.

## Known limitation

The realtime game (Glimworm) uses `session.status = 'ended'` (not `'completed'`), so it won't auto-exit. Left out of this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)