### PR TITLE
fix(web): update PWA manifest for Android TV compatibility

### DIFF
--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -8,18 +8,28 @@
   "background_color": "#151718",
   "theme_color": "#151718",
   "orientation": "any",
+  "categories": ["games", "entertainment"],
+  "prefer_related_applications": false,
   "icons": [
     {
       "src": "/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Play Games",
+      "short_name": "Play",
+      "url": "/games",
+      "description": "Browse and play games"
     }
   ]
 }


### PR DESCRIPTION
## What
Update the PWA manifest to support installation on Android TV devices (Xiaomi A50 Pro TV and similar).

## Why
The current manifest lacks fields needed for proper PWA detection and installation on Android TV browsers, preventing users from installing the app to their smart TVs.

## Changes
- Add `categories: ["games", "entertainment"]` for Android TV app discoverability
- Add `prefer_related_applications: false` to ensure web app is offered for install
- Add `shortcuts` for quick launcher access
- Fix icon `purpose` to `"any"` for better TV display compatibility