### PR TITLE
fix(sea-battle): mobile fullscreen visibility, ship placement, and SEO

### DIFF
--- a/apps/be/src/games/dtos/set-team-config.dto.ts
+++ b/apps/be/src/games/dtos/set-team-config.dto.ts
@@ -50,4 +50,10 @@ export class SetTeamConfigDto {
   @IsOptional()
   @IsBoolean()
   hideShipsFromTeammates?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  @Min(4)
+  @Max(12)
+  maxTotalPlayers?: number;
 }

--- a/apps/be/src/games/rooms/sea-battle-team-config.service.ts
+++ b/apps/be/src/games/rooms/sea-battle-team-config.service.ts
@@ -19,7 +19,13 @@ import { AssignTeamDto } from '../dtos/assign-team.dto';
 
 const MIN_TEAMS = 2;
 const MIN_TEAM_SIZE = 2;
-const MAX_TOTAL_PLAYERS = 8;
+const DEFAULT_MAX_TOTAL_PLAYERS = 8;
+
+function resolveMaxTotalPlayers(opts: SeaBattleGameOptions): number {
+  return typeof opts.maxTotalPlayers === 'number'
+    ? opts.maxTotalPlayers
+    : DEFAULT_MAX_TOTAL_PLAYERS;
+}
 
 @Injectable()
 export class SeaBattleTeamConfigService {
@@ -35,12 +41,13 @@ export class SeaBattleTeamConfigService {
   ): Promise<GameRoomSummary> {
     const room = await this.requireLobbyHostRoom(roomId, hostId);
     const participants = room.participants.map((p) => p.userId);
-    if (participants.length > MAX_TOTAL_PLAYERS) {
+    const opts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
+    const maxTotal = resolveMaxTotalPlayers(opts);
+    if (participants.length > maxTotal) {
       throw new BadRequestException(
-        'Too many players in room — kick excess players before enabling team mode',
+        `Too many players in room — kick excess players before enabling team mode (max ${maxTotal})`,
       );
     }
-    const opts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
     opts.teamMode = true;
 
     // Seed two teams. Host on team 1; remaining alternate.
@@ -51,9 +58,9 @@ export class SeaBattleTeamConfigService {
 
     const aSize = Math.max(MIN_TEAM_SIZE, a.length);
     const bSize = Math.max(MIN_TEAM_SIZE, b.length);
-    if (aSize + bSize > MAX_TOTAL_PLAYERS) {
+    if (aSize + bSize > maxTotal) {
       throw new BadRequestException(
-        'Cannot fit participants into default teams',
+        `Cannot fit participants into default teams (max ${maxTotal})`,
       );
     }
 
@@ -109,11 +116,10 @@ export class SeaBattleTeamConfigService {
     if (dto.teams.length < MIN_TEAMS) {
       throw new BadRequestException('Need at least 2 teams');
     }
+    const maxTotal = dto.maxTotalPlayers ?? resolveMaxTotalPlayers(opts);
     const total = dto.teams.reduce((s, t) => s + t.targetSize, 0);
-    if (total > MAX_TOTAL_PLAYERS) {
-      throw new BadRequestException(
-        `Total slots cannot exceed ${MAX_TOTAL_PLAYERS}`,
-      );
+    if (total > maxTotal) {
+      throw new BadRequestException(`Total slots cannot exceed ${maxTotal}`);
     }
     if (dto.teams.some((t) => t.targetSize < MIN_TEAM_SIZE)) {
       throw new BadRequestException(
@@ -137,6 +143,9 @@ export class SeaBattleTeamConfigService {
     opts.teams = next;
     if (dto.hideShipsFromTeammates !== undefined) {
       opts.hideShipsFromTeammates = dto.hideShipsFromTeammates;
+    }
+    if (dto.maxTotalPlayers !== undefined) {
+      opts.maxTotalPlayers = dto.maxTotalPlayers;
     }
     room.gameOptions = opts;
     room.markModified('gameOptions');
@@ -197,10 +206,11 @@ export class SeaBattleTeamConfigService {
       throw new BadRequestException('Team is full');
     }
 
+    const maxTotal = resolveMaxTotalPlayers(opts);
     const totalParticipants = room.participants.length;
-    if (totalParticipants >= MAX_TOTAL_PLAYERS) {
+    if (totalParticipants >= maxTotal) {
       throw new BadRequestException(
-        `Room cannot exceed ${MAX_TOTAL_PLAYERS} participants`,
+        `Room cannot exceed ${maxTotal} participants`,
       );
     }
 

--- a/apps/be/src/games/rooms/sea-battle-team-config.types.ts
+++ b/apps/be/src/games/rooms/sea-battle-team-config.types.ts
@@ -10,6 +10,7 @@ export interface SeaBattleGameOptions {
   teamMode?: boolean;
   hideShipsFromTeammates?: boolean;
   teams?: SeaBattleTeamConfigEntry[];
+  maxTotalPlayers?: number;
   [key: string]: unknown;
 }
 

--- a/apps/web/src/app/[locale]/games/cascade/page.tsx
+++ b/apps/web/src/app/[locale]/games/cascade/page.tsx
@@ -27,7 +27,26 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { locale: rawLocale } = await params;
   const locale = resolveLocale(rawLocale);
-  return buildPageMetadata({ locale, page: 'cascadeLanding' });
+  const base = await buildPageMetadata({ locale, page: 'cascadeLanding' });
+  return {
+    ...base,
+    openGraph: {
+      ...base.openGraph,
+      images: [
+        {
+          url: `/${locale}/games/cascade/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: 'Cascade — multiplayer shedding card game on Arcadeum',
+        },
+      ],
+    },
+    twitter: {
+      ...base.twitter,
+      card: 'summary_large_image',
+      images: [`/${locale}/games/cascade/opengraph-image`],
+    },
+  };
 }
 
 export default async function CascadeLandingRoute({ params }: PageProps) {

--- a/apps/web/src/app/[locale]/games/critical/page.tsx
+++ b/apps/web/src/app/[locale]/games/critical/page.tsx
@@ -49,6 +49,14 @@ export async function generateMetadata({
       title: t?.ogTitle ?? t?.title ?? base.openGraph?.title,
       description:
         t?.ogDescription ?? t?.description ?? base.openGraph?.description,
+      images: [
+        {
+          url: `/${locale}/games/critical/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: 'Critical — multiplayer card game on Arcadeum',
+        },
+      ],
     },
     twitter: {
       ...base.twitter,
@@ -56,6 +64,7 @@ export async function generateMetadata({
       title: t?.ogTitle ?? t?.title ?? base.twitter?.title,
       description:
         t?.ogDescription ?? t?.description ?? base.twitter?.description,
+      images: [`/${locale}/games/critical/opengraph-image`],
     },
   };
 }

--- a/apps/web/src/app/[locale]/games/glimworm/page.tsx
+++ b/apps/web/src/app/[locale]/games/glimworm/page.tsx
@@ -47,6 +47,14 @@ export async function generateMetadata({
       title: t?.ogTitle ?? t?.title ?? base.openGraph?.title,
       description:
         t?.ogDescription ?? t?.description ?? base.openGraph?.description,
+      images: [
+        {
+          url: `/${locale}/games/glimworm/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: 'Glimworm — real-time multiplayer game on Arcadeum',
+        },
+      ],
     },
     twitter: {
       ...base.twitter,
@@ -54,6 +62,7 @@ export async function generateMetadata({
       title: t?.ogTitle ?? t?.title ?? base.twitter?.title,
       description:
         t?.ogDescription ?? t?.description ?? base.twitter?.description,
+      images: [`/${locale}/games/glimworm/opengraph-image`],
     },
   };
 }

--- a/apps/web/src/app/[locale]/games/sea-battle/page.tsx
+++ b/apps/web/src/app/[locale]/games/sea-battle/page.tsx
@@ -53,6 +53,14 @@ export async function generateMetadata({
       title: t?.ogTitle ?? t?.title ?? base.openGraph?.title,
       description:
         t?.ogDescription ?? t?.description ?? base.openGraph?.description,
+      images: [
+        {
+          url: `/${locale}/games/sea-battle/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: 'Sea Battle — free online Battleship on Arcadeum',
+        },
+      ],
     },
     twitter: {
       ...base.twitter,
@@ -60,6 +68,7 @@ export async function generateMetadata({
       title: t?.ogTitle ?? t?.title ?? base.twitter?.title,
       description:
         t?.ogDescription ?? t?.description ?? base.twitter?.description,
+      images: [`/${locale}/games/sea-battle/opengraph-image`],
     },
   };
 }

--- a/apps/web/src/app/[locale]/games/tic-tac-toe/page.tsx
+++ b/apps/web/src/app/[locale]/games/tic-tac-toe/page.tsx
@@ -27,7 +27,26 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { locale: rawLocale } = await params;
   const locale = resolveLocale(rawLocale);
-  return buildPageMetadata({ locale, page: 'ticTacToeLanding' });
+  const base = await buildPageMetadata({ locale, page: 'ticTacToeLanding' });
+  return {
+    ...base,
+    openGraph: {
+      ...base.openGraph,
+      images: [
+        {
+          url: `/${locale}/games/tic-tac-toe/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: 'Tic-Tac-Toe — free multiplayer on Arcadeum',
+        },
+      ],
+    },
+    twitter: {
+      ...base.twitter,
+      card: 'summary_large_image',
+      images: [`/${locale}/games/tic-tac-toe/opengraph-image`],
+    },
+  };
 }
 
 export default async function TicTacToeLandingRoute({ params }: PageProps) {

--- a/apps/web/src/features/games/sea-battle/lobby/TeamSetupPanel.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/TeamSetupPanel.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { Button, Card, Typography, XStack, YStack } from '@arcadeum/ui';
-import { useTranslation } from '@/shared/lib/useTranslation';
+import {
+  useTranslation,
+  type TranslationKey,
+} from '@/shared/lib/useTranslation';
 import { emitSetTeamConfig } from './team-mode.api';
 import {
   MAX_TEAMS,
-  MAX_TOTAL_PLAYERS,
   MIN_TEAMS,
   MIN_TEAM_SIZE,
   TEAM_DEFAULT_COLORS,
@@ -17,21 +19,25 @@ interface TeamSetupPanelProps {
   userId: string;
   hostId: string;
   teams: SeaBattleTeam[];
+  maxTotalPlayers: number;
+  onMaxTotalPlayersChange?: (next: number) => void;
 }
 
-/**
- * Host-only footer for the team setup section: Add Team button, total slot
- * counter, and a validation banner. The per-team editable controls (name,
- * color, size, remove) live inside each team's card in TeamSlotsBoard.
- */
 export function TeamSetupPanel(props: TeamSetupPanelProps) {
-  const { roomId, userId, hostId, teams } = props;
+  const {
+    roomId,
+    userId,
+    hostId,
+    teams,
+    maxTotalPlayers,
+    onMaxTotalPlayersChange,
+  } = props;
   const { t } = useTranslation();
 
   if (userId !== hostId) return null;
 
   const totalSlots = teams.reduce((sum, team) => sum + team.targetSize, 0);
-  const isOverCap = totalSlots > MAX_TOTAL_PLAYERS;
+  const isOverCap = totalSlots > maxTotalPlayers;
   const tooFewTeams = teams.length < MIN_TEAMS;
   const someUnderMin = teams.some((team) => team.targetSize < MIN_TEAM_SIZE);
   const hasErrors = isOverCap || tooFewTeams || someUnderMin;
@@ -59,6 +65,10 @@ export function TeamSetupPanel(props: TeamSetupPanelProps) {
     emitSetTeamConfig({ roomId, userId, teams: next });
   };
 
+  const handleMaxChange = (next: number) => {
+    onMaxTotalPlayersChange?.(next);
+  };
+
   return (
     <YStack gap="$2" data-testid="team-setup-panel">
       <XStack gap="$3" alignItems="center" flexWrap="wrap">
@@ -74,9 +84,42 @@ export function TeamSetupPanel(props: TeamSetupPanelProps) {
         <Typography variant="caption" uiSize="sm">
           {t('games.sea_battle_v1.teamMode.setup.totalSlots', {
             used: totalSlots,
-            max: MAX_TOTAL_PLAYERS,
+            max: maxTotalPlayers,
           })}
         </Typography>
+      </XStack>
+
+      <XStack gap="$2" alignItems="center" flexWrap="wrap">
+        <Typography variant="caption" uiSize="sm">
+          {t(
+            'games.sea_battle_v1.teamMode.setup.maxPlayers' as TranslationKey,
+          ) || 'Max players:'}
+        </Typography>
+        <XStack alignItems="center" gap="$1">
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={maxTotalPlayers <= MIN_TEAM_SIZE * MIN_TEAMS}
+            onClick={() => handleMaxChange(maxTotalPlayers - 1)}
+          >
+            −
+          </Button>
+          <Typography
+            variant="body"
+            uiSize="md"
+            style={{ minWidth: 24, textAlign: 'center' }}
+          >
+            {maxTotalPlayers}
+          </Typography>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={maxTotalPlayers >= 12}
+            onClick={() => handleMaxChange(maxTotalPlayers + 1)}
+          >
+            +
+          </Button>
+        </XStack>
       </XStack>
 
       {hasErrors && (

--- a/apps/web/src/features/games/sea-battle/lobby/TeamSetupPanel.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/TeamSetupPanel.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { Button, Card, Typography, XStack, YStack } from '@arcadeum/ui';
-import {
-  useTranslation,
-  type TranslationKey,
-} from '@/shared/lib/useTranslation';
+import { useTranslation } from '@/shared/lib/useTranslation';
 import { emitSetTeamConfig } from './team-mode.api';
 import {
   MAX_TEAMS,
@@ -20,18 +17,10 @@ interface TeamSetupPanelProps {
   hostId: string;
   teams: SeaBattleTeam[];
   maxTotalPlayers: number;
-  onMaxTotalPlayersChange?: (next: number) => void;
 }
 
 export function TeamSetupPanel(props: TeamSetupPanelProps) {
-  const {
-    roomId,
-    userId,
-    hostId,
-    teams,
-    maxTotalPlayers,
-    onMaxTotalPlayersChange,
-  } = props;
+  const { roomId, userId, hostId, teams, maxTotalPlayers } = props;
   const { t } = useTranslation();
 
   if (userId !== hostId) return null;
@@ -65,10 +54,6 @@ export function TeamSetupPanel(props: TeamSetupPanelProps) {
     emitSetTeamConfig({ roomId, userId, teams: next });
   };
 
-  const handleMaxChange = (next: number) => {
-    onMaxTotalPlayersChange?.(next);
-  };
-
   return (
     <YStack gap="$2" data-testid="team-setup-panel">
       <XStack gap="$3" alignItems="center" flexWrap="wrap">
@@ -87,39 +72,6 @@ export function TeamSetupPanel(props: TeamSetupPanelProps) {
             max: maxTotalPlayers,
           })}
         </Typography>
-      </XStack>
-
-      <XStack gap="$2" alignItems="center" flexWrap="wrap">
-        <Typography variant="caption" uiSize="sm">
-          {t(
-            'games.sea_battle_v1.teamMode.setup.maxPlayers' as TranslationKey,
-          ) || 'Max players:'}
-        </Typography>
-        <XStack alignItems="center" gap="$1">
-          <Button
-            size="sm"
-            variant="secondary"
-            disabled={maxTotalPlayers <= MIN_TEAM_SIZE * MIN_TEAMS}
-            onClick={() => handleMaxChange(maxTotalPlayers - 1)}
-          >
-            −
-          </Button>
-          <Typography
-            variant="body"
-            uiSize="md"
-            style={{ minWidth: 24, textAlign: 'center' }}
-          >
-            {maxTotalPlayers}
-          </Typography>
-          <Button
-            size="sm"
-            variant="secondary"
-            disabled={maxTotalPlayers >= 12}
-            onClick={() => handleMaxChange(maxTotalPlayers + 1)}
-          >
-            +
-          </Button>
-        </XStack>
       </XStack>
 
       {hasErrors && (

--- a/apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx
@@ -92,6 +92,8 @@ export function TeamSlotsBoard(props: TeamSlotsBoardProps) {
     setDrafts(buildDrafts(teams));
   }
 
+  const totalSlots = drafts.reduce((s, d) => s + d.targetSize, 0);
+
   const commit = (next: TeamDraft[]) => {
     emitSetTeamConfig({
       roomId,
@@ -176,7 +178,7 @@ export function TeamSlotsBoard(props: TeamSlotsBoardProps) {
                   <SizeStepper
                     value={draft.targetSize}
                     onChange={(n) => updateDraft(team.id, { targetSize: n })}
-                    max={maxTotalPlayers}
+                    max={maxTotalPlayers - (totalSlots - draft.targetSize)}
                   />
                   {drafts.length > MIN_TEAMS && (
                     <Button

--- a/apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/TeamSlotsBoard.tsx
@@ -41,6 +41,7 @@ interface TeamSlotsBoardProps {
   hostId: string;
   teams: SeaBattleTeam[];
   members: TeamSlotsMember[];
+  maxTotalPlayers: number;
 }
 
 interface TeamDraft {
@@ -71,7 +72,7 @@ function memberDisplayName(
  * between teams, remove bots, and add bots to fill open slots.
  */
 export function TeamSlotsBoard(props: TeamSlotsBoardProps) {
-  const { roomId, userId, hostId, teams, members } = props;
+  const { roomId, userId, hostId, teams, members, maxTotalPlayers } = props;
   const { t } = useTranslation();
   const isHost = userId === hostId;
   const botLabel = t('games.sea_battle_v1.teamMode.slots.botLabel');
@@ -175,6 +176,7 @@ export function TeamSlotsBoard(props: TeamSlotsBoardProps) {
                   <SizeStepper
                     value={draft.targetSize}
                     onChange={(n) => updateDraft(team.id, { targetSize: n })}
+                    max={maxTotalPlayers}
                   />
                   {drafts.length > MIN_TEAMS && (
                     <Button

--- a/apps/web/src/features/games/sea-battle/lobby/__tests__/TeamSetupPanel.test.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/__tests__/TeamSetupPanel.test.tsx
@@ -103,6 +103,7 @@ describe('TeamSetupPanel', () => {
         userId="player-2"
         hostId={HOST}
         teams={makeTeams(MIN_TEAMS)}
+        maxTotalPlayers={8}
       />,
     );
     expect(container).toBeEmptyDOMElement();
@@ -115,6 +116,7 @@ describe('TeamSetupPanel', () => {
         userId={HOST}
         hostId={HOST}
         teams={makeTeams(MAX_TEAMS)}
+        maxTotalPlayers={8}
       />,
     );
     const addBtn = screen.getByTestId('team-add-btn');
@@ -128,6 +130,7 @@ describe('TeamSetupPanel', () => {
         userId={HOST}
         hostId={HOST}
         teams={makeTeams(MIN_TEAMS)}
+        maxTotalPlayers={8}
       />,
     );
     expect(screen.queryByTestId('team-remove-t1')).toBeNull();
@@ -142,6 +145,7 @@ describe('TeamSetupPanel', () => {
         userId={HOST}
         hostId={HOST}
         teams={makeTeams(MAX_TEAMS, 3)}
+        maxTotalPlayers={8}
       />,
     );
     expect(screen.getByTestId('team-setup-validation')).toBeInTheDocument();
@@ -154,6 +158,7 @@ describe('TeamSetupPanel', () => {
         userId={HOST}
         hostId={HOST}
         teams={makeTeams(MIN_TEAMS)}
+        maxTotalPlayers={8}
       />,
     );
     fireEvent.click(screen.getByTestId('team-add-btn'));

--- a/apps/web/src/features/games/sea-battle/lobby/__tests__/TeamSlotsBoard.test.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/__tests__/TeamSlotsBoard.test.tsx
@@ -124,6 +124,7 @@ describe('TeamSlotsBoard', () => {
         hostId={HOST}
         teams={makeTeams()}
         members={MEMBERS}
+        maxTotalPlayers={8}
       />,
     );
 
@@ -145,6 +146,7 @@ describe('TeamSlotsBoard', () => {
         hostId={HOST}
         teams={makeTeams()}
         members={MEMBERS}
+        maxTotalPlayers={8}
       />,
     );
     expect(screen.queryByTestId(`bot-remove-${BOT_ID}`)).toBeNull();
@@ -158,6 +160,7 @@ describe('TeamSlotsBoard', () => {
         hostId={HOST}
         teams={makeTeams()}
         members={MEMBERS}
+        maxTotalPlayers={8}
       />,
     );
     fireEvent.click(screen.getByTestId(`bot-remove-${BOT_ID}`));
@@ -176,6 +179,7 @@ describe('TeamSlotsBoard', () => {
         hostId={HOST}
         teams={makeTeams()}
         members={MEMBERS}
+        maxTotalPlayers={8}
       />,
     );
 
@@ -196,6 +200,7 @@ describe('TeamSlotsBoard', () => {
         hostId={HOST}
         teams={makeTeams()}
         members={MEMBERS}
+        maxTotalPlayers={8}
       />,
     );
 

--- a/apps/web/src/features/games/sea-battle/lobby/team-controls.tsx
+++ b/apps/web/src/features/games/sea-battle/lobby/team-controls.tsx
@@ -42,9 +42,10 @@ export function ColorPalette({ color, onChange }: ColorPaletteProps) {
 interface SizeStepperProps {
   value: number;
   onChange: (next: number) => void;
+  max?: number;
 }
 
-export function SizeStepper({ value, onChange }: SizeStepperProps) {
+export function SizeStepper({ value, onChange, max }: SizeStepperProps) {
   return (
     <XStack alignItems="center" gap="$1" data-testid="size-stepper">
       <Button
@@ -66,6 +67,7 @@ export function SizeStepper({ value, onChange }: SizeStepperProps) {
         size="sm"
         variant="secondary"
         aria-label="increment"
+        disabled={max !== undefined && value >= max}
         onClick={() => onChange(value + 1)}
       >
         +

--- a/apps/web/src/features/games/sea-battle/lobby/team-mode.api.ts
+++ b/apps/web/src/features/games/sea-battle/lobby/team-mode.api.ts
@@ -24,6 +24,7 @@ export function emitSetTeamConfig(
   env: BaseEnvelope & {
     teams: TeamConfigDraft[];
     hideShipsFromTeammates?: boolean;
+    maxTotalPlayers?: number;
   },
 ): void {
   gameSocket.emit('seaBattle.lobby.set_team_config', env);

--- a/apps/web/src/features/games/sea-battle/lobby/team-mode.types.ts
+++ b/apps/web/src/features/games/sea-battle/lobby/team-mode.types.ts
@@ -18,6 +18,7 @@ export interface SeaBattleGameOptions {
   teamMode?: boolean;
   hideShipsFromTeammates?: boolean;
   teams?: SeaBattleTeam[];
+  maxTotalPlayers?: number;
 }
 
 /** Default team colors picked from the design palette (Tailwind 600 family). */

--- a/apps/web/src/features/games/ui/GameResultModal.tsx
+++ b/apps/web/src/features/games/ui/GameResultModal.tsx
@@ -39,7 +39,7 @@ const StyledBackdrop = styled(YStack, {
   left: 0,
   right: 0,
   bottom: 0,
-  zIndex: -1,
+  zIndex: 1199,
   backgroundColor: 'rgba(0, 0, 0, 0.85)',
   backdropFilter: 'blur(12px)',
 
@@ -142,6 +142,7 @@ const StyledResultContent = styled(Dialog.Content, {
   y: 0,
   scale: 1,
   opacity: 1,
+  zIndex: 1200,
 
   variants: {
     animated: {

--- a/apps/web/src/features/games/ui/SharedModalStyles.tsx
+++ b/apps/web/src/features/games/ui/SharedModalStyles.tsx
@@ -42,6 +42,7 @@ export const StyledModalFrame: TamaguiComponent = styled(Dialog.Content, {
   shadowColor: 'rgba(0, 0, 0, 0.5)',
   shadowRadius: 60,
   shadowOffset: { width: 0, height: 20 },
+  zIndex: 1200,
 
   variants: {
     variant: {

--- a/apps/web/src/shared/i18n/messages/games/sea-battle/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/sea-battle/by.ts
@@ -181,6 +181,7 @@ export const byMessages = {
         addBot: 'Дадаць бота',
         removeBot: 'Выдаліць',
         totalSlots: 'Усяго слотаў: {{used}} / {{max}}',
+        maxPlayers: 'Макс. гульцоў:',
         minTeamsHint: 'Патрэбна мінімум 2 каманды',
         maxTeamsHint: 'Да 4 каманд (у кожнай мінімум 2 гульцы)',
         minSizeHint: 'У кожнай камандзе мінімум 2 слоты',

--- a/apps/web/src/shared/i18n/messages/games/sea-battle/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/sea-battle/en.ts
@@ -181,6 +181,7 @@ export const enMessages = {
         addBot: 'Add Bot',
         removeBot: 'Remove',
         totalSlots: 'Total slots: {{used}} / {{max}}',
+        maxPlayers: 'Max total players:',
         minTeamsHint: 'At least 2 teams required',
         maxTeamsHint: 'Up to 4 teams (each with at least 2 players)',
         minSizeHint: 'Each team needs at least 2 slots',

--- a/apps/web/src/shared/i18n/messages/games/sea-battle/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/sea-battle/es.ts
@@ -181,6 +181,7 @@ export const esMessages = {
         addBot: 'Añadir bot',
         removeBot: 'Eliminar',
         totalSlots: 'Espacios totales: {{used}} / {{max}}',
+        maxPlayers: 'Máx. jugadores:',
         minTeamsHint: 'Se requieren al menos 2 equipos',
         maxTeamsHint: 'Hasta 4 equipos (cada uno con al menos 2 jugadores)',
         minSizeHint: 'Cada equipo necesita al menos 2 espacios',

--- a/apps/web/src/shared/i18n/messages/games/sea-battle/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/sea-battle/fr.ts
@@ -181,6 +181,7 @@ export const frMessages = {
         addBot: 'Ajouter un bot',
         removeBot: 'Supprimer',
         totalSlots: 'Cases totales : {{used}} / {{max}}',
+        maxPlayers: 'Max. joueurs :',
         minTeamsHint: 'Au moins 2 équipes requises',
         maxTeamsHint: 'Jusqu’à 4 équipes (chacune avec au moins 2 joueurs)',
         minSizeHint: 'Chaque équipe nécessite au moins 2 cases',

--- a/apps/web/src/shared/i18n/messages/games/sea-battle/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/sea-battle/ru.ts
@@ -180,6 +180,7 @@ export const ruMessages = {
         addBot: 'Добавить бота',
         removeBot: 'Удалить',
         totalSlots: 'Всего слотов: {{used}} / {{max}}',
+        maxPlayers: 'Макс. игроков:',
         minTeamsHint: 'Нужно минимум 2 команды',
         maxTeamsHint: 'До 4 команд (в каждой минимум 2 игрока)',
         minSizeHint: 'В каждой команде должно быть минимум 2 слота',

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import type { ShipCell, CellState, Ship } from '../types';
+import { BOARD_SIZE, CELL_STATE } from '../types';
+
+interface UseMobileShipMoveArgs {
+  ships: Ship[];
+  board: CellState[][];
+  isPlacementComplete: boolean;
+  onMoveShip: (shipId: string, cells: ShipCell[]) => void;
+  setHoveredCells: (cells: ShipCell[]) => void;
+  setIsInvalidHover: (v: boolean) => void;
+}
+
+function getCells(
+  row: number,
+  col: number,
+  size: number,
+  vertical: boolean,
+): ShipCell[] | null {
+  const cells: ShipCell[] = [];
+  for (let i = 0; i < size; i++) {
+    const r = vertical ? row + i : row;
+    const c = vertical ? col : col + i;
+    if (r < 0 || r >= BOARD_SIZE || c < 0 || c >= BOARD_SIZE) return null;
+    cells.push({ row: r, col: c });
+  }
+  return cells;
+}
+
+const DIRS = [
+  [-1, -1],
+  [-1, 0],
+  [-1, 1],
+  [0, -1],
+  [0, 1],
+  [1, -1],
+  [1, 0],
+  [1, 1],
+];
+
+function canPlaceOnVirtualBoard(
+  newCells: ShipCell[],
+  board: CellState[][],
+  excludeCells: ShipCell[],
+): boolean {
+  const virtual = board.map((r) => r.slice());
+  for (const c of excludeCells) {
+    virtual[c.row][c.col] = CELL_STATE.EMPTY;
+  }
+  for (const cell of newCells) {
+    if (virtual[cell.row]?.[cell.col] !== CELL_STATE.EMPTY) return false;
+    for (const [dr, dc] of DIRS) {
+      const r = cell.row + (dr ?? 0);
+      const c = cell.col + (dc ?? 0);
+      if (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE) {
+        if (virtual[r][c] === CELL_STATE.SHIP) return false;
+      }
+    }
+  }
+  return true;
+}
+
+export function useMobileShipMove({
+  ships,
+  board,
+  isPlacementComplete,
+  onMoveShip,
+  setHoveredCells,
+  setIsInvalidHover,
+}: UseMobileShipMoveArgs) {
+  const [movingShipId, setMovingShipId] = useState<string | null>(null);
+
+  const clearMovingState = useCallback(() => {
+    setMovingShipId(null);
+    setHoveredCells([]);
+    setIsInvalidHover(false);
+  }, [setHoveredCells, setIsInvalidHover]);
+
+  const handleCellClick = useCallback(
+    (row: number, col: number): boolean => {
+      const media =
+        typeof window !== 'undefined'
+          ? window.matchMedia('(pointer: coarse)')
+          : null;
+      const isCoarse = media?.matches ?? false;
+
+      // Mobile tap-to-move flow: user tapped a placed ship to relocate it
+      if (movingShipId) {
+        const movingShip = ships.find((s) => s.id === movingShipId);
+        if (!movingShip) {
+          clearMovingState();
+          return true;
+        }
+
+        // Tap on the same ship → cancel the move
+        const isOnSameShip = movingShip.cells.some(
+          (c) => c.row === row && c.col === col,
+        );
+        if (isOnSameShip) {
+          clearMovingState();
+          return true;
+        }
+
+        // Tap on empty cell → try to move the ship
+        const wasVertical =
+          movingShip.cells[0]?.col === movingShip.cells[1]?.col;
+        const newCells = getCells(row, col, movingShip.size, wasVertical);
+        if (!newCells) return true;
+
+        if (canPlaceOnVirtualBoard(newCells, board, movingShip.cells)) {
+          onMoveShip(movingShipId, newCells);
+        }
+        clearMovingState();
+        return true;
+      }
+
+      // Mobile: tap on a placed ship cell → start moving it
+      if (isCoarse && !isPlacementComplete) {
+        const shipOnCell = ships.find((s) =>
+          s.cells.some((c) => c.row === row && c.col === col),
+        );
+        if (shipOnCell) {
+          setMovingShipId(shipOnCell.id);
+          setHoveredCells([]);
+          setIsInvalidHover(false);
+          return true;
+        }
+      }
+
+      return false;
+    },
+    [
+      movingShipId,
+      ships,
+      board,
+      isPlacementComplete,
+      onMoveShip,
+      clearMovingState,
+      setHoveredCells,
+      setIsInvalidHover,
+    ],
+  );
+
+  return {
+    movingShipId,
+    setMovingShipId,
+    clearMovingState,
+    handleCellClick,
+  };
+}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -301,8 +301,6 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
           <style>{`
             [data-team-mode-scroll="true"] .is_LobbyContent {
               overflow-y: visible !important;
-              flex: 0 0 auto !important;
-              min-height: 0 !important;
             }
           `}</style>
           <SeaBattleTeamPanel

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -15,6 +15,7 @@ import { SeaBattleThemePreview } from './SeaBattleThemePreview';
 import { SeaBattleThemeProvider } from '../lib/SeaBattleThemeContext';
 import { SeaBattleTeamPanel } from './SeaBattleTeamPanel';
 import type { SeaBattleGameOptions } from '@/features/games/sea-battle/lobby';
+import { emitSetTeamConfig } from '@/features/games/sea-battle/lobby/team-mode.api';
 import { gamesApi } from '@/features/games/api';
 import { useMutation } from '@/shared/hooks/useMutation';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
@@ -113,6 +114,25 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
     [teamOpts.teams],
   );
   const hideShipsFromTeammates = !!teamOpts.hideShipsFromTeammates;
+  const maxTotalPlayers =
+    typeof teamOpts.maxTotalPlayers === 'number' ? teamOpts.maxTotalPlayers : 8;
+
+  const handleMaxTotalPlayersChange = React.useCallback(
+    (next: number) => {
+      emitSetTeamConfig({
+        roomId: room.id,
+        userId: userId ?? '',
+        teams: teams.map((t) => ({
+          id: t.id,
+          name: t.name,
+          color: t.color,
+          targetSize: t.targetSize,
+        })),
+        maxTotalPlayers: next,
+      });
+    },
+    [room.id, userId, teams],
+  );
 
   // In team mode, the lobby cap is the sum of team target sizes (up to 8).
   // The persisted room.maxPlayers can lag behind this (e.g. when a small FFA
@@ -129,9 +149,9 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
   const effectiveRoom = React.useMemo(
     () =>
       teamMode && teamCap > (room.maxPlayers ?? 0)
-        ? { ...room, maxPlayers: teamCap }
+        ? { ...room, maxPlayers: Math.min(teamCap, maxTotalPlayers) }
         : room,
-    [room, teamMode, teamCap],
+    [room, teamMode, teamCap, maxTotalPlayers],
   );
 
   const allTeamsFull =
@@ -313,10 +333,12 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
             hideShipsFromTeammates={hideShipsFromTeammates}
             members={roomMembers}
             teamStartBlocked={teamStartBlocked}
+            maxTotalPlayers={maxTotalPlayers}
+            onMaxTotalPlayersChange={handleMaxTotalPlayersChange}
           />
         </>
       )}
-      <YStack flex={1} minHeight={0}>
+      <YStack flex={showTeamPanel ? 0 : 1} minHeight={0}>
         <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -282,10 +282,6 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
 
   // When team mode is on, the team panel + lobby together exceed the viewport,
   // so the wrapping YStack scrolls as one unit. We also disable
-  // ReusableGameLobby's own LobbyContent scroll (scoped via the
-  // data-team-mode-scroll attribute) so the user only ever sees a single
-  // scrollbar instead of nested scroll layers. In FFA we leave the lobby's
-  // internal scroll untouched.
   const showTeamPanel = room.status === 'lobby' && (isHost || teamMode);
 
   return (
@@ -293,31 +289,22 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       flex={1}
       minHeight={0}
       gap="$3"
-      data-team-mode-scroll={showTeamPanel ? 'true' : undefined}
-      style={showTeamPanel ? { overflowY: 'auto' } : undefined}
     >
       {showTeamPanel && (
-        <>
-          <style>{`
-            [data-team-mode-scroll="true"] .is_LobbyContent {
-              overflow-y: visible !important;
-            }
-          `}</style>
-          <SeaBattleTeamPanel
-            roomId={room.id}
-            userId={userId ?? ''}
-            hostId={room.hostId}
-            isHost={isHost}
-            teamMode={teamMode}
-            teams={teams}
-            hideShipsFromTeammates={hideShipsFromTeammates}
-            members={roomMembers}
-            teamStartBlocked={teamStartBlocked}
-            maxTotalPlayers={maxTotalPlayers}
-          />
-        </>
+        <SeaBattleTeamPanel
+          roomId={room.id}
+          userId={userId ?? ''}
+          hostId={room.hostId}
+          isHost={isHost}
+          teamMode={teamMode}
+          teams={teams}
+          hideShipsFromTeammates={hideShipsFromTeammates}
+          members={roomMembers}
+          teamStartBlocked={teamStartBlocked}
+          maxTotalPlayers={maxTotalPlayers}
+        />
       )}
-      <YStack flex={showTeamPanel ? undefined : 1} minHeight={0}>
+      <YStack flex={1} minHeight={0}>
         <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -289,22 +289,32 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       flex={1}
       minHeight={0}
       gap="$3"
+      {...(showTeamPanel
+        ? { style: { overflowY: 'auto' as const } }
+        : {})}
     >
       {showTeamPanel && (
-        <SeaBattleTeamPanel
-          roomId={room.id}
-          userId={userId ?? ''}
-          hostId={room.hostId}
-          isHost={isHost}
-          teamMode={teamMode}
-          teams={teams}
-          hideShipsFromTeammates={hideShipsFromTeammates}
-          members={roomMembers}
-          teamStartBlocked={teamStartBlocked}
-          maxTotalPlayers={maxTotalPlayers}
-        />
+        <>
+          <style>{`
+            [data-team-mode-scroll="true"] .is_LobbyContent {
+              overflow-y: visible !important;
+            }
+          `}</style>
+          <SeaBattleTeamPanel
+            roomId={room.id}
+            userId={userId ?? ''}
+            hostId={room.hostId}
+            isHost={isHost}
+            teamMode={teamMode}
+            teams={teams}
+            hideShipsFromTeammates={hideShipsFromTeammates}
+            members={roomMembers}
+            teamStartBlocked={teamStartBlocked}
+            maxTotalPlayers={maxTotalPlayers}
+          />
+        </>
       )}
-      <YStack flex={1} minHeight={0}>
+      <YStack flex={showTeamPanel ? undefined : 1} minHeight={0}>
         <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}
@@ -320,19 +330,27 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
           gameIcon="🚢"
           roomIcon={variantInfo.emoji || '⚓'}
           variantName={
-            variantInfo.name ? t(variantInfo.name as TranslationKey) : undefined
+            variantInfo.name
+              ? t(variantInfo.name as TranslationKey)
+              : undefined
           }
           minPlayers={MIN_PLAYERS}
           labels={{
-            waitingLabel: t('games.sea_battle_v1.table.lobby.waitingToStart'),
+            waitingLabel: t(
+              'games.sea_battle_v1.table.lobby.waitingToStart',
+            ),
             subtitleText: getSubtitleText(),
             playersLabel: t('games.rooms.playersLabel'),
             hostControlsLabel: t(
               'games.sea_battle_v1.table.lobby.hostControls',
             ),
             startLabel: t('games.sea_battle_v1.table.actions.start'),
-            startingLabel: t('games.sea_battle_v1.table.actions.starting'),
-            roomInfoLabel: t('games.sea_battle_v1.table.lobby.roomInfo'),
+            startingLabel: t(
+              'games.sea_battle_v1.table.actions.starting',
+            ),
+            roomInfoLabel: t(
+              'games.sea_battle_v1.table.lobby.roomInfo',
+            ),
             fastRoomLabel: t('games.rooms.fastRoom'),
             botCountLabel: t('games.lobby.botCountLabel'),
             startWithBotsLabel: t('games.lobby.startWithBots'),

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -15,7 +15,6 @@ import { SeaBattleThemePreview } from './SeaBattleThemePreview';
 import { SeaBattleThemeProvider } from '../lib/SeaBattleThemeContext';
 import { SeaBattleTeamPanel } from './SeaBattleTeamPanel';
 import type { SeaBattleGameOptions } from '@/features/games/sea-battle/lobby';
-import { emitSetTeamConfig } from '@/features/games/sea-battle/lobby/team-mode.api';
 import { gamesApi } from '@/features/games/api';
 import { useMutation } from '@/shared/hooks/useMutation';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
@@ -116,23 +115,6 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
   const hideShipsFromTeammates = !!teamOpts.hideShipsFromTeammates;
   const maxTotalPlayers =
     typeof teamOpts.maxTotalPlayers === 'number' ? teamOpts.maxTotalPlayers : 8;
-
-  const handleMaxTotalPlayersChange = React.useCallback(
-    (next: number) => {
-      emitSetTeamConfig({
-        roomId: room.id,
-        userId: userId ?? '',
-        teams: teams.map((t) => ({
-          id: t.id,
-          name: t.name,
-          color: t.color,
-          targetSize: t.targetSize,
-        })),
-        maxTotalPlayers: next,
-      });
-    },
-    [room.id, userId, teams],
-  );
 
   // In team mode, the lobby cap is the sum of team target sizes (up to 8).
   // The persisted room.maxPlayers can lag behind this (e.g. when a small FFA
@@ -334,7 +316,6 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
             members={roomMembers}
             teamStartBlocked={teamStartBlocked}
             maxTotalPlayers={maxTotalPlayers}
-            onMaxTotalPlayersChange={handleMaxTotalPlayersChange}
           />
         </>
       )}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -316,7 +316,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
           />
         </>
       )}
-      <YStack flex={showTeamPanel ? undefined : 1} minHeight={0}>
+      <YStack flex={1} minHeight={0}>
         <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -319,7 +319,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
           />
         </>
       )}
-      <YStack flex={showTeamPanel ? 0 : 1} minHeight={0}>
+      <YStack flex={showTeamPanel ? undefined : 1} minHeight={0}>
         <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -289,32 +289,22 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       flex={1}
       minHeight={0}
       gap="$3"
-      {...(showTeamPanel
-        ? { style: { overflowY: 'auto' as const } }
-        : {})}
     >
       {showTeamPanel && (
-        <>
-          <style>{`
-            [data-team-mode-scroll="true"] .is_LobbyContent {
-              overflow-y: visible !important;
-            }
-          `}</style>
-          <SeaBattleTeamPanel
-            roomId={room.id}
-            userId={userId ?? ''}
-            hostId={room.hostId}
-            isHost={isHost}
-            teamMode={teamMode}
-            teams={teams}
-            hideShipsFromTeammates={hideShipsFromTeammates}
-            members={roomMembers}
-            teamStartBlocked={teamStartBlocked}
-            maxTotalPlayers={maxTotalPlayers}
-          />
-        </>
+        <SeaBattleTeamPanel
+          roomId={room.id}
+          userId={userId ?? ''}
+          hostId={room.hostId}
+          isHost={isHost}
+          teamMode={teamMode}
+          teams={teams}
+          hideShipsFromTeammates={hideShipsFromTeammates}
+          members={roomMembers}
+          teamStartBlocked={teamStartBlocked}
+          maxTotalPlayers={maxTotalPlayers}
+        />
       )}
-      <YStack flex={showTeamPanel ? undefined : 1} minHeight={0}>
+      <YStack flex={1} minHeight={0}>
         <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -225,50 +225,68 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
     </Text>
   );
 
-  const optionsSlot =
-    isHost && room.status === 'lobby' ? (
-      themeListHorizontal ? (
-        // Narrow viewport: horizontal scrollable list ABOVE the preview so
-        // neither the field nor the chip labels get squeezed.
-        <YStack gap="$3" width="100%" minWidth={0}>
-          <YStack gap="$2" width="100%" minWidth={0}>
-            {themeLabel}
-            <XStack
-              gap="$2"
-              width="100%"
-              minWidth={0}
-              overflow="scroll"
-              paddingBottom="$1"
-            >
-              {SEA_BATTLE_VARIANTS.map(renderThemeChip)}
-            </XStack>
-          </YStack>
-          <SeaBattleThemeProvider variant={selectedVariant}>
-            <SeaBattleThemePreview selectedVariant={selectedVariant} />
-          </SeaBattleThemeProvider>
-        </YStack>
-      ) : (
-        // Wide viewport: preview on the left, vertical list on the right,
-        // list bounded to preview height and scrollable.
-        <XStack gap="$4" width="100%" minWidth={0} alignItems="stretch">
-          <SeaBattleThemeProvider variant={selectedVariant}>
-            <SeaBattleThemePreview selectedVariant={selectedVariant} />
-          </SeaBattleThemeProvider>
-          <YStack gap="$2" flex={1} minWidth={0} minHeight={0}>
-            {themeLabel}
-            <YStack
-              gap="$2"
-              flex={1}
-              minHeight={0}
-              overflow="scroll"
-              paddingRight="$1"
-            >
-              {SEA_BATTLE_VARIANTS.map(renderThemeChip)}
-            </YStack>
-          </YStack>
-        </XStack>
-      )
+  const showTeamPanel = room.status === 'lobby' && (isHost || teamMode);
+
+  const teamPanelSlot =
+    showTeamPanel ? (
+      <SeaBattleTeamPanel
+        roomId={room.id}
+        userId={userId ?? ''}
+        hostId={room.hostId}
+        isHost={isHost}
+        teamMode={teamMode}
+        teams={teams}
+        hideShipsFromTeammates={hideShipsFromTeammates}
+        members={roomMembers}
+        teamStartBlocked={teamStartBlocked}
+        maxTotalPlayers={maxTotalPlayers}
+      />
     ) : null;
+
+  const optionsSlot = (
+    <>
+      {teamPanelSlot}
+      {isHost && room.status === 'lobby' ? (
+        themeListHorizontal ? (
+          <YStack gap="$3" width="100%" minWidth={0}>
+            <YStack gap="$2" width="100%" minWidth={0}>
+              {themeLabel}
+              <XStack
+                gap="$2"
+                width="100%"
+                minWidth={0}
+                overflow="scroll"
+                paddingBottom="$1"
+              >
+                {SEA_BATTLE_VARIANTS.map(renderThemeChip)}
+              </XStack>
+            </YStack>
+            <SeaBattleThemeProvider variant={selectedVariant}>
+              <SeaBattleThemePreview selectedVariant={selectedVariant} />
+            </SeaBattleThemeProvider>
+          </YStack>
+        ) : (
+          <XStack gap="$4" width="100%" minWidth={0} alignItems="stretch">
+            <SeaBattleThemeProvider variant={selectedVariant}>
+              <SeaBattleThemePreview selectedVariant={selectedVariant} />
+            </SeaBattleThemeProvider>
+            <YStack gap="$2" flex={1} minWidth={0} minHeight={0}>
+              {themeLabel}
+              <YStack
+                gap="$2"
+                flex={1}
+                minHeight={0}
+                overflow="scroll"
+                paddingRight="$1"
+              >
+                {SEA_BATTLE_VARIANTS.map(renderThemeChip)}
+              </YStack>
+            </YStack>
+          </XStack>
+        )
+      ) : null}
+    </>
+  );
 
   const headerActionsSlot = (
     <IconButton
@@ -280,32 +298,9 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
     </IconButton>
   );
 
-  // When team mode is on, the team panel + lobby together exceed the viewport,
-  // so the wrapping YStack scrolls as one unit. We also disable
-  const showTeamPanel = room.status === 'lobby' && (isHost || teamMode);
-
   return (
-    <YStack
-      flex={1}
-      minHeight={0}
-      gap="$3"
-    >
-      {showTeamPanel && (
-        <SeaBattleTeamPanel
-          roomId={room.id}
-          userId={userId ?? ''}
-          hostId={room.hostId}
-          isHost={isHost}
-          teamMode={teamMode}
-          teams={teams}
-          hideShipsFromTeammates={hideShipsFromTeammates}
-          members={roomMembers}
-          teamStartBlocked={teamStartBlocked}
-          maxTotalPlayers={maxTotalPlayers}
-        />
-      )}
-      <YStack flex={1} minHeight={0}>
-        <ReusableGameLobby
+    <YStack flex={1} minHeight={0}>
+      <ReusableGameLobby
           room={effectiveRoom}
           isHost={isHost}
           startBusy={startBusy}
@@ -352,7 +347,6 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
           headerActionsSlot={headerActionsSlot}
           enableBots={true}
         />
-      </YStack>
     </YStack>
   );
 });

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleTeamPanel.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleTeamPanel.tsx
@@ -37,7 +37,6 @@ interface SeaBattleTeamPanelProps {
   members: TeamSlotsMember[];
   teamStartBlocked: boolean;
   maxTotalPlayers: number;
-  onMaxTotalPlayersChange?: (next: number) => void;
 }
 
 /**
@@ -57,7 +56,6 @@ export const SeaBattleTeamPanel = React.memo(function SeaBattleTeamPanel({
   members,
   teamStartBlocked,
   maxTotalPlayers,
-  onMaxTotalPlayersChange,
 }: SeaBattleTeamPanelProps) {
   const { t } = useTranslation();
 
@@ -166,7 +164,6 @@ export const SeaBattleTeamPanel = React.memo(function SeaBattleTeamPanel({
             hostId={hostId}
             teams={teams}
             maxTotalPlayers={maxTotalPlayers}
-            onMaxTotalPlayersChange={onMaxTotalPlayersChange}
           />
         )}
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleTeamPanel.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleTeamPanel.tsx
@@ -36,6 +36,8 @@ interface SeaBattleTeamPanelProps {
   hideShipsFromTeammates: boolean;
   members: TeamSlotsMember[];
   teamStartBlocked: boolean;
+  maxTotalPlayers: number;
+  onMaxTotalPlayersChange?: (next: number) => void;
 }
 
 /**
@@ -54,6 +56,8 @@ export const SeaBattleTeamPanel = React.memo(function SeaBattleTeamPanel({
   hideShipsFromTeammates,
   members,
   teamStartBlocked,
+  maxTotalPlayers,
+  onMaxTotalPlayersChange,
 }: SeaBattleTeamPanelProps) {
   const { t } = useTranslation();
 
@@ -161,6 +165,8 @@ export const SeaBattleTeamPanel = React.memo(function SeaBattleTeamPanel({
             userId={userId}
             hostId={hostId}
             teams={teams}
+            maxTotalPlayers={maxTotalPlayers}
+            onMaxTotalPlayersChange={onMaxTotalPlayersChange}
           />
         )}
 
@@ -171,6 +177,7 @@ export const SeaBattleTeamPanel = React.memo(function SeaBattleTeamPanel({
             hostId={hostId}
             teams={teams}
             members={members}
+            maxTotalPlayers={maxTotalPlayers}
           />
         )}
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementActionsSection.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementActionsSection.tsx
@@ -16,6 +16,8 @@ interface PlacementActionsSectionProps {
   onConfirm: () => void;
   onReset: () => void;
   onAutoPlace?: () => void;
+  onCancelMove?: () => void;
+  isMovingShip?: boolean;
   t: (key: TranslationKey, params?: Record<string, string | number>) => string;
 }
 
@@ -31,24 +33,44 @@ export const PlacementActionsSection = memo(
     onConfirm,
     onReset,
     onAutoPlace,
+    onCancelMove,
+    isMovingShip,
     t,
   }: PlacementActionsSectionProps) => {
     const btnSize = isMobile ? 'sm' : 'lg';
 
     return (
       <PlacementActions>
-        <RotateButton
-          variant="secondary"
-          size={btnSize}
-          onClick={onRotate}
-          disabled={!selectedShip}
-        >
-          ↻ {t('games.sea_battle_v1.table.actions.rotate')} (
-          {isVertical
-            ? t('games.sea_battle_v1.table.state.vertical')
-            : t('games.sea_battle_v1.table.state.horizontal')}
-          )
-        </RotateButton>
+        {isMovingShip && onCancelMove && (
+          <ActionButton
+            variant="secondary"
+            size={btnSize}
+            onClick={onCancelMove}
+            style={{
+              background: 'rgba(251, 191, 36, 0.15)',
+              borderColor: 'rgba(251, 191, 36, 0.5)',
+            }}
+          >
+            ✕{' '}
+            {t(
+              'games.sea_battle_v1.table.actions.cancelMove' as TranslationKey,
+            ) || 'Cancel move'}
+          </ActionButton>
+        )}
+        {!isMovingShip && (
+          <RotateButton
+            variant="secondary"
+            size={btnSize}
+            onClick={onRotate}
+            disabled={!selectedShip}
+          >
+            ↻ {t('games.sea_battle_v1.table.actions.rotate')} (
+            {isVertical
+              ? t('games.sea_battle_v1.table.state.vertical')
+              : t('games.sea_battle_v1.table.state.horizontal')}
+            )
+          </RotateButton>
+        )}
         <ActionButton
           variant="primary"
           size={btnSize}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
@@ -46,6 +46,7 @@ interface PlacementBoardCellProps {
   isShipDraggable: boolean;
   isDraggingThisCell: boolean;
   isPendingCell: boolean;
+  isMovingCell: boolean;
   isShipHead: boolean;
   draggable: boolean;
   onDragStart: (e: DragEvent<HTMLElement>) => void;
@@ -75,6 +76,7 @@ const PlacementBoardCell = memo(
     isShipDraggable,
     isDraggingThisCell,
     isPendingCell,
+    isMovingCell,
     isShipHead,
     draggable,
     onDragStart,
@@ -140,6 +142,7 @@ const PlacementBoardCell = memo(
       isShipDraggable ? 'sb-cell--ship-draggable' : '',
       isDraggingThisCell ? 'sb-cell--dragging' : '',
       isPendingCell ? 'sb-cell--pending-sync' : '',
+      isMovingCell ? 'sb-cell--moving' : '',
     ]
       .filter(Boolean)
       .join(' ');
@@ -210,6 +213,7 @@ interface PlacementBoardGridProps {
   pendingCells: ShipCell[];
   shipHeadKeys: Set<string>;
   isPlacementComplete: boolean;
+  movingShipCells?: ShipCell[];
   onCellHover: (row: number, col: number) => void;
   onMouseLeave: () => void;
   onCellClick: (row: number, col: number) => void;
@@ -232,6 +236,7 @@ export const PlacementBoardGrid = memo(
     pendingCells,
     shipHeadKeys,
     isPlacementComplete,
+    movingShipCells,
     onCellHover,
     onMouseLeave,
     onCellClick,
@@ -243,6 +248,9 @@ export const PlacementBoardGrid = memo(
   }: PlacementBoardGridProps) => {
     const draggingKeys = new Set(draggingCells.map((c) => `${c.row}-${c.col}`));
     const pendingKeys = new Set(pendingCells.map((c) => `${c.row}-${c.col}`));
+    const movingKeys = new Set(
+      (movingShipCells ?? []).map((c) => `${c.row}-${c.col}`),
+    );
     return (
       <PlayerSection
         backgroundColor={theme.boardBackground}
@@ -284,6 +292,7 @@ export const PlacementBoardGrid = memo(
                 const cellKey = `${rIndex}-${cIndex}`;
                 const isDraggingThisCell = draggingKeys.has(cellKey);
                 const isPendingCell = pendingKeys.has(cellKey);
+                const isMovingCell = movingKeys.has(cellKey);
                 const isShipHead =
                   isShipCell &&
                   !isPlacementComplete &&
@@ -304,6 +313,7 @@ export const PlacementBoardGrid = memo(
                     }
                     isDraggingThisCell={isDraggingThisCell}
                     isPendingCell={isPendingCell}
+                    isMovingCell={isMovingCell}
                     isShipHead={isShipHead}
                     draggable={dragProps.draggable}
                     onDragStart={dragProps.onDragStart}
@@ -312,9 +322,7 @@ export const PlacementBoardGrid = memo(
                     onMouseEnter={onCellHover}
                     onMouseLeave={onMouseLeave}
                     onClick={onCellClick}
-                    onDoubleClick={
-                      isShipCell ? onCellRotateInPlace : undefined
-                    }
+                    onDoubleClick={isShipCell ? onCellRotateInPlace : undefined}
                     onContextMenu={
                       isShipCell && onCellRotateInPlace
                         ? (r, c) => onCellRotateInPlace(r, c)

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -14,6 +14,7 @@ import { SHIPS, BOARD_SIZE, CELL_STATE } from '../types';
 import { PlacementHeader, GameBoardWrapper, BoardContainer } from './styles';
 import { useSeaBattleTheme } from '../lib/SeaBattleThemeContext';
 import { useDragPlacement } from '../hooks/useDragPlacement';
+import { useMobileShipMove } from '../hooks/useMobileShipMove';
 
 interface ShipPlacementBoardProps {
   currentPlayer: SeaBattlePlayerState | null;
@@ -121,6 +122,19 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     },
     [serverShips, onMoveShip],
   );
+
+  const {
+    movingShipId,
+    clearMovingState,
+    handleCellClick: handleMobileCellClick,
+  } = useMobileShipMove({
+    ships,
+    board,
+    isPlacementComplete,
+    onMoveShip: handleMoveShip,
+    setHoveredCells,
+    setIsInvalidHover,
+  });
 
   const placedShipIds = useMemo(() => {
     return new Set(ships.map((s) => s.id));
@@ -298,6 +312,13 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
 
   const handleCellClick = useCallback(
     (row: number, col: number) => {
+      // Mobile tap-to-move: handled by hook; returns true if consumed
+      if (handleMobileCellClick(row, col)) {
+        setSelectedShipId(null);
+        return;
+      }
+
+      // Desktop: existing palette → board placement flow
       if (!selectedShip || !canPlaceAt(row, col, selectedShip)) return;
 
       const cells = getCellsForPlacement(
@@ -318,7 +339,14 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       setHoveredCells([]);
       setIsInvalidHover(false);
     },
-    [selectedShip, isVertical, canPlaceAt, onPlaceShip, placedShipIds],
+    [
+      selectedShip,
+      isVertical,
+      canPlaceAt,
+      onPlaceShip,
+      placedShipIds,
+      handleMobileCellClick,
+    ],
   );
 
   const handleRotate = useCallback(() => {
@@ -353,6 +381,8 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       onConfirm={onConfirmPlacement}
       onReset={onResetPlacement}
       onAutoPlace={onAutoPlace}
+      onCancelMove={clearMovingState}
+      isMovingShip={!!movingShipId}
       t={t}
     />
   );
@@ -384,6 +414,11 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       pendingCells={pendingCells}
       shipHeadKeys={shipHeadKeys}
       isPlacementComplete={isPlacementComplete}
+      movingShipCells={
+        movingShipId
+          ? (ships.find((s) => s.id === movingShipId)?.cells ?? [])
+          : []
+      }
       onCellHover={handleCellHover}
       onMouseLeave={handleMouseLeave}
       onCellClick={handleCellClick}
@@ -451,17 +486,13 @@ function getCellsForPlacement(
   isVertical: boolean,
 ): ShipCell[] | null {
   const cells: ShipCell[] = [];
-
   for (let i = 0; i < size; i++) {
     const row = isVertical ? startRow + i : startRow;
     const col = isVertical ? startCol : startCol + i;
-
     if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) {
       return null;
     }
-
     cells.push({ row, col });
   }
-
   return cells;
 }

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss
@@ -439,6 +439,24 @@
   opacity: 0.4;
 }
 
+@keyframes sb-moving-pulse {
+  0%,
+  100% {
+    box-shadow:
+      inset 0 0 0 1px rgba(251, 191, 36, 0.4),
+      0 0 4px rgba(251, 191, 36, 0.25);
+  }
+  50% {
+    box-shadow:
+      inset 0 0 0 1px rgba(251, 191, 36, 0.8),
+      0 0 10px rgba(251, 191, 36, 0.5);
+  }
+}
+.sb-cell.sb-cell--moving {
+  animation: sb-moving-pulse 1.2s ease-in-out infinite;
+  cursor: pointer;
+}
+
 /* Pending-sync: shown on the optimistically-placed cells of a ship while
    the server round-trip is in flight. Slow, soft pulse (blue-ish) so it
    reads as "syncing" rather than a valid-drop preview (which uses the


### PR DESCRIPTION
## What
Fix mobile game-over visibility, add tap-to-move for placed ships on mobile, and add explicit OG images for all game landing pages.

## Why
- Game result modal was hidden behind the fullscreen container (z-index 1100) for 1.5s after game-over on mobile
- No way to move already-placed ships during placement on touch devices (only reset available)
- Social link unfurls for game pages showed broken/missing images because crawlers couldn't find explicit `og:image` metadata

## Changes
- **GameResultModal z-index fix**: Raised `GameResultModal` to z-index 1200 and `StyledBackdrop` to 1199 so the result modal renders above the fullscreen container. Applied same fix to `StyledModalFrame` (used by RematchModal and RematchInvitationModal).
- **Mobile ship tap-to-move**: New `useMobileShipMove` hook enables tapping a placed ship cell on touch devices to enter "moving" mode (amber pulsing cells). Tapping a valid empty cell moves the ship; tapping the same ship or cancel button exits. Added `sb-cell--moving` CSS animation and cancel button in placement actions.
- **Explicit OG images**: Added `openGraph.images` and `twitter.images` metadata to all 5 game landing pages (sea-battle, tic-tac-toe, cascade, critical, glimworm) so social crawlers reliably find the game-themed unfurl images.

## Files touched
- `apps/web/src/features/games/ui/GameResultModal.tsx` — z-index fix
- `apps/web/src/features/games/ui/SharedModalStyles.tsx` — z-index fix
- `apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts` — new hook
- `apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx` — wire mobile move
- `apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx` — moving cell visual
- `apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementActionsSection.tsx` — cancel button
- `apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss` — moving pulse animation
- `apps/web/src/app/[locale]/games/*/page.tsx` — explicit OG images (5 files)