### PR TITLE
feat(battle-pass): pay out tier rewards on claim + e2e/integration coverage (ARC-759)

### DIFF
--- a/apps/be/src/battle-pass/battle-pass.constants.ts
+++ b/apps/be/src/battle-pass/battle-pass.constants.ts
@@ -12,6 +12,8 @@ export type BattlePassReward = {
   amount?: number;
   /** Display label (e.g. cosmetic name / "150 Coins"). */
   label: string;
+  /** Catalog item id for cosmetic rewards — granted on claim. */
+  itemId?: string;
 };
 
 export type BattlePassTier = {
@@ -51,7 +53,11 @@ export const CURRENT_SEASON: BattlePassSeason = {
       tier: 3,
       xpRequired: 400,
       freeReward: { type: 'coins', amount: 200, label: '200 Coins' },
-      premiumReward: { type: 'cosmetic', label: 'Genesis Frame' },
+      premiumReward: {
+        type: 'cosmetic',
+        label: 'Genesis Frame',
+        itemId: 'frame-prism',
+      },
     },
     {
       tier: 4,
@@ -63,7 +69,11 @@ export const CURRENT_SEASON: BattlePassSeason = {
       tier: 5,
       xpRequired: 1200,
       freeReward: { type: 'gems', amount: 10, label: '10 Gems' },
-      premiumReward: { type: 'cosmetic', label: 'Aurora Aura' },
+      premiumReward: {
+        type: 'cosmetic',
+        label: 'Aurora Aura',
+        itemId: 'aura-prism',
+      },
     },
     {
       tier: 6,
@@ -75,13 +85,21 @@ export const CURRENT_SEASON: BattlePassSeason = {
       tier: 7,
       xpRequired: 2600,
       freeReward: { type: 'coins', amount: 450, label: '450 Coins' },
-      premiumReward: { type: 'cosmetic', label: 'Genesis Banner' },
+      premiumReward: {
+        type: 'cosmetic',
+        label: 'Genesis Banner',
+        itemId: 'banner-nebula',
+      },
     },
     {
       tier: 8,
       xpRequired: 3600,
       freeReward: { type: 'gems', amount: 25, label: '25 Gems' },
-      premiumReward: { type: 'cosmetic', label: 'Mythic Genesis Avatar' },
+      premiumReward: {
+        type: 'cosmetic',
+        label: 'Mythic Genesis Avatar',
+        itemId: 'avatar-cosmic-01',
+      },
     },
   ],
 };

--- a/apps/be/src/battle-pass/battle-pass.module.ts
+++ b/apps/be/src/battle-pass/battle-pass.module.ts
@@ -1,4 +1,4 @@
-import { Module, forwardRef } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { BattlePassController } from './battle-pass.controller';
@@ -10,6 +10,8 @@ import {
 import { User, UserSchema } from '../auth/schemas/user.schema';
 import { AuthModule } from '../auth/auth.module';
 import { GamesModule } from '../games/games.module';
+import { WalletModule } from '../wallet/wallet.module';
+import { ShopModule } from '../shop/shop.module';
 
 @Module({
   imports: [
@@ -18,7 +20,9 @@ import { GamesModule } from '../games/games.module';
       { name: User.name, schema: UserSchema },
     ]),
     AuthModule,
-    forwardRef(() => GamesModule),
+    GamesModule,
+    WalletModule,
+    ShopModule,
   ],
   controllers: [BattlePassController],
   providers: [BattlePassService],

--- a/apps/be/src/battle-pass/battle-pass.service.integration-spec.ts
+++ b/apps/be/src/battle-pass/battle-pass.service.integration-spec.ts
@@ -1,0 +1,156 @@
+import { Test } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { MongooseModule, getModelToken } from '@nestjs/mongoose';
+import { MongoMemoryReplSet } from 'mongodb-memory-server';
+import { Model, Types } from 'mongoose';
+
+import { BattlePassService } from './battle-pass.service';
+import {
+  BattlePassProgress,
+  BattlePassProgressSchema,
+} from './schemas/battle-pass-progress.schema';
+import { WalletModule } from '../wallet/wallet.module';
+import { WalletService } from '../wallet/wallet.service';
+import { WalletGateway } from '../wallet/wallet.gateway';
+import {
+  WalletTransaction,
+  WalletTransactionDocument,
+} from '../wallet/schemas/wallet-transaction.schema';
+import { ShopModule } from '../shop/shop.module';
+import { InventoryService } from '../shop/services/inventory.service';
+import {
+  UserInventoryItem,
+  UserInventoryItemDocument,
+} from '../shop/schemas/user-inventory-item.schema';
+import { AuthModule } from '../auth/auth.module';
+import { User, UserSchema } from '../auth/schemas/user.schema';
+import { GameHistoryStatsService } from '../games/history/game-history-stats.service';
+
+// Real Mongo + real WalletService/InventoryService — proves a claim actually
+// credits the wallet and grants the cosmetic, and that it's idempotent. XP is
+// stubbed (the stats source) so all tiers are unlocked deterministically.
+describe('BattlePassService (integration)', () => {
+  let replSet: MongoMemoryReplSet;
+  let service: BattlePassService;
+  let wallet: WalletService;
+  let inventory: InventoryService;
+  let userModel: Model<User>;
+  let txModel: Model<WalletTransactionDocument>;
+  let invModel: Model<UserInventoryItemDocument>;
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true }),
+        MongooseModule.forRoot(replSet.getUri()),
+        MongooseModule.forFeature([
+          { name: BattlePassProgress.name, schema: BattlePassProgressSchema },
+          { name: User.name, schema: UserSchema },
+        ]),
+        AuthModule,
+        WalletModule,
+        ShopModule,
+      ],
+      providers: [
+        BattlePassService,
+        {
+          // Stub the XP source so every tier is unlocked.
+          provide: GameHistoryStatsService,
+          useValue: {
+            getPlayerStats: jest.fn(() =>
+              Promise.resolve({
+                totalGames: 500,
+                wins: 400,
+                losses: 100,
+                winRate: 80,
+                byGameType: [],
+              }),
+            ),
+          },
+        },
+      ],
+    })
+      .overrideProvider(WalletGateway)
+      .useValue({ emitBalance: jest.fn(), emitAfterCommit: jest.fn() })
+      .compile();
+
+    service = moduleRef.get(BattlePassService);
+    wallet = moduleRef.get(WalletService);
+    inventory = moduleRef.get(InventoryService);
+    userModel = moduleRef.get<Model<User>>(getModelToken(User.name));
+    txModel = moduleRef.get<Model<WalletTransactionDocument>>(
+      getModelToken(WalletTransaction.name),
+    );
+    invModel = moduleRef.get<Model<UserInventoryItemDocument>>(
+      getModelToken(UserInventoryItem.name),
+    );
+    // Enforce the unique idempotency / purchase indexes that make grants safe.
+    await txModel.syncIndexes();
+    await invModel.syncIndexes();
+  }, 60_000);
+
+  afterAll(async () => {
+    await replSet.stop();
+  }, 30_000);
+
+  afterEach(async () => {
+    await Promise.all([
+      userModel.deleteMany({}),
+      txModel.deleteMany({}),
+      invModel.deleteMany({}),
+    ]);
+  });
+
+  const createPremiumUser = async () => {
+    const uid = new Types.ObjectId().toHexString();
+    const doc = await userModel.create({
+      email: `bp-${uid}@test.com`,
+      passwordHash: 'hash',
+      username: `bp_${uid}`,
+      usernameNormalized: `bp_${uid}`,
+      role: 'premium',
+      coins: 0,
+      gems: 0,
+      blockedUsers: [],
+    });
+    return doc._id.toString();
+  };
+
+  it('credits coins and grants the premium cosmetic on claim', async () => {
+    const userId = await createPremiumUser();
+
+    // Tier 3: free = 200 coins, premium = cosmetic frame-prism.
+    const result = await service.claim(userId, 3);
+    expect(result.claimedTiers).toContain(3);
+
+    // Destructure to satisfy the lint rule banning direct .coins/.gems access.
+    const { coins } = await wallet.getBalance(userId);
+    expect(coins).toBe(200);
+    expect(await inventory.owns(userId, 'frame-prism')).toBe(true);
+  });
+
+  it('is idempotent — re-claiming does not double-credit or double-grant', async () => {
+    const userId = await createPremiumUser();
+
+    await service.claim(userId, 3);
+    await service.claim(userId, 3); // repeat
+
+    const { coins } = await wallet.getBalance(userId);
+    expect(coins).toBe(200); // not 400
+
+    const rows = await invModel.countDocuments({
+      userId: new Types.ObjectId(userId),
+      itemId: 'frame-prism',
+    });
+    expect(rows).toBe(1); // single grant
+  });
+
+  it('persists claimed tiers across calls', async () => {
+    const userId = await createPremiumUser();
+    await service.claim(userId, 1);
+    await service.claim(userId, 2);
+    const state = await service.getState(userId);
+    expect(state.claimedTiers.sort()).toEqual([1, 2]);
+  });
+});

--- a/apps/be/src/battle-pass/battle-pass.service.spec.ts
+++ b/apps/be/src/battle-pass/battle-pass.service.spec.ts
@@ -43,13 +43,17 @@ describe('BattlePassService', () => {
         }),
       ),
     };
+    const wallet = { credit: jest.fn(() => Promise.resolve({})) };
+    const inventory = { grant: jest.fn(() => Promise.resolve()) };
     type Args = ConstructorParameters<typeof BattlePassService>;
     const service = new BattlePassService(
       progressModel as unknown as Args[0],
       userModel as unknown as Args[1],
       stats as unknown as Args[2],
+      wallet as unknown as Args[3],
+      inventory as unknown as Args[4],
     );
-    return { service, userModel, progressModel, stats };
+    return { service, userModel, progressModel, stats, wallet, inventory };
   }
 
   it('derives xp, current tier and premium flag', async () => {
@@ -89,9 +93,9 @@ describe('BattlePassService', () => {
     );
   });
 
-  it('claims an unlocked tier and returns premium rewards for prestige users', async () => {
-    // High stats → all tiers unlocked.
-    const { service, progressModel } = build({
+  it('claims an unlocked tier, credits currency and grants the premium cosmetic', async () => {
+    // High stats → all tiers unlocked. Tier 3: free = coins, premium = cosmetic.
+    const { service, progressModel, wallet, inventory } = build({
       role: 'premium',
       totalGames: 500,
       wins: 400,
@@ -100,13 +104,48 @@ describe('BattlePassService', () => {
     expect(progressModel.findOneAndUpdate).toHaveBeenCalled();
     expect(result.tier).toBe(3);
     expect(result.claimedTiers).toContain(3);
-    // Free + premium reward for a premium user.
-    expect(result.rewards).toHaveLength(2);
+    expect(result.rewards).toHaveLength(2); // free + premium
+
+    // Free coins credited with a deterministic idempotency key.
+    expect(wallet.credit).toHaveBeenCalledWith(
+      'user-1',
+      'coins',
+      expect.any(Number),
+      'battle_pass_reward',
+      'bp:season-1:3:free:user-1',
+      expect.any(Object),
+    );
+    // Premium cosmetic granted.
+    expect(inventory.grant).toHaveBeenCalledWith(
+      'user-1',
+      'frame-prism',
+      'bp:season-1:3:premium:user-1',
+    );
   });
 
-  it('returns only the free reward for non-premium users', async () => {
-    const { service } = build({ role: 'free', totalGames: 500, wins: 400 });
+  it('credits only the free reward for non-premium users', async () => {
+    const { service, wallet, inventory } = build({
+      role: 'free',
+      totalGames: 500,
+      wins: 400,
+    });
     const result = await service.claim('user-1', 3);
     expect(result.rewards).toHaveLength(1);
+    expect(wallet.credit).toHaveBeenCalledTimes(1);
+    expect(inventory.grant).not.toHaveBeenCalled();
+  });
+
+  it('does not pay out again when the tier is already claimed', async () => {
+    const { service, wallet, inventory, progressModel } = build({
+      role: 'premium',
+      totalGames: 500,
+      wins: 400,
+      claimedTiers: [3],
+    });
+    const result = await service.claim('user-1', 3);
+    expect(result.claimedTiers).toEqual([3]);
+    expect(wallet.credit).not.toHaveBeenCalled();
+    expect(inventory.grant).not.toHaveBeenCalled();
+    expect(progressModel.findOneAndUpdate).not.toHaveBeenCalled();
   });
 });

--- a/apps/be/src/battle-pass/battle-pass.service.ts
+++ b/apps/be/src/battle-pass/battle-pass.service.ts
@@ -1,14 +1,11 @@
-import {
-  BadRequestException,
-  Injectable,
-  forwardRef,
-  Inject,
-} from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { GameHistoryStatsService } from '../games/history/game-history-stats.service';
 import { User } from '../auth/schemas/user.schema';
+import { WalletService } from '../wallet/wallet.service';
+import { InventoryService } from '../shop/services/inventory.service';
 import {
   BattlePassProgress,
   type BattlePassProgressDocument,
@@ -19,8 +16,11 @@ import {
   isPremiumRole,
   xpForStats,
   type BattlePassReward,
+  type BattlePassTier,
 } from './battle-pass.constants';
 import type { BattlePassStateDto, ClaimResultDto } from './dto/battle-pass.dto';
+
+type RewardLane = 'free' | 'premium';
 
 @Injectable()
 export class BattlePassService {
@@ -29,8 +29,9 @@ export class BattlePassService {
     private readonly progressModel: Model<BattlePassProgressDocument>,
     @InjectModel(User.name)
     private readonly userModel: Model<User>,
-    @Inject(forwardRef(() => GameHistoryStatsService))
     private readonly stats: GameHistoryStatsService,
+    private readonly wallet: WalletService,
+    private readonly inventory: InventoryService,
   ) {}
 
   private async resolveXp(userId: string): Promise<number> {
@@ -75,22 +76,79 @@ export class BattlePassService {
     };
   }
 
+  private rewardsFor(
+    tierDef: BattlePassTier,
+    isPremium: boolean,
+  ): Array<{ lane: RewardLane; reward: BattlePassReward }> {
+    const entries: Array<{ lane: RewardLane; reward: BattlePassReward }> = [
+      { lane: 'free', reward: tierDef.freeReward },
+    ];
+    if (isPremium) {
+      entries.push({ lane: 'premium', reward: tierDef.premiumReward });
+    }
+    return entries;
+  }
+
+  /**
+   * Pay out a tier's rewards. Each grant carries a deterministic idempotency key
+   * (`bp:season:tier:lane:user`) so a retry — or a concurrent double-claim —
+   * never credits or grants twice. Grants run before the tier is marked claimed;
+   * if one fails the tier stays unclaimed and the (idempotent) grants re-run on
+   * retry. A single cross-service transaction is unnecessary given the keys.
+   */
+  private async grantRewards(
+    userId: string,
+    tier: number,
+    entries: Array<{ lane: RewardLane; reward: BattlePassReward }>,
+  ): Promise<void> {
+    for (const { lane, reward } of entries) {
+      const key = `bp:${CURRENT_SEASON.id}:${tier}:${lane}:${userId}`;
+      if (reward.type === 'coins' || reward.type === 'gems') {
+        if (!reward.amount) continue;
+        await this.wallet.credit(
+          userId,
+          reward.type,
+          reward.amount,
+          'battle_pass_reward',
+          key,
+          { seasonId: CURRENT_SEASON.id, tier, lane },
+        );
+      } else if (reward.type === 'cosmetic' && reward.itemId) {
+        await this.inventory.grant(userId, reward.itemId, key);
+      }
+    }
+  }
+
   async claim(userId: string, tier: number): Promise<ClaimResultDto> {
     const tierDef = CURRENT_SEASON.tiers.find((t) => t.tier === tier);
     if (!tierDef) {
       throw new BadRequestException('Unknown battle pass tier');
     }
 
-    const [xp, isPremium] = await Promise.all([
+    const [xp, isPremium, progress] = await Promise.all([
       this.resolveXp(userId),
       this.resolveIsPremium(userId),
+      this.progressModel
+        .findOne({ userId, seasonId: CURRENT_SEASON.id })
+        .lean<{ claimedTiers: number[] } | null>(),
     ]);
+
+    const entries = this.rewardsFor(tierDef, isPremium);
+    const rewards = entries.map((e) => e.reward);
+    const alreadyClaimed = progress?.claimedTiers ?? [];
+
+    // Already claimed → idempotent no-op (don't pay out again).
+    if (alreadyClaimed.includes(tier)) {
+      return { tier, claimedTiers: alreadyClaimed, rewards };
+    }
 
     if (xp < tierDef.xpRequired) {
       throw new BadRequestException('Tier is not unlocked yet');
     }
 
-    // Idempotent upsert: only add the tier if it isn't already claimed.
+    // Pay out first, then record the claim so a payout failure is retryable.
+    await this.grantRewards(userId, tier, entries);
+
     const updated = await this.progressModel
       .findOneAndUpdate(
         { userId, seasonId: CURRENT_SEASON.id },
@@ -99,13 +157,6 @@ export class BattlePassService {
       )
       .lean<{ claimedTiers: number[] } | null>();
 
-    const claimedTiers = updated?.claimedTiers ?? [tier];
-
-    // Reward grant (wallet credit / cosmetic unlock) is intentionally a
-    // follow-up — claims are recorded here and surfaced to the client.
-    const rewards: BattlePassReward[] = [tierDef.freeReward];
-    if (isPremium) rewards.push(tierDef.premiumReward);
-
-    return { tier, claimedTiers, rewards };
+    return { tier, claimedTiers: updated?.claimedTiers ?? [tier], rewards };
   }
 }

--- a/apps/be/src/shop/services/inventory.service.ts
+++ b/apps/be/src/shop/services/inventory.service.ts
@@ -168,6 +168,35 @@ export class InventoryService {
     }
   }
 
+  /**
+   * Grant ownership of a single catalog item to a user (no payment). Used by
+   * non-shop reward flows (e.g. Battle Pass tiers). Idempotent on `purchaseId`:
+   * a duplicate grant with the same id is a no-op, so retries never duplicate.
+   */
+  async grant(
+    userId: string,
+    itemId: string,
+    purchaseId: string,
+  ): Promise<void> {
+    const def = getCatalogItem(itemId);
+    if (!def) throw new BadRequestException('shop.unknownItem');
+    try {
+      await this.inventoryModel.create([
+        {
+          userId: new Types.ObjectId(userId),
+          itemId,
+          purchaseId,
+          acquiredVia: 'grant',
+          paidAmount: null,
+          paidCurrency: null,
+        },
+      ]);
+    } catch (err) {
+      if (this.isDuplicateKey(err)) return; // already granted — idempotent
+      throw err;
+    }
+  }
+
   // Equip / unequip freshness contract:
   //  - /chat (player-to-player): live — equipped IDs are read on every page
   //    of messages via the chat helper's batched User lookup.
@@ -205,7 +234,7 @@ export class InventoryService {
               equippedAuraId: 1,
               equippedFrameId: 1,
               equippedGameSkinId: 1,
-          equippedBackgroundId: 1,
+              equippedBackgroundId: 1,
             },
           },
         )
@@ -233,7 +262,7 @@ export class InventoryService {
             equippedAuraId: 1,
             equippedFrameId: 1,
             equippedGameSkinId: 1,
-          equippedBackgroundId: 1,
+            equippedBackgroundId: 1,
           },
         },
       )

--- a/apps/be/src/wallet/interfaces/wallet-types.ts
+++ b/apps/be/src/wallet/interfaces/wallet-types.ts
@@ -16,5 +16,6 @@ export const WALLET_REASONS = [
   'daily_reward',
   'shop_purchase',
   'shop_sell_refund',
+  'battle_pass_reward',
 ] as const;
 export type WalletReason = (typeof WALLET_REASONS)[number];

--- a/apps/web/e2e/victory-celebration.spec.ts
+++ b/apps/web/e2e/victory-celebration.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test';
+import { test } from './fixtures/test-utils';
+import {
+  mockSession,
+  navigateTo,
+  mockRoomInfo,
+  waitForRoomReady,
+  mockGameSocket,
+} from './fixtures/test-utils';
+
+// The celebration FX layer (gold confetti / sparkles / bloom) is rendered
+// inside the shared GameResultModal on a win. This verifies it actually mounts
+// for the winner — the visible "wow" moment.
+test.describe('Victory celebration', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockSession(page);
+  });
+
+  test('renders the celebration FX layer on a win', async ({ page }) => {
+    const roomId = '500000000000000000000051';
+    const winnerId = '507f191e810c19729de860ea';
+
+    const roomData = {
+      id: roomId,
+      status: 'completed' as const,
+      members: [
+        { id: winnerId, displayName: 'Winner', isHost: true },
+        { id: '507f191e810c19729de860e2', displayName: 'Loser', isHost: false },
+      ],
+      gameOptions: { cardVariant: 'default' },
+    };
+
+    const sessionData = {
+      sessionId: 'sess-celebrate',
+      roomId,
+      userId: winnerId,
+      status: 'completed' as const,
+      state: {
+        players: [
+          { playerId: winnerId, alive: true, hand: [], stash: [] },
+          {
+            playerId: '507f191e810c19729de860e2',
+            alive: false,
+            hand: [],
+            stash: [],
+          },
+        ],
+        playerOrder: [winnerId, '507f191e810c19729de860e2'],
+        currentTurnIndex: 0,
+        deck: [],
+        discardPile: [],
+        logs: [],
+        winnerId,
+      },
+    };
+
+    await mockRoomInfo(page, { room: roomData, session: sessionData });
+    await mockGameSocket(page, roomId, winnerId, {
+      roomJoinedPayload: { ...roomData, session: sessionData },
+    });
+
+    await navigateTo(page, `/games/rooms/${roomId}`);
+    await waitForRoomReady(page);
+
+    // Result modal shows victory…
+    await expect(page.getByTestId('game-result-title')).toContainText(
+      /Victory|🏆|won|победа/i,
+    );
+    // …and the celebration FX layer is mounted.
+    await expect(page.getByTestId('victory-celebration')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What
Closes the two follow-ups from the premium pack (#766): **Battle Pass claims now actually pay out**, and the new flows get real test coverage.

### Payouts
- `BattlePassService.claim` now **credits coins/gems** (via `WalletService`) and **grants cosmetics** (via a new `InventoryService.grant`).
- **Idempotent**: every grant carries a deterministic key (`bp:season:tier:lane:user`), so retries or concurrent double-claims never pay out twice. The tier is marked claimed only *after* grants succeed (failure stays retryable).
- Cosmetic rewards map to **real catalog items** (`frame-prism`, `aura-prism`, `banner-nebula`, `avatar-cosmic-01`). New `battle_pass_reward` wallet reason.

### Boot fix
- Dropped an unnecessary `forwardRef(() => GamesModule)` in `BattlePassModule` (there's no Battle Pass ↔ Games cycle). It had broken `WalletService` resolution at app startup — caught by the new e2e booting the real BE.

### Tests
- **Integration spec** (real in-memory Mongo + real `WalletService`/`InventoryService`): a claim credits 200 coins, grants the cosmetic, is idempotent (no double credit/grant), and persists claimed tiers.
- **Unit spec** updated: asserts currency credit + cosmetic grant + no double-pay when already claimed.
- **Playwright e2e**: the victory celebration FX layer renders on a win — and confirms a clean BE boot (0 DI errors).

## Verification
- Typecheck **0 errors** (be/web) · ESLint clean on changed files · `check-file-length` clean.
- BE: 10 Battle Pass tests (7 unit + 3 integration) pass; 151 shop/wallet specs still green.
- e2e `victory-celebration` passes in chromium.

## Notes
- Reward grant is **not** wrapped in a single cross-service transaction; the deterministic idempotency keys make sequential grants safe to retry, which is simpler and avoids coupling Wallet + Shop + progress into one session.
- The Battle Pass **page/claim UI** isn't browser-e2e'd: the page fetches server-side (RSC) and the e2e harness mocks at the browser layer with a fake token, so the rail can't render under that harness. The end-to-end *logic* is covered by the integration spec instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)