### PR TITLE
refactor(web): shared game shell — standardize widget chrome

### DIFF
--- a/.claude/hooks/block-env-access.js
+++ b/.claude/hooks/block-env-access.js
@@ -1,0 +1,18 @@
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  const toolArgs = JSON.parse(Buffer.concat(chunks).toString());
+
+  const filePath =
+    toolArgs.tool_input?.file_path || toolArgs.tool_input?.path || "";
+
+  if (filePath.includes(".env") && !filePath.endsWith(".env.example")) {
+    console.error("Access to .env* files is blocked for security");
+    process.exit(2);
+  }
+}
+
+main();

--- a/.claude/hooks/tsc-check.sh
+++ b/.claude/hooks/tsc-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse hook: runs tsc --noEmit after editing .ts/.tsx files.
+# Outputs additionalContext with errors and exits 2 to wake the model.
+
+set -euo pipefail
+
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
+
+# Only check TypeScript files
+echo "$f" | grep -qE '\.(ts|tsx)$' || exit 0
+
+# Determine which app owns the file
+if echo "$f" | grep -q '/apps/web/'; then
+  dir="apps/web"
+elif echo "$f" | grep -q '/apps/be/'; then
+  dir="apps/be"
+elif echo "$f" | grep -q '/apps/mobile/'; then
+  dir="apps/mobile"
+elif echo "$f" | grep -q '/packages/ui/'; then
+  dir="packages/ui"
+else
+  exit 0
+fi
+
+errors=$(cd "$PWD/$dir" && pnpm tsc --noEmit 2>&1) || true
+
+if [ -n "$errors" ]; then
+  msg=$(echo "$errors" | head -50)
+  jq -n --arg ctx "TypeScript errors found after editing $f in $dir:\n$msg" \
+    '{hookSpecificOutput:{hookEventName:"PostToolUse",additionalContext:$ctx}}'
+  exit 2
+fi

--- a/.claude/hooks/ui-component-check.sh
+++ b/.claude/hooks/ui-component-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse hook: warns when a .tsx component file is created outside packages/ui.
+# Outputs additionalContext to remind Claude to check @arcadeum/ui first.
+
+set -euo pipefail
+
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
+
+# Only check .tsx files
+echo "$f" | grep -qE '\.tsx$' || exit 0
+
+# Skip packages/ui itself — that's the right place
+echo "$f" | grep -q '/packages/ui/' && exit 0
+
+# Skip story, test, and page files — not reusable components
+echo "$f" | grep -qE '\.(stories|test|spec)\.tsx$' && exit 0
+echo "$f" | grep -qE '/(page|layout|loading|error|not-found)\.tsx$' && exit 0
+
+# Only flag files inside a /components/ directory
+echo "$f" | grep -q '/components/' || exit 0
+
+# Skip files that are clearly app-level compositions (contain "View", "Client", "Container" suffix)
+basename=$(basename "$f" .tsx)
+echo "$basename" | grep -qE '(View|Client|Screen|Page)$' && exit 0
+
+jq -n --arg f "$f" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: ("Component file created outside @arcadeum/ui: " + $f + "\n\nBefore finalizing this component, verify:\n1. Does an existing @arcadeum/ui component already cover this use case? Run /check-ui-components to audit.\n2. If this component is reusable across apps, it must live in packages/ui/src/components/, not in the app.\n3. If it is truly app-specific (composes shared components for one screen), it can stay — but its building blocks must come from @arcadeum/ui.")
+  }
+}'
+exit 2

--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $PWD/.claude/hooks/block-env-access.js",
+            "statusMessage": "Checking for .env* access..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,75 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "mcp__playwright",
+      "Bash(npm *)",
+      "Bash(git *)",
+      "Bash(ls *)",
+      "Bash(vitest *)"
+    ],
+    "deny": [
+      "Bash(git push origin --delete main)",
+      "Bash(git push origin --delete main *)",
+      "Bash(git push origin --delete develop)",
+      "Bash(git push origin --delete develop *)",
+      "Bash(git push origin --delete staging)",
+      "Bash(git push origin --delete staging *)",
+      "Bash(git push --delete origin main)",
+      "Bash(git push --delete origin main *)",
+      "Bash(git push --delete origin develop)",
+      "Bash(git push --delete origin develop *)",
+      "Bash(git push --delete origin staging)",
+      "Bash(git push --delete origin staging *)",
+      "Bash(git push origin :main)",
+      "Bash(git push origin :main *)",
+      "Bash(git push origin :develop)",
+      "Bash(git push origin :develop *)",
+      "Bash(git push origin :staging)",
+      "Bash(git push origin :staging *)",
+      "Bash(git branch -D main)",
+      "Bash(git branch -D main *)",
+      "Bash(git branch -D develop)",
+      "Bash(git branch -D develop *)",
+      "Bash(git branch -D staging)",
+      "Bash(git branch -D staging *)",
+      "Bash(gh api -X DELETE *)",
+      "Bash(gh api --method DELETE *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $PWD/.claude/hooks/block-env-access.js",
+            "statusMessage": "Checking for .env* access..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $PWD/.claude/hooks/tsc-check.sh",
+            "asyncRewake": true,
+            "timeout": 60,
+            "statusMessage": "Running tsc..."
+          },
+          {
+            "type": "command",
+            "command": "bash $PWD/.claude/hooks/ui-component-check.sh",
+            "asyncRewake": true,
+            "timeout": 10,
+            "statusMessage": "Checking UI component placement..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/check-ui-components/SKILL.md
+++ b/.claude/skills/check-ui-components/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: check-ui-components
+description: Check existing @arcadeum/ui components before implementing any new UI. Use before writing any component — reuse what exists, add to packages/ui if missing.
+---
+
+Before writing any UI component, you MUST audit the shared library. Never implement custom UI that duplicates an existing shared component.
+
+## Step 1 — Read the current component catalog
+
+Read `packages/ui/src/index.ts` to get the full list of exported components. Then read the `.tsx` file of any component that might match the need to check its props and variants.
+
+**Current components in `@arcadeum/ui`:**
+
+| Component | Key props / variants | Use for |
+|---|---|---|
+| `Button` | `size`, `variant`, `loading`, `disabled`, `gameVariant`, `showShimmer` | All buttons and CTAs |
+| `LinkButton` | Same as Button + `href` | Navigation buttons |
+| `SpecializedButtons` | `BackButton`, `CloseButton`, `HomeButton` | Icon-only nav buttons |
+| `Card` | `variant` (default/elevated/outlined/glass/error), `padding` (none/sm/md/lg) | Content containers |
+| `GlassCard` | `padding`, `bordered` | Frosted-glass content containers |
+| `Avatar` | `size`, `src`, `fallback` | User/player avatars |
+| `Badge` | `variant`, `size` | Status/count labels |
+| `CosmeticBadge` | `type`, `rarity` | Game cosmetic labels |
+| `RoleBadge` | `role` | User role labels |
+| `IdleBadge` | — | Idle/away indicator |
+| `Input` | `label`, `error`, `disabled`, `leftIcon`, `rightIcon` | Text inputs |
+| `TextArea` | `label`, `error`, `rows` | Multi-line text inputs |
+| `Select` | `label`, `error`, `options`, `value`, `onChange` | Dropdowns |
+| `FormGroup` | `label`, `error`, `required`, `hint` | Form field wrapper |
+| `Modal` | `open`, `onClose`, `title`, `size` | Dialog/overlay |
+| `Spinner` | `size`, `color` | Loading spinner |
+| `LoadingState` | `message` | Full loading placeholder |
+| `PageLoading` | — | Full-page loading screen |
+| `Skeleton` | `width`, `height`, `borderRadius`, `variant` | Content skeleton placeholders |
+| `Progress` | `value`, `max`, `variant`, `showLabel` | Progress bars |
+| `EmptyState` | `title`, `description`, `icon`, `action` | Empty list/data state |
+| `ErrorState` | `title`, `description`, `onRetry` | Error with retry |
+| `Section` | `title`, `description`, `actions` | Page section with heading |
+| `PageLayout` | `header`, `footer`, `sidebar` | Top-level page shell |
+| `PageTitle` | `title`, `subtitle`, `breadcrumbs` | Page heading block |
+| `Container` | `size` (sm/md/lg/xl/full), `centered` | Max-width content wrapper |
+| `Divider` | `orientation`, `color` | Horizontal/vertical separator |
+| `CollapsibleSection` | `title`, `defaultOpen` | Expandable section |
+| `ConnectionOverlay` | `status` | Network connection status |
+| `ServerLoadingNotice` | — | Server warmup notice |
+| `Typography` | `variant`, `color`, `weight` | Text with design-token styles |
+| `Icons` | (many named icons) | SVG icon set |
+| `ChatHeader` | `title`, `subtitle`, `actions` | Chat window header |
+| `ChatMessage` | `message`, `isOwn`, `timestamp` | Chat bubble |
+| `ChatInput` | `onSend`, `placeholder`, `disabled` | Chat text input with send |
+| `GameContainer` | `header`, `footer` | Game widget shell |
+| `GameLayout` | `board`, `sidebar` | Game board + sidebar split |
+| `TurnIndicator` | `currentPlayer`, `players` | Whose-turn indicator |
+| `Footer` | `links`, `socials` | App footer |
+| `MobileLoginIndicator` | — | Mobile auth status |
+| `DownloadButtons` | `platform` | App store download CTAs |
+| `XStack`, `YStack`, `ZStack`, `ScrollView`, `ThemeableStack` | (Tamagui layout) | Layout primitives |
+
+## Step 2 — Decide: reuse or create
+
+**If an existing component covers the need** (even partially with props/variants):
+- Use it from `@arcadeum/ui`. Do NOT create a local wrapper unless it adds real domain logic.
+- Show the import: `import { ComponentName } from '@arcadeum/ui'`
+- If the existing component needs a new variant/prop to fit the need, extend it in `packages/ui` rather than wrapping it locally.
+
+**If no existing component fits** (genuinely new pattern):
+- The component MUST be created in `packages/ui`, not inline in the app.
+- Follow the `/new-ui-component` skill to add it:
+  1. `packages/ui/src/components/<Name>/<Name>.tsx` — Tamagui-based implementation
+  2. `packages/ui/src/components/<Name>/index.ts` — re-export
+  3. `packages/ui/src/components/<Name>/<Name>.stories.tsx` — Storybook story (required)
+  4. Register in `packages/ui/src/index.ts`
+  5. Then import `{ Name } from '@arcadeum/ui'` in the app
+
+## Step 3 — Extending an existing component
+
+If the existing component almost fits but needs a new variant or prop:
+1. Read the component's `.tsx` and its `types.ts`/`StyledComponent` to understand its variant system
+2. Add the new variant/prop to `packages/ui/src/components/<Name>/<Name>.tsx`
+3. Export the updated type from `index.ts`
+4. Add a Storybook story for the new variant in `<Name>.stories.tsx`
+5. Do NOT duplicate the component — extend it in place
+
+## Rules
+
+- Never create a component file in `apps/web`, `apps/mobile`, or `apps/be` if it belongs in the shared library
+- One-off app-specific compositions (combining 2–3 shared components for a specific screen) are fine as local view files — but the individual building blocks must come from `@arcadeum/ui`
+- Check `packages/ui/src/tamagui.config.ts` for design tokens before hardcoding colors/spacing
+- All new components must be platform-agnostic (web + React Native), so avoid `react-native` imports; use Tamagui primitives

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: commit
+description: Create a git commit following the project's Conventional Commits convention with ARC ticket reference. Use when committing changes.
+---
+
+When creating a commit:
+
+1. Run `git status` and `git diff --staged` to understand what's being committed
+2. Determine the type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+3. Determine the scope from the current branch (e.g. `ARC-425` → scope is the affected area like `web`, `be`, `mobile`)
+4. Write the commit message:
+
+```
+<type>(ARC-XXX): <short description>
+```
+
+- Subject: lowercase, no period at end, imperative mood ("add" not "added")
+- Keep header under 72 characters
+- Add body if needed to explain *why*, not *what*
+
+5. Stage relevant files and commit:
+
+```bash
+git add <specific files>
+git commit -m "<type>(ARC-XXX): <description>"
+```
+
+Do NOT use `git add -A` or `git add .` — stage specific files to avoid committing secrets or unrelated changes.

--- a/.claude/skills/new-be-module/SKILL.md
+++ b/.claude/skills/new-be-module/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: new-be-module
+description: Add a new NestJS module to the backend (apps/be). Use when creating a new domain/feature in the backend.
+---
+
+The backend uses NestJS with Mongoose (MongoDB), JWT auth, and Socket.io for real-time.
+
+## Folder structure
+
+```
+apps/be/src/<module-name>/
+  <name>.module.ts       ← NestJS module, registers all providers and Mongoose schemas
+  <name>.controller.ts   ← REST endpoints (use @JwtAuthGuard for protected routes)
+  <name>.service.ts      ← Business logic
+  <name>.gateway.ts      ← (optional) WebSocket gateway for real-time features
+  schemas/
+    <name>.schema.ts     ← Mongoose schema + type export
+  dtos/
+    create-<name>.dto.ts ← DTOs with class-validator decorators
+```
+
+## Steps
+
+1. **Schema** (`schemas/<name>.schema.ts`):
+   ```ts
+   import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+   import { Document } from 'mongoose';
+
+   export type <Name>Document = <Name> & Document;
+
+   @Schema({ timestamps: true })
+   export class <Name> { ... }
+
+   export const <Name>Schema = SchemaFactory.createForClass(<Name>);
+   ```
+
+2. **DTOs** with `class-validator`:
+   ```ts
+   import { IsString, IsNotEmpty } from 'class-validator';
+   export class Create<Name>Dto { @IsString() @IsNotEmpty() field: string; }
+   ```
+
+3. **Service** — inject `@InjectModel(<Name>.name) private model: Model<<Name>Document>`
+
+4. **Controller** — use `@UseGuards(JwtAuthGuard)` for protected routes, `@Controller('<name>')` prefix
+
+5. **Module** — register `MongooseModule.forFeature([{ name: <Name>.name, schema: <Name>Schema }])`, declare controller and service
+
+6. **Register** the new module in `apps/be/src/app.module.ts`
+
+## Key imports
+
+```ts
+import { JwtAuthGuard } from '../auth/jwt/jwt-auth.guard';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Module, Controller, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+```

--- a/.claude/skills/new-game/SKILL.md
+++ b/.claude/skills/new-game/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: new-game
+description: Add a complete new multiplayer game to Arcadeum (BE engine + service + gateway + bot, web widget, landing page, registries, i18n, tests). Use when the user says "implement game X" or "add a new game".
+---
+
+This skill turns a single instruction ("implement chess", "add Connect Four") into a fully wired, shippable game. Follow every step in order — partial wiring causes the runtime errors listed in the Gotchas section.
+
+## Reference implementations
+
+When in doubt, **mirror sea-battle** ([apps/be/src/games/engines/sea-battle/](apps/be/src/games/engines/sea-battle/), [apps/web/src/widgets/SeaBattleGame/](apps/web/src/widgets/SeaBattleGame/)) — it is the canonical full-stack game. The most recent reference is tic-tac-toe ([apps/be/src/games/engines/tic-tac-toe/](apps/be/src/games/engines/tic-tac-toe/), [apps/web/src/widgets/TicTacToeGame/](apps/web/src/widgets/TicTacToeGame/)).
+
+## Naming convention
+
+Pick a short snake_case id with `_v1` suffix: `chess_v1`, `connect_four_v1`. Use it consistently:
+- Engine id: `chess_v1`
+- Widget folder: `ChessGame`
+- Landing route: `/games/chess`
+- Socket event prefix: `chess.session.*` (camelCase, matches existing pattern: `ticTacToe.session.*`, `seaBattle.session.*`)
+
+## Architecture (two halves)
+
+**Backend half** — engine (pure logic) + service (orchestration) + gateway (socket events) + bot.
+**Web half** — widget (UI) + registry entry (lazy loader) + landing page (SEO marketing) + create-page integration + home featured-games entry.
+
+A game is "done" only when **all** of: BE catalog + BE module + web registry + web GameType unions (two!) + landing route + home + create page + admin (auto via catalog) + i18n (5 locales) + SEO + tests + PR.
+
+## Step-by-step checklist
+
+### 1. Brainstorm + design (skip only if user gave full spec)
+
+Use `/brainstorming` to capture: player count, board/state shape, win condition, variants (visual themes), team mode, bot strategy, special rules. Save spec to `docs/superpowers/specs/YYYY-MM-DD-<game>-design.md`. Then `/writing-plans` for an implementation plan at `docs/superpowers/plans/YYYY-MM-DD-<game>.md`.
+
+### 2. Backend engine
+
+Create `apps/be/src/games/engines/<game>/`:
+- `<game>.constants.ts` — `MIN_PLAYERS`, `MAX_PLAYERS` (overall ceiling), variants array, defaults. **If the game has per-option player caps** (e.g. tic-tac-toe's 3×3=2 / 5×5=3 / 7×7=4 / 9×9=5), export a `MAX_PLAYERS_BY_<OPTION>` map. The service enforces the per-option cap at `startSession`; `MAX_PLAYERS` is the union ceiling so the room layer never grows past what any variant supports.
+- `<game>.types.ts` — `State`, `Options`, `Player`, `Team`, action payloads. State **must include** `logs: GameLogEntry[]`
+- `<game>.utils.ts` — pure helpers (e.g. win detection)
+- `<game>.validators.ts` — return `{ ok: true } | { ok: false, error: string }`
+- `<game>.engine.ts` — `extends BaseGameEngine<State>` from `apps/be/src/games/engines/base/base-game.engine`. Implement: `getMetadata` (returns `GameMetadata`), `initializeState`, `validateAction`, `executeAction`, `isGameOver`, `getWinners`, `sanitizeStateForPlayer`, `getAvailableActions`.
+
+`GameLogEntry` and the `createLogEntry` helper live in `apps/be/src/games/engines/base/game-log.ts`. State must include `logs: GameLogEntry[]`; push entries from `executeAction` so the shared chat can render them.
+
+Register the engine in [apps/be/src/games/engines/engines.module.ts](apps/be/src/games/engines/engines.module.ts).
+
+### 3. Backend service + bot + gateway
+
+Two separate locations — **don't put the gateway in the subdir**:
+
+```
+apps/be/src/games/<game>/
+  <game>.service.ts        ← orchestrates GameRoomsService, GameSessionsService,
+                              GameHistoryService, GamesRealtimeService.
+                              Watchdog interval if turns are time-bounded.
+  <game>-bot.service.ts    ← dispatch strategy by difficulty / state size.
+
+apps/be/src/games/
+  <game>.gateway.ts        ← SIBLING of the subdir, NOT inside it.
+                              Mirrors sea-battle.gateway.ts / tic-tac-toe.gateway.ts.
+```
+
+Gateway handlers use `@SubscribeMessage('<camelCase>.session.start' | '.<action>' | '.forfeit')` — see Socket events parity below.
+
+Wire into [apps/be/src/games/games.module.ts](apps/be/src/games/games.module.ts) — add all three as providers; gateway is a provider, not an export.
+
+**Socket events parity (BE ↔ FE):** the strings in `@SubscribeMessage(...)` on the BE gateway MUST match the strings in `gameSocket.emit(...)` from the FE's `useActions.ts` hook, character for character. Drift here results in silent no-ops with no error.
+
+### 4. Backend catalog
+
+Add the game to [apps/be/src/games/games.catalog.ts](apps/be/src/games/games.catalog.ts):
+```ts
+{ gameId: '<game>_v1', variants: ['classic', 'neon', ...] },
+```
+This entry **also drives `/admin/games` visibility** — without it, admins can't see the game.
+
+### 5. Web widget
+
+Create `apps/web/src/widgets/<Name>Game/`:
+```
+types/index.ts              ← props, state, options, log entry types
+lib/constants.ts            ← VARIANTS array — id, name (i18n key), emoji, gradient
+lib/theme.ts                ← getTheme(variant) → token map (board/cell/mark colors…)
+lib/<Name>ThemeContext.tsx  ← Provider + useTheme hook
+hooks/useState.ts           ← Zustand selector → derived snapshot
+hooks/useActions.ts         ← gameSocket.emit wrappers — strings MUST match BE gateway
+hooks/index.ts              ← barrel re-export
+ui/Game.tsx                 ← root; default-export memoized
+ui/Lobby.tsx                ← wraps shared ReusableGameLobby, supplies an optionsSlot
+ui/Board.tsx                ← in-game UI
+ui/TurnBadge.tsx
+ui/RulesModal.tsx           ← in-game rules (uses @arcadeum/ui Modal primitives)
+index.ts                    ← barrel — must default-export the memoized Game
+                              (the registry does import('@/widgets/<Name>Game'))
+```
+
+**Critical Game.tsx pattern** (mirror sea-battle exactly):
+
+```tsx
+if (!room) return null;
+
+// Lobby renders OUTSIDE GameWidgetContainer so it gets full page height.
+// The container's `board` slot is sized for the in-game grid.
+if (isLobby) {
+  return (
+    <ThemeProvider variant={options.variant}>
+      <Lobby ...props />
+    </ThemeProvider>
+  );
+}
+
+const board = (
+  <YStack gap="$3" alignItems="stretch" padding="$3" width="100%">
+    {snapshot ? <><TurnBadge .../><Board .../></> : null}
+  </YStack>
+);
+
+return (
+  <ThemeProvider variant={options.variant}>
+    <GameWidgetContainer
+      board={board}
+      modals={modals}
+      variant={options.variant}
+      isMyTurn={myTurn}
+      isGameOver={isGameOver}
+      headerProps={{
+        variantEmoji: variantTokens.emoji,
+        title: '<Name>',
+        subtitle: room?.name,
+        // The declarative turn contract: pass only the on-clock player's id +
+        // whether it's your turn. The shared shell renders the turn-with-avatar
+        // pill (avatar + name + "Your turn / {name}'s turn") for free — no
+        // per-game header markup, no manual turnStatusText.
+        turn: {
+          onClockUserId: currentTurnUserId, // e.g. snapshot.currentEntryId
+          isMyTurn: myTurn,
+          isGameOver,
+        },
+      }}
+    />
+  </ThemeProvider>
+);
+```
+
+**Turn header — always use the `turn` contract.** `onClockUserId` is the
+**userId** of the player on the clock (compare it against `currentUserId` to
+derive `myTurn`). The shell resolves their display name (chat-store resolver,
+registered via `useGameChatIntegration`) and equipped avatar
+([InGameAvatar](apps/web/src/features/games/ui/InGameAvatar.tsx)). Pass `null`
+when nobody is on the clock (setup / between turns) → the pill shows "Waiting…".
+
+**Real-time games (no turns)** — skip the `turn` contract and use the legacy
+escape hatch instead: `turnStatusText` + `turnStatusVariant` for a plain status
+pill (see [GlimwormGame](apps/web/src/widgets/GlimwormGame/GlimwormGame.tsx),
+which shows Get ready / In play / Round over with no avatar).
+
+**Critical Board.tsx pattern** — the grid container MUST have explicit `width: '100%'` plus `boxSizing: 'border-box'`. Without `width`, an `aspectRatio: '1/1'` grid of empty buttons collapses to ~0px and you see only a colored sliver. See [apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx](apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx).
+
+**End-game UI: reuse the shared [GameResultModal](apps/web/src/features/games/ui/GameResultModal.tsx).** Don't write a per-game game-over modal. It already handles victory/defeat/draw tones (gold / red / silver), confetti, rematch button, animated entrance, and `Back to home` link. If your game's vocabulary differs from `games.table.victory/defeat/draw`, pass a `messages={{ title, message? }}` prop to override the headline/body without touching shared i18n. Map your game's local result type (`'won'|'lost'|'draw'`) to the shared `'victory'|'defeat'|'draw'` before passing it in. See [apps/web/src/widgets/TicTacToeGame/ui/Game.tsx](apps/web/src/widgets/TicTacToeGame/ui/Game.tsx).
+
+**Required Game.tsx hooks:** every widget needs the same shared hooks wired the same way. Forgetting one means: no rematch (no `useRematch`), no chat panel (no `useGameChatIntegration`), or runtime errors when passing `t` to `GameResultModal` (no `useTranslation`).
+
+```tsx
+const { t } = useTranslation();
+const { rematchLoading, handleRematch } = useRematch({ roomId });
+useGameChatIntegration(snapshot?.logs as never, (_msg, _scope) => {
+  // chat sends go through the shared composer — no game-specific socket event
+});
+```
+
+**Lobby pattern:** `<Name>Lobby.tsx` wraps the shared `ReusableGameLobby` and only contributes an `optionsSlot` (variant picker, board-size selector, team toggle, etc.). Don't reimplement the player list, kick controls, host badge, or start button — they live in `ReusableGameLobby`.
+
+### 6. Web registry — three files
+
+a. [apps/web/src/features/games/registry.ts](apps/web/src/features/games/registry.ts) — add lazy loader:
+```ts
+'<game>_v1': () => import('@/widgets/<Name>Game'),
+```
+Plus a metadata entry with: `name`, `description`, `category`, `minPlayers`, `maxPlayers` (overall ceiling — match BE engine `getMetadata()`), `estimatedDuration`, `complexity`, `ageRating`, `thumbnail`, `version`, `supportsAI`, `tags`, `status` (`'stable'|'beta'`).
+
+b. [apps/web/src/features/games/lib/gameIdMapping.ts](apps/web/src/features/games/lib/gameIdMapping.ts) — add `'<game>_v1'` to **both** the `GameType` union AND the `VALID_GAME_IDS` array.
+
+c. [apps/web/src/features/games/hooks/useGameActions.ts](apps/web/src/features/games/hooks/useGameActions.ts) — has a **separate** `GameType` union (yes, duplicated). Add `'<game>_v1'` here too. **Forgetting this throws "Unsupported game type" at runtime.**
+
+### 7. Landing page
+
+Create `apps/web/src/app/[locale]/games/<game>/`:
+- `page.tsx` — server component with `buildPageMetadata` + `JsonLd` VideoGame schema
+- `<Name>Landing.tsx` — hero, highlights, steps, themes, rules, FAQ, CTAs, breadcrumbs
+- `<Name>Hero.tsx` — static decorative board/state preview
+- `<Name>ThemesGrid.tsx`
+- `<Name>FinalCtaButtons.tsx`
+- `opengraph-image.tsx` — 1200×630 `ImageResponse`
+- `twitter-image.tsx` — `export { default } from './opengraph-image'`
+
+Add to:
+- [apps/web/src/shared/config/routes.ts](apps/web/src/shared/config/routes.ts) — `<game>Landing: '/${locale}/games/<game>'`
+- [apps/web/src/shared/seo/buildPageMetadata.ts](apps/web/src/shared/seo/buildPageMetadata.ts) — `DEFAULT_PATH_BUILDERS` entry
+
+**`createRoomHref` MUST use `?gameId=<game>_v1`** (the param name `GameCreateView` reads via `searchParams.get('gameId')`). Don't invent `?slug=` or `?game=` — those silently fall through to `VISIBLE_GAMES[0]` (Critical) and the user lands on the wrong preselected game. Don't append `&variant=...`; the view defaults to `themesFor(gameId)[0]` and appending a default would duplicate the param when the themes-grid links add their own.
+
+### 8. Home + Create page
+
+a. [apps/web/src/app/[locale]/home/data/games.ts](apps/web/src/app/[locale]/home/data/games.ts) — add to `featuredGames` (players range, duration, `landingHref`, variant count).
+
+a2. **Home featured-card symbol** — create `apps/web/src/app/[locale]/home/components/featured-games/symbols/<Name>Symbol.tsx` (64×64 SVG using `stroke="currentColor"`, mirroring [SeaBattleSymbol.tsx](apps/web/src/app/[locale]/home/components/featured-games/symbols/SeaBattleSymbol.tsx)). Export it from `symbols/index.ts` and add a `case '<game>_v1':` branch to [`GameSymbol`](apps/web/src/app/[locale]/home/components/featured-games/gameMeta.tsx). Without this, the home card cover renders `null` instead of a glyph.
+
+b. [apps/web/src/features/games/ui/create/redesign/data/themes.ts](apps/web/src/features/games/ui/create/redesign/data/themes.ts):
+- Extend `GameId` union
+- Add `GAMES` entry
+- Add to `VISIBLE_GAMES`
+- Add `<NAME>_THEMES` constant
+- Add a `themesFor()` branch
+- Export a `find<Name>Theme()` helper
+
+c. [apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx](apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx) — add picker block for the game. **The button MUST include a `<div className={s.themeArt}>` with a real-board thumbnail** (mirroring sea-battle's `SeaBattleBoardPoster` and critical's `CriticalMiniCluster`). Text-only picker cards look broken next to other games. Create `art/<Name>BoardPoster.tsx` as a pure SVG that renders a fixed mid-game snapshot using the widget's per-variant palette (import `getTheme(variant)` from the widget's `lib/theme.ts` — don't re-declare palettes). Use `preserveAspectRatio="xMidYMid slice"` and fill the container with the variant background — the poster slot is wide (16:9 sm, 5:4 lg), not square. See [apps/web/src/features/games/ui/create/redesign/art/TicTacToeBoardPoster.tsx](apps/web/src/features/games/ui/create/redesign/art/TicTacToeBoardPoster.tsx).
+
+d. [apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx](apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx) — **MUST add a branch for the new game**. This component routes the small game-card thumbnail (left grid on `/games/create`) AND the right-rail LIVE PREVIEW. The default fallback is the Glimworm snake poster, so any unrouted game silently renders as glowing snake trails. Add: `if (gameId === '<game>_v1') return <NameBoardPoster theme={find<Name>Theme(themeId)} size={size} />;`
+
+e. [apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx](apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx) — wire the game's `RulesModal` here. Without this, the "Game Rules" button on the create-page rail renders but does nothing when clicked (the button is only hidden for `glimworm_v1`; every other game shows it). Add a `dynamic()` import for `@/widgets/<Name>Game/ui/RulesModal` and a `gameId === '<game>_v1' ? <NameRulesModal ... /> : null` branch.
+
+f. **Mount the same `RulesModal` in BOTH the lobby AND the in-game branch of `Game.tsx`.** The room shell ([GameRoomPage](apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx)) drives `showRulesOpen` from a header button that's visible mid-game; the widget receives `showRulesOpen` / `onShowRulesClose` as props. If you only mount the modal in the lobby's render branch, clicking the in-game rules button toggles state but no modal appears. Wire it via the in-game `modals` slot alongside `GameResultModal`. The header rules trigger is built into the shared shell — you do NOT need to add a button anywhere.
+
+g. [apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx](apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx):
+- Add to `URL_TO_GAME_ID`
+- Add a `buildGameOptions()` branch returning the game's `Options` shape
+
+### 9. i18n — write keys BEFORE referencing them
+
+`TranslationKey` is strictly typed against the catalog. **Components that reference missing keys fail typecheck.** Write all five locale files first:
+
+```
+apps/web/src/shared/i18n/messages/games/<game>/{en,es,fr,ru,by}.ts
+apps/web/src/shared/i18n/messages/seo/{en,es,fr,ru,by}.ts  ← add <game>Landing
+```
+
+Cover: landing (hero/highlights/steps/themes/rules/faq), lobby (variants/options/players/start/leave), in-game (turn/status/result), chat scopes, errors, each variant name+description.
+
+### 10. Tests
+
+- **BE engine**: `apps/be/src/games/engines/<game>/<game>.engine.spec.ts` — happy path, win conditions, illegal actions, forfeit
+- **BE service**: orchestration smoke
+- **BE bot**: difficulty-by-difficulty pickMove (use real engine state, not mocks — see lessons in [feedback_pull_develop_before_push](.claude/projects/.../memory/))
+- **Web hooks**: vitest for `useState`/`useActions`
+- **Web widget**: render test with `TamaguiProvider defaultTheme="light"`
+- **Playwright e2e**: lobby → start → place move → win (can be deferred and listed as follow-up in PR)
+
+### 11. Before-PR punch list
+
+Walk this list manually — these are the surfaces where missing wiring causes silent regressions (text-only thumbnails, "Unsupported game type" toasts, button-clicks that toggle state into the void, etc.):
+
+- [ ] BE engine registered in `engines.module.ts`; service+bot+gateway in `games.module.ts`; entry in `games.catalog.ts`.
+- [ ] Web widget folder has an `index.ts` barrel that default-exports the memoized `Game`.
+- [ ] Widget registered in `features/games/registry.ts` (loader + metadata).
+- [ ] `<game>_v1` added to **both** `GameType` unions: `lib/gameIdMapping.ts` AND `hooks/useGameActions.ts`.
+- [ ] Landing route in `shared/config/routes.ts` + `seo/buildPageMetadata.ts`; CTA uses `?gameId=`.
+- [ ] Home featured-card: data entry in `home/data/games.ts` + symbol branch in `gameMeta.tsx`.
+- [ ] Create page: `themes.ts` + `ThemePicker.tsx` block + `art/<Name>BoardPoster.tsx` + `GameArt.tsx` branch + `GameCreateView.tsx` branch.
+- [ ] Rules modal mounted in lobby AND in-game branches of `Game.tsx`; also wired in `RulesAccess.tsx`.
+- [ ] End-game modal is the shared `GameResultModal`, not a per-game one.
+- [ ] i18n keys present in all 5 locales (en, es, fr, ru, by) — including SEO entries.
+- [ ] BE engine spec + bot spec passing; web hook/widget vitest passing.
+- [ ] [`apps/web/e2e/home-games-slider.spec.ts`](apps/web/e2e/home-games-slider.spec.ts) — bump the expected `toHaveCount(N)` and add the new game's `<h3>` assertion; the test hardcodes the featured-games count and order.
+
+**Mobile scope:** the new-game flow targets web + BE only. Add a mobile screen only if the user explicitly asks; otherwise note "mobile follow-up" in the PR.
+
+### 12. Verify locally, then PR
+
+```bash
+pnpm --filter @arcadeum/be test
+pnpm --filter @arcadeum/web test
+pnpm --filter @arcadeum/be lint
+pnpm --filter @arcadeum/web lint
+pnpm --filter @arcadeum/be typecheck
+pnpm --filter @arcadeum/web typecheck
+pnpm check-file-length
+```
+
+If the pre-push hook flakes (known: see [feedback_web_pre_push_hook_flaky](memory)), verify tests in isolation then push with `--no-verify`. **PR base is `develop`, never `main`** — see [feedback_pr_base_develop](memory).
+
+```bash
+gh pr create --base develop --title "feat(games): add <name> (ARC-XXX)" --body "..."
+```
+
+## Gotchas (every one of these bit us during tic-tac-toe)
+
+1. **Two `GameType` unions.** [gameIdMapping.ts](apps/web/src/features/games/lib/gameIdMapping.ts) AND [useGameActions.ts](apps/web/src/features/games/hooks/useGameActions.ts). Missing the second throws "Unsupported game type: <id>" at runtime, not compile time.
+
+2. **Lobby inside `GameWidgetContainer.board` collapses.** That slot is sized for the in-game grid. Early-return the lobby OUTSIDE the container (sea-battle pattern).
+
+3. **Grid `aspectRatio` without `width: '100%'` collapses to 0px** when children are empty buttons. Always set both `width: '100%'` and `boxSizing: 'border-box'` on the grid container.
+
+4. **Write i18n keys first.** `TranslationKey` validates strictly — component code referencing missing keys won't typecheck.
+
+5. **`GameWidgetContainer` is not children-based.** Props are `board`, `modals`, `headerProps`, `variant`, `isMyTurn`, `isGameOver`. Don't pass children.
+
+6. **Header turn display is the shared `turn` contract**, not hand-rolled text/avatar. Pass `headerProps.turn = { onClockUserId, isMyTurn, isGameOver }` and the shell renders avatar + name + turn label for free. Only real-time/no-turn games fall back to `turnStatusText` + `turnStatusVariant`.
+
+7. **In-game chat popups are free** — the shell renders `GameChatPopupOverlay` for incoming messages. Leave `showChatPopup` at its default (`true`). Only pass `showChatPopup={false}` if your game shows incoming chat its own way (e.g. per-player bubbles) and you need to avoid double display.
+
+6. **`SharedHeaderProps` field names:** `variantEmoji`, `title`, `subtitle`, `turnStatusVariant`, `turnStatusText` (not `gameTitle` / `gameIcon`).
+
+7. **`TurnStatusVariant`** union is `'completed' | 'yourTurn' | 'waiting'` — camelCase, not kebab.
+
+8. **`useRematch`** returns `{ rematchLoading, handleRematch }` (not `loading` / `handleRematchClick`). No `currentUserId` option.
+
+9. **`useGameChatIntegration`** signature is positional: `(logs, sendMessage, resolveDisplayName?, resolveActorColor?)`. Not an options object.
+
+10. **`GameRoomSummary.members`** (not `participants`); each member has `id` (not `userId`).
+
+11. **Tamagui prop strictness:** `Dialog` has no `animation` prop; `Button` has no `themeInverse` prop. Don't add either.
+
+12. **`TamaguiProvider` test render** needs `defaultTheme="light"`.
+
+13. **`GameLogEntry` helper** options: `targetId?: string` — pass `undefined`, not `null`.
+
+14. **Bot test setup:** when testing "bot must block", make sure the bot can't *win* on the same move — otherwise it takes the win and your blocking assertion fails.
+
+15. **Theme picker thumbnail required.** A text-only theme card looks broken next to sea-battle/critical cards that render real boards. Always ship `art/<Name>BoardPoster.tsx` (SVG with a fixed mid-game snapshot) and wire it via `<div className={s.themeArt}>` inside the picker button — pull palette tokens from the widget's `getTheme(variant)`, don't redeclare.
+
+16. **`GameArt.tsx` default falls through to Glimworm snake art.** If you ship a new game and forget to add a branch in `art/GameArt.tsx`, the small game-card thumbnail on `/games/create` AND the right-rail LIVE PREVIEW will both render glowing pink/green snake trails. Always add `if (gameId === '<game>_v1') return <YourBoardPoster ...>` alongside the branches for critical/sea-battle/tic-tac-toe.
+
+17. **`GameSymbol` default returns `null`.** [home/components/featured-games/gameMeta.tsx](apps/web/src/app/[locale]/home/components/featured-games/gameMeta.tsx) is a `switch (gameId)` that returns `null` in its default branch — so a missing case renders an empty cover glyph on the home featured-card. Always add the `case '<game>_v1':` and ship a sibling SVG in `symbols/`.
+
+18. **Landing-page CTA must use `?gameId=`.** `GameCreateView` reads `searchParams.get('gameId')`; any other query key (`?slug=`, `?game=`) is silently ignored and the user lands on Critical (the first entry of `VISIBLE_GAMES`). Sea Battle's landing is the reference: `${routes.gameCreate}?gameId=${SLUG}`.
+
+19. **"Game Rules" button needs its modal wired in `RulesAccess`.** [RulesAccess.tsx](apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx) always renders the button (it only hides for Glimworm). For every other game, you must add a `gameId === '<game>_v1' ? <NameRulesModal .../> : null` branch — otherwise clicking the button toggles `open` but no modal mounts. **Watch the prop name**: sea-battle/critical use `isOpen`, but tic-tac-toe's modal uses `open` — copy whichever name the modal you're wiring actually accepts.
+
+20. **`Dialog.Description` renders as `<p>` — only string/inline children allowed.** Putting a `<YStack>` (or any block element) inside `Dialog.Description` produces invalid HTML (`<div> cannot be a descendant of <p>`) and triggers React's hydration error. Keep `Dialog.Description` as a single short string (it's the `aria-describedby` summary anyway) and hoist any multi-block content out as a sibling of `Description` inside `Dialog.Content`. Or skip raw `Dialog` entirely — `@arcadeum/ui`'s `Modal` / `ModalContent` / `ModalHeader` / `ModalBody` primitives don't have this trap.
+
+21. **Don't write a per-game end-game modal.** [GameResultModal](apps/web/src/features/games/ui/GameResultModal.tsx) is the shared end-game UI (confetti, gold/red/silver tones, rematch button, home link). It accepts `result: 'victory'|'defeat'|'draw'|null` and an optional `messages={{title, message?}}` override for games whose copy doesn't match the shared `games.table.*` keys — tic-tac-toe uses this to surface its own `gameOver.won/lost/draw` strings without touching shared i18n.
+
+22. **Per-option player caps go through the service, not the room.** If players-per-game depends on a game-option (board size, mode, etc.), don't try to mutate the room's `maxPlayers` when the option changes — leave room.maxPlayers at the overall ceiling. Enforce the per-option cap at `startSession` (BE) and surface it in the lobby selector ("3×3 · up to 2"). The BE error message tells the host to reduce players or pick a different option.
+
+23. **`home-games-slider.spec.ts` hardcodes the featured-games count and order.** Adding a new game to `home/data/games.ts` breaks `await expect(gameCards).toHaveCount(N)` and the per-index `toHaveText` assertions. Update both the count and add the new `<h3>` assertion in the same commit as the data change.
+
+## When the user says "implement game X"
+
+Default to fully autonomous mode unless they pause you:
+1. Brainstorm (or accept user-supplied spec), write spec doc.
+2. Write plan doc.
+3. Execute end-to-end through this checklist on a branch `ARC-XXX-<game>` (create if needed).
+4. Commit in logical chunks. Don't squash mid-flight.
+5. Open the PR against `develop`. Done.
+
+Stop only for: ambiguous game rules, design choices that materially affect scope (e.g., "does this need spectator mode?"), or hard failures the skill doesn't cover.

--- a/.claude/skills/new-mobile-screen/SKILL.md
+++ b/.claude/skills/new-mobile-screen/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: new-mobile-screen
+description: Add a new screen to the mobile app (apps/mobile). Use when creating a new route/screen in the Expo Router app.
+---
+
+The mobile app uses Expo Router (file-based routing) with React Native, Tamagui UI, and a custom `useTranslation` hook for i18n.
+
+## Routing structure
+
+```
+apps/mobile/app/
+  (tabs)/          ← tab navigator screens
+  (tv)/            ← TV-specific screens
+  <screen>.tsx     ← top-level screen
+  <domain>/
+    [id].tsx       ← dynamic route
+    _layout.tsx    ← nested layout
+```
+
+## Steps
+
+1. **Create the screen file** at the appropriate path under `apps/mobile/app/`:
+   - Use `export default function <Name>Screen()` (Expo Router requires default export)
+   - For tab screens, place under `(tabs)/`
+
+2. **Use i18n** with the `useTranslation` hook:
+   ```ts
+   import { useTranslation } from '@/lib/i18n';
+   const { t } = useTranslation();
+   // t('some.key')
+   ```
+
+3. **Use shared UI components** from `@arcadeum/ui` (imported via workspace alias):
+   ```ts
+   import { Button, Card, YStack, XStack, Text } from '@arcadeum/ui';
+   ```
+
+4. **Navigation** — use `expo-router` hooks:
+   ```ts
+   import { useRouter, useLocalSearchParams } from 'expo-router';
+   ```
+
+5. **Add translations** to `apps/mobile/lib/i18n/messages/` for all locales.
+
+6. **Register in tab bar** (if adding a tab): update `apps/mobile/app/(tabs)/_layout.tsx`
+
+## Key patterns
+
+- Wrap screens with `<SafeAreaView>` or the project's screen wrapper
+- Auth-protected screens should check `useSessionTokens()` store and redirect to `auth` if unauthenticated
+- Use `useColorScheme()` from `@/hooks/useColorScheme` for theme-aware styling

--- a/.claude/skills/new-ui-component/SKILL.md
+++ b/.claude/skills/new-ui-component/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: new-ui-component
+description: Add a new shared UI component to the @arcadeum/ui package (packages/ui). Use when creating reusable components shared across web and mobile.
+---
+
+The shared UI library (`packages/ui`) uses Tamagui as the component foundation and is consumed by both `apps/web` and `apps/mobile` via `@arcadeum/ui`.
+
+## Structure
+
+```
+packages/ui/src/components/
+  <ComponentName>/
+    index.ts                     ← re-export
+    <ComponentName>.tsx
+    <ComponentName>.stories.tsx  ← Storybook story (required)
+```
+
+## Steps
+
+1. **Create component** in `packages/ui/src/components/<Name>/<Name>.tsx`:
+   - Use Tamagui primitives (`YStack`, `XStack`, `Text`, `Stack`, etc.)
+   - Export named: `export const <Name> = ...`
+   - Accept typed props extending Tamagui's component props where appropriate
+
+2. **Create `index.ts`** re-export:
+   ```ts
+   export { <Name> } from './<Name>';
+   export type { <Name>Props } from './<Name>';
+   ```
+
+3. **Register in barrel export** `packages/ui/src/index.ts`:
+   ```ts
+   export * from './components/<Name>';
+   ```
+
+4. **Create `<Name>.stories.tsx`** (required for every component):
+   ```tsx
+   import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+   import { <Name> } from './<Name>';
+
+   const meta: Meta<typeof <Name>> = {
+     title: 'Shared/<Name>',
+     component: <Name>,
+     tags: ['autodocs'],
+     argTypes: {
+       // declare each prop with control type and description
+       variant: { control: 'select', options: [...], description: '...' },
+     },
+   };
+
+   export default meta;
+   type Story = StoryObj<typeof <Name>>;
+
+   export const Default: Story = { args: { /* minimal props */ } };
+
+   // Add a story per meaningful variant/state, e.g.:
+   // export const Disabled: Story = { args: { disabled: true } };
+   // export const AllVariants: Story = { render: () => <...> };
+   ```
+   - `title` follows `'Shared/<Name>'` convention
+   - Always include `tags: ['autodocs']`
+   - Cover: default state, each variant, disabled/error/loading states where applicable
+   - Add an `AllVariants` render story when there are multiple visual variants
+
+5. **Tamagui primitives reference**:
+   ```ts
+   import { YStack, XStack, Text, Stack, View, styled } from 'tamagui';
+   // Use styled() for variant-driven components
+   const MyComponent = styled(Stack, {
+     variants: {
+       size: { sm: { padding: '$2' }, md: { padding: '$4' } }
+     }
+   });
+   ```
+
+## Notes
+
+- Keep components platform-agnostic — they run on both web and React Native
+- Avoid importing from `react-native` directly; use Tamagui equivalents
+- Check `packages/ui/src/tamagui.config.ts` for design tokens (`$colors`, `$space`, `$size`)
+- Run `pnpm storybook` from `apps/web` to verify stories render correctly

--- a/.claude/skills/new-web-page/SKILL.md
+++ b/.claude/skills/new-web-page/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: new-web-page
+description: Add a new page to the Next.js web app (apps/web). Use when creating a new route/page in the web app.
+---
+
+The web app uses Next.js App Router with a three-file pattern per page and server-side i18n.
+
+## Pattern
+
+```
+apps/web/src/app/<route>/
+  page.tsx          ← Server Component: fetches translations, exports metadata
+  <Name>Client.tsx  ← 'use client': dynamic import wrapper with loading skeleton
+  <Name>View.tsx    ← actual UI (lazy-loaded via dynamic import in Client file)
+```
+
+## Steps
+
+1. **Create `page.tsx`** (Server Component):
+   - Import `getTranslations` from `@/shared/i18n/server`
+   - Export `metadata` with `title: \`Page Title - \${appConfig.appName}\``
+   - Fetch translations with `const messages = await getTranslations()`
+   - Pass only the relevant translation slice as `t` prop to the Client component
+
+2. **Create `<Name>Client.tsx`** (`'use client'`):
+   - Use `dynamic(() => import('./<Name>View').then(mod => mod.<Name>View), { ssr: false, loading: LoadingSkeleton })`
+   - Define `LoadingSkeleton` using `PageLayout`, `Container`, `GlassCard`, `Skeleton`, `YStack` from `@/shared/ui`
+
+3. **Create `<Name>View.tsx`**:
+   - Build the actual page UI using components from `@arcadeum/ui` and `@/shared/ui`
+   - Accept `t` prop for translations
+
+4. **Add translations** to all locale files:
+   - `apps/web/src/shared/i18n/messages/pages/en.ts` (and `by.ts`, `es.ts`, `fr.ts`, `ru.ts`)
+   - Export the translation key from `apps/web/src/shared/i18n/messages/pages.ts`
+
+## Key imports
+
+```ts
+import { appConfig } from '@/shared/config/app-config';
+import { getTranslations } from '@/shared/i18n/server';
+import { PageLayout, Container, GlassCard, Skeleton, YStack } from '@/shared/ui';
+```

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: pr-description
+description: Writes pull request descriptions. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a pull request.
+---
+
+When writing a PR description:
+
+1. Run `git diff main...HEAD` to see all changes on this branch
+2. Write a description following this format:
+
+## What
+One sentence explaining what this PR does.
+
+## Why
+Brief context on why this change is needed
+
+## Changes
+- Bullet points of specific changes made
+- Group related changes together
+- Mention any files deleted or renamed

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ coverage/
 # E2E test logs
 backend-e2e-errors.log
 
-.claude
 .claw
 .playwright-mcp
 .superpowers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-05-29
+
+### Added
+- add optional aurora card style for Cascade (ARC-760) (ARC-760)
+- bring full prototype polish to the Cascade table (ARC-760) (ARC-760)
+- rework Cascade cards into on-brand dark-glass faces (ARC-760) (ARC-760)
+- modernize the Cascade wild-color picker (ARC-760) (ARC-760)
+- modernize the Cascade board for a more playable table (ARC-760) (ARC-760)
+
+### Documentation
+- add the Cascade board card-rework handoff (ARC-760) (ARC-760)
+
+
 ## [1.16.0] - 2026-05-29
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-05-29
+
+
+
+
 ## [1.15.11] - 2026-05-29
 
 ### Added

--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile",
   "main": "expo-router/entry",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "scripts": {
     "dev": "node ./scripts/dev.js",
     "start": "expo start",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile",
   "main": "expo-router/entry",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "scripts": {
     "dev": "node ./scripts/dev.js",
     "start": "expo start",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "private": true,
   "browserslist": [
     "chrome >= 87",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "browserslist": [
     "chrome >= 87",

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -304,6 +304,12 @@ interface GameWidgetContainerProps {
   isMyTurn?: boolean;
   /** When true, the widget auto-exits its fullscreen shortly after finish. */
   isGameOver?: boolean;
+  /**
+   * Renders the shared in-game chat message popup overlay (default true).
+   * Set false for games that show incoming chat their own way (e.g. Critical
+   * renders per-opponent chat bubbles) to avoid showing each message twice.
+   */
+  showChatPopup?: boolean;
 }
 
 const gameWidgetGlobalStyles = `
@@ -333,6 +339,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   variant,
   isMyTurn,
   isGameOver,
+  showChatPopup = true,
 }: GameWidgetContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Widget-only fullscreen — independent of the page-level toggle in
@@ -456,7 +463,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
           </SharedHandSection>
         )}
         {modals}
-        <GameChatPopupOverlay />
+        {showChatPopup && <GameChatPopupOverlay />}
       </Container>
     </>
   );

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -13,6 +13,11 @@ import { useFullscreen } from '../hooks/useFullscreen';
 import { useAutoExitFullscreen } from '../hooks/useAutoExitFullscreen';
 import { scrollbarStyles } from '@/shared/lib/styles';
 import { GameChatPopupOverlay } from '@/widgets/GameChat';
+import {
+  TurnIndicator,
+  resolveTurnStatus,
+  type TurnContract,
+} from './TurnIndicator';
 
 // --- Styled components (based on CriticalGame's layout.tsx) ---
 
@@ -264,11 +269,21 @@ interface SharedHeaderProps {
   title: string;
   /** Optional subtitle (e.g. room name) */
   subtitle?: string;
-  /** Turn status pill variant */
-  turnStatusVariant: TurnStatusVariant;
-  /** Turn status text */
-  turnStatusText: string;
-  /** Optional avatar of the player on the clock, rendered inside the turn pill */
+  /**
+   * Preferred: declarative turn contract. The header renders the shared
+   * {@link TurnIndicator} (avatar + name + "Your turn / {name}'s turn") and
+   * derives the pill status from these fields. A new game gets the full turn
+   * display by passing only an id + isMyTurn.
+   */
+  turn?: TurnContract;
+  /**
+   * Legacy / non-turn escape hatch (e.g. real-time games like Glimworm that
+   * have no turns). Ignored when `turn` is provided.
+   */
+  turnStatusVariant?: TurnStatusVariant;
+  /** Legacy / non-turn status text. Ignored when `turn` is provided. */
+  turnStatusText?: string;
+  /** Legacy free-form avatar node. Ignored when `turn` is provided. */
   turnAvatar?: React.ReactNode;
   /** Optional extra actions rendered before fullscreen button */
   extraActions?: React.ReactNode;
@@ -335,6 +350,12 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
     exitFullscreen,
   });
 
+  const pillStatus: TurnStatusVariant = headerProps
+    ? headerProps.turn
+      ? resolveTurnStatus(headerProps.turn)
+      : (headerProps.turnStatusVariant ?? 'default')
+    : 'default';
+
   const renderedHeader =
     header ??
     (headerProps ? (
@@ -373,16 +394,28 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
           </YStack>
         </GameInfo>
 
-        <TurnStatusPill
-          $status={headerProps.turnStatusVariant}
-          gap={headerProps.turnAvatar ? '$2' : undefined}
-          paddingLeft={headerProps.turnAvatar ? '$1' : undefined}
-        >
-          {headerProps.turnAvatar}
-          <TurnStatusText $status={headerProps.turnStatusVariant}>
-            {headerProps.turnStatusText}
-          </TurnStatusText>
-        </TurnStatusPill>
+        {headerProps.turn ? (
+          <TurnStatusPill
+            $status={pillStatus}
+            gap="$2"
+            paddingLeft="$1"
+            data-testid="turn-status-pill"
+          >
+            <TurnIndicator turn={headerProps.turn} />
+          </TurnStatusPill>
+        ) : (
+          <TurnStatusPill
+            $status={pillStatus}
+            gap={headerProps.turnAvatar ? '$2' : undefined}
+            paddingLeft={headerProps.turnAvatar ? '$1' : undefined}
+            data-testid="turn-status-pill"
+          >
+            {headerProps.turnAvatar}
+            <TurnStatusText $status={pillStatus}>
+              {headerProps.turnStatusText}
+            </TurnStatusText>
+          </TurnStatusPill>
+        )}
 
         <HeaderActions>
           {headerProps.extraActions}

--- a/apps/web/src/features/games/ui/TurnIndicator.test.tsx
+++ b/apps/web/src/features/games/ui/TurnIndicator.test.tsx
@@ -1,0 +1,134 @@
+import { render as rtlRender, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import config from '@/shared/config/tamagui.config';
+import { TurnIndicator, resolveTurnStatus } from './TurnIndicator';
+import { useGameChatStore } from '@/widgets/GameChat';
+
+// Translate keys to their final form with `{{name}}` interpolation so we can
+// assert on rendered copy without coupling to a specific locale string.
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const labels: Record<string, string> = {
+        'games.table.turn.yourTurn': 'Your turn',
+        'games.table.turn.otherTurn': "{{name}}'s turn",
+        'games.table.turn.waiting': 'Waiting…',
+        'games.table.turn.gameOver': 'Game over',
+      };
+      const base = labels[key] ?? key;
+      return params
+        ? Object.entries(params).reduce(
+            (s, [k, v]) => s.replace(`{{${k}}}`, String(v)),
+            base,
+          )
+        : base;
+    },
+  }),
+}));
+
+// InGameAvatar reaches into the game store + cosmetics hook; stub it to a marker
+// so this test focuses on TurnIndicator's own logic (name + label + status).
+vi.mock('./InGameAvatar', () => ({
+  InGameAvatar: ({ name }: { name: string }) => (
+    <div data-testid="turn-indicator-avatar">{name}</div>
+  ),
+}));
+
+const render = (ui: React.ReactElement) =>
+  rtlRender(
+    <TamaguiProvider config={config} defaultTheme="dark">
+      {ui}
+    </TamaguiProvider>,
+  );
+
+describe('resolveTurnStatus', () => {
+  it('maps game over → completed regardless of turn', () => {
+    expect(
+      resolveTurnStatus({
+        onClockUserId: 'u-1',
+        isMyTurn: true,
+        isGameOver: true,
+      }),
+    ).toBe('completed');
+  });
+
+  it('maps my turn → yourTurn', () => {
+    expect(resolveTurnStatus({ onClockUserId: 'u-1', isMyTurn: true })).toBe(
+      'yourTurn',
+    );
+  });
+
+  it('maps another player on the clock → waiting', () => {
+    expect(resolveTurnStatus({ onClockUserId: 'u-2', isMyTurn: false })).toBe(
+      'waiting',
+    );
+  });
+
+  it('maps nobody on the clock → default', () => {
+    expect(resolveTurnStatus({ onClockUserId: null, isMyTurn: false })).toBe(
+      'default',
+    );
+  });
+});
+
+describe('TurnIndicator', () => {
+  beforeEach(() => {
+    useGameChatStore.setState({
+      resolveDisplayName: (id?: string) => (id === 'u-2' ? 'Jane' : undefined),
+      fallbackResolveDisplayName: null,
+    });
+  });
+
+  it("shows 'Your turn' and the on-clock avatar when it is the local player's turn", () => {
+    render(<TurnIndicator turn={{ onClockUserId: 'u-1', isMyTurn: true }} />);
+    expect(screen.getByTestId('turn-indicator-label')).toHaveTextContent(
+      'Your turn',
+    );
+    // The on-clock avatar still renders (it's the local player on the clock).
+    expect(screen.getByTestId('turn-indicator-avatar')).toBeInTheDocument();
+  });
+
+  it("shows the other player's name + avatar when waiting on them", () => {
+    render(<TurnIndicator turn={{ onClockUserId: 'u-2', isMyTurn: false }} />);
+    expect(screen.getByTestId('turn-indicator-label')).toHaveTextContent(
+      "Jane's turn",
+    );
+    expect(screen.getByTestId('turn-indicator-avatar')).toHaveTextContent(
+      'Jane',
+    );
+  });
+
+  it("shows 'Waiting…' and no avatar when nobody is on the clock", () => {
+    render(<TurnIndicator turn={{ onClockUserId: null, isMyTurn: false }} />);
+    expect(screen.getByTestId('turn-indicator-label')).toHaveTextContent(
+      'Waiting…',
+    );
+    expect(screen.queryByTestId('turn-indicator-avatar')).not.toBeInTheDocument();
+  });
+
+  it("shows 'Game over' and no avatar when the game is finished", () => {
+    render(
+      <TurnIndicator
+        turn={{ onClockUserId: 'u-2', isMyTurn: false, isGameOver: true }}
+      />,
+    );
+    expect(screen.getByTestId('turn-indicator-label')).toHaveTextContent(
+      'Game over',
+    );
+    expect(
+      screen.queryByTestId('turn-indicator-avatar'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('honors an explicit onClockName override', () => {
+    render(
+      <TurnIndicator
+        turn={{ onClockUserId: 'u-9', isMyTurn: false, onClockName: 'Bot 9' }}
+      />,
+    );
+    expect(screen.getByTestId('turn-indicator-label')).toHaveTextContent(
+      "Bot 9's turn",
+    );
+  });
+});

--- a/apps/web/src/features/games/ui/TurnIndicator.tsx
+++ b/apps/web/src/features/games/ui/TurnIndicator.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { memo } from 'react';
+import { Text, XStack } from 'tamagui';
+import { useTranslation } from '@/shared/lib/useTranslation';
+import { useGameChatStore } from '@/widgets/GameChat';
+import { InGameAvatar } from './InGameAvatar';
+import type { TurnStatusVariant } from './GameWidgetContainer';
+
+/**
+ * Declarative turn contract shared by every game's header. A widget passes only
+ * the on-clock player's id + whether it's the local player's turn; the indicator
+ * resolves the display name (via the GameChat store resolver registered by each
+ * game) and the avatar cosmetics (via {@link InGameAvatar}, which reads equipped
+ * items from the game store by `playerId`). This is what makes the avatar+name
+ * turn display "free" for any new game.
+ */
+export interface TurnContract {
+  /** id of the player currently on the clock; null when nobody is (setup / between turns) */
+  onClockUserId: string | null;
+  /** is the local player the one on the clock */
+  isMyTurn: boolean;
+  /** game finished — show a neutral "completed" state instead of a turn */
+  isGameOver?: boolean;
+  /** override the resolved display name for the on-clock player (optional) */
+  onClockName?: string;
+}
+
+/** Map the turn contract onto the header pill's status variant. */
+export function resolveTurnStatus(turn: TurnContract): TurnStatusVariant {
+  if (turn.isGameOver) return 'completed';
+  if (turn.isMyTurn) return 'yourTurn';
+  return turn.onClockUserId ? 'waiting' : 'default';
+}
+
+const STATUS_COLOR: Record<TurnStatusVariant, string> = {
+  yourTurn: '$success',
+  waiting: '$warning',
+  completed: '$secondary',
+  default: '$color',
+};
+
+interface TurnIndicatorProps {
+  turn: TurnContract;
+  'data-testid'?: string;
+}
+
+/**
+ * Renders the avatar + label that live inside the header turn pill. The pill
+ * chrome itself (background / border) is owned by `GameWidgetContainer`, which
+ * derives the same status via {@link resolveTurnStatus}.
+ */
+export const TurnIndicator = memo(function TurnIndicator({
+  turn,
+  'data-testid': testId,
+}: TurnIndicatorProps) {
+  const { t } = useTranslation();
+  const resolveDisplayName = useGameChatStore((s) => s.resolveDisplayName);
+  const fallbackResolveDisplayName = useGameChatStore(
+    (s) => s.fallbackResolveDisplayName,
+  );
+
+  const status = resolveTurnStatus(turn);
+  const { onClockUserId, isMyTurn, isGameOver, onClockName } = turn;
+
+  const resolvedName =
+    onClockName ??
+    (onClockUserId
+      ? (resolveDisplayName?.(onClockUserId) ??
+        fallbackResolveDisplayName?.(onClockUserId) ??
+        onClockUserId)
+      : undefined);
+
+  const label = isGameOver
+    ? t('games.table.turn.gameOver')
+    : isMyTurn
+      ? t('games.table.turn.yourTurn')
+      : onClockUserId && resolvedName
+        ? t('games.table.turn.otherTurn', { name: resolvedName })
+        : t('games.table.turn.waiting');
+
+  // Avatar only makes sense when someone is on the clock and the game is live.
+  const showAvatar = !!onClockUserId && !isGameOver;
+
+  return (
+    <XStack alignItems="center" gap="$2" data-testid={testId}>
+      {showAvatar && resolvedName ? (
+        <InGameAvatar
+          playerId={onClockUserId}
+          name={resolvedName}
+          size="icon"
+          data-testid="turn-indicator-avatar"
+        />
+      ) : null}
+      <Text
+        fontSize={14}
+        fontWeight="600"
+        color={STATUS_COLOR[status]}
+        opacity={status === 'default' ? 0.7 : 1}
+        numberOfLines={1}
+        data-testid="turn-indicator-label"
+      >
+        {label}
+      </Text>
+    </XStack>
+  );
+});

--- a/apps/web/src/features/games/ui/index.ts
+++ b/apps/web/src/features/games/ui/index.ts
@@ -11,3 +11,8 @@ export { RematchModal } from './RematchModal';
 export { RematchInvitationModal } from './RematchInvitationModal';
 export { GameVariantSelector } from './GameVariantSelector';
 export { InGameAvatar, type InGameAvatarProps } from './InGameAvatar';
+export {
+  TurnIndicator,
+  resolveTurnStatus,
+  type TurnContract,
+} from './TurnIndicator';

--- a/apps/web/src/shared/i18n/messages/games/critical/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/by.ts
@@ -354,6 +354,12 @@ export const byMessages = {
       },
     },
     log: { title: 'Журнал гульні', empty: 'Дзеянняў пакуль няма' },
+    turn: {
+      yourTurn: 'Ваш ход',
+      otherTurn: 'Ход {{name}}',
+      waiting: 'Чаканне…',
+      gameOver: 'Гульня скончана',
+    },
     chat: {
       title: 'Чат стала',
       empty: 'Паведамленняў пакуль няма. Разбіце лёд!',

--- a/apps/web/src/shared/i18n/messages/games/critical/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/en.ts
@@ -295,6 +295,12 @@ export const enMessages = {
       },
     },
     log: { title: 'Game Log', empty: 'No activity yet' },
+    turn: {
+      yourTurn: 'Your turn',
+      otherTurn: "{{name}}'s turn",
+      waiting: 'Waiting…',
+      gameOver: 'Game over',
+    },
     chat: {
       title: 'Table Chat',
       empty: 'No messages yet. Break the ice!',

--- a/apps/web/src/shared/i18n/messages/games/critical/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/es.ts
@@ -295,6 +295,12 @@ export const esMessages = {
       },
     },
     log: { title: 'Registro del Juego', empty: 'Sin actividad aún' },
+    turn: {
+      yourTurn: 'Tu turno',
+      otherTurn: 'Turno de {{name}}',
+      waiting: 'Esperando…',
+      gameOver: 'Juego terminado',
+    },
     chat: {
       title: 'Chat de la Mesa',
       empty: 'Sin mensajes aún. ¡Rompe el hielo!',

--- a/apps/web/src/shared/i18n/messages/games/critical/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/fr.ts
@@ -351,6 +351,12 @@ export const frMessages = {
       title: 'Journal de la Partie',
       empty: 'Aucune activité pour le moment',
     },
+    turn: {
+      yourTurn: 'À vous de jouer',
+      otherTurn: 'Au tour de {{name}}',
+      waiting: 'En attente…',
+      gameOver: 'Partie terminée',
+    },
     chat: {
       title: 'Chat de Table',
       empty: 'Aucun message. Lancez la conversation !',

--- a/apps/web/src/shared/i18n/messages/games/critical/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/critical/ru.ts
@@ -352,6 +352,12 @@ export const ruMessages = {
       },
     },
     log: { title: 'Журнал игры', empty: 'Действий пока нет' },
+    turn: {
+      yourTurn: 'Ваш ход',
+      otherTurn: 'Ход игрока {{name}}',
+      waiting: 'Ожидание…',
+      gameOver: 'Игра окончена',
+    },
     chat: {
       title: 'Чат стола',
       empty: 'Сообщений пока нет. Разбейте лед!',

--- a/apps/web/src/shared/i18n/messages/games/glimworm/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/glimworm/by.ts
@@ -51,6 +51,9 @@ export const byMessages = {
       connecting: 'Падключэнне…',
       reconnecting: 'Перападключэнне…',
       slowConnection: 'Павольнае злучэнне',
+      getReady: 'Прыгатуйцеся',
+      inPlay: 'Ідзе гульня',
+      roundOver: 'Раўнд скончаны',
     },
     rules: {
       objective:

--- a/apps/web/src/shared/i18n/messages/games/glimworm/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/glimworm/en.ts
@@ -51,6 +51,9 @@ export const enMessages = {
       connecting: 'Connecting…',
       reconnecting: 'Reconnecting…',
       slowConnection: 'Slow connection',
+      getReady: 'Get ready',
+      inPlay: 'In play',
+      roundOver: 'Round over',
     },
     rules: {
       objective:

--- a/apps/web/src/shared/i18n/messages/games/glimworm/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/glimworm/es.ts
@@ -55,6 +55,9 @@ export const esMessages = {
       connecting: 'Conectando…',
       reconnecting: 'Reconectando…',
       slowConnection: 'Conexión lenta',
+      getReady: 'Prepárate',
+      inPlay: 'En juego',
+      roundOver: 'Ronda terminada',
     },
     rules: {
       objective:

--- a/apps/web/src/shared/i18n/messages/games/glimworm/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/glimworm/fr.ts
@@ -52,6 +52,9 @@ export const frMessages = {
       connecting: 'Connexion…',
       reconnecting: 'Reconnexion…',
       slowConnection: 'Connexion lente',
+      getReady: 'Préparez-vous',
+      inPlay: 'En jeu',
+      roundOver: 'Manche terminée',
     },
     rules: {
       objective:

--- a/apps/web/src/shared/i18n/messages/games/glimworm/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/glimworm/ru.ts
@@ -52,6 +52,9 @@ export const ruMessages = {
       connecting: 'Подключение…',
       reconnecting: 'Переподключение…',
       slowConnection: 'Медленное соединение',
+      getReady: 'Приготовьтесь',
+      inPlay: 'Идёт игра',
+      roundOver: 'Раунд окончен',
     },
     rules: {
       objective:

--- a/apps/web/src/shared/i18n/messages/games/shared/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/by.ts
@@ -288,6 +288,12 @@ export const byMessages = {
       show: 'Паказаць чат',
       hide: 'Схаваць чат',
     },
+    turn: {
+      yourTurn: 'Ваш ход',
+      otherTurn: 'Ход {{name}}',
+      waiting: 'Чаканне…',
+      gameOver: 'Гульня скончана',
+    },
     victory: {
       title: 'Перамога!',
       message: 'Выдатная гульня! Вы дамінавалі ў гэтым матчы.',

--- a/apps/web/src/shared/i18n/messages/games/shared/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/en.ts
@@ -288,6 +288,12 @@ export const enMessages = {
       show: 'Show Chat',
       hide: 'Hide Chat',
     },
+    turn: {
+      yourTurn: 'Your turn',
+      otherTurn: "{{name}}'s turn",
+      waiting: 'Waiting…',
+      gameOver: 'Game over',
+    },
     victory: {
       title: 'Victory!',
       message: 'Excellent performance! You dominated the game.',

--- a/apps/web/src/shared/i18n/messages/games/shared/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/es.ts
@@ -292,6 +292,12 @@ export const esMessages = {
       show: 'Mostrar chat',
       hide: 'Ocultar chat',
     },
+    turn: {
+      yourTurn: 'Tu turno',
+      otherTurn: 'Turno de {{name}}',
+      waiting: 'Esperando…',
+      gameOver: 'Juego terminado',
+    },
     victory: {
       title: '¡Victoria!',
       message: '¡Excelente desempeño! Has dominado la partida.',

--- a/apps/web/src/shared/i18n/messages/games/shared/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/fr.ts
@@ -294,6 +294,12 @@ export const frMessages = {
       show: 'Afficher le chat',
       hide: 'Masquer le chat',
     },
+    turn: {
+      yourTurn: 'À vous de jouer',
+      otherTurn: 'Au tour de {{name}}',
+      waiting: 'En attente…',
+      gameOver: 'Partie terminée',
+    },
     victory: {
       title: 'Victoire !',
       message: 'Excellente performance ! Vous avez dominé la partie.',

--- a/apps/web/src/shared/i18n/messages/games/shared/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/ru.ts
@@ -289,6 +289,12 @@ export const ruMessages = {
       show: 'Показать чат',
       hide: 'Скрыть чат',
     },
+    turn: {
+      yourTurn: 'Ваш ход',
+      otherTurn: 'Ход игрока {{name}}',
+      waiting: 'Ожидание…',
+      gameOver: 'Игра окончена',
+    },
     victory: {
       title: 'Победа!',
       message: 'Отличная игра! Вы доминировали в этом матче.',

--- a/apps/web/src/widgets/CascadeGame/hooks/useActionToasts.ts
+++ b/apps/web/src/widgets/CascadeGame/hooks/useActionToasts.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { CardKind, CascadeCard } from '../types';
+
+export interface ActionToast {
+  key: string;
+  glyph: string;
+  label: string;
+}
+
+// Short, mechanic-level captions for the cards that change the flow of play.
+// Plain wilds only recolour, so they don't toast.
+const ACTION_TOAST: Partial<Record<CardKind, string>> = {
+  SKIP: 'Skip',
+  REVERSE: 'Reverse',
+  DRAW_TWO: '+2',
+  WILD_DRAW_FOUR: '+4',
+};
+
+/**
+ * Pops a transient toast whenever the discard's top card changes to an action
+ * card. Driven purely off `topCard.id` so it works from the shared snapshot
+ * without any extra events; each toast self-clears after its animation.
+ */
+export function useActionToasts(
+  topCard: CascadeCard | undefined,
+  symbols: Record<string, string>,
+): ActionToast[] {
+  const [toasts, setToasts] = useState<ActionToast[]>([]);
+  const prevId = useRef<string | null>(topCard?.id ?? null);
+
+  useEffect(() => {
+    const id = topCard?.id ?? null;
+    if (!id || id === prevId.current) return;
+    prevId.current = id;
+
+    const label = topCard ? ACTION_TOAST[topCard.kind] : undefined;
+    if (!label || !topCard) return;
+
+    const key = `${id}-${Date.now()}`;
+    const glyph = symbols[topCard.kind] ?? '';
+    // Enqueue a toast in response to the snapshot's top card changing — the
+    // sanctioned "react to external state change" use of setState-in-effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setToasts((list) => [...list, { key, glyph, label }]);
+    const timer = setTimeout(
+      () => setToasts((list) => list.filter((t) => t.key !== key)),
+      1300,
+    );
+    return () => clearTimeout(timer);
+  }, [topCard, symbols]);
+
+  return toasts;
+}

--- a/apps/web/src/widgets/CascadeGame/hooks/useCardFly.tsx
+++ b/apps/web/src/widgets/CascadeGame/hooks/useCardFly.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useLayoutEffect, useState } from 'react';
+import { Card } from '../ui/Card';
+import styles from '../ui/CascadeGame.module.css';
+import type { CascadeCard } from '../types';
+
+interface FlyState {
+  card: CascadeCard;
+  from: DOMRect;
+  to: DOMRect;
+  key: number;
+}
+
+/**
+ * Animates a face-up clone of the played card from its slot to the discard
+ * pile. A fixed-position overlay (outside the table's clipped bounds) so it
+ * reads even as the real hand re-renders from the next snapshot. No-ops when
+ * elements aren't laid out (e.g. jsdom), so it's safe in tests.
+ */
+export function useCardFly() {
+  const [fly, setFly] = useState<FlyState | null>(null);
+  const [arrived, setArrived] = useState(false);
+
+  const launch = useCallback(
+    (
+      card: CascadeCard,
+      fromEl: HTMLElement | null | undefined,
+      toEl: HTMLElement | null | undefined,
+    ) => {
+      if (!fromEl || !toEl) return;
+      const from = fromEl.getBoundingClientRect();
+      const to = toEl.getBoundingClientRect();
+      if (!from.width || !to.width) return;
+      setArrived(false);
+      setFly({ card, from, to, key: Date.now() });
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    if (!fly) return;
+    const raf = requestAnimationFrame(() => setArrived(true));
+    const timer = setTimeout(() => setFly(null), 460);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+    };
+  }, [fly]);
+
+  const node = fly ? (
+    <div
+      key={fly.key}
+      className={styles.fly}
+      style={{
+        left: fly.from.left,
+        top: fly.from.top,
+        width: fly.from.width,
+        height: fly.from.height,
+        transformOrigin: 'top left',
+        opacity: arrived ? 0.25 : 1,
+        transform: arrived
+          ? `translate(${fly.to.left - fly.from.left}px, ${
+              fly.to.top - fly.from.top
+            }px) scale(${fly.to.width / fly.from.width})`
+          : 'none',
+      }}
+    >
+      <Card card={fly.card} />
+    </div>
+  ) : null;
+
+  return { node, launch };
+}

--- a/apps/web/src/widgets/CascadeGame/lib/theme.ts
+++ b/apps/web/src/widgets/CascadeGame/lib/theme.ts
@@ -19,8 +19,14 @@ export interface CascadeThemeTokens {
   cardBorder: string;
   /** Text color on cards. */
   cardText: string;
+  /** Variant accent — drives the playable-card glow and hover ring. */
+  accent: string;
+  /** Same accent as an "r,g,b" triplet for rgba() composition. */
+  accentRGB: string;
   /** Per-color card backgrounds. */
   palette: CardPalette;
+  /** Per-color flavour name shown on the wild picker (e.g. "Red Giant"). */
+  colorNames: CardPalette;
   /** Localized symbol per action card kind. */
   symbols: {
     SKIP: string;
@@ -71,12 +77,21 @@ export const THEMES: Record<CascadeVariant, CascadeThemeTokens> = {
     surface: 'rgba(124, 58, 237, 0.16)',
     cardBorder: 'rgba(255, 255, 255, 0.18)',
     cardText: '#f8fafc',
+    accent: '#a78bfa',
+    accentRGB: '167,139,250',
     palette: {
       R: '#ef4444', // Red Giant
       Y: '#fbbf24', // Solar Flare
       G: '#10b981', // Nebula
       B: '#3b82f6', // Pulsar
       W: '#1f1b3d', // Singularity
+    },
+    colorNames: {
+      R: 'Red Giant',
+      Y: 'Solar Flare',
+      G: 'Nebula',
+      B: 'Pulsar',
+      W: 'Singularity',
     },
     symbols: SHARED_SYMBOLS.cosmic,
   },
@@ -88,12 +103,21 @@ export const THEMES: Record<CascadeVariant, CascadeThemeTokens> = {
     surface: 'rgba(217, 70, 239, 0.18)',
     cardBorder: 'rgba(255, 255, 255, 0.2)',
     cardText: '#fef3c7',
+    accent: '#e879f9',
+    accentRGB: '232,121,249',
     palette: {
       R: '#dc2626', // Pyromancy
       Y: '#fcd34d', // Lumen
       G: '#22c55e', // Druidic
       B: '#0ea5e9', // Hydromancy
       W: '#1a0826', // Polymorph
+    },
+    colorNames: {
+      R: 'Pyromancy',
+      Y: 'Lumen',
+      G: 'Druidic',
+      B: 'Hydromancy',
+      W: 'Polymorph',
     },
     symbols: SHARED_SYMBOLS.arcane,
   },
@@ -105,12 +129,21 @@ export const THEMES: Record<CascadeVariant, CascadeThemeTokens> = {
     surface: 'rgba(8, 145, 178, 0.22)',
     cardBorder: 'rgba(34, 211, 238, 0.6)',
     cardText: '#ecfeff',
+    accent: '#22d3ee',
+    accentRGB: '34,211,238',
     palette: {
       R: '#f43f5e', // Crimson
       Y: '#fde047', // Voltage
       G: '#22d3ee', // Matrix (cyan-green hybrid)
       B: '#6366f1', // Cobalt
       W: '#0b1020', // Glitch
+    },
+    colorNames: {
+      R: 'Crimson',
+      Y: 'Voltage',
+      G: 'Matrix',
+      B: 'Cobalt',
+      W: 'Glitch',
     },
     symbols: SHARED_SYMBOLS.cyberpunk,
   },
@@ -122,12 +155,21 @@ export const THEMES: Record<CascadeVariant, CascadeThemeTokens> = {
     surface: 'rgba(202, 138, 4, 0.16)',
     cardBorder: 'rgba(255, 247, 237, 0.25)',
     cardText: '#f8fafc',
+    accent: '#fbbf24',
+    accentRGB: '251,191,36',
     palette: {
       R: '#dc2626', // Fire
       Y: '#a16207', // Stone
       G: '#16a34a', // Leaf
       B: '#2563eb', // Tide
       W: '#1c1917', // Storm
+    },
+    colorNames: {
+      R: 'Fire',
+      Y: 'Stone',
+      G: 'Leaf',
+      B: 'Tide',
+      W: 'Storm',
     },
     symbols: SHARED_SYMBOLS.elemental,
   },

--- a/apps/web/src/widgets/CascadeGame/types/index.ts
+++ b/apps/web/src/widgets/CascadeGame/types/index.ts
@@ -16,6 +16,9 @@ export type CascadeVariant = (typeof CASCADE_VARIANT_IDS)[number];
 export const CASCADE_MODE_IDS = ['classic', 'pure', 'speed'] as const;
 export type CascadeMode = (typeof CASCADE_MODE_IDS)[number];
 
+export const CASCADE_CARD_STYLES = ['neon', 'aurora'] as const;
+export type CascadeCardStyle = (typeof CASCADE_CARD_STYLES)[number];
+
 export const CARD_COLORS = ['R', 'Y', 'G', 'B', 'W'] as const;
 export type CardColor = (typeof CARD_COLORS)[number];
 
@@ -61,6 +64,12 @@ export interface CascadeOptions {
    * player can press the Cascade button; first press wins. Default true.
    */
   lastCardCallEnabled: boolean;
+  /**
+   * Card face treatment. `neon` (default) is the edge-glow dark glass;
+   * `aurora` pools the colour into the corners. A/B switch — defaults to
+   * `neon` when unset.
+   */
+  cardStyle?: CascadeCardStyle;
 }
 
 export interface LastCardWindow {

--- a/apps/web/src/widgets/CascadeGame/ui/Card.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Card.tsx
@@ -15,6 +15,11 @@ interface CardProps {
   playable?: boolean;
   selected?: boolean;
   disabled?: boolean;
+  /**
+   * Visually muted but still interactive — used for unplayable cards on the
+   * player's turn so a click can trigger the "illegal move" shake.
+   */
+  dimmed?: boolean;
   onClick?: () => void;
   size?: 'sm' | 'md' | 'lg';
   ariaLabel?: string;
@@ -35,6 +40,7 @@ function CardImpl({
   playable = false,
   selected = false,
   disabled = false,
+  dimmed = false,
   onClick,
   size = 'md',
   ariaLabel,
@@ -62,7 +68,7 @@ function CardImpl({
     isClickable && styles.clickable,
     playable && styles.playable,
     selected && styles.selected,
-    disabled && !faceDown && styles.disabled,
+    !faceDown && (dimmed || disabled) && styles.disabled,
   ]
     .filter(Boolean)
     .join(' ');
@@ -83,7 +89,13 @@ function CardImpl({
         } as React.CSSProperties
       }
     >
-      {faceDown ? null : (
+      {faceDown ? (
+        <span aria-hidden="true" className={styles.backMark}>
+          <span style={{ fontSize: glyphSize * 0.7 }}>
+            {theme.symbols.WILD}
+          </span>
+        </span>
+      ) : (
         <>
           <span
             aria-hidden="true"

--- a/apps/web/src/widgets/CascadeGame/ui/Card.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Card.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/shared/lib/useTranslation';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
 import type { CascadeCard, CascadeVariant } from '../types';
+import styles from './CascadeGame.module.css';
 
 interface CardProps {
   card: CascadeCard;
@@ -19,10 +20,13 @@ interface CardProps {
   ariaLabel?: string;
 }
 
-const SIZES: Record<NonNullable<CardProps['size']>, { w: number; h: number; font: number }> = {
-  sm: { w: 48, h: 70, font: 14 },
-  md: { w: 64, h: 96, font: 18 },
-  lg: { w: 88, h: 132, font: 24 },
+const SIZES: Record<
+  NonNullable<CardProps['size']>,
+  { w: number; h: number; glyph: number; corner: number }
+> = {
+  sm: { w: 50, h: 74, glyph: 22, corner: 12 },
+  md: { w: 66, h: 98, glyph: 30, corner: 15 },
+  lg: { w: 92, h: 138, glyph: 42, corner: 19 },
 };
 
 function CardImpl({
@@ -40,10 +44,21 @@ function CardImpl({
   const dims = SIZES[size];
 
   const isClickable = !!onClick && !disabled;
-  const bg = faceDown ? theme.surface : theme.palette[card.color];
+  const faceColor = faceDown ? theme.surface : theme.palette[card.color];
   const symbol = renderSymbol(card, theme.symbols);
   const resolvedLabel =
     ariaLabel ?? describeCard(card, faceDown, theme.variant, t);
+
+  const className = [
+    styles.card,
+    faceDown && styles.faceDown,
+    isClickable && styles.clickable,
+    playable && styles.playable,
+    selected && styles.selected,
+    disabled && !faceDown && styles.disabled,
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <button
@@ -52,38 +67,40 @@ function CardImpl({
       disabled={disabled || !isClickable}
       aria-label={resolvedLabel}
       aria-pressed={selected || undefined}
-      style={{
-        width: dims.w,
-        height: dims.h,
-        borderRadius: Math.round(dims.w * 0.14),
-        background: bg,
-        color: theme.cardText,
-        border: `2px solid ${
-          selected
-            ? '#fbbf24'
-            : playable
-              ? 'rgba(255, 255, 255, 0.85)'
-              : theme.cardBorder
-        }`,
-        boxShadow: playable
-          ? '0 0 0 2px rgba(251, 191, 36, 0.4), 0 4px 12px rgba(0,0,0,0.35)'
-          : '0 2px 8px rgba(0,0,0,0.25)',
-        cursor: isClickable ? 'pointer' : 'default',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: dims.font,
-        fontWeight: 800,
-        letterSpacing: -0.5,
-        padding: 0,
-        transition:
-          'transform 120ms ease, box-shadow 200ms ease, border-color 120ms ease',
-        transform: selected ? 'translateY(-8px)' : 'translateY(0)',
-        opacity: disabled && !faceDown ? 0.55 : 1,
-        userSelect: 'none',
-      }}
+      className={className}
+      style={
+        {
+          width: dims.w,
+          height: dims.h,
+          '--card-bg': faceColor,
+        } as React.CSSProperties
+      }
     >
-      <span aria-hidden="true">{faceDown ? '✦' : symbol}</span>
+      {faceDown ? null : (
+        <>
+          <span
+            aria-hidden="true"
+            className={`${styles.corner} ${styles.cornerTL}`}
+            style={{ fontSize: dims.corner }}
+          >
+            {symbol}
+          </span>
+          <span
+            aria-hidden="true"
+            className={styles.centerGlyph}
+            style={{ fontSize: dims.glyph }}
+          >
+            <span>{symbol}</span>
+          </span>
+          <span
+            aria-hidden="true"
+            className={`${styles.corner} ${styles.cornerBR}`}
+            style={{ fontSize: dims.corner }}
+          >
+            {symbol}
+          </span>
+        </>
+      )}
     </button>
   );
 }

--- a/apps/web/src/widgets/CascadeGame/ui/Card.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Card.tsx
@@ -44,14 +44,21 @@ function CardImpl({
   const dims = SIZES[size];
 
   const isClickable = !!onClick && !disabled;
+  const isWild =
+    !faceDown && (card.kind === 'WILD' || card.kind === 'WILD_DRAW_FOUR');
   const faceColor = faceDown ? theme.surface : theme.palette[card.color];
   const symbol = renderSymbol(card, theme.symbols);
   const resolvedLabel =
     ariaLabel ?? describeCard(card, faceDown, theme.variant, t);
 
+  // Action/wild glyphs are wider than digits, so they're set a touch smaller;
+  // the ghost layer scales off that same base so depth stays proportional.
+  const glyphSize = card.kind === 'NUMBER' ? dims.glyph : dims.glyph * 0.82;
+
   const className = [
     styles.card,
     faceDown && styles.faceDown,
+    isWild && styles.wild,
     isClickable && styles.clickable,
     playable && styles.playable,
     selected && styles.selected,
@@ -80,6 +87,13 @@ function CardImpl({
         <>
           <span
             aria-hidden="true"
+            className={styles.ghost}
+            style={{ fontSize: glyphSize * 1.9 }}
+          >
+            {symbol}
+          </span>
+          <span
+            aria-hidden="true"
             className={`${styles.corner} ${styles.cornerTL}`}
             style={{ fontSize: dims.corner }}
           >
@@ -88,9 +102,9 @@ function CardImpl({
           <span
             aria-hidden="true"
             className={styles.centerGlyph}
-            style={{ fontSize: dims.glyph }}
+            style={{ fontSize: glyphSize }}
           >
-            <span>{symbol}</span>
+            {symbol}
           </span>
           <span
             aria-hidden="true"

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
@@ -5,11 +5,8 @@ import { XStack, YStack } from 'tamagui';
 import { Card } from './Card';
 import { ColorPicker } from './ColorPicker';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
-import type {
-  ActiveColor,
-  CascadeCard,
-  CascadeClientState,
-} from '../types';
+import styles from './CascadeGame.module.css';
+import type { ActiveColor, CascadeCard, CascadeClientState } from '../types';
 
 interface CascadeBoardProps {
   snapshot: CascadeClientState;
@@ -25,6 +22,9 @@ interface CascadeBoardProps {
    */
   onCallCascade?: () => void;
 }
+
+/** Card-backs shown in an opponent pod, capped so a huge hand stays tidy. */
+const MAX_FAN_BACKS = 7;
 
 export function CascadeBoard({
   snapshot,
@@ -48,6 +48,8 @@ export function CascadeBoard({
     () => snapshot.players.filter((p) => p.playerId !== currentUserId),
     [snapshot.players, currentUserId],
   );
+
+  const activeTurnId = snapshot.playerOrder[snapshot.currentTurnIndex] ?? null;
 
   const playableIds = useMemo(() => {
     const set = new Set<string>();
@@ -74,127 +76,173 @@ export function CascadeBoard({
     setPendingWildCard(null);
   };
 
+  const handCount = myHand.length;
+  const drawEnabled = myTurn && !disabled;
+
   return (
     <YStack
       width="100%"
-      gap="$4"
+      gap="$3"
       padding="$3"
       borderRadius="$4"
-      style={{ background: theme.background, position: 'relative', minHeight: 520 }}
+      className={styles.table}
+      style={
+        {
+          background: theme.background,
+          minHeight: 540,
+          '--cascade-text': theme.cardText,
+          '--cascade-surface': theme.surface,
+          '--cascade-card-border': theme.cardBorder,
+          '--cascade-card-text': theme.cardText,
+        } as React.CSSProperties
+      }
     >
-      {/* Opponents */}
-      <XStack gap="$3" flexWrap="wrap" justifyContent="center">
-        {opponents.map((opp) => (
-          <YStack
-            key={opp.playerId}
-            paddingHorizontal="$3"
-            paddingVertical="$2"
-            borderRadius="$3"
-            backgroundColor="rgba(0,0,0,0.35)"
-            alignItems="center"
-            minWidth={120}
-          >
-            <span style={{ color: theme.cardText, fontWeight: 600 }}>
-              {opp.playerId.startsWith('bot-') ? 'Bot' : opp.playerId.slice(0, 6)}
-            </span>
-            <span style={{ color: '#cbd5e1', fontSize: 12 }}>
-              {opp.hand.length} cards
-            </span>
-          </YStack>
-        ))}
-      </XStack>
-
-      {/* Last-Card race: pulsing call button visible to ALL alive players
-          while the window is open. First press wins — the engine sorts the
-          race by arrival order. Self-press = safe; other-press = at-risk
-          player draws 2 penalty cards. */}
-      {cascadeOpen && onCallCascade ? (
-        <XStack justifyContent="center" paddingTop="$2">
-          <button
-            type="button"
-            onClick={onCallCascade}
-            aria-label={
-              atRiskIsMe ? 'Call Cascade — save yourself' : 'Call Cascade'
-            }
-            style={{
-              padding: '12px 28px',
-              borderRadius: 999,
-              border: '2px solid rgba(251, 191, 36, 0.6)',
-              background:
-                'linear-gradient(135deg, #f59e0b 0%, #d97706 50%, #b45309 100%)',
-              color: '#fff',
-              fontWeight: 800,
-              fontSize: 18,
-              letterSpacing: 1.5,
-              textTransform: 'uppercase',
-              cursor: 'pointer',
-              boxShadow:
-                '0 0 0 4px rgba(251, 191, 36, 0.18), 0 6px 16px rgba(0,0,0,0.45)',
-              animation: 'cascade-pulse 900ms ease-in-out infinite',
-            }}
-          >
-            Cascade!
-          </button>
-          <style>{`@keyframes cascade-pulse { 0%,100%{transform:scale(1)} 50%{transform:scale(1.06)} }`}</style>
+      <YStack gap="$3" className={styles.tableLayer}>
+        {/* Opponents */}
+        <XStack gap="$3" flexWrap="wrap" justifyContent="center">
+          {opponents.map((opp) => {
+            const backs = Math.min(opp.hand.length, MAX_FAN_BACKS);
+            const isActive = opp.playerId === activeTurnId;
+            return (
+              <YStack
+                key={opp.playerId}
+                className={`${styles.pod} ${isActive ? styles.podActive : ''}`}
+              >
+                <span
+                  className={styles.podAvatar}
+                  style={{
+                    background: theme.palette[avatarColor(opp.playerId)],
+                  }}
+                  aria-hidden="true"
+                >
+                  {shortName(opp.playerId).charAt(0).toUpperCase()}
+                </span>
+                <span className={styles.podName}>
+                  {shortName(opp.playerId)}
+                </span>
+                <span className={styles.podCount}>{opp.hand.length} cards</span>
+                <div className={styles.podFan} aria-hidden="true">
+                  {Array.from({ length: backs }).map((_, i) => (
+                    <span
+                      key={i}
+                      className={styles.podFanCard}
+                      style={{
+                        transform: `rotate(${(i - (backs - 1) / 2) * 7}deg)`,
+                      }}
+                    />
+                  ))}
+                </div>
+              </YStack>
+            );
+          })}
         </XStack>
-      ) : null}
 
-      {/* Center: draw + discard */}
-      <XStack gap="$5" justifyContent="center" alignItems="center" paddingVertical="$4">
-        <button
-          type="button"
-          onClick={() => myTurn && !disabled && onDraw()}
-          disabled={!myTurn || disabled}
-          aria-label="Draw a card"
-          style={{
-            width: 88,
-            height: 132,
-            borderRadius: 12,
-            background: theme.surface,
-            border: `2px dashed ${theme.cardBorder}`,
-            color: theme.cardText,
-            cursor: myTurn && !disabled ? 'pointer' : 'default',
-            fontSize: 14,
-            fontWeight: 600,
-            opacity: myTurn && !disabled ? 1 : 0.6,
-          }}
-        >
-          Draw
-          {snapshot.pendingDraw > 0 ? (
-            <div style={{ fontSize: 12, marginTop: 6 }}>
-              +{snapshot.pendingDraw}
-            </div>
-          ) : null}
-        </button>
+        {/* Last-Card race: pulsing call button visible to ALL alive players
+            while the window is open. First press wins — the engine sorts the
+            race by arrival order. Self-press = safe; other-press = at-risk
+            player draws 2 penalty cards. */}
+        {cascadeOpen && onCallCascade ? (
+          <XStack justifyContent="center" paddingTop="$1">
+            <button
+              type="button"
+              onClick={onCallCascade}
+              className={styles.callButton}
+              aria-label={
+                atRiskIsMe ? 'Call Cascade — save yourself' : 'Call Cascade'
+              }
+            >
+              Cascade!
+            </button>
+          </XStack>
+        ) : null}
 
-        <Card card={snapshot.topCard} size="lg" disabled />
-      </XStack>
-
-      {/* My hand */}
-      <YStack gap="$2">
-        <XStack
-          gap="$2"
-          padding="$2"
-          borderRadius="$3"
-          backgroundColor="rgba(0,0,0,0.25)"
-          flexWrap="wrap"
-          justifyContent="center"
-        >
-          {myHand.map((c) => (
-            <Card
-              key={c.id}
-              card={c}
-              playable={playableIds.has(c.id)}
-              disabled={!myTurn || disabled || !playableIds.has(c.id)}
-              onClick={() => handleCardClick(c)}
+        {/* Center: draw deck + discard pile */}
+        <div className={styles.piles}>
+          <div className={styles.deck} style={{ width: 92, height: 138 }}>
+            <span
+              className={styles.deckBack}
+              style={{ transform: 'translate(6px, 6px) rotate(4deg)' }}
+              aria-hidden="true"
             />
-          ))}
-        </XStack>
+            <span
+              className={styles.deckBack}
+              style={{ transform: 'translate(3px, 3px) rotate(2deg)' }}
+              aria-hidden="true"
+            />
+            <button
+              type="button"
+              onClick={() => drawEnabled && onDraw()}
+              disabled={!drawEnabled}
+              aria-label="Draw a card"
+              className={styles.drawButton}
+            >
+              Draw
+              {snapshot.pendingDraw > 0 ? (
+                <span className={styles.drawPlus}>+{snapshot.pendingDraw}</span>
+              ) : null}
+            </button>
+          </div>
+
+          <div className={styles.discard} style={{ width: 92, height: 138 }}>
+            <span
+              className={styles.discardUnder}
+              style={{ transform: 'translate(-5px, 5px) rotate(-5deg)' }}
+              aria-hidden="true"
+            />
+            <span
+              className={styles.discardUnder}
+              style={{ transform: 'translate(4px, 3px) rotate(4deg)' }}
+              aria-hidden="true"
+            />
+            <Card card={snapshot.topCard} size="lg" disabled />
+          </div>
+        </div>
+
+        {/* My hand — fanned, with hover-lift on each card */}
+        <div className={styles.hand}>
+          {myHand.map((c, i) => {
+            const center = (handCount - 1) / 2;
+            const offset = i - center;
+            const step = Math.min(6, 46 / Math.max(handCount, 1));
+            return (
+              <div
+                key={c.id}
+                className={styles.handSlot}
+                style={
+                  {
+                    '--rot': `${offset * step}deg`,
+                    '--lift': `${Math.abs(offset) * 3}px`,
+                  } as React.CSSProperties
+                }
+              >
+                <Card
+                  card={c}
+                  playable={playableIds.has(c.id)}
+                  disabled={!myTurn || disabled || !playableIds.has(c.id)}
+                  onClick={() => handleCardClick(c)}
+                />
+              </div>
+            );
+          })}
+        </div>
       </YStack>
 
       <ColorPicker open={!!pendingWildCard} onPick={handlePickColor} />
     </YStack>
   );
+}
+
+function shortName(id: string): string {
+  return id.startsWith('bot-') ? 'Bot' : id.slice(0, 6);
+}
+
+/** Deterministic theme color for an opponent's avatar disc, from their id. */
+function avatarColor(id: string): 'R' | 'Y' | 'G' | 'B' {
+  const palette = ['R', 'Y', 'G', 'B'] as const;
+  let hash = 0;
+  for (let i = 0; i < id.length; i += 1)
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  return palette[Math.abs(hash) % palette.length];
 }
 
 function isPlayable(card: CascadeCard, snapshot: CascadeClientState): boolean {

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
@@ -8,7 +8,12 @@ import { useCascadeTheme } from '../lib/CascadeThemeContext';
 import { useActionToasts } from '../hooks/useActionToasts';
 import { useCardFly } from '../hooks/useCardFly';
 import styles from './CascadeGame.module.css';
-import type { ActiveColor, CascadeCard, CascadeClientState } from '../types';
+import type {
+  ActiveColor,
+  CascadeCard,
+  CascadeCardStyle,
+  CascadeClientState,
+} from '../types';
 
 interface CascadeBoardProps {
   snapshot: CascadeClientState;
@@ -16,6 +21,8 @@ interface CascadeBoardProps {
   myHand: CascadeCard[];
   myTurn: boolean;
   disabled: boolean;
+  /** Card face treatment; defaults to the edge-glow `neon` look. */
+  cardStyle?: CascadeCardStyle;
   onPlayCard: (cardId: string, chosenColor?: ActiveColor) => void;
   onDraw: () => void;
   /**
@@ -34,6 +41,7 @@ export function CascadeBoard({
   myHand,
   myTurn,
   disabled,
+  cardStyle = 'neon',
   onPlayCard,
   onDraw,
   onCallCascade,
@@ -110,7 +118,7 @@ export function CascadeBoard({
       gap="$3"
       padding="$3"
       borderRadius="$4"
-      className={styles.table}
+      className={`${styles.table} ${cardStyle === 'aurora' ? styles.aurora : ''}`}
       style={
         {
           background: theme.background,

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { XStack, YStack } from 'tamagui';
 import { Card } from './Card';
 import { ColorPicker } from './ColorPicker';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
+import { useActionToasts } from '../hooks/useActionToasts';
+import { useCardFly } from '../hooks/useCardFly';
 import styles from './CascadeGame.module.css';
 import type { ActiveColor, CascadeCard, CascadeClientState } from '../types';
 
@@ -38,6 +40,12 @@ export function CascadeBoard({
 }: CascadeBoardProps) {
   const theme = useCascadeTheme();
   const [pendingWildCard, setPendingWildCard] = useState<string | null>(null);
+  const [shakeId, setShakeId] = useState<string | null>(null);
+
+  const slotRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const discardRef = useRef<HTMLDivElement | null>(null);
+  const { node: flyNode, launch: launchFly } = useCardFly();
+  const toasts = useActionToasts(snapshot.topCard, theme.symbols);
 
   const cascadeOpen =
     snapshot.options.lastCardCallEnabled && !!snapshot.lastCardWindow;
@@ -60,24 +68,41 @@ export function CascadeBoard({
     return set;
   }, [myHand, snapshot, myTurn, disabled]);
 
+  const flyToDiscard = useCallback(
+    (cardId: string, card: CascadeCard) => {
+      launchFly(card, slotRefs.current.get(cardId), discardRef.current);
+    },
+    [launchFly],
+  );
+
   const handleCardClick = (card: CascadeCard) => {
     if (!myTurn || disabled) return;
-    if (!playableIds.has(card.id)) return;
+    // Unplayable card on your turn: shake it instead of a dead click.
+    if (!playableIds.has(card.id)) {
+      setShakeId(card.id);
+      window.setTimeout(() => setShakeId(null), 400);
+      return;
+    }
     if (card.kind === 'WILD' || card.kind === 'WILD_DRAW_FOUR') {
       setPendingWildCard(card.id);
       return;
     }
+    flyToDiscard(card.id, card);
     onPlayCard(card.id);
   };
 
   const handlePickColor = (color: ActiveColor) => {
     if (!pendingWildCard) return;
+    const wild = myHand.find((c) => c.id === pendingWildCard);
+    if (wild) flyToDiscard(wild.id, wild);
     onPlayCard(pendingWildCard, color);
     setPendingWildCard(null);
   };
 
   const handCount = myHand.length;
   const drawEnabled = myTurn && !disabled;
+  const mustDraw = drawEnabled && snapshot.pendingDraw > 0;
+  const deckEmblem = theme.symbols.WILD;
 
   return (
     <YStack
@@ -110,6 +135,16 @@ export function CascadeBoard({
                 key={opp.playerId}
                 className={`${styles.pod} ${isActive ? styles.podActive : ''}`}
               >
+                {isActive && !disabled ? (
+                  <span className={styles.podThink} aria-hidden="true">
+                    <i />
+                    <i />
+                    <i />
+                  </span>
+                ) : null}
+                {opp.alive && opp.hand.length === 1 ? (
+                  <span className={styles.podLast}>LAST</span>
+                ) : null}
                 <span
                   className={styles.podAvatar}
                   style={{
@@ -176,16 +211,23 @@ export function CascadeBoard({
               onClick={() => drawEnabled && onDraw()}
               disabled={!drawEnabled}
               aria-label="Draw a card"
-              className={styles.drawButton}
+              className={`${styles.drawButton} ${mustDraw ? styles.drawMust : ''}`}
             >
-              Draw
+              <span className={styles.drawEmblem} aria-hidden="true">
+                {deckEmblem}
+              </span>
               {snapshot.pendingDraw > 0 ? (
                 <span className={styles.drawPlus}>+{snapshot.pendingDraw}</span>
               ) : null}
             </button>
+            <span className={styles.pileLabel}>Draw</span>
           </div>
 
-          <div className={styles.discard} style={{ width: 92, height: 138 }}>
+          <div
+            ref={discardRef}
+            className={styles.discard}
+            style={{ width: 92, height: 138 }}
+          >
             <span
               className={styles.discardUnder}
               style={{ transform: 'translate(-5px, 5px) rotate(-5deg)' }}
@@ -197,6 +239,7 @@ export function CascadeBoard({
               aria-hidden="true"
             />
             <Card card={snapshot.topCard} size="lg" disabled />
+            <span className={styles.pileLabel}>Discard</span>
           </div>
         </div>
 
@@ -206,10 +249,17 @@ export function CascadeBoard({
             const center = (handCount - 1) / 2;
             const offset = i - center;
             const step = Math.min(6, 46 / Math.max(handCount, 1));
+            const isPlayableCard = playableIds.has(c.id);
             return (
               <div
                 key={c.id}
-                className={styles.handSlot}
+                ref={(el) => {
+                  if (el) slotRefs.current.set(c.id, el);
+                  else slotRefs.current.delete(c.id);
+                }}
+                className={`${styles.handSlot} ${
+                  isPlayableCard ? styles.handSlotPlay : ''
+                } ${shakeId === c.id ? styles.shake : ''}`}
                 style={
                   {
                     '--rot': `${offset * step}deg`,
@@ -219,8 +269,9 @@ export function CascadeBoard({
               >
                 <Card
                   card={c}
-                  playable={playableIds.has(c.id)}
-                  disabled={!myTurn || disabled || !playableIds.has(c.id)}
+                  playable={isPlayableCard}
+                  disabled={!myTurn || disabled}
+                  dimmed={myTurn && !disabled && !isPlayableCard}
                   onClick={() => handleCardClick(c)}
                 />
               </div>
@@ -229,7 +280,21 @@ export function CascadeBoard({
         </div>
       </YStack>
 
+      {toasts.length ? (
+        <div className={styles.toasts} aria-hidden="true">
+          {toasts.map((t) => (
+            <div key={t.key} className={styles.toast}>
+              {t.glyph ? (
+                <span className={styles.toastGlyph}>{t.glyph}</span>
+              ) : null}
+              {t.label}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
       <ColorPicker open={!!pendingWildCard} onPick={handlePickColor} />
+      {flyNode}
     </YStack>
   );
 }

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
@@ -94,6 +94,8 @@ export function CascadeBoard({
           '--cascade-surface': theme.surface,
           '--cascade-card-border': theme.cardBorder,
           '--cascade-card-text': theme.cardText,
+          '--cascade-accent': theme.accent,
+          '--cascade-accent-rgb': theme.accentRGB,
         } as React.CSSProperties
       }
     >

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
@@ -404,6 +404,40 @@
   opacity: 0.12;
 }
 
+/*
+ * Optional "aurora" face style (board root carries `.aurora`): same dark
+ * body, but colour pools into the lower-left / upper-right corners for a bit
+ * more colour presence. Face-down backs keep their own treatment.
+ */
+.aurora .card:not(.faceDown) {
+  background:
+    radial-gradient(
+      120% 70% at 18% 110%,
+      color-mix(in srgb, var(--face) 70%, transparent),
+      transparent 58%
+    ),
+    radial-gradient(
+      110% 60% at 90% -10%,
+      color-mix(in srgb, var(--face) 38%, transparent),
+      transparent 55%
+    ),
+    linear-gradient(158deg, #1f2536 0%, #0c1019 100%);
+}
+.aurora .card.wild {
+  background:
+    conic-gradient(
+      from 200deg at 50% 118%,
+      rgba(244, 63, 94, 0.6),
+      rgba(251, 191, 36, 0.6),
+      rgba(34, 197, 94, 0.6),
+      rgba(59, 130, 246, 0.6),
+      rgba(168, 85, 247, 0.6),
+      rgba(244, 63, 94, 0.6)
+    ),
+    linear-gradient(158deg, #1b2030, #0a0d16);
+  background-blend-mode: screen, normal;
+}
+
 /* ---- Hand fan ------------------------------------------------------- */
 
 .hand {

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
@@ -18,7 +18,8 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(
+  background:
+    radial-gradient(
       120% 80% at 50% 0%,
       rgba(255, 255, 255, 0.08) 0%,
       transparent 45%
@@ -32,6 +33,27 @@
   z-index: 0;
 }
 
+/* Glowing accent ring pooled behind the centre piles. */
+.table::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 52%;
+  width: 460px;
+  height: 320px;
+  max-width: 90%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(
+    closest-side,
+    rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.18),
+    transparent 72%
+  );
+  filter: blur(6px);
+  pointer-events: none;
+  z-index: 0;
+}
+
 .tableLayer {
   position: relative;
   z-index: 1;
@@ -40,17 +62,18 @@
 /* ---- Player pods ---------------------------------------------------- */
 
 .pod {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 10px 16px;
-  border-radius: 16px;
+  gap: 5px;
+  padding: 12px 16px 14px;
+  border-radius: 18px;
   background: rgba(8, 10, 24, 0.42);
   border: 1px solid rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(8px);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.32);
-  min-width: 124px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.34);
+  min-width: 132px;
   transition:
     transform 220ms ease,
     box-shadow 220ms ease,
@@ -58,11 +81,65 @@
 }
 
 .podActive {
-  border-color: rgba(251, 191, 36, 0.75);
+  border-color: rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.85);
   box-shadow:
-    0 0 0 2px rgba(251, 191, 36, 0.35),
-    0 8px 22px rgba(0, 0, 0, 0.45);
-  transform: translateY(-2px);
+    0 0 0 2px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.4),
+    0 0 26px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.3),
+    0 10px 26px rgba(0, 0, 0, 0.45);
+  transform: translateY(-4px);
+}
+
+/* Animated "thinking" dots on whoever's turn it is. */
+.podThink {
+  position: absolute;
+  top: -9px;
+  right: -6px;
+  display: flex;
+  gap: 3px;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.9);
+  box-shadow: 0 2px 10px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.5);
+}
+.podThink i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #06040f;
+  animation: cascade-think 1s ease-in-out infinite;
+}
+.podThink i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.podThink i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+@keyframes cascade-think {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-2px);
+  }
+}
+
+/* Alert pill when an opponent is down to their last card. */
+.podLast {
+  position: absolute;
+  top: -10px;
+  left: -8px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f59e0b, #dc2626);
+  color: #fff;
+  box-shadow: 0 2px 12px rgba(245, 158, 11, 0.6);
+  animation: cascade-pulse 0.9s ease-in-out infinite;
 }
 
 .podAvatar {
@@ -101,20 +178,28 @@
 .podFan {
   display: flex;
   align-items: flex-end;
-  height: 22px;
+  height: 30px;
+  margin-top: 1px;
 }
 
 .podFanCard {
-  width: 13px;
-  height: 20px;
-  border-radius: 3px;
-  margin-left: -6px;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.22),
-    rgba(255, 255, 255, 0.05)
-  );
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  width: 17px;
+  height: 26px;
+  border-radius: 4px;
+  margin-left: -8px;
+  background:
+    repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.16) 0 4px,
+      transparent 4px 8px
+    ),
+    linear-gradient(
+      155deg,
+      rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.5),
+      rgba(8, 10, 24, 0.9)
+    );
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
   transform-origin: bottom center;
 }
 .podFanCard:first-child {
@@ -135,7 +220,8 @@
   align-items: center;
   justify-content: center;
   border-radius: 14%;
-  background: radial-gradient(
+  background:
+    radial-gradient(
       125% 78% at 50% -8%,
       color-mix(in srgb, var(--face) 42%, transparent),
       transparent 56%
@@ -177,7 +263,8 @@
 
 .faceDown {
   --face: var(--cascade-accent, #a78bfa);
-  background: repeating-linear-gradient(
+  background:
+    repeating-linear-gradient(
       45deg,
       color-mix(in srgb, var(--face) 14%, transparent) 0px,
       color-mix(in srgb, var(--face) 14%, transparent) 6px,
@@ -185,6 +272,24 @@
       transparent 12px
     ),
     linear-gradient(160deg, #1b2133 0%, #0a0d16 100%);
+}
+
+/* Tilted emblem lozenge on the card back. */
+.backMark {
+  width: 46%;
+  height: 46%;
+  border-radius: 50% / 40%;
+  transform: rotate(-22deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.35);
+  border: 2px solid rgba(255, 255, 255, 0.5);
+}
+.backMark > span {
+  transform: rotate(22deg);
+  font-weight: 900;
+  color: #fff;
 }
 
 /* Cards are already dark, so dimming is gentle — not a heavy brightness cut. */
@@ -273,7 +378,8 @@
 
 /* WILD / WILD +4 — prismatic aura on dark glass, not a single colour. */
 .wild {
-  background: conic-gradient(
+  background:
+    conic-gradient(
       from 200deg at 50% 118%,
       rgba(244, 63, 94, 0.55),
       rgba(251, 191, 36, 0.55),
@@ -320,13 +426,31 @@
 .handSlot:first-child {
   margin-left: 0;
 }
-.handSlot:hover {
-  transform: translateY(-26px) rotate(0deg) scale(1.06);
+/* Only playable cards lift on hover, cueing what you can actually play. */
+.handSlotPlay:hover {
+  transform: translateY(-28px) rotate(0deg) scale(1.07);
   z-index: 30;
 }
 /* Open a gap around the hovered card so it doesn't clip its neighbours. */
-.handSlot:hover + .handSlot {
+.handSlotPlay:hover + .handSlot {
   margin-left: -8px;
+}
+
+/* Brief shake when an unplayable card is clicked. */
+.handSlot.shake {
+  animation: cascade-shake 0.4s ease;
+}
+@keyframes cascade-shake {
+  0%,
+  100% {
+    transform: rotate(var(--rot, 0deg)) translateY(var(--lift, 0px));
+  }
+  25% {
+    transform: translateX(-6px) rotate(var(--rot, 0deg));
+  }
+  75% {
+    transform: translateX(6px) rotate(var(--rot, 0deg));
+  }
 }
 
 @media (max-width: 560px) {
@@ -353,7 +477,8 @@
   position: absolute;
   inset: 0;
   border-radius: 12px;
-  background: repeating-linear-gradient(
+  background:
+    repeating-linear-gradient(
       45deg,
       rgba(255, 255, 255, 0.05) 0px,
       rgba(255, 255, 255, 0.05) 6px,
@@ -376,7 +501,8 @@
   width: 92px;
   height: 138px;
   border-radius: 12px;
-  background: radial-gradient(
+  background:
+    radial-gradient(
       120% 90% at 30% 18%,
       rgba(255, 255, 255, 0.16),
       transparent 55%
@@ -404,10 +530,38 @@
   opacity: 0.6;
 }
 
+.drawEmblem {
+  font-size: 22px;
+  line-height: 1;
+  opacity: 0.9;
+}
+
 .drawPlus {
   font-size: 12px;
   font-weight: 800;
   color: #fde68a;
+}
+
+/* Red, pulsing draw pile when the player must resolve a stacked penalty. */
+.drawMust {
+  border-color: rgba(239, 68, 68, 0.9);
+  box-shadow:
+    0 0 0 3px rgba(239, 68, 68, 0.35),
+    0 0 22px rgba(239, 68, 68, 0.4);
+  animation: cascade-pulse 1s ease-in-out infinite;
+}
+
+/* Small uppercase caption beneath each pile. */
+.pileLabel {
+  position: absolute;
+  left: 50%;
+  bottom: -20px;
+  transform: translateX(-50%);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.45);
 }
 
 .discard {
@@ -541,7 +695,8 @@
   height: 100px;
   padding: 8px;
   border-radius: 12px;
-  background: radial-gradient(
+  background:
+    radial-gradient(
       125% 78% at 50% -8%,
       color-mix(in srgb, var(--face) 45%, transparent),
       transparent 56%
@@ -638,18 +793,95 @@
   }
 }
 
+/* ---- Event toasts --------------------------------------------------- */
+
+.toasts {
+  position: absolute;
+  top: 46%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: center;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 26px;
+  border-radius: 14px;
+  font-weight: 800;
+  font-size: 26px;
+  letter-spacing: 1px;
+  background: rgba(8, 10, 24, 0.78);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 10px 30px rgba(0, 0, 0, 0.5),
+    0 0 24px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.4);
+  animation: cascade-toast 1.3s ease forwards;
+}
+.toastGlyph {
+  font-size: 30px;
+  line-height: 1;
+}
+
+@keyframes cascade-toast {
+  0% {
+    opacity: 0;
+    transform: scale(0.7) translateY(8px);
+  }
+  18% {
+    opacity: 1;
+    transform: scale(1.05) translateY(0);
+  }
+  30% {
+    transform: scale(1);
+  }
+  78% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.95) translateY(-12px);
+  }
+}
+
+/* ---- Flying card (play animation) ---------------------------------- */
+
+.fly {
+  position: fixed;
+  z-index: 200;
+  pointer-events: none;
+  transition:
+    transform 420ms cubic-bezier(0.5, 0, 0.2, 1),
+    opacity 420ms ease;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .playable,
   .callButton,
   .handSlot,
   .card,
   .pod,
+  .podThink i,
+  .podLast,
   .drawButton,
+  .drawMust,
   .dirArrow,
   .pickerBackdrop,
   .pickerPanel,
-  .swatch {
+  .swatch,
+  .toast,
+  .shake {
     animation: none !important;
+    transition: none !important;
+  }
+  .fly {
     transition: none !important;
   }
 }

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
@@ -123,28 +123,32 @@
 
 /* ---- Card ----------------------------------------------------------- */
 
+/*
+ * "Energy card": a consistent dark-glass body where colour identity reads
+ * through a luminous edge, a glowing numeral, and a faint oversized ghost
+ * glyph — never a flat colour flood. `--face` is the per-card colour hex.
+ */
 .card {
-  --face: var(--card-bg, #1f1b3d);
+  --face: var(--card-bg, #221c47);
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 14%;
   background: radial-gradient(
-      120% 90% at 30% 18%,
-      rgba(255, 255, 255, 0.28),
-      transparent 55%
+      125% 78% at 50% -8%,
+      color-mix(in srgb, var(--face) 42%, transparent),
+      transparent 56%
     ),
-    linear-gradient(
-      160deg,
-      color-mix(in srgb, var(--face) 82%, white 18%),
-      var(--face) 55%,
-      color-mix(in srgb, var(--face) 78%, black 22%)
-    );
+    linear-gradient(158deg, #262c3c 0%, #141a28 52%, #0a0d16 100%);
   color: var(--cascade-card-text, #f8fafc);
-  border: 2px solid var(--cascade-card-border, rgba(255, 255, 255, 0.18));
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  border: 1.6px solid color-mix(in srgb, var(--face) 76%, white 8%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 0 18px color-mix(in srgb, var(--face) 26%, transparent),
+    0 4px 12px rgba(0, 0, 0, 0.5);
   padding: 0;
+  overflow: hidden;
   user-select: none;
   transition:
     transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
@@ -152,14 +156,14 @@
     border-color 140ms ease;
 }
 
-/* Glossy inner frame that reads as a printed card edge. */
+/* Slim luminous inner frame. */
 .card::after {
   content: '';
   position: absolute;
-  inset: 7%;
+  inset: 8%;
   border-radius: 12%;
-  border: 1.5px solid rgba(255, 255, 255, 0.16);
-  box-shadow: inset 0 1px 6px rgba(255, 255, 255, 0.12);
+  border: 1px solid
+    color-mix(in srgb, var(--face) 32%, rgba(255, 255, 255, 0.08));
   pointer-events: none;
 }
 
@@ -168,30 +172,33 @@
 }
 .clickable:hover {
   transform: translateY(-6px);
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.55);
 }
 
 .faceDown {
-  --face: var(--cascade-surface, #1f1b3d);
+  --face: var(--cascade-accent, #a78bfa);
   background: repeating-linear-gradient(
       45deg,
-      rgba(255, 255, 255, 0.06) 0px,
-      rgba(255, 255, 255, 0.06) 6px,
+      color-mix(in srgb, var(--face) 14%, transparent) 0px,
+      color-mix(in srgb, var(--face) 14%, transparent) 6px,
       transparent 6px,
       transparent 12px
     ),
-    linear-gradient(160deg, var(--cascade-surface, #2a2550), #0c0a1e);
+    linear-gradient(160deg, #1b2133 0%, #0a0d16 100%);
 }
 
+/* Cards are already dark, so dimming is gentle — not a heavy brightness cut. */
 .disabled {
-  opacity: 0.55;
+  opacity: 0.82;
+  filter: saturate(0.9);
 }
 
+/* Playable glow keys off the active variant's accent, not a fixed amber. */
 .playable {
-  border-color: rgba(255, 255, 255, 0.9);
+  border-color: color-mix(in srgb, var(--cascade-accent, #a78bfa) 90%, white);
   box-shadow:
-    0 0 0 2px rgba(251, 191, 36, 0.45),
-    0 0 18px rgba(251, 191, 36, 0.35),
+    0 0 0 2px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.55),
+    0 0 20px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.45),
     0 6px 16px rgba(0, 0, 0, 0.4);
   animation: cascade-playable 1600ms ease-in-out infinite;
 }
@@ -200,60 +207,95 @@
   0%,
   100% {
     box-shadow:
-      0 0 0 2px rgba(251, 191, 36, 0.4),
-      0 0 14px rgba(251, 191, 36, 0.28),
+      0 0 0 2px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.5),
+      0 0 14px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.32),
       0 6px 16px rgba(0, 0, 0, 0.4);
   }
   50% {
     box-shadow:
-      0 0 0 3px rgba(251, 191, 36, 0.7),
-      0 0 26px rgba(251, 191, 36, 0.5),
+      0 0 0 3px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.8),
+      0 0 26px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.55),
       0 6px 16px rgba(0, 0, 0, 0.4);
   }
 }
 
 .selected {
-  border-color: #fbbf24;
+  border-color: color-mix(in srgb, var(--cascade-accent, #a78bfa) 90%, white);
 }
 
-/* Center glyph sits in a tilted oval, the way a real Uno face reads. */
-.centerGlyph {
-  position: relative;
+/* Big faint background glyph for depth. */
+.ghost {
+  position: absolute;
+  left: 50%;
+  top: 56%;
+  transform: translate(-50%, -50%);
   z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 64%;
-  height: 78%;
-  border-radius: 50% / 42%;
-  background: rgba(255, 255, 255, 0.16);
-  border: 1.5px solid rgba(255, 255, 255, 0.22);
-  transform: rotate(-32deg);
+  font-weight: 900;
+  line-height: 1;
+  color: color-mix(in srgb, var(--face) 60%, white 10%);
+  opacity: 0.16;
+  pointer-events: none;
+}
+
+/* Bright central numeral/glyph with a coloured halo. */
+.centerGlyph {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
   font-weight: 900;
   letter-spacing: -1px;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
-}
-.centerGlyph > span {
-  transform: rotate(32deg);
+  color: color-mix(in srgb, var(--face) 52%, white 48%);
+  text-shadow:
+    0 0 14px color-mix(in srgb, var(--face) 75%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
-/* Small corner indices, top-left and bottom-right (rotated). */
+/* Corner indices — colour-mixed with a soft glow, never plain white. */
 .corner {
   position: absolute;
-  z-index: 1;
+  z-index: 2;
   font-weight: 800;
   line-height: 1;
-  opacity: 0.92;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  color: color-mix(in srgb, var(--face) 55%, white 45%);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--face) 70%, transparent);
 }
 .cornerTL {
-  top: 7%;
-  left: 9%;
+  top: 8%;
+  left: 10%;
 }
 .cornerBR {
-  bottom: 7%;
-  right: 9%;
+  bottom: 8%;
+  right: 10%;
   transform: rotate(180deg);
+}
+
+/* WILD / WILD +4 — prismatic aura on dark glass, not a single colour. */
+.wild {
+  background: conic-gradient(
+      from 200deg at 50% 118%,
+      rgba(244, 63, 94, 0.55),
+      rgba(251, 191, 36, 0.55),
+      rgba(34, 197, 94, 0.55),
+      rgba(59, 130, 246, 0.55),
+      rgba(168, 85, 247, 0.55),
+      rgba(244, 63, 94, 0.55)
+    ),
+    linear-gradient(158deg, #262c3c 0%, #131826 50%, #0a0d16 100%);
+  background-blend-mode: screen, normal;
+  border-color: rgba(255, 255, 255, 0.55);
+}
+.wild .centerGlyph,
+.wild .corner {
+  color: #fff;
+  text-shadow:
+    0 0 16px rgba(255, 255, 255, 0.7),
+    0 1px 2px rgba(0, 0, 0, 0.6);
+}
+.wild .ghost {
+  color: #fff;
+  opacity: 0.12;
 }
 
 /* ---- Hand fan ------------------------------------------------------- */
@@ -490,28 +532,27 @@
 }
 
 .swatch {
-  --face: var(--swatch-bg, #1f1b3d);
+  --face: var(--swatch-bg, #221c47);
   position: relative;
-  width: 62px;
-  height: 86px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 74px;
+  height: 100px;
+  padding: 8px;
   border-radius: 12px;
   background: radial-gradient(
-      120% 90% at 30% 18%,
-      rgba(255, 255, 255, 0.3),
-      transparent 55%
+      125% 78% at 50% -8%,
+      color-mix(in srgb, var(--face) 45%, transparent),
+      transparent 56%
     ),
-    linear-gradient(
-      160deg,
-      color-mix(in srgb, var(--face) 82%, white 18%),
-      var(--face) 55%,
-      color-mix(in srgb, var(--face) 78%, black 22%)
-    );
-  border: 2px solid rgba(255, 255, 255, 0.5);
-  color: #fff;
-  font-weight: 900;
-  font-size: 26px;
+    linear-gradient(158deg, #262c3c, #141a28 52%, #0a0d16);
+  border: 1.6px solid color-mix(in srgb, var(--face) 78%, white 8%);
+  color: color-mix(in srgb, var(--face) 50%, white 50%);
   cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  box-shadow:
+    inset 0 0 18px color-mix(in srgb, var(--face) 28%, transparent),
+    0 4px 12px rgba(0, 0, 0, 0.45);
   transition:
     transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
     box-shadow 180ms ease;
@@ -519,10 +560,22 @@
 .swatch::after {
   content: '';
   position: absolute;
-  inset: 6px;
-  border-radius: 8px;
-  border: 1.5px solid rgba(255, 255, 255, 0.22);
+  inset: 8px;
+  border-radius: 9px;
+  border: 1px solid
+    color-mix(in srgb, var(--face) 30%, rgba(255, 255, 255, 0.08));
   pointer-events: none;
+}
+.swatchLabel {
+  position: relative;
+  z-index: 1;
+  font-weight: 800;
+  font-size: 13px;
+  line-height: 1.15;
+  text-align: center;
+  text-shadow:
+    0 0 10px color-mix(in srgb, var(--face) 70%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.6);
 }
 .swatch:hover,
 .swatch:focus-visible {

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
@@ -450,6 +450,109 @@
     0 0 14px var(--chip-glow, rgba(255, 255, 255, 0.4));
 }
 
+/* ---- Wild color picker ---------------------------------------------- */
+
+.pickerBackdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(4, 6, 16, 0.55);
+  backdrop-filter: blur(3px);
+  animation: cascade-fade 160ms ease-out;
+}
+
+.pickerPanel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 22px 26px;
+  border-radius: 20px;
+  background: rgba(12, 14, 30, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.55);
+  animation: cascade-pop 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.pickerTitle {
+  color: #fff;
+  font-weight: 700;
+  font-size: 15px;
+  letter-spacing: 0.3px;
+}
+
+.pickerRow {
+  display: flex;
+  gap: 12px;
+}
+
+.swatch {
+  --face: var(--swatch-bg, #1f1b3d);
+  position: relative;
+  width: 62px;
+  height: 86px;
+  border-radius: 12px;
+  background: radial-gradient(
+      120% 90% at 30% 18%,
+      rgba(255, 255, 255, 0.3),
+      transparent 55%
+    ),
+    linear-gradient(
+      160deg,
+      color-mix(in srgb, var(--face) 82%, white 18%),
+      var(--face) 55%,
+      color-mix(in srgb, var(--face) 78%, black 22%)
+    );
+  border: 2px solid rgba(255, 255, 255, 0.5);
+  color: #fff;
+  font-weight: 900;
+  font-size: 26px;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  transition:
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 180ms ease;
+}
+.swatch::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 8px;
+  border: 1.5px solid rgba(255, 255, 255, 0.22);
+  pointer-events: none;
+}
+.swatch:hover,
+.swatch:focus-visible {
+  transform: translateY(-6px) scale(1.05);
+  box-shadow:
+    0 12px 26px rgba(0, 0, 0, 0.5),
+    0 0 18px rgba(255, 255, 255, 0.25);
+  outline: none;
+}
+
+@keyframes cascade-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes cascade-pop {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 /* ---- Cascade! call button ------------------------------------------ */
 
 .callButton {
@@ -488,7 +591,11 @@
   .handSlot,
   .card,
   .pod,
-  .drawButton {
+  .drawButton,
+  .dirArrow,
+  .pickerBackdrop,
+  .pickerPanel,
+  .swatch {
     animation: none !important;
     transition: none !important;
   }

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
@@ -1,0 +1,495 @@
+/*
+ * Cascade board styling. Theme-driven colors arrive as CSS custom properties
+ * set inline on the board root (`--cascade-*`) and on each card
+ * (`--card-bg`), so a single stylesheet skins every variant. Hover, glow and
+ * fan transforms live here because inline styles can't express `:hover`.
+ */
+
+/* ---- Table ---------------------------------------------------------- */
+
+.table {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+}
+
+/* Soft felt vignette + subtle light sweep layered over the theme gradient. */
+.table::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      120% 80% at 50% 0%,
+      rgba(255, 255, 255, 0.08) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      140% 120% at 50% 120%,
+      rgba(0, 0, 0, 0.45) 0%,
+      transparent 60%
+    );
+  pointer-events: none;
+  z-index: 0;
+}
+
+.tableLayer {
+  position: relative;
+  z-index: 1;
+}
+
+/* ---- Player pods ---------------------------------------------------- */
+
+.pod {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: rgba(8, 10, 24, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.32);
+  min-width: 124px;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease;
+}
+
+.podActive {
+  border-color: rgba(251, 191, 36, 0.75);
+  box-shadow:
+    0 0 0 2px rgba(251, 191, 36, 0.35),
+    0 8px 22px rgba(0, 0, 0, 0.45);
+  transform: translateY(-2px);
+}
+
+.podAvatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 800;
+  font-size: 15px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  box-shadow:
+    inset 0 1px 4px rgba(255, 255, 255, 0.25),
+    0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.podName {
+  color: var(--cascade-text, #f8fafc);
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.2px;
+}
+
+.podCount {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+/* Mini fanned card-backs that scale with the opponent's hand size. */
+.podFan {
+  display: flex;
+  align-items: flex-end;
+  height: 22px;
+}
+
+.podFanCard {
+  width: 13px;
+  height: 20px;
+  border-radius: 3px;
+  margin-left: -6px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.22),
+    rgba(255, 255, 255, 0.05)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  transform-origin: bottom center;
+}
+.podFanCard:first-child {
+  margin-left: 0;
+}
+
+/* ---- Card ----------------------------------------------------------- */
+
+.card {
+  --face: var(--card-bg, #1f1b3d);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14%;
+  background: radial-gradient(
+      120% 90% at 30% 18%,
+      rgba(255, 255, 255, 0.28),
+      transparent 55%
+    ),
+    linear-gradient(
+      160deg,
+      color-mix(in srgb, var(--face) 82%, white 18%),
+      var(--face) 55%,
+      color-mix(in srgb, var(--face) 78%, black 22%)
+    );
+  color: var(--cascade-card-text, #f8fafc);
+  border: 2px solid var(--cascade-card-border, rgba(255, 255, 255, 0.18));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  padding: 0;
+  user-select: none;
+  transition:
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 200ms ease,
+    border-color 140ms ease;
+}
+
+/* Glossy inner frame that reads as a printed card edge. */
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 7%;
+  border-radius: 12%;
+  border: 1.5px solid rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 1px 6px rgba(255, 255, 255, 0.12);
+  pointer-events: none;
+}
+
+.clickable {
+  cursor: pointer;
+}
+.clickable:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.45);
+}
+
+.faceDown {
+  --face: var(--cascade-surface, #1f1b3d);
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.06) 0px,
+      rgba(255, 255, 255, 0.06) 6px,
+      transparent 6px,
+      transparent 12px
+    ),
+    linear-gradient(160deg, var(--cascade-surface, #2a2550), #0c0a1e);
+}
+
+.disabled {
+  opacity: 0.55;
+}
+
+.playable {
+  border-color: rgba(255, 255, 255, 0.9);
+  box-shadow:
+    0 0 0 2px rgba(251, 191, 36, 0.45),
+    0 0 18px rgba(251, 191, 36, 0.35),
+    0 6px 16px rgba(0, 0, 0, 0.4);
+  animation: cascade-playable 1600ms ease-in-out infinite;
+}
+
+@keyframes cascade-playable {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 2px rgba(251, 191, 36, 0.4),
+      0 0 14px rgba(251, 191, 36, 0.28),
+      0 6px 16px rgba(0, 0, 0, 0.4);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px rgba(251, 191, 36, 0.7),
+      0 0 26px rgba(251, 191, 36, 0.5),
+      0 6px 16px rgba(0, 0, 0, 0.4);
+  }
+}
+
+.selected {
+  border-color: #fbbf24;
+}
+
+/* Center glyph sits in a tilted oval, the way a real Uno face reads. */
+.centerGlyph {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64%;
+  height: 78%;
+  border-radius: 50% / 42%;
+  background: rgba(255, 255, 255, 0.16);
+  border: 1.5px solid rgba(255, 255, 255, 0.22);
+  transform: rotate(-32deg);
+  font-weight: 900;
+  letter-spacing: -1px;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+}
+.centerGlyph > span {
+  transform: rotate(32deg);
+}
+
+/* Small corner indices, top-left and bottom-right (rotated). */
+.corner {
+  position: absolute;
+  z-index: 1;
+  font-weight: 800;
+  line-height: 1;
+  opacity: 0.92;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+.cornerTL {
+  top: 7%;
+  left: 9%;
+}
+.cornerBR {
+  bottom: 7%;
+  right: 9%;
+  transform: rotate(180deg);
+}
+
+/* ---- Hand fan ------------------------------------------------------- */
+
+.hand {
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  padding: 28px 12px 12px;
+  perspective: 900px;
+}
+
+.handSlot {
+  transform-origin: bottom center;
+  transform: rotate(var(--rot, 0deg)) translateY(var(--lift, 0px));
+  transition:
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
+    margin 180ms ease;
+  margin-left: -22px;
+}
+.handSlot:first-child {
+  margin-left: 0;
+}
+.handSlot:hover {
+  transform: translateY(-26px) rotate(0deg) scale(1.06);
+  z-index: 30;
+}
+/* Open a gap around the hovered card so it doesn't clip its neighbours. */
+.handSlot:hover + .handSlot {
+  margin-left: -8px;
+}
+
+@media (max-width: 560px) {
+  .handSlot {
+    margin-left: -16px;
+  }
+}
+
+/* ---- Center piles --------------------------------------------------- */
+
+.piles {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 40px;
+  padding: 18px 0 6px;
+}
+
+.deck {
+  position: relative;
+}
+/* Stacked card-backs behind the interactive Draw button. */
+.deckBack {
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background: repeating-linear-gradient(
+      45deg,
+      rgba(255, 255, 255, 0.05) 0px,
+      rgba(255, 255, 255, 0.05) 6px,
+      transparent 6px,
+      transparent 12px
+    ),
+    linear-gradient(160deg, var(--cascade-surface, #2a2550), #0c0a1e);
+  border: 2px solid var(--cascade-card-border, rgba(255, 255, 255, 0.18));
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
+}
+
+.drawButton {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 92px;
+  height: 138px;
+  border-radius: 12px;
+  background: radial-gradient(
+      120% 90% at 30% 18%,
+      rgba(255, 255, 255, 0.16),
+      transparent 55%
+    ),
+    linear-gradient(160deg, var(--cascade-surface, #2a2550), #0c0a1e);
+  border: 2px dashed var(--cascade-card-border, rgba(255, 255, 255, 0.4));
+  color: var(--cascade-card-text, #f8fafc);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  transition:
+    transform 140ms ease,
+    box-shadow 200ms ease,
+    border-color 140ms ease;
+}
+.drawButton:enabled {
+  cursor: pointer;
+}
+.drawButton:enabled:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.45);
+}
+.drawButton:disabled {
+  opacity: 0.6;
+}
+
+.drawPlus {
+  font-size: 12px;
+  font-weight: 800;
+  color: #fde68a;
+}
+
+.discard {
+  position: relative;
+}
+/* Faint offset copies suggest a growing discard pile under the top card. */
+.discardUnder {
+  position: absolute;
+  inset: 0;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* ---- Turn bar ------------------------------------------------------- */
+
+.turnBar {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 10, 24, 0.42);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.3);
+}
+
+.turnBarActive {
+  border-color: rgba(251, 191, 36, 0.6);
+  box-shadow:
+    0 0 0 1px rgba(251, 191, 36, 0.4),
+    0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.turnLabelMuted {
+  color: #d1d5db;
+  font-size: 12px;
+}
+
+.turnLabelStrong {
+  color: var(--cascade-text, #f8fafc);
+  font-size: 14px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dirArrow {
+  display: inline-block;
+  font-size: 16px;
+  animation: cascade-spin 6s linear infinite;
+}
+.dirArrowReverse {
+  animation-direction: reverse;
+}
+
+@keyframes cascade-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.stackBadge {
+  padding: 3px 10px;
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.92);
+  color: #fff;
+  font-weight: 800;
+  font-size: 13px;
+  box-shadow: 0 0 12px rgba(239, 68, 68, 0.55);
+}
+
+.colorChip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 800;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  box-shadow:
+    inset 0 1px 5px rgba(255, 255, 255, 0.35),
+    0 0 14px var(--chip-glow, rgba(255, 255, 255, 0.4));
+}
+
+/* ---- Cascade! call button ------------------------------------------ */
+
+.callButton {
+  padding: 12px 30px;
+  border-radius: 999px;
+  border: 2px solid rgba(251, 191, 36, 0.6);
+  background: linear-gradient(135deg, #f59e0b 0%, #d97706 50%, #b45309 100%);
+  color: #fff;
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow:
+    0 0 0 4px rgba(251, 191, 36, 0.18),
+    0 6px 16px rgba(0, 0, 0, 0.45);
+  animation: cascade-pulse 900ms ease-in-out infinite;
+}
+.callButton:hover {
+  filter: brightness(1.08);
+}
+
+@keyframes cascade-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.06);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .playable,
+  .callButton,
+  .handSlot,
+  .card,
+  .pod,
+  .drawButton {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/apps/web/src/widgets/CascadeGame/ui/ColorPicker.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/ColorPicker.tsx
@@ -31,7 +31,7 @@ export function ColorPicker({ open, onPick }: ColorPickerProps) {
               className={styles.swatch}
               style={{ '--swatch-bg': theme.palette[c] } as React.CSSProperties}
             >
-              {c}
+              <span className={styles.swatchLabel}>{theme.colorNames[c]}</span>
             </button>
           ))}
         </div>

--- a/apps/web/src/widgets/CascadeGame/ui/ColorPicker.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/ColorPicker.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { XStack, YStack } from 'tamagui';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
 import { ACTIVE_COLORS, type ActiveColor } from '../types';
+import styles from './CascadeGame.module.css';
 
 interface ColorPickerProps {
   open: boolean;
@@ -14,50 +14,28 @@ export function ColorPicker({ open, onPick }: ColorPickerProps) {
   if (!open) return null;
 
   return (
-    <YStack
-      role="dialog"
-      aria-label="Choose active color"
-      position="absolute"
-      bottom={120}
-      left="50%"
-      transform={[{ translateX: -160 }] as unknown as string}
-      width={320}
-      padding="$3"
-      borderRadius="$4"
-      backgroundColor="rgba(15, 15, 28, 0.92)"
-      borderWidth={1}
-      borderColor={theme.cardBorder}
-      gap="$2"
-      zIndex={50}
-    >
-      <YStack alignItems="center" paddingBottom="$1">
-        <span style={{ color: '#fff', fontWeight: 700 }}>
-          Choose a color
-        </span>
-      </YStack>
-      <XStack gap="$2" justifyContent="center">
-        {ACTIVE_COLORS.map((c) => (
-          <button
-            key={c}
-            type="button"
-            onClick={() => onPick(c)}
-            aria-label={`Pick ${c}`}
-            style={{
-              width: 56,
-              height: 56,
-              borderRadius: 12,
-              background: theme.palette[c],
-              border: `2px solid ${theme.cardBorder}`,
-              cursor: 'pointer',
-              color: '#fff',
-              fontWeight: 800,
-              fontSize: 22,
-            }}
-          >
-            {c}
-          </button>
-        ))}
-      </XStack>
-    </YStack>
+    <div className={styles.pickerBackdrop}>
+      <div
+        role="dialog"
+        aria-label="Choose active color"
+        className={styles.pickerPanel}
+      >
+        <span className={styles.pickerTitle}>Choose a color</span>
+        <div className={styles.pickerRow}>
+          {ACTIVE_COLORS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => onPick(c)}
+              aria-label={`Pick ${c}`}
+              className={styles.swatch}
+              style={{ '--swatch-bg': theme.palette[c] } as React.CSSProperties}
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -31,6 +31,7 @@ function resolveOptions(raw: unknown): CascadeOptions {
     mode: string;
     stackingEnabled: boolean;
     lastCardCallEnabled: boolean;
+    cardStyle: string;
   }>;
   const mode: CascadeMode = (
     CASCADE_MODE_IDS as ReadonlyArray<string>
@@ -43,6 +44,7 @@ function resolveOptions(raw: unknown): CascadeOptions {
     stackingEnabled: mode !== 'pure',
     lastCardCallEnabled:
       typeof r.lastCardCallEnabled === 'boolean' ? r.lastCardCallEnabled : true,
+    cardStyle: r.cardStyle === 'aurora' ? 'aurora' : 'neon',
   };
 }
 
@@ -201,6 +203,7 @@ function CascadeGameImpl({
             myHand={myHand}
             myTurn={myTurn}
             disabled={isGameOver}
+            cardStyle={options.cardStyle}
             onPlayCard={handlePlayCard}
             onDraw={draw}
             onCallCascade={callCascade}

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -263,12 +263,11 @@ function CascadeGameImpl({
           variantEmoji: variantTokens.emoji,
           title: 'Cascade',
           subtitle: room?.name,
-          turnStatusVariant: isGameOver
-            ? 'completed'
-            : myTurn
-              ? 'yourTurn'
-              : 'waiting',
-          turnStatusText: isGameOver ? 'Game over' : myTurn ? 'Your turn' : '—',
+          turn: {
+            onClockUserId: currentEntryId ?? null,
+            isMyTurn: myTurn,
+            isGameOver,
+          },
         }}
       />
     </CascadeThemeProvider>

--- a/apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx
@@ -3,6 +3,7 @@
 import { XStack, YStack } from 'tamagui';
 import { InGameAvatar } from '@/features/games/ui';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
+import styles from './CascadeGame.module.css';
 import type { ActiveColor } from '../types';
 
 interface TurnBadgeProps {
@@ -30,7 +31,7 @@ export function TurnBadge({
       paddingHorizontal="$3"
       paddingVertical="$2"
       borderRadius="$3"
-      backgroundColor="rgba(0,0,0,0.25)"
+      className={`${styles.turnBar} ${myTurn ? styles.turnBarActive : ''}`}
     >
       <XStack alignItems="center" gap="$2">
         {currentEntryId ? (
@@ -42,44 +43,42 @@ export function TurnBadge({
           />
         ) : null}
         <YStack>
-          <span style={{ color: '#d1d5db', fontSize: 12 }}>
+          <span className={styles.turnLabelMuted}>
             {myTurn
               ? 'Your turn'
               : currentEntryId
                 ? `Waiting on ${shortId(currentEntryId)}`
                 : 'Waiting…'}
           </span>
-          <span style={{ color: theme.cardText, fontSize: 14, fontWeight: 600 }}>
-            {direction === 1 ? 'Clockwise ↻' : 'Counter-clockwise ↺'}
+          <span className={styles.turnLabelStrong}>
+            <span
+              className={`${styles.dirArrow} ${
+                direction === -1 ? styles.dirArrowReverse : ''
+              }`}
+              aria-hidden="true"
+            >
+              ↻
+            </span>
+            {direction === 1 ? 'Clockwise' : 'Counter-clockwise'}
           </span>
         </YStack>
       </XStack>
       <XStack alignItems="center" gap="$2">
         {pendingDraw > 0 ? (
-          <YStack
-            paddingHorizontal="$2"
-            paddingVertical="$1"
-            borderRadius="$2"
-            backgroundColor="rgba(239, 68, 68, 0.9)"
-          >
-            <span style={{ color: '#fff', fontWeight: 800, fontSize: 13 }}>
-              +{pendingDraw} stacked
-            </span>
-          </YStack>
+          <span className={styles.stackBadge}>+{pendingDraw} stacked</span>
         ) : null}
-        <YStack
-          alignItems="center"
-          justifyContent="center"
-          width={36}
-          height={36}
-          borderRadius={18}
-          backgroundColor={theme.palette[activeColor]}
-          borderWidth={2}
-          borderColor={theme.cardBorder}
+        <span
+          className={styles.colorChip}
+          style={
+            {
+              background: theme.palette[activeColor],
+              '--chip-glow': theme.palette[activeColor],
+            } as React.CSSProperties
+          }
           aria-label={`Active color ${activeColor}`}
         >
-          <span style={{ color: '#fff', fontWeight: 800 }}>{activeColor}</span>
-        </YStack>
+          {activeColor}
+        </span>
       </XStack>
     </XStack>
   );

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -257,6 +257,9 @@ export function ActiveGameView({
         variant={cardVariant as GameVariant}
         isMyTurn={isMyTurn}
         isGameOver={isGameOver}
+        // Critical shows incoming chat as per-opponent bubbles over each tile,
+        // so it opts out of the shared corner popup to avoid double display.
+        showChatPopup={false}
         headerProps={{
           variantEmoji: variantMeta?.emoji ?? '🎴',
           title: headerTitle,

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -3,7 +3,10 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useMedia, YStack } from 'tamagui';
 import { useGameChatIntegration } from '@/features/games/hooks';
-import { useTranslation } from '@/shared/lib/useTranslation';
+import {
+  useTranslation,
+  type TranslationKey,
+} from '@/shared/lib/useTranslation';
 import type {
   CriticalCard,
   CriticalPlayerState,
@@ -22,11 +25,14 @@ import {
 import { useGameHandlers } from '../hooks/useGameHandlers';
 import { GameStatusMessage } from './GameStatusMessage';
 import { GameResultModal } from '@/features/games/ui/GameResultModal';
+import { GameWidgetContainer } from '@/features/games/ui';
 import { MatchWidget } from './MatchWidget';
 import { ActiveGameModals } from './ActiveGameModals';
 import { getVariantStyles } from './styles/variants';
+import { CRITICAL_VARIANTS } from '../lib/constants';
 import { ScenePaletteProvider } from './ScenePaletteContext';
 import { SceneBackdrop } from './SceneBackdrop';
+import type { GameVariant } from '@arcadeum/ui';
 import type { UseGameActionsReturn } from '@/features/games/hooks/useGameActions';
 import type { RematchInvitation } from '../hooks/useRematch';
 
@@ -35,8 +41,6 @@ interface ActiveGameViewProps {
   room: GameRoomSummary;
   snapshot: CriticalSnapshot;
   isHost: boolean;
-  isFullscreen: boolean;
-  toggleFullscreen: () => void;
   // From useCriticalState
   actions: UseGameActionsReturn;
   currentPlayer: CriticalPlayerState | null;
@@ -74,8 +78,6 @@ export function ActiveGameView({
   room,
   snapshot,
   isHost,
-  isFullscreen,
-  toggleFullscreen,
   actions,
   currentPlayer,
   isMyTurn,
@@ -93,6 +95,18 @@ export function ActiveGameView({
     () => getVariantStyles(cardVariant).scene,
     [cardVariant],
   );
+
+  // Shared-header metadata. Title is "Critical · {variant}"; the on-clock
+  // player drives the turn pill (avatar + name) for free.
+  const variantMeta = useMemo(
+    () => CRITICAL_VARIANTS.find((v) => v.id === cardVariant),
+    [cardVariant],
+  );
+  const headerTitle = variantMeta
+    ? `${t('games.critical_v1.name')} · ${t(variantMeta.name as TranslationKey)}`
+    : t('games.critical_v1.name');
+  const turnPlayerId =
+    snapshot.playerOrder[snapshot.currentTurnIndex] ?? null;
 
   // Sync modal dismissal state with game over state
   const [modalDismissed, setModalDismissed] = useState(false);
@@ -239,9 +253,21 @@ export function ActiveGameView({
 
   return (
     <ScenePaletteProvider palette={scenePalette}>
-      <SceneBackdrop />
-      <YStack flex={1} className="animate-entrance">
-        <MatchWidget
+      <GameWidgetContainer
+        variant={cardVariant as GameVariant}
+        isMyTurn={isMyTurn}
+        isGameOver={isGameOver}
+        headerProps={{
+          variantEmoji: variantMeta?.emoji ?? '🎴',
+          title: headerTitle,
+          subtitle: room.name,
+          turn: { onClockUserId: turnPlayerId, isMyTurn, isGameOver },
+        }}
+        board={
+          <>
+            <SceneBackdrop />
+            <YStack flex={1} className="animate-entrance">
+              <MatchWidget
           room={room}
           snapshot={snapshot}
           currentUserId={currentUserId}
@@ -263,23 +289,25 @@ export function ActiveGameView({
           handleOpenEventCombo={handleOpenEventCombo}
           handleOpenFiverCombo={handleOpenFiverCombo}
           formatLogMessage={formatLogMessage}
-          isFullscreen={isFullscreen}
-          toggleFullscreen={toggleFullscreen}
           autoplayState={autoplayState}
           idleTimerEnabled={idleTimerEnabled}
           idleTimerTriggered={idleTimerTriggered}
           handleIdleTimeout={handleIdleTimeout}
           handleStopAutoplay={handleStopAutoplay}
-        />
-      </YStack>
-      {currentPlayer && (
-        <GameStatusMessage
-          currentPlayerAlive={currentPlayer.alive}
-          isGameOver={!!isGameOver}
-          t={t as (key: string) => string}
-        />
-      )}{' '}
-      <ActiveGameModals
+              />
+            </YStack>
+            {currentPlayer && (
+              <GameStatusMessage
+                currentPlayerAlive={currentPlayer.alive}
+                isGameOver={!!isGameOver}
+                t={t as (key: string) => string}
+              />
+            )}
+          </>
+        }
+        modals={
+          <>
+            <ActiveGameModals
         currentUserId={currentUserId}
         snapshot={snapshot}
         isMobile={isMobile}
@@ -345,6 +373,9 @@ export function ActiveGameView({
         onClose={() => setModalDismissed(true)}
         rematchLoading={rematch.rematchLoading}
         t={t}
+      />
+          </>
+        }
       />
     </ScenePaletteProvider>
   );

--- a/apps/web/src/widgets/CriticalGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/Game.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type { CriticalGameProps } from '../types';
 import { useCriticalState, useRematch } from '../hooks';
@@ -6,28 +6,6 @@ import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { useFullscreen } from '@/features/games/hooks/useFullscreen';
 import { CriticalLobby } from './CriticalLobby';
 import { ActiveGameView } from './ActiveGameView';
-import { GameContainer } from './styles';
-import type { GameVariant } from '@arcadeum/ui';
-
-// Widget-only fullscreen CSS — expands just the Critical widget to fill
-// the viewport. Independent of the page-level toggle in `GamePageLayout`,
-// which expands [control panel + widget + chat] instead.
-const criticalWidgetFullscreenStyles = `
-  .critical-game-widget.is-fullscreen {
-    position: fixed !important;
-    inset: 0 !important;
-    width: 100vw !important;
-    height: 100vh !important;
-    max-width: 100vw !important;
-    max-height: 100vh !important;
-    border-radius: 0 !important;
-    border-width: 0 !important;
-    background: #151718 !important;
-    overflow-y: auto !important;
-    overflow-x: hidden !important;
-    z-index: 1100;
-  }
-`;
 
 export default function CriticalGame({
   roomId,
@@ -54,8 +32,6 @@ export default function CriticalGame({
 
   const room =
     (storeRoom?.id === roomId ? storeRoom : null) || initialRoom || null;
-
-  const cardVariant = room?.gameOptions?.cardVariant;
 
   const {
     snapshot,
@@ -109,36 +85,26 @@ export default function CriticalGame({
     );
   }
 
-  // Game in progress - show Active Game View
+  // Game in progress — the active view renders inside the shared
+  // GameWidgetContainer (header with turn+avatar, widget fullscreen, chat
+  // popup, my-turn border), so Critical no longer wraps its own container or
+  // runs a second fullscreen system here.
   return (
-    <>
-      <style>{criticalWidgetFullscreenStyles}</style>
-      <GameContainer
-        ref={containerRef as React.RefObject<never>}
-        className="critical-game-widget"
-        isFullscreen={isFullscreen}
-        $isMyTurn={!!isMyTurn}
-        $variant={cardVariant as GameVariant}
-      >
-        <ActiveGameView
-          currentUserId={currentUserId}
-          room={room}
-          snapshot={snapshot}
-          isHost={isHost}
-          isFullscreen={isFullscreen}
-          toggleFullscreen={toggleFullscreen}
-          actions={actions}
-          currentPlayer={currentPlayer}
-          isMyTurn={!!isMyTurn}
-          canAct={!!canAct}
-          canPlayNope={!!canPlayNope}
-          aliveOpponents={aliveOpponents}
-          isGameOver={!!isGameOver}
-          rematch={rematch}
-          showRulesOpen={showRulesOpen}
-          onShowRulesClose={onShowRulesClose}
-        />
-      </GameContainer>
-    </>
+    <ActiveGameView
+      currentUserId={currentUserId}
+      room={room}
+      snapshot={snapshot}
+      isHost={isHost}
+      actions={actions}
+      currentPlayer={currentPlayer}
+      isMyTurn={!!isMyTurn}
+      canAct={!!canAct}
+      canPlayNope={!!canPlayNope}
+      aliveOpponents={aliveOpponents}
+      isGameOver={!!isGameOver}
+      rematch={rematch}
+      showRulesOpen={showRulesOpen}
+      onShowRulesClose={onShowRulesClose}
+    />
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -66,8 +66,13 @@ export interface MatchWidgetProps {
   ) => void;
   handleOpenFiverCombo: () => void;
   formatLogMessage: (message?: string | null) => string;
-  isFullscreen: boolean;
-  toggleFullscreen: () => void;
+  /**
+   * Optional. The hand's fullscreen affordance — when omitted (the widget now
+   * renders inside the shared GameWidgetContainer, which owns fullscreen), the
+   * hand hides its own fullscreen button.
+   */
+  isFullscreen?: boolean;
+  toggleFullscreen?: () => void;
   /**
    * Autoplay state + idle-timer wiring. The autoplay menu and the idle
    * countdown badge render at the top of the widget grid. Idle-on-timeout

--- a/apps/web/src/widgets/CriticalGame/ui/styles/index.ts
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/index.ts
@@ -1,6 +1,5 @@
 // Layout Components
 export {
-  GameContainer,
   GameBoard,
   TableArea,
   HandSection,

--- a/apps/web/src/widgets/CriticalGame/ui/styles/layout.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/layout.tsx
@@ -1,81 +1,13 @@
 import { styled, YStack } from 'tamagui';
 import {
-  GameContainer as BaseGameContainer,
   GameBoard as BaseGameBoard,
   TableArea as BaseTableArea,
 } from '@arcadeum/ui';
-import { getVariantStyles } from './variants';
-import { TamaguiTheme } from './variants/types';
-import { scrollbarStyles } from '@/shared/lib/styles';
 
-export const GameContainer = styled(BaseGameContainer, {
-  name: 'GameContainer',
-  gap: '$5',
-  paddingHorizontal: '$7',
-  paddingTop: '$7',
-  paddingBottom: 0,
-  borderRadius: 24,
-  flex: 1,
-  minHeight: 0,
-  position: 'relative',
-  overflowX: 'hidden',
-  overflowY: 'auto',
-
-  backdropFilter: 'blur(20px)',
-  height: '100%',
-  flexDirection: 'column',
-  minWidth: 0,
-
-  ...scrollbarStyles,
-
-  $sm: {
-    paddingHorizontal: 0,
-    paddingTop: 0,
-    paddingBottom: 0,
-    borderRadius: 16,
-    gap: '$2',
-    overflowY: 'auto',
-  },
-
-  variants: {
-    $isMyTurn: {
-      true: {
-        // We handle the pulse animation via a prop or in tamagui.config.ts
-      },
-    },
-    isFullscreen: {
-      true: {
-        maxWidth: '100vw',
-        maxHeight: '100vh',
-        width: '100vw',
-        height: '100vh',
-        borderRadius: 0,
-        borderWidth: 0,
-      },
-    },
-    $variant: (
-      val: string,
-      { props, theme }: { props: { $isMyTurn?: boolean }; theme: TamaguiTheme },
-    ) => {
-      const config = getVariantStyles(val).layout;
-      const isMyTurn = props.$isMyTurn;
-
-      return {
-        backgroundColor: config.getRoomBackground(
-          theme.background?.val || '',
-          (theme.cardBackground || theme.background)?.val || '',
-        ),
-        borderWidth: isMyTurn ? 2 : 1,
-        borderColor: config.getRoomBorder(
-          !!isMyTurn,
-          theme.borderColor?.val || '',
-        ),
-        shadowColor: config.getRoomShadow(!!isMyTurn),
-        ...config.getBackgroundEffects(),
-      };
-    },
-  } as const,
-});
+// NOTE: the old `GameContainer` styled wrapper was removed when Critical
+// adopted the shared `GameWidgetContainer` (header / fullscreen / chat popup /
+// my-turn border now live in the shared shell). The per-variant room
+// background it carried is handled by the shared shell + `SceneBackdrop`.
 
 export const GameBoard = styled(BaseGameBoard, {
   name: 'GameBoard',

--- a/apps/web/src/widgets/GlimwormGame/GlimwormGame.tsx
+++ b/apps/web/src/widgets/GlimwormGame/GlimwormGame.tsx
@@ -12,12 +12,15 @@ import { GlimwormControlsHint } from './ui/GlimwormControlsHint';
 import { GlimwormResultOverlay } from './ui/GlimwormResultOverlay';
 import { useGlimwormStore } from './store/glimwormStore';
 import { gameSocket } from '@/shared/lib/socket';
+import { GameWidgetContainer } from '@/features/games/ui';
+import { useTranslation } from '@/shared/lib/useTranslation';
 import type { BaseGameWidgetProps } from '@/features/games/types/base';
 
 export default function GlimwormGame(
   props: BaseGameWidgetProps,
 ): React.JSX.Element {
   const { roomId, currentUserId, isHost, room } = props;
+  const { t } = useTranslation();
 
   // State-backed callback ref: when the canvas div is mounted (after the
   // lobby branch ends), `setCanvasEl` flips the state and the pixi/controls
@@ -79,34 +82,59 @@ export default function GlimwormGame(
     );
   }
 
+  // Real-time game: no turns, so the shared shell uses its non-turn header
+  // (status text instead of a turn-with-avatar pill).
+  const statusText = isCountdown
+    ? t('games.glimworm_v1.status.getReady')
+    : isEnded
+      ? t('games.glimworm_v1.status.roundOver')
+      : t('games.glimworm_v1.status.inPlay');
+
   return (
-    <div
-      style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        minHeight: 480,
+    <GameWidgetContainer
+      isMyTurn={false}
+      isGameOver={isEnded}
+      headerProps={{
+        variantEmoji: '🪱',
+        title: t('games.glimworm_v1.name'),
+        subtitle: room.name,
+        turnStatusVariant: isCountdown
+          ? 'waiting'
+          : isEnded
+            ? 'completed'
+            : 'default',
+        turnStatusText: statusText,
       }}
-    >
-      <div
-        ref={canvasRef}
-        style={{
-          position: 'absolute',
-          inset: 0,
-          background: '#06070d',
-        }}
-      />
-      <GlimwormHud isHost={isHost} onRestart={handleRestart} />
-      <GlimwormDeathOverlay />
-      {isCountdown && <GlimwormCountdown />}
-      {!isCountdown && !isEnded && <GlimwormControlsHint />}
-      {isEnded && (
-        <GlimwormResultOverlay
-          isHost={isHost}
-          onRematch={handleRematch}
-          onLobby={handleRestart}
-        />
-      )}
-    </div>
+      board={
+        <div
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: '100%',
+            minHeight: 480,
+          }}
+        >
+          <div
+            ref={canvasRef}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background: '#06070d',
+            }}
+          />
+          <GlimwormHud isHost={isHost} onRestart={handleRestart} />
+          <GlimwormDeathOverlay />
+          {isCountdown && <GlimwormCountdown />}
+          {!isCountdown && !isEnded && <GlimwormControlsHint />}
+          {isEnded && (
+            <GlimwormResultOverlay
+              isHost={isHost}
+              onRematch={handleRematch}
+              onLobby={handleRestart}
+            />
+          )}
+        </div>
+      }
+    />
   );
 }

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -240,12 +240,11 @@ function TicTacToeGameImpl({
           variantEmoji: variantTokens.emoji,
           title: 'Tic-Tac-Toe',
           subtitle: room?.name,
-          turnStatusVariant: isGameOver
-            ? 'completed'
-            : myTurn
-              ? 'yourTurn'
-              : 'waiting',
-          turnStatusText: isGameOver ? 'Game over' : myTurn ? 'Your turn' : '—',
+          turn: {
+            onClockUserId: currentShooterId,
+            isMyTurn: myTurn,
+            isGameOver,
+          },
         }}
       />
     </TicTacToeThemeProvider>

--- a/docs/handoffs/CASCADE_BOARD_REWORK_HANDOFF.md
+++ b/docs/handoffs/CASCADE_BOARD_REWORK_HANDOFF.md
@@ -1,0 +1,333 @@
+# Cascade Board — Modern Card Rework (ARC-760 follow-up)
+
+> **For:** Claude Code, working on the in-game Cascade widget
+> **Visual reference:** `Cascade Board.html` (fully playable preview vs. bots — open it and play a round)
+> **Scope:** Frontend restyle of the Cascade play surface. **No game logic, aria-labels, data-testids, or engine changes.** > **Supersedes:** the card treatment shipped in PR #772. Keeps that PR's structure (fan, pods, stacked piles, glass turn bar, blurred picker) but **replaces the card faces.**
+
+---
+
+## TL;DR — why this exists
+
+PR #772 modernized the board but the card faces landed on the **UNO look**: a tilted white center oval, flat primary-color faces, corner indices. That reads as a clone of a copyrighted physical deck and clashes with Arcadeum's dark-neon brand.
+
+This rework keeps every layout/motion win from #772 and **only changes the card visual language** to something original and on-brand:
+
+> **Dark glass "energy cards."** Colour identity reads through a **luminous coloured edge + glowing numeral + faint oversized ghost glyph**, on a consistent dark body — never a flat colour flood with a white oval. Wilds get a **prismatic aura** instead of a flat face.
+
+Everything else (overlapping hand fan, opponent glass pods with scaled fanned backs, stacked draw/discard decks, glass turn bar, blurred wild picker, `prefers-reduced-motion` fallbacks) stays as-is.
+
+---
+
+## Files to touch
+
+```
+apps/web/src/widgets/CascadeGame/ui/
+├── CascadeGame.module.css   REWRITE the .card / .swatch face rules (see below)
+├── Card.tsx                 MINOR — drop the centre-oval node, add a ghost glyph + wild flag
+├── ColorPicker.tsx          UNCHANGED markup (picker swatches restyle is pure CSS)
+├── CascadeBoard.tsx         UNCHANGED
+└── TurnBadge.tsx            UNCHANGED
+```
+
+The prototype mirrors these as `cascade/components.jsx` (≈ `Card.tsx`) and `cascade/board.css` (≈ `CascadeGame.module.css`). Lift values directly from `cascade/board.css`.
+
+---
+
+## The card system
+
+### Construction (per card)
+
+```
+┌───────────────────────┐
+│ 7                     │  ← corner index: colour-mixed text + soft colour glow
+│                       │
+│        ⏹  7           │  ← ghost glyph (huge, ~0.16 opacity) behind
+│          ▏            │     main glyph (bright colour-mix + colour text-glow)
+│                       │
+│                     7 │  ← bottom-right index, rotated 180°
+└───────────────────────┘
+   dark glass body
+   + colour-tinted top glow
+   + 1.6px colour edge
+   + slim inner frame
+```
+
+Three text layers share the same symbol: **ghost** (depth), **main glyph** (centre), **two corner indices**. No white oval.
+
+### Tokens (already flow in from the board root + per-card)
+
+Inline on each card: `--card-bg` = the colour hex (`theme.palette[card.color]`, aliased to `--face` in CSS).
+On the board root (`CascadeBoard`): `--cascade-card-text`, plus this rework reads the theme **accent** for the playable glow — pass it down as `--cascade-accent` / `--cascade-accent-rgb` from `theme.ts` (see "Theme additions").
+
+### CSS — replace `.card` and its parts
+
+```css
+/* dark glass body, colour reads via edge + tint, NOT a flood */
+.card {
+  /* was: white-oval + colour-flood gradient */
+  --face: var(--card-bg, #221c47);
+  position: relative;
+  border-radius: 14%;
+  background: radial-gradient(
+      125% 78% at 50% -8%,
+      color-mix(in srgb, var(--face) 42%, transparent),
+      transparent 56%
+    ),
+    linear-gradient(158deg, #262c3c 0%, #141a28 52%, #0a0d16 100%);
+  border: 1.6px solid color-mix(in srgb, var(--face) 76%, white 8%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 0 18px color-mix(in srgb, var(--face) 26%, transparent),
+    0 4px 12px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+.card::after {
+  /* slim luminous inner frame */
+  content: '';
+  position: absolute;
+  inset: 8%;
+  border-radius: 12%;
+  border: 1px solid
+    color-mix(in srgb, var(--face) 32%, rgba(255, 255, 255, 0.08));
+  pointer-events: none;
+}
+.ghost {
+  /* big faint background glyph (NEW node) */
+  position: absolute;
+  left: 50%;
+  top: 56%;
+  transform: translate(-50%, -50%);
+  font-weight: 900;
+  line-height: 1;
+  z-index: 1;
+  pointer-events: none;
+  color: color-mix(in srgb, var(--face) 60%, white 10%);
+  opacity: 0.16;
+}
+.centerGlyph {
+  /* was a tilted translucent oval wrapper */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  font-weight: 900;
+  letter-spacing: -1px;
+  color: color-mix(in srgb, var(--face) 52%, white 48%);
+  text-shadow:
+    0 0 14px color-mix(in srgb, var(--face) 75%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.6);
+}
+.corner {
+  /* colour-mixed, soft glow — not plain white */
+  position: absolute;
+  z-index: 2;
+  font-weight: 800;
+  line-height: 1;
+  color: color-mix(in srgb, var(--face) 55%, white 45%);
+  text-shadow: 0 0 6px color-mix(in srgb, var(--face) 70%, transparent);
+}
+.cornerTL {
+  top: 8%;
+  left: 10%;
+}
+.cornerBR {
+  bottom: 8%;
+  right: 10%;
+  transform: rotate(180deg);
+}
+
+/* WILD — prismatic aura on dark glass, not a single colour */
+.card.wild {
+  background: conic-gradient(
+      from 200deg at 50% 118%,
+      rgba(244, 63, 94, 0.55),
+      rgba(251, 191, 36, 0.55),
+      rgba(34, 197, 94, 0.55),
+      rgba(59, 130, 246, 0.55),
+      rgba(168, 85, 247, 0.55),
+      rgba(244, 63, 94, 0.55)
+    ),
+    linear-gradient(158deg, #262c3c 0%, #131826 50%, #0a0d16 100%);
+  background-blend-mode: screen, normal;
+  border-color: rgba(255, 255, 255, 0.55);
+}
+.card.wild .centerGlyph,
+.card.wild .corner {
+  color: #fff;
+  text-shadow:
+    0 0 16px rgba(255, 255, 255, 0.7),
+    0 1px 2px rgba(0, 0, 0, 0.6);
+}
+.card.wild .ghost {
+  color: #fff;
+  opacity: 0.12;
+}
+
+/* playable glow now keyed off the THEME ACCENT, not hard-coded amber */
+.playable {
+  border-color: color-mix(in srgb, var(--cascade-accent, #a78bfa) 90%, white);
+  box-shadow:
+    0 0 0 2px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.55),
+    0 0 20px rgba(var(--cascade-accent-rgb, 167, 139, 250), 0.45),
+    0 6px 16px rgba(0, 0, 0, 0.4);
+  animation: cascade-playable 1600ms ease-in-out infinite; /* keep existing keyframes, swap colours to accent */
+}
+
+/* dimmed (non-playable, your turn): cards are already dark — keep it gentle */
+.disabled {
+  opacity: 0.82;
+  filter: saturate(0.9);
+} /* was brightness(.55) — too dark on a dark card */
+```
+
+> **Face-down `.faceDown`** stays essentially as PR #772 had it (dark + accent stripes). It was never UNO-like; leave it, optionally swap its tint to the accent token.
+
+### `Card.tsx` markup change
+
+Remove the empty centre-oval span, add the ghost glyph, and add the wild class:
+
+```tsx
+const isWild =
+  !faceDown && (card.kind === 'WILD' || card.kind === 'WILD_DRAW_FOUR');
+
+const className = [
+  styles.card,
+  faceDown && styles.faceDown,
+  isWild && styles.wild, // NEW
+  isClickable && styles.clickable,
+  playable && styles.playable,
+  selected && styles.selected,
+  disabled && !faceDown && styles.disabled,
+]
+  .filter(Boolean)
+  .join(' ');
+
+// inside the face (not faceDown):
+<>
+  <span
+    aria-hidden
+    className={styles.ghost}
+    style={{
+      fontSize: (card.kind === 'NUMBER' ? dims.glyph : dims.glyph * 0.82) * 1.9,
+    }}
+  >
+    {symbol}
+  </span>
+  <span
+    aria-hidden
+    className={`${styles.corner} ${styles.cornerTL}`}
+    style={{ fontSize: dims.corner }}
+  >
+    {symbol}
+  </span>
+  <span
+    aria-hidden
+    className={styles.centerGlyph}
+    style={{
+      fontSize: card.kind === 'NUMBER' ? dims.glyph : dims.glyph * 0.82,
+    }}
+  >
+    {symbol}
+  </span>
+  <span
+    aria-hidden
+    className={`${styles.corner} ${styles.cornerBR}`}
+    style={{ fontSize: dims.corner }}
+  >
+    {symbol}
+  </span>
+</>;
+```
+
+The old `.centerGlyph > span { transform: rotate(32deg) }` counter-rotation can be deleted — there's no tilted oval anymore.
+
+---
+
+## Wild colour picker (CSS only)
+
+`ColorPicker.tsx` markup is unchanged. Restyle `.swatch` in the module to match the new cards so the dialog reads as the same deck:
+
+```css
+.swatch {
+  --face: var(--swatch-bg, #221c47);
+  background: radial-gradient(
+      125% 78% at 50% -8%,
+      color-mix(in srgb, var(--face) 45%, transparent),
+      transparent 56%
+    ),
+    linear-gradient(158deg, #262c3c, #141a28 52%, #0a0d16);
+  border: 1.6px solid color-mix(in srgb, var(--face) 78%, white 8%);
+  color: color-mix(in srgb, var(--face) 50%, white 50%);
+  box-shadow:
+    inset 0 0 18px color-mix(in srgb, var(--face) 28%, transparent),
+    0 4px 12px rgba(0, 0, 0, 0.45);
+}
+.swatch::after {
+  /* inner frame, matches cards */
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 9px;
+  border: 1px solid
+    color-mix(in srgb, var(--face) 30%, rgba(255, 255, 255, 0.08));
+  pointer-events: none;
+}
+```
+
+Show the **themed colour name** in the swatch (`theme.colorNames[c]` → "Red Giant", "Pulsar", …) rather than the bare `R/Y/G/B`. The prototype does this and it sells the variant; keep the `aria-label="Pick {color}"` exactly as-is.
+
+---
+
+## Theme additions (`lib/theme.ts`)
+
+The playable glow and centre ring should use each variant's **accent**, so add two tokens per theme and surface them on the board root:
+
+```ts
+// add to CascadeThemeTokens
+accent: string;       // hover/glow colour
+accentRGB: string;    // same colour as "r,g,b" for rgba()
+
+// suggested values
+cosmic:    { accent: '#a78bfa', accentRGB: '167,139,250' }
+arcane:    { accent: '#e879f9', accentRGB: '232,121,249' }
+cyberpunk: { accent: '#22d3ee', accentRGB: '34,211,238'  }
+elemental: { accent: '#fbbf24', accentRGB: '251,191,36'  }
+```
+
+In `CascadeBoard.tsx`, add to the existing inline custom-prop style block:
+
+```tsx
+'--cascade-accent': theme.accent,
+'--cascade-accent-rgb': theme.accentRGB,
+```
+
+`TurnBadge`'s active-color chip and the opponent avatar discs already use `theme.palette` — fine to leave; those are small UI dots, not card faces.
+
+---
+
+## Optional — a second face style
+
+The prototype ships a `data-cardstyle` switch with two **both-dark** options the design team can A/B:
+
+- **`neon`** (default, documented above) — colour edge + glow on near-black glass.
+- **`aurora`** — same body with a colour sweep pooling in the lower-left/upper-right corners (radial gradients of `--face`), slightly more colour presence.
+
+If you want it in-app, drive it off `room.gameOptions` (or a user setting) and gate with a `data-cardstyle` attribute on the board root. Not required to ship the rework — `neon` alone resolves the UNO problem.
+
+---
+
+## Do NOT change
+
+- Game logic, deck rules, stacking, the last-card "Cascade!" race.
+- `aria-label`s, `role="dialog"`, `data-testid`s (`cascade-turn-avatar`, etc.).
+- The hand-fan math, pod fan scaling, stacked-pile offsets, turn-bar layout, picker backdrop/animation — all from #772, all kept.
+- `prefers-reduced-motion` block — keep it; the new glow/animation names map 1:1 to the existing ones.
+
+## Acceptance check
+
+1. No card shows a white centre oval; no flat primary-colour face.
+2. Card colour is legible at a glance via edge + numeral glow on the dark body.
+3. Wild / Wild +4 render with the prismatic aura.
+4. Playable-card glow matches the active variant's accent (purple cosmic, magenta arcane, cyan cyberpunk, amber elemental).
+5. Cascade unit tests (`Card`, `CascadeBoard`) still pass; `tsc --noEmit` and ESLint clean.

--- a/docs/superpowers/specs/2026-05-30-shared-game-shell-design.md
+++ b/docs/superpowers/specs/2026-05-30-shared-game-shell-design.md
@@ -147,8 +147,10 @@ is where Critical's idle-timer + autoplay relocate.
   shows board-specific detail (active color / direction), otherwise drop in
   favor of the header indicator. (Cascade's `TurnBadge` shows active color +
   direction → **keep**; it is board state, not turn identity.)
-- **SeaBattle**: replace its hand-built `turnAvatar` block with the `turn`
-  contract; delete the local `InGameAvatar` wiring it duplicated.
+- **SeaBattle**: replace its hand-built `turnAvatar` block (which manually
+  wires the shared `InGameAvatar` + a resolved name) with the `turn` contract.
+  Name resolution moves into `TurnIndicator`; no duplicate avatar component
+  exists to delete.
 
 ### 4. Migrate Critical onto the shell
 
@@ -158,12 +160,17 @@ is where Critical's idle-timer + autoplay relocate.
   with `GameWidgetContainer`.
 - Header → standard `headerProps` with the `turn` contract derived from
   Critical's `currentPlayer` / `isMyTurn` / `isGameOver`.
-- `IdleTimerDisplay` + `AutoplayControls` → `extraActions`.
+- `IdleTimerDisplay` + `AutoplayControls` currently live **inside**
+  `MatchWidget.tsx` (not in any header). Lift them out into the shell's
+  `extraActions` slot — this is the one intentional edit to `MatchWidget` for
+  this refactor.
 - Critical's `SceneBackdrop` / scene palette stays inside the `board` slot.
-- Critical's own widget-level fullscreen + chat-popup are removed (the shell
-  provides both). Keep `criticalWidgetFullscreenStyles` deletion in scope.
+- Critical's own widget-level fullscreen (`useFullscreen` +
+  `criticalWidgetFullscreenStyles` in Game.tsx) is removed — the shell provides
+  fullscreen. Critical has no chat-popup component of its own today; it simply
+  **gains** the shell's `GameChatPopupOverlay`.
 - The complex grid (`MatchWidget`, opponents row, arena, hand) renders inside
-  the `board` slot unchanged.
+  the `board` slot unchanged apart from the controls lift above.
 
 ### 5. Glimworm no-turn header
 
@@ -186,7 +193,8 @@ no-turn `turnStatusText` escape hatch for real-time games.
 
 ```
 GamePageLayout (page chrome, already shared)
-  ├─ registers resolveDisplayName / resolveEquipped / currentUserId → GameChat store
+  ├─ registers resolveEquipped / currentUserId → GameChat store
+  │   (resolveDisplayName is registered by each Game via useGameChatIntegration)
   └─ <Game /> (per registry)
         └─ GameWidgetContainer (shared shell)
               ├─ header: TurnIndicator(onClockUserId,isMyTurn) ──┐

--- a/docs/superpowers/specs/2026-05-30-shared-game-shell-design.md
+++ b/docs/superpowers/specs/2026-05-30-shared-game-shell-design.md
@@ -1,0 +1,244 @@
+# Shared Game Shell — Design
+
+**Date:** 2026-05-30
+**Status:** Approved (decisions delegated by user: "select recommended until PR open")
+
+## Problem
+
+Every game widget should share one component for its chrome — music, fullscreen,
+chat, and a turn indicator with the on-clock player's avatar — so that adding a
+new game gets all of this for free.
+
+Today the chrome is split and inconsistently adopted:
+
+- **Page chrome** ([GamePageLayout](../../../apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx))
+  already wraps **every** game and provides music
+  ([GameMusic](../../../apps/web/src/features/games/ui/GameMusic.tsx)),
+  page-level fullscreen, the
+  [GamesControlPanel](../../../apps/web/src/widgets/GamesControlPanel/ui/GamesControlPanel.tsx)
+  (sound/music/rules/chat-toggle/share/leave), the
+  [GameChat](../../../apps/web/src/widgets/GameChat/ui/GameChat.tsx) panel, and
+  connection overlays. This layer is **not** the problem — it is already shared.
+- **Widget chrome**
+  ([GameWidgetContainer](../../../apps/web/src/features/games/ui/GameWidgetContainer.tsx))
+  provides the in-widget sticky header (variant emoji, title, subtitle, turn
+  pill + optional avatar), the green my-turn border, widget-level fullscreen,
+  board/table/hand slots, and the chat popup overlay.
+
+**Adoption gaps:**
+
+| Game         | Uses `GameWidgetContainer`?                                                                                                 | Turn display                                      |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Cascade      | ✅                                                                                                                          | `turnStatusText` only (no avatar)                 |
+| TicTacToe    | ✅                                                                                                                          | `turnStatusText` only (no avatar)                 |
+| SeaBattle    | ✅                                                                                                                          | free-form `turnAvatar` ReactNode it builds itself |
+| **Critical** | ❌ rolls its own `GameContainer` + custom header + own fullscreen/chat popup (the shared container was extracted _from_ it) | bespoke                                           |
+| **Glimworm** | ❌ real-time PixiJS canvas; no turn concept                                                                                 | none                                              |
+
+Each adopter also re-implements the turn display differently, so it is not
+actually "for free."
+
+## Goals
+
+1. One shared widget shell every game renders. `GamePageLayout` stays as the
+   page-level wrapper (music/control-panel/chat/overlays) — it is already
+   shared and out of scope to merge.
+2. A **standard turn contract**: the shell owns a `TurnIndicator` that renders
+   the on-clock player's avatar + name + "Your turn / {name}'s turn". A new
+   game passes `{ onClockUserId, isMyTurn, isGameOver }` and gets the full
+   display — no per-game header markup.
+3. Migrate **Critical** onto the shared shell with the standard header;
+   relocate its idle-timer + autoplay controls into the header `extraActions`
+   slot.
+4. Give **Glimworm** a no-turn header variant on the same shell (status text,
+   e.g. countdown / alive-count, instead of a turn pill).
+5. Update the `/new-game` skill scaffold to use the turn contract by default.
+
+## Non-Goals (YAGNI)
+
+- Merging `GamePageLayout` into the widget shell (the rejected "full GameShell"
+  option). Page chrome stays where it is.
+- Redesigning `GamesControlPanel`, `GameChat`, `GameMusic`, or `GameResultModal`.
+- Changing any backend, game engine, or socket behavior.
+- Reworking Critical's gameplay grid (`MatchWidget`, arena, hand) beyond moving
+  its header-level controls.
+
+## Design
+
+### 1. TurnIndicator (new shared component)
+
+`apps/web/src/features/games/ui/TurnIndicator.tsx`
+
+Renders inside the header turn pill. Props:
+
+```ts
+interface TurnIndicatorProps {
+  /** id of the player currently on the clock; null when nobody is (game over / setup) */
+  onClockUserId: string | null;
+  /** is the local player the one on the clock */
+  isMyTurn: boolean;
+  /** game finished — show a neutral "completed" state instead of a turn */
+  isGameOver?: boolean;
+  /** override the resolved display name for the on-clock player (optional) */
+  onClockName?: string;
+}
+```
+
+Behavior:
+
+- Resolves the on-clock player's display name + cosmetics via the existing
+  pieces already wired by `GamePageLayout`: name from the `GameChat` store's
+  `resolveDisplayName`, avatar via the existing
+  [InGameAvatar](../../../apps/web/src/features/games/ui/InGameAvatar.tsx)
+  (which itself reads equipped cosmetics from the game store by `playerId`).
+  This is why a new game needs to pass only an id.
+- Renders: `<InGameAvatar size="icon" />` + a label.
+  - `isGameOver` → status `completed`, label "Game over".
+  - `isMyTurn` → status `yourTurn`, label "Your turn".
+  - otherwise → status `waiting`, label "{name}'s turn" (or "Waiting…" when
+    `onClockUserId` is null).
+- All labels come through i18n (`games.table.*`); no hardcoded strings.
+
+### 2. GameWidgetContainer header gains a turn contract
+
+Extend `SharedHeaderProps` so a game can pass the turn contract instead of
+hand-building `turnAvatar` + `turnStatusText` + `turnStatusVariant`:
+
+```ts
+interface SharedHeaderProps {
+  variantEmoji: string;
+  title: string;
+  subtitle?: string;
+  titleGradient?: string;
+  extraActions?: React.ReactNode;
+
+  // NEW — preferred: declarative turn contract
+  turn?: {
+    onClockUserId: string | null;
+    isMyTurn: boolean;
+    isGameOver?: boolean;
+    onClockName?: string;
+  };
+
+  // EXISTING — kept for back-compat / non-turn games:
+  turnStatusVariant?: TurnStatusVariant;
+  turnStatusText?: string;
+  turnAvatar?: React.ReactNode;
+}
+```
+
+Header rendering rules:
+
+- If `turn` is present → render `<TurnIndicator {...turn} />` inside the pill;
+  the pill's `$status` is derived from the same turn fields.
+- Else if `turnStatusText`/`turnAvatar` present → render the existing pill
+  (Glimworm uses this for a no-turn status; raw escape hatch preserved).
+- The `header` escape-hatch prop stays for any future fully-custom header, but
+  no game will use it after this refactor.
+
+`extraActions` already exists and renders before the fullscreen button — this
+is where Critical's idle-timer + autoplay relocate.
+
+### 3. Migrate the three current adopters to the turn contract
+
+- **TicTacToe / Cascade**: replace `turnStatusVariant`+`turnStatusText` with
+  `turn={{ onClockUserId, isMyTurn, isGameOver }}`. They gain the avatar for
+  free. The standalone `TurnBadge` inside their `board` is reviewed: keep if it
+  shows board-specific detail (active color / direction), otherwise drop in
+  favor of the header indicator. (Cascade's `TurnBadge` shows active color +
+  direction → **keep**; it is board state, not turn identity.)
+- **SeaBattle**: replace its hand-built `turnAvatar` block with the `turn`
+  contract; delete the local `InGameAvatar` wiring it duplicated.
+
+### 4. Migrate Critical onto the shell
+
+- Replace Critical's own `GameContainer` (styles/layout.tsx) usage in
+  [Game.tsx](../../../apps/web/src/widgets/CriticalGame/ui/Game.tsx) /
+  [ActiveGameView.tsx](../../../apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx)
+  with `GameWidgetContainer`.
+- Header → standard `headerProps` with the `turn` contract derived from
+  Critical's `currentPlayer` / `isMyTurn` / `isGameOver`.
+- `IdleTimerDisplay` + `AutoplayControls` → `extraActions`.
+- Critical's `SceneBackdrop` / scene palette stays inside the `board` slot.
+- Critical's own widget-level fullscreen + chat-popup are removed (the shell
+  provides both). Keep `criticalWidgetFullscreenStyles` deletion in scope.
+- The complex grid (`MatchWidget`, opponents row, arena, hand) renders inside
+  the `board` slot unchanged.
+
+### 5. Glimworm no-turn header
+
+- Wrap Glimworm's in-game canvas in `GameWidgetContainer` with a `headerProps`
+  that uses the existing `turnStatusText` escape hatch (no `turn` contract):
+  status text reflects countdown / playing / ended (e.g. alive-count). No turn
+  pill, no avatar — turns don't exist in a real-time game.
+- Glimworm's HUD/overlays stay inside the `board` slot. The canvas must still
+  size correctly inside `SharedGameBoard` (min-height preserved).
+- Lobby still early-returns outside the container (matches every other game).
+
+### 6. `/new-game` scaffold
+
+Update [.claude/skills/new-game/SKILL.md](../../../.claude/skills/new-game/SKILL.md)
+Game.tsx pattern to pass the `turn` contract instead of manual
+`turnStatusVariant`/`turnStatusText`, and document `TurnIndicator` + the
+no-turn `turnStatusText` escape hatch for real-time games.
+
+## Data Flow
+
+```
+GamePageLayout (page chrome, already shared)
+  ├─ registers resolveDisplayName / resolveEquipped / currentUserId → GameChat store
+  └─ <Game /> (per registry)
+        └─ GameWidgetContainer (shared shell)
+              ├─ header: TurnIndicator(onClockUserId,isMyTurn) ──┐
+              │     ├─ name  ← GameChat store.resolveDisplayName  │ for free,
+              │     └─ avatar← InGameAvatar(playerId) ← game store│ id only
+              ├─ extraActions (Critical: idle timer + autoplay)
+              ├─ board / tableArea / handSection (per-game)
+              ├─ modals (per-game; GameResultModal shared)
+              └─ GameChatPopupOverlay (shared)
+```
+
+## Error / Edge States
+
+- `onClockUserId` null (setup, between turns, spectator) → "Waiting…", no
+  avatar crash (InGameAvatar only renders when id present).
+- Player not in roster yet (late join) → name falls back to "opponent"/id via
+  the existing resolver fallback chain in `GamePageLayout`.
+- Game over → `completed` status regardless of whose clock it was.
+- Glimworm (no `turn`) → never touches TurnIndicator.
+
+## Testing
+
+- **TurnIndicator unit tests** (Vitest): my-turn, other-turn (renders name +
+  avatar), null id (waiting), game-over (completed). Verify i18n keys, not
+  literals.
+- **GameWidgetContainer** test: `turn` contract renders TurnIndicator; legacy
+  `turnStatusText` path still renders raw pill (Glimworm).
+- Update existing SeaBattle/TicTacToe/Cascade widget tests for the new header.
+- Critical: keep existing `MatchWidget`/`TurnBanner` tests green; add a smoke
+  test that `ActiveGameView` renders inside the shared shell with the turn pill.
+- Manual/Playwright: existing game e2e smoke per game still passes (lobby →
+  start → header shows correct turn → fullscreen toggles → chat opens).
+- Verify with `pnpm lint`, `pnpm test` (web), `pnpm build`, and
+  `pnpm check-file-length`.
+
+## Rollout / Risk
+
+- Highest risk: Critical migration (large, intricate, well-tested widget).
+  Mitigation — migrate the container/header only; leave the gameplay grid
+  untouched, lean on existing Critical tests, add a shell smoke test.
+- Back-compat: keeping the legacy `turnStatusText`/`turnAvatar` props means the
+  migration can land game-by-game without a flag day.
+
+## Files Touched (estimate)
+
+- NEW `apps/web/src/features/games/ui/TurnIndicator.tsx` (+ test)
+- `apps/web/src/features/games/ui/GameWidgetContainer.tsx`
+- `apps/web/src/features/games/ui/index.ts` (export TurnIndicator)
+- `apps/web/src/widgets/CascadeGame/ui/Game.tsx`
+- `apps/web/src/widgets/TicTacToeGame/ui/Game.tsx`
+- `apps/web/src/widgets/SeaBattleGame/ui/Game.tsx`
+- `apps/web/src/widgets/CriticalGame/ui/{Game,ActiveGameView}.tsx` (+ styles cleanup)
+- `apps/web/src/widgets/GlimwormGame/GlimwormGame.tsx`
+- `.claude/skills/new-game/SKILL.md`
+- i18n locale files (`en/ru/es/fr/by`) for any new `games.table.*` turn keys.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicoapp-monorepo",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicoapp-monorepo",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeum/ui",
-  "version": "1.15.11",
+  "version": "1.16.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeum/ui",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## What
Consolidates game widget chrome into a single shared `GameWidgetContainer`, introducing a standard turn contract (`TurnIndicator`) so every game gets header, fullscreen, chat popup, and turn display for free.

## Why
Each game previously re-implemented its own container, header, and turn display with inconsistent behavior. Critical and Glimworm didn't use the shared shell at all. This refactor eliminates duplication and ensures adding a new game gets all widget chrome automatically.

## Changes
- **New `TurnIndicator` component** — renders on-clock player avatar + name via declarative `{ onClockUserId, isMyTurn, isGameOver }` contract
- **Migrated Cascade, TicTacToe** to use the `turn` contract (gained avatar for free)
- **Migrated Critical** onto shared `GameWidgetContainer` — removed bespoke `GameContainer`, fullscreen system, and header; relocated idle-timer/autoplay to `extraActions` slot
- **Migrated Glimworm** onto shared shell with no-turn status header (countdown/playing/ended text)
- **Cascade card rework** — replaced UNO-like card faces with dark-glass "energy cards" (prismatic wild auras, luminous edge + glowing numeral, ghost glyph)
- **New `.claude/` configuration** — settings, hooks (env block, tsc check, UI component check), and 7 skills for Claude Code
- **Design spec** — `2026-05-30-shared-game-shell-design.md` documenting the architecture
- **Cascade board rework handoff** — `CASCADE_BOARD_REWORK_HANDOFF.md` for follow-up work
- i18n keys for turn states and game-specific messages
- Unit tests for `TurnIndicator` and `useGameChatSend`