### PR TITLE
ARC-455 feat: claude config

### DIFF
--- a/.claude/hooks/block-env-access.js
+++ b/.claude/hooks/block-env-access.js
@@ -1,0 +1,18 @@
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  const toolArgs = JSON.parse(Buffer.concat(chunks).toString());
+
+  const filePath =
+    toolArgs.tool_input?.file_path || toolArgs.tool_input?.path || "";
+
+  if (filePath.includes(".env") && !filePath.endsWith(".env.example")) {
+    console.error("Access to .env* files is blocked for security");
+    process.exit(2);
+  }
+}
+
+main();

--- a/.claude/hooks/tsc-check.sh
+++ b/.claude/hooks/tsc-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse hook: runs tsc --noEmit after editing .ts/.tsx files.
+# Outputs additionalContext with errors and exits 2 to wake the model.
+
+set -euo pipefail
+
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
+
+# Only check TypeScript files
+echo "$f" | grep -qE '\.(ts|tsx)$' || exit 0
+
+# Determine which app owns the file
+if echo "$f" | grep -q '/apps/web/'; then
+  dir="apps/web"
+elif echo "$f" | grep -q '/apps/be/'; then
+  dir="apps/be"
+elif echo "$f" | grep -q '/apps/mobile/'; then
+  dir="apps/mobile"
+elif echo "$f" | grep -q '/packages/ui/'; then
+  dir="packages/ui"
+else
+  exit 0
+fi
+
+errors=$(cd "$PWD/$dir" && pnpm tsc --noEmit 2>&1) || true
+
+if [ -n "$errors" ]; then
+  msg=$(echo "$errors" | head -50)
+  jq -n --arg ctx "TypeScript errors found after editing $f in $dir:\n$msg" \
+    '{hookSpecificOutput:{hookEventName:"PostToolUse",additionalContext:$ctx}}'
+  exit 2
+fi

--- a/.claude/hooks/ui-component-check.sh
+++ b/.claude/hooks/ui-component-check.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse hook: warns when a .tsx component file is created outside packages/ui.
+# Outputs additionalContext to remind Claude to check @arcadeum/ui first.
+
+set -euo pipefail
+
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty' 2>/dev/null)
+
+# Only check .tsx files
+echo "$f" | grep -qE '\.tsx$' || exit 0
+
+# Skip packages/ui itself — that's the right place
+echo "$f" | grep -q '/packages/ui/' && exit 0
+
+# Skip story, test, and page files — not reusable components
+echo "$f" | grep -qE '\.(stories|test|spec)\.tsx$' && exit 0
+echo "$f" | grep -qE '/(page|layout|loading|error|not-found)\.tsx$' && exit 0
+
+# Only flag files inside a /components/ directory
+echo "$f" | grep -q '/components/' || exit 0
+
+# Skip files that are clearly app-level compositions (contain "View", "Client", "Container" suffix)
+basename=$(basename "$f" .tsx)
+echo "$basename" | grep -qE '(View|Client|Screen|Page)$' && exit 0
+
+jq -n --arg f "$f" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: ("Component file created outside @arcadeum/ui: " + $f + "\n\nBefore finalizing this component, verify:\n1. Does an existing @arcadeum/ui component already cover this use case? Run /check-ui-components to audit.\n2. If this component is reusable across apps, it must live in packages/ui/src/components/, not in the app.\n3. If it is truly app-specific (composes shared components for one screen), it can stay — but its building blocks must come from @arcadeum/ui.")
+  }
+}'
+exit 2

--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $PWD/.claude/hooks/block-env-access.js",
+            "statusMessage": "Checking for .env* access..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,75 @@
+{
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "mcp__playwright",
+      "Bash(npm *)",
+      "Bash(git *)",
+      "Bash(ls *)",
+      "Bash(vitest *)"
+    ],
+    "deny": [
+      "Bash(git push origin --delete main)",
+      "Bash(git push origin --delete main *)",
+      "Bash(git push origin --delete develop)",
+      "Bash(git push origin --delete develop *)",
+      "Bash(git push origin --delete staging)",
+      "Bash(git push origin --delete staging *)",
+      "Bash(git push --delete origin main)",
+      "Bash(git push --delete origin main *)",
+      "Bash(git push --delete origin develop)",
+      "Bash(git push --delete origin develop *)",
+      "Bash(git push --delete origin staging)",
+      "Bash(git push --delete origin staging *)",
+      "Bash(git push origin :main)",
+      "Bash(git push origin :main *)",
+      "Bash(git push origin :develop)",
+      "Bash(git push origin :develop *)",
+      "Bash(git push origin :staging)",
+      "Bash(git push origin :staging *)",
+      "Bash(git branch -D main)",
+      "Bash(git branch -D main *)",
+      "Bash(git branch -D develop)",
+      "Bash(git branch -D develop *)",
+      "Bash(git branch -D staging)",
+      "Bash(git branch -D staging *)",
+      "Bash(gh api -X DELETE *)",
+      "Bash(gh api --method DELETE *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node $PWD/.claude/hooks/block-env-access.js",
+            "statusMessage": "Checking for .env* access..."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $PWD/.claude/hooks/tsc-check.sh",
+            "asyncRewake": true,
+            "timeout": 60,
+            "statusMessage": "Running tsc..."
+          },
+          {
+            "type": "command",
+            "command": "bash $PWD/.claude/hooks/ui-component-check.sh",
+            "asyncRewake": true,
+            "timeout": 10,
+            "statusMessage": "Checking UI component placement..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/check-ui-components/SKILL.md
+++ b/.claude/skills/check-ui-components/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: check-ui-components
+description: Check existing @arcadeum/ui components before implementing any new UI. Use before writing any component — reuse what exists, add to packages/ui if missing.
+---
+
+Before writing any UI component, you MUST audit the shared library. Never implement custom UI that duplicates an existing shared component.
+
+## Step 1 — Read the current component catalog
+
+Read `packages/ui/src/index.ts` to get the full list of exported components. Then read the `.tsx` file of any component that might match the need to check its props and variants.
+
+**Current components in `@arcadeum/ui`:**
+
+| Component | Key props / variants | Use for |
+|---|---|---|
+| `Button` | `size`, `variant`, `loading`, `disabled`, `gameVariant`, `showShimmer` | All buttons and CTAs |
+| `LinkButton` | Same as Button + `href` | Navigation buttons |
+| `SpecializedButtons` | `BackButton`, `CloseButton`, `HomeButton` | Icon-only nav buttons |
+| `Card` | `variant` (default/elevated/outlined/glass/error), `padding` (none/sm/md/lg) | Content containers |
+| `GlassCard` | `padding`, `bordered` | Frosted-glass content containers |
+| `Avatar` | `size`, `src`, `fallback` | User/player avatars |
+| `Badge` | `variant`, `size` | Status/count labels |
+| `CosmeticBadge` | `type`, `rarity` | Game cosmetic labels |
+| `RoleBadge` | `role` | User role labels |
+| `IdleBadge` | — | Idle/away indicator |
+| `Input` | `label`, `error`, `disabled`, `leftIcon`, `rightIcon` | Text inputs |
+| `TextArea` | `label`, `error`, `rows` | Multi-line text inputs |
+| `Select` | `label`, `error`, `options`, `value`, `onChange` | Dropdowns |
+| `FormGroup` | `label`, `error`, `required`, `hint` | Form field wrapper |
+| `Modal` | `open`, `onClose`, `title`, `size` | Dialog/overlay |
+| `Spinner` | `size`, `color` | Loading spinner |
+| `LoadingState` | `message` | Full loading placeholder |
+| `PageLoading` | — | Full-page loading screen |
+| `Skeleton` | `width`, `height`, `borderRadius`, `variant` | Content skeleton placeholders |
+| `Progress` | `value`, `max`, `variant`, `showLabel` | Progress bars |
+| `EmptyState` | `title`, `description`, `icon`, `action` | Empty list/data state |
+| `ErrorState` | `title`, `description`, `onRetry` | Error with retry |
+| `Section` | `title`, `description`, `actions` | Page section with heading |
+| `PageLayout` | `header`, `footer`, `sidebar` | Top-level page shell |
+| `PageTitle` | `title`, `subtitle`, `breadcrumbs` | Page heading block |
+| `Container` | `size` (sm/md/lg/xl/full), `centered` | Max-width content wrapper |
+| `Divider` | `orientation`, `color` | Horizontal/vertical separator |
+| `CollapsibleSection` | `title`, `defaultOpen` | Expandable section |
+| `ConnectionOverlay` | `status` | Network connection status |
+| `ServerLoadingNotice` | — | Server warmup notice |
+| `Typography` | `variant`, `color`, `weight` | Text with design-token styles |
+| `Icons` | (many named icons) | SVG icon set |
+| `ChatHeader` | `title`, `subtitle`, `actions` | Chat window header |
+| `ChatMessage` | `message`, `isOwn`, `timestamp` | Chat bubble |
+| `ChatInput` | `onSend`, `placeholder`, `disabled` | Chat text input with send |
+| `GameContainer` | `header`, `footer` | Game widget shell |
+| `GameLayout` | `board`, `sidebar` | Game board + sidebar split |
+| `TurnIndicator` | `currentPlayer`, `players` | Whose-turn indicator |
+| `Footer` | `links`, `socials` | App footer |
+| `MobileLoginIndicator` | — | Mobile auth status |
+| `DownloadButtons` | `platform` | App store download CTAs |
+| `XStack`, `YStack`, `ZStack`, `ScrollView`, `ThemeableStack` | (Tamagui layout) | Layout primitives |
+
+## Step 2 — Decide: reuse or create
+
+**If an existing component covers the need** (even partially with props/variants):
+- Use it from `@arcadeum/ui`. Do NOT create a local wrapper unless it adds real domain logic.
+- Show the import: `import { ComponentName } from '@arcadeum/ui'`
+- If the existing component needs a new variant/prop to fit the need, extend it in `packages/ui` rather than wrapping it locally.
+
+**If no existing component fits** (genuinely new pattern):
+- The component MUST be created in `packages/ui`, not inline in the app.
+- Follow the `/new-ui-component` skill to add it:
+  1. `packages/ui/src/components/<Name>/<Name>.tsx` — Tamagui-based implementation
+  2. `packages/ui/src/components/<Name>/index.ts` — re-export
+  3. `packages/ui/src/components/<Name>/<Name>.stories.tsx` — Storybook story (required)
+  4. Register in `packages/ui/src/index.ts`
+  5. Then import `{ Name } from '@arcadeum/ui'` in the app
+
+## Step 3 — Extending an existing component
+
+If the existing component almost fits but needs a new variant or prop:
+1. Read the component's `.tsx` and its `types.ts`/`StyledComponent` to understand its variant system
+2. Add the new variant/prop to `packages/ui/src/components/<Name>/<Name>.tsx`
+3. Export the updated type from `index.ts`
+4. Add a Storybook story for the new variant in `<Name>.stories.tsx`
+5. Do NOT duplicate the component — extend it in place
+
+## Rules
+
+- Never create a component file in `apps/web`, `apps/mobile`, or `apps/be` if it belongs in the shared library
+- One-off app-specific compositions (combining 2–3 shared components for a specific screen) are fine as local view files — but the individual building blocks must come from `@arcadeum/ui`
+- Check `packages/ui/src/tamagui.config.ts` for design tokens before hardcoding colors/spacing
+- All new components must be platform-agnostic (web + React Native), so avoid `react-native` imports; use Tamagui primitives

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: commit
+description: Create a git commit following the project's Conventional Commits convention with ARC ticket reference. Use when committing changes.
+---
+
+When creating a commit:
+
+1. Run `git status` and `git diff --staged` to understand what's being committed
+2. Determine the type: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+3. Determine the scope from the current branch (e.g. `ARC-425` → scope is the affected area like `web`, `be`, `mobile`)
+4. Write the commit message:
+
+```
+<type>(ARC-XXX): <short description>
+```
+
+- Subject: lowercase, no period at end, imperative mood ("add" not "added")
+- Keep header under 72 characters
+- Add body if needed to explain *why*, not *what*
+
+5. Stage relevant files and commit:
+
+```bash
+git add <specific files>
+git commit -m "<type>(ARC-XXX): <description>"
+```
+
+Do NOT use `git add -A` or `git add .` — stage specific files to avoid committing secrets or unrelated changes.

--- a/.claude/skills/new-be-module/SKILL.md
+++ b/.claude/skills/new-be-module/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: new-be-module
+description: Add a new NestJS module to the backend (apps/be). Use when creating a new domain/feature in the backend.
+---
+
+The backend uses NestJS with Mongoose (MongoDB), JWT auth, and Socket.io for real-time.
+
+## Folder structure
+
+```
+apps/be/src/<module-name>/
+  <name>.module.ts       ← NestJS module, registers all providers and Mongoose schemas
+  <name>.controller.ts   ← REST endpoints (use @JwtAuthGuard for protected routes)
+  <name>.service.ts      ← Business logic
+  <name>.gateway.ts      ← (optional) WebSocket gateway for real-time features
+  schemas/
+    <name>.schema.ts     ← Mongoose schema + type export
+  dtos/
+    create-<name>.dto.ts ← DTOs with class-validator decorators
+```
+
+## Steps
+
+1. **Schema** (`schemas/<name>.schema.ts`):
+   ```ts
+   import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+   import { Document } from 'mongoose';
+
+   export type <Name>Document = <Name> & Document;
+
+   @Schema({ timestamps: true })
+   export class <Name> { ... }
+
+   export const <Name>Schema = SchemaFactory.createForClass(<Name>);
+   ```
+
+2. **DTOs** with `class-validator`:
+   ```ts
+   import { IsString, IsNotEmpty } from 'class-validator';
+   export class Create<Name>Dto { @IsString() @IsNotEmpty() field: string; }
+   ```
+
+3. **Service** — inject `@InjectModel(<Name>.name) private model: Model<<Name>Document>`
+
+4. **Controller** — use `@UseGuards(JwtAuthGuard)` for protected routes, `@Controller('<name>')` prefix
+
+5. **Module** — register `MongooseModule.forFeature([{ name: <Name>.name, schema: <Name>Schema }])`, declare controller and service
+
+6. **Register** the new module in `apps/be/src/app.module.ts`
+
+## Key imports
+
+```ts
+import { JwtAuthGuard } from '../auth/jwt/jwt-auth.guard';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Module, Controller, Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+```

--- a/.claude/skills/new-game/SKILL.md
+++ b/.claude/skills/new-game/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: new-game
+description: Add a complete new multiplayer game to Arcadeum (BE engine + service + gateway + bot, web widget, landing page, registries, i18n, tests). Use when the user says "implement game X" or "add a new game".
+---
+
+This skill turns a single instruction ("implement chess", "add Connect Four") into a fully wired, shippable game. Follow every step in order — partial wiring causes the runtime errors listed in the Gotchas section.
+
+## Reference implementations
+
+When in doubt, **mirror sea-battle** ([apps/be/src/games/engines/sea-battle/](apps/be/src/games/engines/sea-battle/), [apps/web/src/widgets/SeaBattleGame/](apps/web/src/widgets/SeaBattleGame/)) — it is the canonical full-stack game. The most recent reference is tic-tac-toe ([apps/be/src/games/engines/tic-tac-toe/](apps/be/src/games/engines/tic-tac-toe/), [apps/web/src/widgets/TicTacToeGame/](apps/web/src/widgets/TicTacToeGame/)).
+
+## Naming convention
+
+Pick a short snake_case id with `_v1` suffix: `chess_v1`, `connect_four_v1`. Use it consistently:
+- Engine id: `chess_v1`
+- Widget folder: `ChessGame`
+- Landing route: `/games/chess`
+- Socket event prefix: `chess.session.*` (camelCase, matches existing pattern: `ticTacToe.session.*`, `seaBattle.session.*`)
+
+## Architecture (two halves)
+
+**Backend half** — engine (pure logic) + service (orchestration) + gateway (socket events) + bot.
+**Web half** — widget (UI) + registry entry (lazy loader) + landing page (SEO marketing) + create-page integration + home featured-games entry.
+
+A game is "done" only when **all** of: BE catalog + BE module + web registry + web GameType unions (two!) + landing route + home + create page + admin (auto via catalog) + i18n (5 locales) + SEO + tests + PR.
+
+## Step-by-step checklist
+
+### 1. Brainstorm + design (skip only if user gave full spec)
+
+Use `/brainstorming` to capture: player count, board/state shape, win condition, variants (visual themes), team mode, bot strategy, special rules. Save spec to `docs/superpowers/specs/YYYY-MM-DD-<game>-design.md`. Then `/writing-plans` for an implementation plan at `docs/superpowers/plans/YYYY-MM-DD-<game>.md`.
+
+### 2. Backend engine
+
+Create `apps/be/src/games/engines/<game>/`:
+- `<game>.constants.ts` — `MIN_PLAYERS`, `MAX_PLAYERS` (overall ceiling), variants array, defaults. **If the game has per-option player caps** (e.g. tic-tac-toe's 3×3=2 / 5×5=3 / 7×7=4 / 9×9=5), export a `MAX_PLAYERS_BY_<OPTION>` map. The service enforces the per-option cap at `startSession`; `MAX_PLAYERS` is the union ceiling so the room layer never grows past what any variant supports.
+- `<game>.types.ts` — `State`, `Options`, `Player`, `Team`, action payloads. State **must include** `logs: GameLogEntry[]`
+- `<game>.utils.ts` — pure helpers (e.g. win detection)
+- `<game>.validators.ts` — return `{ ok: true } | { ok: false, error: string }`
+- `<game>.engine.ts` — `extends BaseGameEngine<State>` from `apps/be/src/games/engines/base/base-game.engine`. Implement: `getMetadata` (returns `GameMetadata`), `initializeState`, `validateAction`, `executeAction`, `isGameOver`, `getWinners`, `sanitizeStateForPlayer`, `getAvailableActions`.
+
+`GameLogEntry` and the `createLogEntry` helper live in `apps/be/src/games/engines/base/game-log.ts`. State must include `logs: GameLogEntry[]`; push entries from `executeAction` so the shared chat can render them.
+
+Register the engine in [apps/be/src/games/engines/engines.module.ts](apps/be/src/games/engines/engines.module.ts).
+
+### 3. Backend service + bot + gateway
+
+Two separate locations — **don't put the gateway in the subdir**:
+
+```
+apps/be/src/games/<game>/
+  <game>.service.ts        ← orchestrates GameRoomsService, GameSessionsService,
+                              GameHistoryService, GamesRealtimeService.
+                              Watchdog interval if turns are time-bounded.
+  <game>-bot.service.ts    ← dispatch strategy by difficulty / state size.
+
+apps/be/src/games/
+  <game>.gateway.ts        ← SIBLING of the subdir, NOT inside it.
+                              Mirrors sea-battle.gateway.ts / tic-tac-toe.gateway.ts.
+```
+
+Gateway handlers use `@SubscribeMessage('<camelCase>.session.start' | '.<action>' | '.forfeit')` — see Socket events parity below.
+
+Wire into [apps/be/src/games/games.module.ts](apps/be/src/games/games.module.ts) — add all three as providers; gateway is a provider, not an export.
+
+**Socket events parity (BE ↔ FE):** the strings in `@SubscribeMessage(...)` on the BE gateway MUST match the strings in `gameSocket.emit(...)` from the FE's `useActions.ts` hook, character for character. Drift here results in silent no-ops with no error.
+
+### 4. Backend catalog
+
+Add the game to [apps/be/src/games/games.catalog.ts](apps/be/src/games/games.catalog.ts):
+```ts
+{ gameId: '<game>_v1', variants: ['classic', 'neon', ...] },
+```
+This entry **also drives `/admin/games` visibility** — without it, admins can't see the game.
+
+### 5. Web widget
+
+Create `apps/web/src/widgets/<Name>Game/`:
+```
+types/index.ts              ← props, state, options, log entry types
+lib/constants.ts            ← VARIANTS array — id, name (i18n key), emoji, gradient
+lib/theme.ts                ← getTheme(variant) → token map (board/cell/mark colors…)
+lib/<Name>ThemeContext.tsx  ← Provider + useTheme hook
+hooks/useState.ts           ← Zustand selector → derived snapshot
+hooks/useActions.ts         ← gameSocket.emit wrappers — strings MUST match BE gateway
+hooks/index.ts              ← barrel re-export
+ui/Game.tsx                 ← root; default-export memoized
+ui/Lobby.tsx                ← wraps shared ReusableGameLobby, supplies an optionsSlot
+ui/Board.tsx                ← in-game UI
+ui/TurnBadge.tsx
+ui/RulesModal.tsx           ← in-game rules (uses @arcadeum/ui Modal primitives)
+index.ts                    ← barrel — must default-export the memoized Game
+                              (the registry does import('@/widgets/<Name>Game'))
+```
+
+**Critical Game.tsx pattern** (mirror sea-battle exactly):
+
+```tsx
+if (!room) return null;
+
+// Lobby renders OUTSIDE GameWidgetContainer so it gets full page height.
+// The container's `board` slot is sized for the in-game grid.
+if (isLobby) {
+  return (
+    <ThemeProvider variant={options.variant}>
+      <Lobby ...props />
+    </ThemeProvider>
+  );
+}
+
+const board = (
+  <YStack gap="$3" alignItems="stretch" padding="$3" width="100%">
+    {snapshot ? <><TurnBadge .../><Board .../></> : null}
+  </YStack>
+);
+
+return (
+  <ThemeProvider variant={options.variant}>
+    <GameWidgetContainer
+      board={board}
+      modals={modals}
+      variant={options.variant}
+      isMyTurn={myTurn}
+      isGameOver={isGameOver}
+      headerProps={{
+        variantEmoji: variantTokens.emoji,
+        title: '<Name>',
+        subtitle: room?.name,
+        // The declarative turn contract: pass only the on-clock player's id +
+        // whether it's your turn. The shared shell renders the turn-with-avatar
+        // pill (avatar + name + "Your turn / {name}'s turn") for free — no
+        // per-game header markup, no manual turnStatusText.
+        turn: {
+          onClockUserId: currentTurnUserId, // e.g. snapshot.currentEntryId
+          isMyTurn: myTurn,
+          isGameOver,
+        },
+      }}
+    />
+  </ThemeProvider>
+);
+```
+
+**Turn header — always use the `turn` contract.** `onClockUserId` is the
+**userId** of the player on the clock (compare it against `currentUserId` to
+derive `myTurn`). The shell resolves their display name (chat-store resolver,
+registered via `useGameChatIntegration`) and equipped avatar
+([InGameAvatar](apps/web/src/features/games/ui/InGameAvatar.tsx)). Pass `null`
+when nobody is on the clock (setup / between turns) → the pill shows "Waiting…".
+
+**Real-time games (no turns)** — skip the `turn` contract and use the legacy
+escape hatch instead: `turnStatusText` + `turnStatusVariant` for a plain status
+pill (see [GlimwormGame](apps/web/src/widgets/GlimwormGame/GlimwormGame.tsx),
+which shows Get ready / In play / Round over with no avatar).
+
+**Critical Board.tsx pattern** — the grid container MUST have explicit `width: '100%'` plus `boxSizing: 'border-box'`. Without `width`, an `aspectRatio: '1/1'` grid of empty buttons collapses to ~0px and you see only a colored sliver. See [apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx](apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx).
+
+**End-game UI: reuse the shared [GameResultModal](apps/web/src/features/games/ui/GameResultModal.tsx).** Don't write a per-game game-over modal. It already handles victory/defeat/draw tones (gold / red / silver), confetti, rematch button, animated entrance, and `Back to home` link. If your game's vocabulary differs from `games.table.victory/defeat/draw`, pass a `messages={{ title, message? }}` prop to override the headline/body without touching shared i18n. Map your game's local result type (`'won'|'lost'|'draw'`) to the shared `'victory'|'defeat'|'draw'` before passing it in. See [apps/web/src/widgets/TicTacToeGame/ui/Game.tsx](apps/web/src/widgets/TicTacToeGame/ui/Game.tsx).
+
+**Required Game.tsx hooks:** every widget needs the same shared hooks wired the same way. Forgetting one means: no rematch (no `useRematch`), no chat panel (no `useGameChatIntegration`), or runtime errors when passing `t` to `GameResultModal` (no `useTranslation`).
+
+```tsx
+const { t } = useTranslation();
+const { rematchLoading, handleRematch } = useRematch({ roomId });
+useGameChatIntegration(snapshot?.logs as never, (_msg, _scope) => {
+  // chat sends go through the shared composer — no game-specific socket event
+});
+```
+
+**Lobby pattern:** `<Name>Lobby.tsx` wraps the shared `ReusableGameLobby` and only contributes an `optionsSlot` (variant picker, board-size selector, team toggle, etc.). Don't reimplement the player list, kick controls, host badge, or start button — they live in `ReusableGameLobby`.
+
+### 6. Web registry — three files
+
+a. [apps/web/src/features/games/registry.ts](apps/web/src/features/games/registry.ts) — add lazy loader:
+```ts
+'<game>_v1': () => import('@/widgets/<Name>Game'),
+```
+Plus a metadata entry with: `name`, `description`, `category`, `minPlayers`, `maxPlayers` (overall ceiling — match BE engine `getMetadata()`), `estimatedDuration`, `complexity`, `ageRating`, `thumbnail`, `version`, `supportsAI`, `tags`, `status` (`'stable'|'beta'`).
+
+b. [apps/web/src/features/games/lib/gameIdMapping.ts](apps/web/src/features/games/lib/gameIdMapping.ts) — add `'<game>_v1'` to **both** the `GameType` union AND the `VALID_GAME_IDS` array.
+
+c. [apps/web/src/features/games/hooks/useGameActions.ts](apps/web/src/features/games/hooks/useGameActions.ts) — has a **separate** `GameType` union (yes, duplicated). Add `'<game>_v1'` here too. **Forgetting this throws "Unsupported game type" at runtime.**
+
+### 7. Landing page
+
+Create `apps/web/src/app/[locale]/games/<game>/`:
+- `page.tsx` — server component with `buildPageMetadata` + `JsonLd` VideoGame schema
+- `<Name>Landing.tsx` — hero, highlights, steps, themes, rules, FAQ, CTAs, breadcrumbs
+- `<Name>Hero.tsx` — static decorative board/state preview
+- `<Name>ThemesGrid.tsx`
+- `<Name>FinalCtaButtons.tsx`
+- `opengraph-image.tsx` — 1200×630 `ImageResponse`
+- `twitter-image.tsx` — `export { default } from './opengraph-image'`
+
+Add to:
+- [apps/web/src/shared/config/routes.ts](apps/web/src/shared/config/routes.ts) — `<game>Landing: '/${locale}/games/<game>'`
+- [apps/web/src/shared/seo/buildPageMetadata.ts](apps/web/src/shared/seo/buildPageMetadata.ts) — `DEFAULT_PATH_BUILDERS` entry
+
+**`createRoomHref` MUST use `?gameId=<game>_v1`** (the param name `GameCreateView` reads via `searchParams.get('gameId')`). Don't invent `?slug=` or `?game=` — those silently fall through to `VISIBLE_GAMES[0]` (Critical) and the user lands on the wrong preselected game. Don't append `&variant=...`; the view defaults to `themesFor(gameId)[0]` and appending a default would duplicate the param when the themes-grid links add their own.
+
+### 8. Home + Create page
+
+a. [apps/web/src/app/[locale]/home/data/games.ts](apps/web/src/app/[locale]/home/data/games.ts) — add to `featuredGames` (players range, duration, `landingHref`, variant count).
+
+a2. **Home featured-card symbol** — create `apps/web/src/app/[locale]/home/components/featured-games/symbols/<Name>Symbol.tsx` (64×64 SVG using `stroke="currentColor"`, mirroring [SeaBattleSymbol.tsx](apps/web/src/app/[locale]/home/components/featured-games/symbols/SeaBattleSymbol.tsx)). Export it from `symbols/index.ts` and add a `case '<game>_v1':` branch to [`GameSymbol`](apps/web/src/app/[locale]/home/components/featured-games/gameMeta.tsx). Without this, the home card cover renders `null` instead of a glyph.
+
+b. [apps/web/src/features/games/ui/create/redesign/data/themes.ts](apps/web/src/features/games/ui/create/redesign/data/themes.ts):
+- Extend `GameId` union
+- Add `GAMES` entry
+- Add to `VISIBLE_GAMES`
+- Add `<NAME>_THEMES` constant
+- Add a `themesFor()` branch
+- Export a `find<Name>Theme()` helper
+
+c. [apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx](apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx) — add picker block for the game. **The button MUST include a `<div className={s.themeArt}>` with a real-board thumbnail** (mirroring sea-battle's `SeaBattleBoardPoster` and critical's `CriticalMiniCluster`). Text-only picker cards look broken next to other games. Create `art/<Name>BoardPoster.tsx` as a pure SVG that renders a fixed mid-game snapshot using the widget's per-variant palette (import `getTheme(variant)` from the widget's `lib/theme.ts` — don't re-declare palettes). Use `preserveAspectRatio="xMidYMid slice"` and fill the container with the variant background — the poster slot is wide (16:9 sm, 5:4 lg), not square. See [apps/web/src/features/games/ui/create/redesign/art/TicTacToeBoardPoster.tsx](apps/web/src/features/games/ui/create/redesign/art/TicTacToeBoardPoster.tsx).
+
+d. [apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx](apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx) — **MUST add a branch for the new game**. This component routes the small game-card thumbnail (left grid on `/games/create`) AND the right-rail LIVE PREVIEW. The default fallback is the Glimworm snake poster, so any unrouted game silently renders as glowing snake trails. Add: `if (gameId === '<game>_v1') return <NameBoardPoster theme={find<Name>Theme(themeId)} size={size} />;`
+
+e. [apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx](apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx) — wire the game's `RulesModal` here. Without this, the "Game Rules" button on the create-page rail renders but does nothing when clicked (the button is only hidden for `glimworm_v1`; every other game shows it). Add a `dynamic()` import for `@/widgets/<Name>Game/ui/RulesModal` and a `gameId === '<game>_v1' ? <NameRulesModal ... /> : null` branch.
+
+f. **Mount the same `RulesModal` in BOTH the lobby AND the in-game branch of `Game.tsx`.** The room shell ([GameRoomPage](apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx)) drives `showRulesOpen` from a header button that's visible mid-game; the widget receives `showRulesOpen` / `onShowRulesClose` as props. If you only mount the modal in the lobby's render branch, clicking the in-game rules button toggles state but no modal appears. Wire it via the in-game `modals` slot alongside `GameResultModal`. The header rules trigger is built into the shared shell — you do NOT need to add a button anywhere.
+
+g. [apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx](apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx):
+- Add to `URL_TO_GAME_ID`
+- Add a `buildGameOptions()` branch returning the game's `Options` shape
+
+### 9. i18n — write keys BEFORE referencing them
+
+`TranslationKey` is strictly typed against the catalog. **Components that reference missing keys fail typecheck.** Write all five locale files first:
+
+```
+apps/web/src/shared/i18n/messages/games/<game>/{en,es,fr,ru,by}.ts
+apps/web/src/shared/i18n/messages/seo/{en,es,fr,ru,by}.ts  ← add <game>Landing
+```
+
+Cover: landing (hero/highlights/steps/themes/rules/faq), lobby (variants/options/players/start/leave), in-game (turn/status/result), chat scopes, errors, each variant name+description.
+
+### 10. Tests
+
+- **BE engine**: `apps/be/src/games/engines/<game>/<game>.engine.spec.ts` — happy path, win conditions, illegal actions, forfeit
+- **BE service**: orchestration smoke
+- **BE bot**: difficulty-by-difficulty pickMove (use real engine state, not mocks — see lessons in [feedback_pull_develop_before_push](.claude/projects/.../memory/))
+- **Web hooks**: vitest for `useState`/`useActions`
+- **Web widget**: render test with `TamaguiProvider defaultTheme="light"`
+- **Playwright e2e**: lobby → start → place move → win (can be deferred and listed as follow-up in PR)
+
+### 11. Before-PR punch list
+
+Walk this list manually — these are the surfaces where missing wiring causes silent regressions (text-only thumbnails, "Unsupported game type" toasts, button-clicks that toggle state into the void, etc.):
+
+- [ ] BE engine registered in `engines.module.ts`; service+bot+gateway in `games.module.ts`; entry in `games.catalog.ts`.
+- [ ] Web widget folder has an `index.ts` barrel that default-exports the memoized `Game`.
+- [ ] Widget registered in `features/games/registry.ts` (loader + metadata).
+- [ ] `<game>_v1` added to **both** `GameType` unions: `lib/gameIdMapping.ts` AND `hooks/useGameActions.ts`.
+- [ ] Landing route in `shared/config/routes.ts` + `seo/buildPageMetadata.ts`; CTA uses `?gameId=`.
+- [ ] Home featured-card: data entry in `home/data/games.ts` + symbol branch in `gameMeta.tsx`.
+- [ ] Create page: `themes.ts` + `ThemePicker.tsx` block + `art/<Name>BoardPoster.tsx` + `GameArt.tsx` branch + `GameCreateView.tsx` branch.
+- [ ] Rules modal mounted in lobby AND in-game branches of `Game.tsx`; also wired in `RulesAccess.tsx`.
+- [ ] End-game modal is the shared `GameResultModal`, not a per-game one.
+- [ ] i18n keys present in all 5 locales (en, es, fr, ru, by) — including SEO entries.
+- [ ] BE engine spec + bot spec passing; web hook/widget vitest passing.
+- [ ] [`apps/web/e2e/home-games-slider.spec.ts`](apps/web/e2e/home-games-slider.spec.ts) — bump the expected `toHaveCount(N)` and add the new game's `<h3>` assertion; the test hardcodes the featured-games count and order.
+
+**Mobile scope:** the new-game flow targets web + BE only. Add a mobile screen only if the user explicitly asks; otherwise note "mobile follow-up" in the PR.
+
+### 12. Verify locally, then PR
+
+```bash
+pnpm --filter @arcadeum/be test
+pnpm --filter @arcadeum/web test
+pnpm --filter @arcadeum/be lint
+pnpm --filter @arcadeum/web lint
+pnpm --filter @arcadeum/be typecheck
+pnpm --filter @arcadeum/web typecheck
+pnpm check-file-length
+```
+
+If the pre-push hook flakes (known: see [feedback_web_pre_push_hook_flaky](memory)), verify tests in isolation then push with `--no-verify`. **PR base is `develop`, never `main`** — see [feedback_pr_base_develop](memory).
+
+```bash
+gh pr create --base develop --title "feat(games): add <name> (ARC-XXX)" --body "..."
+```
+
+## Gotchas (every one of these bit us during tic-tac-toe)
+
+1. **Two `GameType` unions.** [gameIdMapping.ts](apps/web/src/features/games/lib/gameIdMapping.ts) AND [useGameActions.ts](apps/web/src/features/games/hooks/useGameActions.ts). Missing the second throws "Unsupported game type: <id>" at runtime, not compile time.
+
+2. **Lobby inside `GameWidgetContainer.board` collapses.** That slot is sized for the in-game grid. Early-return the lobby OUTSIDE the container (sea-battle pattern).
+
+3. **Grid `aspectRatio` without `width: '100%'` collapses to 0px** when children are empty buttons. Always set both `width: '100%'` and `boxSizing: 'border-box'` on the grid container.
+
+4. **Write i18n keys first.** `TranslationKey` validates strictly — component code referencing missing keys won't typecheck.
+
+5. **`GameWidgetContainer` is not children-based.** Props are `board`, `modals`, `headerProps`, `variant`, `isMyTurn`, `isGameOver`. Don't pass children.
+
+6. **Header turn display is the shared `turn` contract**, not hand-rolled text/avatar. Pass `headerProps.turn = { onClockUserId, isMyTurn, isGameOver }` and the shell renders avatar + name + turn label for free. Only real-time/no-turn games fall back to `turnStatusText` + `turnStatusVariant`.
+
+7. **In-game chat popups are free** — the shell renders `GameChatPopupOverlay` for incoming messages. Leave `showChatPopup` at its default (`true`). Only pass `showChatPopup={false}` if your game shows incoming chat its own way (e.g. per-player bubbles) and you need to avoid double display.
+
+6. **`SharedHeaderProps` field names:** `variantEmoji`, `title`, `subtitle`, `turnStatusVariant`, `turnStatusText` (not `gameTitle` / `gameIcon`).
+
+7. **`TurnStatusVariant`** union is `'completed' | 'yourTurn' | 'waiting'` — camelCase, not kebab.
+
+8. **`useRematch`** returns `{ rematchLoading, handleRematch }` (not `loading` / `handleRematchClick`). No `currentUserId` option.
+
+9. **`useGameChatIntegration`** signature is positional: `(logs, sendMessage, resolveDisplayName?, resolveActorColor?)`. Not an options object.
+
+10. **`GameRoomSummary.members`** (not `participants`); each member has `id` (not `userId`).
+
+11. **Tamagui prop strictness:** `Dialog` has no `animation` prop; `Button` has no `themeInverse` prop. Don't add either.
+
+12. **`TamaguiProvider` test render** needs `defaultTheme="light"`.
+
+13. **`GameLogEntry` helper** options: `targetId?: string` — pass `undefined`, not `null`.
+
+14. **Bot test setup:** when testing "bot must block", make sure the bot can't *win* on the same move — otherwise it takes the win and your blocking assertion fails.
+
+15. **Theme picker thumbnail required.** A text-only theme card looks broken next to sea-battle/critical cards that render real boards. Always ship `art/<Name>BoardPoster.tsx` (SVG with a fixed mid-game snapshot) and wire it via `<div className={s.themeArt}>` inside the picker button — pull palette tokens from the widget's `getTheme(variant)`, don't redeclare.
+
+16. **`GameArt.tsx` default falls through to Glimworm snake art.** If you ship a new game and forget to add a branch in `art/GameArt.tsx`, the small game-card thumbnail on `/games/create` AND the right-rail LIVE PREVIEW will both render glowing pink/green snake trails. Always add `if (gameId === '<game>_v1') return <YourBoardPoster ...>` alongside the branches for critical/sea-battle/tic-tac-toe.
+
+17. **`GameSymbol` default returns `null`.** [home/components/featured-games/gameMeta.tsx](apps/web/src/app/[locale]/home/components/featured-games/gameMeta.tsx) is a `switch (gameId)` that returns `null` in its default branch — so a missing case renders an empty cover glyph on the home featured-card. Always add the `case '<game>_v1':` and ship a sibling SVG in `symbols/`.
+
+18. **Landing-page CTA must use `?gameId=`.** `GameCreateView` reads `searchParams.get('gameId')`; any other query key (`?slug=`, `?game=`) is silently ignored and the user lands on Critical (the first entry of `VISIBLE_GAMES`). Sea Battle's landing is the reference: `${routes.gameCreate}?gameId=${SLUG}`.
+
+19. **"Game Rules" button needs its modal wired in `RulesAccess`.** [RulesAccess.tsx](apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx) always renders the button (it only hides for Glimworm). For every other game, you must add a `gameId === '<game>_v1' ? <NameRulesModal .../> : null` branch — otherwise clicking the button toggles `open` but no modal mounts. **Watch the prop name**: sea-battle/critical use `isOpen`, but tic-tac-toe's modal uses `open` — copy whichever name the modal you're wiring actually accepts.
+
+20. **`Dialog.Description` renders as `<p>` — only string/inline children allowed.** Putting a `<YStack>` (or any block element) inside `Dialog.Description` produces invalid HTML (`<div> cannot be a descendant of <p>`) and triggers React's hydration error. Keep `Dialog.Description` as a single short string (it's the `aria-describedby` summary anyway) and hoist any multi-block content out as a sibling of `Description` inside `Dialog.Content`. Or skip raw `Dialog` entirely — `@arcadeum/ui`'s `Modal` / `ModalContent` / `ModalHeader` / `ModalBody` primitives don't have this trap.
+
+21. **Don't write a per-game end-game modal.** [GameResultModal](apps/web/src/features/games/ui/GameResultModal.tsx) is the shared end-game UI (confetti, gold/red/silver tones, rematch button, home link). It accepts `result: 'victory'|'defeat'|'draw'|null` and an optional `messages={{title, message?}}` override for games whose copy doesn't match the shared `games.table.*` keys — tic-tac-toe uses this to surface its own `gameOver.won/lost/draw` strings without touching shared i18n.
+
+22. **Per-option player caps go through the service, not the room.** If players-per-game depends on a game-option (board size, mode, etc.), don't try to mutate the room's `maxPlayers` when the option changes — leave room.maxPlayers at the overall ceiling. Enforce the per-option cap at `startSession` (BE) and surface it in the lobby selector ("3×3 · up to 2"). The BE error message tells the host to reduce players or pick a different option.
+
+23. **`home-games-slider.spec.ts` hardcodes the featured-games count and order.** Adding a new game to `home/data/games.ts` breaks `await expect(gameCards).toHaveCount(N)` and the per-index `toHaveText` assertions. Update both the count and add the new `<h3>` assertion in the same commit as the data change.
+
+## When the user says "implement game X"
+
+Default to fully autonomous mode unless they pause you:
+1. Brainstorm (or accept user-supplied spec), write spec doc.
+2. Write plan doc.
+3. Execute end-to-end through this checklist on a branch `ARC-XXX-<game>` (create if needed).
+4. Commit in logical chunks. Don't squash mid-flight.
+5. Open the PR against `develop`. Done.
+
+Stop only for: ambiguous game rules, design choices that materially affect scope (e.g., "does this need spectator mode?"), or hard failures the skill doesn't cover.

--- a/.claude/skills/new-mobile-screen/SKILL.md
+++ b/.claude/skills/new-mobile-screen/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: new-mobile-screen
+description: Add a new screen to the mobile app (apps/mobile). Use when creating a new route/screen in the Expo Router app.
+---
+
+The mobile app uses Expo Router (file-based routing) with React Native, Tamagui UI, and a custom `useTranslation` hook for i18n.
+
+## Routing structure
+
+```
+apps/mobile/app/
+  (tabs)/          ← tab navigator screens
+  (tv)/            ← TV-specific screens
+  <screen>.tsx     ← top-level screen
+  <domain>/
+    [id].tsx       ← dynamic route
+    _layout.tsx    ← nested layout
+```
+
+## Steps
+
+1. **Create the screen file** at the appropriate path under `apps/mobile/app/`:
+   - Use `export default function <Name>Screen()` (Expo Router requires default export)
+   - For tab screens, place under `(tabs)/`
+
+2. **Use i18n** with the `useTranslation` hook:
+   ```ts
+   import { useTranslation } from '@/lib/i18n';
+   const { t } = useTranslation();
+   // t('some.key')
+   ```
+
+3. **Use shared UI components** from `@arcadeum/ui` (imported via workspace alias):
+   ```ts
+   import { Button, Card, YStack, XStack, Text } from '@arcadeum/ui';
+   ```
+
+4. **Navigation** — use `expo-router` hooks:
+   ```ts
+   import { useRouter, useLocalSearchParams } from 'expo-router';
+   ```
+
+5. **Add translations** to `apps/mobile/lib/i18n/messages/` for all locales.
+
+6. **Register in tab bar** (if adding a tab): update `apps/mobile/app/(tabs)/_layout.tsx`
+
+## Key patterns
+
+- Wrap screens with `<SafeAreaView>` or the project's screen wrapper
+- Auth-protected screens should check `useSessionTokens()` store and redirect to `auth` if unauthenticated
+- Use `useColorScheme()` from `@/hooks/useColorScheme` for theme-aware styling

--- a/.claude/skills/new-ui-component/SKILL.md
+++ b/.claude/skills/new-ui-component/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: new-ui-component
+description: Add a new shared UI component to the @arcadeum/ui package (packages/ui). Use when creating reusable components shared across web and mobile.
+---
+
+The shared UI library (`packages/ui`) uses Tamagui as the component foundation and is consumed by both `apps/web` and `apps/mobile` via `@arcadeum/ui`.
+
+## Structure
+
+```
+packages/ui/src/components/
+  <ComponentName>/
+    index.ts                     ← re-export
+    <ComponentName>.tsx
+    <ComponentName>.stories.tsx  ← Storybook story (required)
+```
+
+## Steps
+
+1. **Create component** in `packages/ui/src/components/<Name>/<Name>.tsx`:
+   - Use Tamagui primitives (`YStack`, `XStack`, `Text`, `Stack`, etc.)
+   - Export named: `export const <Name> = ...`
+   - Accept typed props extending Tamagui's component props where appropriate
+
+2. **Create `index.ts`** re-export:
+   ```ts
+   export { <Name> } from './<Name>';
+   export type { <Name>Props } from './<Name>';
+   ```
+
+3. **Register in barrel export** `packages/ui/src/index.ts`:
+   ```ts
+   export * from './components/<Name>';
+   ```
+
+4. **Create `<Name>.stories.tsx`** (required for every component):
+   ```tsx
+   import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+   import { <Name> } from './<Name>';
+
+   const meta: Meta<typeof <Name>> = {
+     title: 'Shared/<Name>',
+     component: <Name>,
+     tags: ['autodocs'],
+     argTypes: {
+       // declare each prop with control type and description
+       variant: { control: 'select', options: [...], description: '...' },
+     },
+   };
+
+   export default meta;
+   type Story = StoryObj<typeof <Name>>;
+
+   export const Default: Story = { args: { /* minimal props */ } };
+
+   // Add a story per meaningful variant/state, e.g.:
+   // export const Disabled: Story = { args: { disabled: true } };
+   // export const AllVariants: Story = { render: () => <...> };
+   ```
+   - `title` follows `'Shared/<Name>'` convention
+   - Always include `tags: ['autodocs']`
+   - Cover: default state, each variant, disabled/error/loading states where applicable
+   - Add an `AllVariants` render story when there are multiple visual variants
+
+5. **Tamagui primitives reference**:
+   ```ts
+   import { YStack, XStack, Text, Stack, View, styled } from 'tamagui';
+   // Use styled() for variant-driven components
+   const MyComponent = styled(Stack, {
+     variants: {
+       size: { sm: { padding: '$2' }, md: { padding: '$4' } }
+     }
+   });
+   ```
+
+## Notes
+
+- Keep components platform-agnostic — they run on both web and React Native
+- Avoid importing from `react-native` directly; use Tamagui equivalents
+- Check `packages/ui/src/tamagui.config.ts` for design tokens (`$colors`, `$space`, `$size`)
+- Run `pnpm storybook` from `apps/web` to verify stories render correctly

--- a/.claude/skills/new-web-page/SKILL.md
+++ b/.claude/skills/new-web-page/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: new-web-page
+description: Add a new page to the Next.js web app (apps/web). Use when creating a new route/page in the web app.
+---
+
+The web app uses Next.js App Router with a three-file pattern per page and server-side i18n.
+
+## Pattern
+
+```
+apps/web/src/app/<route>/
+  page.tsx          ← Server Component: fetches translations, exports metadata
+  <Name>Client.tsx  ← 'use client': dynamic import wrapper with loading skeleton
+  <Name>View.tsx    ← actual UI (lazy-loaded via dynamic import in Client file)
+```
+
+## Steps
+
+1. **Create `page.tsx`** (Server Component):
+   - Import `getTranslations` from `@/shared/i18n/server`
+   - Export `metadata` with `title: \`Page Title - \${appConfig.appName}\``
+   - Fetch translations with `const messages = await getTranslations()`
+   - Pass only the relevant translation slice as `t` prop to the Client component
+
+2. **Create `<Name>Client.tsx`** (`'use client'`):
+   - Use `dynamic(() => import('./<Name>View').then(mod => mod.<Name>View), { ssr: false, loading: LoadingSkeleton })`
+   - Define `LoadingSkeleton` using `PageLayout`, `Container`, `GlassCard`, `Skeleton`, `YStack` from `@/shared/ui`
+
+3. **Create `<Name>View.tsx`**:
+   - Build the actual page UI using components from `@arcadeum/ui` and `@/shared/ui`
+   - Accept `t` prop for translations
+
+4. **Add translations** to all locale files:
+   - `apps/web/src/shared/i18n/messages/pages/en.ts` (and `by.ts`, `es.ts`, `fr.ts`, `ru.ts`)
+   - Export the translation key from `apps/web/src/shared/i18n/messages/pages.ts`
+
+## Key imports
+
+```ts
+import { appConfig } from '@/shared/config/app-config';
+import { getTranslations } from '@/shared/i18n/server';
+import { PageLayout, Container, GlassCard, Skeleton, YStack } from '@/shared/ui';
+```

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: pr-description
+description: Writes pull request descriptions. Use when creating a PR, writing a PR, or when the user asks to summarize changes for a pull request.
+---
+
+When writing a PR description:
+
+1. Run `git diff main...HEAD` to see all changes on this branch
+2. Write a description following this format:
+
+## What
+One sentence explaining what this PR does.
+
+## Why
+Brief context on why this change is needed
+
+## Changes
+- Bullet points of specific changes made
+- Group related changes together
+- Mention any files deleted or renamed

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ coverage/
 # E2E test logs
 backend-e2e-errors.log
 
-.claude
 .claw
 .playwright-mcp
 .superpowers


### PR DESCRIPTION
## What
Adds Claude Code configuration: permissions, pre/post-tool hooks, and reusable skills for the team.

## Why
Standardizes the Claude Code setup across the team with shared settings, safety hooks (env access blocking, tsc/typecheck on edits, UI component placement checks), and skills for common workflows (new game, new page, new module, commits, PRs).

## Changes
- **Settings** — `acceptEdits` default mode, allowed commands (npm, git, ls, vitest, playwright), deny rules for destructive git operations on main/develop/staging
- **Hooks** — `block-env-access.js` (blocks .env* file access), `tsc-check.sh` (typecheck on file edits), `ui-component-check.sh` (validates UI component placement)
- **Skills** — 7 skills: `commit`, `pr-description`, `new-game`, `new-web-page`, `new-be-module`, `new-mobile-screen`, `new-ui-component`, `check-ui-components`