### PR TITLE
feat(ci): daily social changelog + release social poster

### DIFF
--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -1,0 +1,90 @@
+name: Daily Develop Changelog Poster
+
+on:
+  schedule:
+    - cron: '0 9 * * *' # Runs automatically every single day at 9:00 AM UTC
+  workflow_dispatch: # Allows you to manually trigger this anytime from the GitHub "Actions" tab to test it
+
+jobs:
+  gather-and-post:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetches full commit history to scan the last 24 hours
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Process Commits and Post to Buffer
+        env:
+          BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
+          FACEBOOK_ID: ${{ secrets.BUFFER_FACEBOOK_ID }}
+          THREADS_ID: ${{ secrets.BUFFER_THREADS_ID }}
+        run: |
+          python - <<EOF
+          import os
+          import subprocess
+          import requests
+
+          # 1. Fetch commits from the last 24 hours
+          try:
+              raw_commits = subprocess.check_output(['git', 'log', '--since="24 hours ago"', '--pretty=format:%s']).decode('utf-8')
+          except Exception as e:
+              print(f"Error fetching logs: {e}")
+              raw_commits = ""
+
+          if not raw_commits.strip():
+              print("No updates found in the last 24 hours. Skipping social posts.")
+              exit(0)
+
+          # 2. Filter out noisy merge lines and automated version chores
+          clean_updates = []
+          for line in raw_commits.split('\n'):
+              if not line.strip() or "Merge pull request" in line or "Merge remote-tracking" in line or "chore: bump version" in line:
+                  continue
+
+              # Standardize prefixes for clean public readability
+              cleaned = line.replace("feat(web):", "✨")\
+                            .replace("fix(web):", "🛠️")\
+                            .replace("refactor(web):", "⚙️")\
+                            .replace("fix(web,critical):", "🚨")
+              clean_updates.append(f"- {cleaned}")
+
+          if not clean_updates:
+              print("No consumer-facing changes found today. Skipping.")
+              exit(0)
+
+          changelog_text = "\n".join(clean_updates)
+
+          # 3. Create platform-specific variants
+          facebook_text = f"🚀 Daily Development Update!\n\nHere is a live look at what we added and optimized in the platform codebase yesterday:\n\n{changelog_text}\n\n#buildinpublic #indiedev #gamedevelopment"
+          threads_text = f"Another productive day in the books. Shipped these updates to the platform yesterday:\n\n{changelog_text}\n\nWhat are you coding today? 🛠️"
+
+          # Prevent text overflow on Threads micro-blog limit safely
+          if len(threads_text) > 480:
+              threads_text = threads_text[:475] + "..."
+
+          # 4. Push updates directly to your Buffer Queue
+          buffer_url = "https://api.bufferapp.com/1/updates/create.json"
+          headers = {
+              "Authorization": f"Bearer {os.environ['BUFFER_API_TOKEN']}"
+          }
+
+          # Array of payloads for each connected channel
+          payloads = [
+              {"profile_ids[]": os.environ['FACEBOOK_ID'], "text": facebook_text, "now": True},
+              {"profile_ids[]": os.environ['THREADS_ID'], "text": threads_text, "now": True}
+          ]
+
+          for data in payloads:
+              response = requests.post(buffer_url, headers=headers, data=data)
+              if response.status_code == 200:
+                  print(f"Successfully posted update to profile ID: {data['profile_ids[]']}")
+              else:
+                  print(f"Failed to post to {data['profile_ids[]']}: {response.text}")
+
+          EOF

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -2,13 +2,20 @@ name: Daily Develop Changelog Poster
 
 on:
   schedule:
-    - cron: '0 9 * * *' # Runs automatically every single day at 9:00 AM UTC
+    - cron: '0 8 * * *' # Triggers at 8:00 AM UTC, then sleeps a random 0-2 hours
   workflow_dispatch: # Allows you to manually trigger this anytime from the GitHub "Actions" tab to test it
 
 jobs:
   gather-and-post:
     runs-on: ubuntu-latest
     steps:
+      - name: Randomize posting time (0-2 hours)
+        run: |
+          SLEEP_SEC=$(( RANDOM % 7201 ))
+          echo "Sleeping $SLEEP_SEC seconds before posting..."
+          sleep "$SLEEP_SEC"
+          echo "Done sleeping."
+
       - name: Checkout Code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install requests
+        run: pip install requests
+
       - name: Process Commits and Post to Buffer
         env:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
@@ -30,9 +33,12 @@ jobs:
           import subprocess
           import requests
 
-          # 1. Fetch commits from the last 24 hours
+          # 1. Fetch commits from the last 24 hours on develop
           try:
-              raw_commits = subprocess.check_output(['git', 'log', '--since="24 hours ago"', '--pretty=format:%s']).decode('utf-8')
+              raw_commits = subprocess.check_output(
+                  ['git', 'log', 'origin/develop', '--since="24 hours ago"', '--pretty=format:%s'],
+                  text=True
+              )
           except Exception as e:
               print(f"Error fetching logs: {e}")
               raw_commits = ""
@@ -42,49 +48,78 @@ jobs:
               exit(0)
 
           # 2. Filter out noisy merge lines and automated version chores
-          clean_updates = []
-          for line in raw_commits.split('\n'):
-              if not line.strip() or "Merge pull request" in line or "Merge remote-tracking" in line or "chore: bump version" in line:
-                  continue
+          skip_patterns = [
+              "Merge pull request",
+              "Merge remote-tracking",
+              "chore: bump version",
+              "chore: update changelog",
+              "chore: start next minor",
+          ]
+          emoji_map = {
+              "feat(web):": "✨",
+              "feat(be):": "✅",
+              "feat(ui):": "🎨",
+              "feat:": "✨",
+              "fix(web):": "🛠️",
+              "fix(be):": "🔧",
+              "fix(ui):": "🖌️",
+              "fix:": "🛠️",
+              "refactor(web):": "⚙️",
+              "refactor(be):": "⚙️",
+              "refactor:": "⚙️",
+              "fix(web,critical):": "🚨",
+          }
 
-              # Standardize prefixes for clean public readability
-              cleaned = line.replace("feat(web):", "✨")\
-                            .replace("fix(web):", "🛠️")\
-                            .replace("refactor(web):", "⚙️")\
-                            .replace("fix(web,critical):", "🚨")
+          clean_updates = []
+          seen = set()
+          for line in raw_commits.split('\n'):
+              line = line.strip()
+              if not line or any(p in line for p in skip_patterns) or line in seen:
+                  continue
+              seen.add(line)
+
+              cleaned = line
+              for prefix, emoji in emoji_map.items():
+                  cleaned = cleaned.replace(prefix, emoji)
               clean_updates.append(f"- {cleaned}")
 
           if not clean_updates:
               print("No consumer-facing changes found today. Skipping.")
               exit(0)
 
-          changelog_text = "\n".join(clean_updates)
+          # Cap at 15 items to keep posts scannable
+          changelog_text = "\n".join(clean_updates[:15])
 
           # 3. Create platform-specific variants
-          facebook_text = f"🚀 Daily Development Update!\n\nHere is a live look at what we added and optimized in the platform codebase yesterday:\n\n{changelog_text}\n\n#buildinpublic #indiedev #gamedevelopment"
-          threads_text = f"Another productive day in the books. Shipped these updates to the platform yesterday:\n\n{changelog_text}\n\nWhat are you coding today? 🛠️"
+          facebook_text = (
+              f"🚀 Daily Development Update!\n\n"
+              f"Here is a live look at what we added and optimized yesterday:\n\n"
+              f"{changelog_text}\n\n"
+              f"#buildinpublic #indiedev #gamedevelopment"
+          )
+          threads_text = (
+              f"Another productive day in the books. Shipped yesterday:\n\n"
+              f"{changelog_text}\n\n"
+              f"What are you coding today? 🛠️"
+          )
 
-          # Prevent text overflow on Threads micro-blog limit safely
           if len(threads_text) > 480:
               threads_text = threads_text[:475] + "..."
 
           # 4. Push updates directly to your Buffer Queue
           buffer_url = "https://api.bufferapp.com/1/updates/create.json"
-          headers = {
-              "Authorization": f"Bearer {os.environ['BUFFER_API_TOKEN']}"
-          }
+          headers = {"Authorization": f"Bearer {os.environ['BUFFER_API_TOKEN']}"}
 
-          # Array of payloads for each connected channel
           payloads = [
               {"profile_ids[]": os.environ['FACEBOOK_ID'], "text": facebook_text, "now": True},
-              {"profile_ids[]": os.environ['THREADS_ID'], "text": threads_text, "now": True}
+              {"profile_ids[]": os.environ['THREADS_ID'], "text": threads_text, "now": True},
           ]
 
           for data in payloads:
-              response = requests.post(buffer_url, headers=headers, data=data)
-              if response.status_code == 200:
-                  print(f"Successfully posted update to profile ID: {data['profile_ids[]']}")
+              resp = requests.post(buffer_url, headers=headers, data=data)
+              if resp.status_code == 200:
+                  print(f"Posted daily update to {data['profile_ids[]']}")
               else:
-                  print(f"Failed to post to {data['profile_ids[]']}: {response.text}")
+                  print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
 
           EOF

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install requests
+        run: pip install requests
+
       - name: Gather Release Changes and Post
         env:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
@@ -27,6 +30,7 @@ jobs:
           python - <<EOF
           import os
           import subprocess
+          import re
           import requests
 
           # 1. Find the latest tag (the version just released)
@@ -41,13 +45,11 @@ jobs:
 
           # 2. Get all commits included in this release
           try:
-              # Commits between the previous tag and the current one
               raw_commits = subprocess.check_output(
                   ['git', 'log', f'{tag}^..{tag}', '--pretty=format:%s'],
                   text=True
               ).strip()
           except Exception:
-              # Fallback: get the single tagged commit
               raw_commits = subprocess.check_output(
                   ['git', 'log', '-1', '--pretty=format:%s', tag],
                   text=True
@@ -57,13 +59,11 @@ jobs:
               print("No commit messages found. Skipping.")
               exit(0)
 
-          # 3. Also read the CHANGELOG section for this version
+          # 3. Read the CHANGELOG section for this version
           changelog_section = ""
           try:
               with open("CHANGELOG.md", "r") as f:
                   content = f.read()
-              # Find the section starting with ## [vX.Y.Z] or ## [X.Y.Z]
-              import re
               match = re.search(
                   rf"## \[{re.escape(tag.lstrip('v'))}\].*?(?=## \[|\Z)",
                   content,
@@ -75,31 +75,39 @@ jobs:
               pass
 
           # 4. Filter and clean commits
+          skip_patterns = [
+              "Merge pull request",
+              "Merge remote-tracking",
+              "chore: bump version",
+              "chore: update changelog",
+              "chore: start next minor",
+          ]
+          emoji_map = {
+              "feat(web):": "✨",
+              "feat(be):": "✅",
+              "feat(ui):": "🎨",
+              "feat:": "✨",
+              "fix(web):": "🛠️",
+              "fix(be):": "🔧",
+              "fix(ui):": "🖌️",
+              "fix:": "🛠️",
+              "refactor(web):": "⚙️",
+              "refactor(be):": "⚙️",
+              "refactor:": "⚙️",
+              "fix(web,critical):": "🚨",
+          }
+
           clean_updates = []
           seen = set()
           for line in raw_commits.split('\n'):
               line = line.strip()
-              if not line:
-                  continue
-              if "Merge pull request" in line or "Merge remote-tracking" in line:
-                  continue
-              if "chore: bump version" in line or "chore: update changelog" in line:
-                  continue
-              if "chore: start next minor" in line:
-                  continue
-              if line in seen:
+              if not line or any(p in line for p in skip_patterns) or line in seen:
                   continue
               seen.add(line)
 
-              cleaned = line.replace("feat(web):", "✨")\
-                            .replace("fix(web):", "🛠️")\
-                            .replace("refactor(web):", "⚙️")\
-                            .replace("feat(be):", "✅")\
-                            .replace("fix(be):", "🔧")\
-                            .replace("feat:", "✨")\
-                            .replace("fix:", "🛠️")\
-                            .replace("feat(ui):", "🎨")\
-                            .replace("fix(ui):", "🖌️")
+              cleaned = line
+              for prefix, emoji in emoji_map.items():
+                  cleaned = cleaned.replace(prefix, emoji)
               clean_updates.append(f"- {cleaned}")
 
           if not clean_updates:
@@ -107,7 +115,7 @@ jobs:
               exit(0)
 
           version = tag.lstrip('v')
-          updates_text = "\n".join(clean_updates[:10])  # Cap at 10 items
+          updates_text = "\n".join(clean_updates[:10])
 
           # 5. Build platform-specific posts
           facebook_text = (

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -1,0 +1,145 @@
+name: Release Social Poster
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  post-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Gather Release Changes and Post
+        env:
+          BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
+          FACEBOOK_ID: ${{ secrets.BUFFER_FACEBOOK_ID }}
+          THREADS_ID: ${{ secrets.BUFFER_THREADS_ID }}
+        run: |
+          python - <<EOF
+          import os
+          import subprocess
+          import requests
+
+          # 1. Find the latest tag (the version just released)
+          try:
+              tag = subprocess.check_output(
+                  ['git', 'describe', '--tags', '--abbrev=0'],
+                  text=True
+              ).strip()
+          except Exception:
+              print("No tags found. Skipping release post.")
+              exit(0)
+
+          # 2. Get all commits included in this release
+          try:
+              # Commits between the previous tag and the current one
+              raw_commits = subprocess.check_output(
+                  ['git', 'log', f'{tag}^..{tag}', '--pretty=format:%s'],
+                  text=True
+              ).strip()
+          except Exception:
+              # Fallback: get the single tagged commit
+              raw_commits = subprocess.check_output(
+                  ['git', 'log', '-1', '--pretty=format:%s', tag],
+                  text=True
+              ).strip()
+
+          if not raw_commits.strip():
+              print("No commit messages found. Skipping.")
+              exit(0)
+
+          # 3. Also read the CHANGELOG section for this version
+          changelog_section = ""
+          try:
+              with open("CHANGELOG.md", "r") as f:
+                  content = f.read()
+              # Find the section starting with ## [vX.Y.Z] or ## [X.Y.Z]
+              import re
+              match = re.search(
+                  rf"## \[{re.escape(tag.lstrip('v'))}\].*?(?=## \[|\Z)",
+                  content,
+                  re.DOTALL,
+              )
+              if match:
+                  changelog_section = match.group(0).strip()
+          except FileNotFoundError:
+              pass
+
+          # 4. Filter and clean commits
+          clean_updates = []
+          seen = set()
+          for line in raw_commits.split('\n'):
+              line = line.strip()
+              if not line:
+                  continue
+              if "Merge pull request" in line or "Merge remote-tracking" in line:
+                  continue
+              if "chore: bump version" in line or "chore: update changelog" in line:
+                  continue
+              if "chore: start next minor" in line:
+                  continue
+              if line in seen:
+                  continue
+              seen.add(line)
+
+              cleaned = line.replace("feat(web):", "✨")\
+                            .replace("fix(web):", "🛠️")\
+                            .replace("refactor(web):", "⚙️")\
+                            .replace("feat(be):", "✅")\
+                            .replace("fix(be):", "🔧")\
+                            .replace("feat:", "✨")\
+                            .replace("fix:", "🛠️")\
+                            .replace("feat(ui):", "🎨")\
+                            .replace("fix(ui):", "🖌️")
+              clean_updates.append(f"- {cleaned}")
+
+          if not clean_updates:
+              print("No consumer-facing changes in this release. Skipping.")
+              exit(0)
+
+          version = tag.lstrip('v')
+          updates_text = "\n".join(clean_updates[:10])  # Cap at 10 items
+
+          # 5. Build platform-specific posts
+          facebook_text = (
+              f"🚀 New Release: v{version}\n\n"
+              f"What shipped:\n{updates_text}\n\n"
+              f"Try it now at arcadeum.games\n\n"
+              f"#arcadeum #gamedev #newrelease #boardgames"
+          )
+
+          threads_text = (
+              f"Shipped v{version} 🚀\n\n"
+              f"{updates_text}\n\n"
+              f"Play now → arcadeum.games"
+          )
+
+          if len(threads_text) > 480:
+              threads_text = threads_text[:475] + "..."
+
+          # 6. Post to Buffer
+          buffer_url = "https://api.bufferapp.com/1/updates/create.json"
+          headers = {"Authorization": f"Bearer {os.environ['BUFFER_API_TOKEN']}"}
+
+          payloads = [
+              {"profile_ids[]": os.environ['FACEBOOK_ID'], "text": facebook_text, "now": True},
+              {"profile_ids[]": os.environ['THREADS_ID'], "text": threads_text, "now": True},
+          ]
+
+          for data in payloads:
+              resp = requests.post(buffer_url, headers=headers, data=data)
+              if resp.status_code == 200:
+                  print(f"Posted release v{version} to {data['profile_ids[]']}")
+              else:
+                  print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+
+          EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,35 +26,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Generate Changelog
-        run: pnpm changelog
-
-      - name: Check if CHANGELOG.md was updated
-        id: check-changelog
-        run: |
-          if git diff --quiet HEAD -- CHANGELOG.md; then
-            echo "no-changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "no-changes=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit and Push Changelog
-        if: steps.check-changelog.outputs.no-changes == 'false'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add CHANGELOG.md
-          git commit -m "chore: update changelog for ${{ github.ref_name }}" --allow-empty
-          git push origin main
-
       - name: Run E2E Tests
         env:
           MONGODB_URI: mongodb://localhost:27017/arcadeum_test
           AUTH_JWT_SECRET: ${{ secrets.AUTH_JWT_SECRET || 'test_jwt_secret_key_for_e2e_only' }}
           NEXT_PUBLIC_E2E: 'true'
         run: pnpm --filter web test:e2e
-
-      - name: Notify on No Changes
-        if: steps.check-changelog.outputs.no-changes == 'true'
-        run: |
-          echo "No changes to CHANGELOG.md — release tag pushed without changelog update."


### PR DESCRIPTION
## What
- Add `daily-social-updater.yml` — posts develop commits to Facebook/Threads every 9 AM UTC
- Add `release-social-poster.yml` — posts release changelog to Facebook/Threads on merge to main
- Fix `release.yml` — remove duplicate changelog push that conflicted with version-bump workflow

## Why
Automate social media presence by sharing daily dev progress and release announcements via Buffer API.

## Changes
- New workflow: daily commit digest from develop
- New workflow: release announcement on push to main
- Fixed release.yml — removed changelog re-generation that raced with version-bump.yml

## Required Secrets
`BUFFER_API_TOKEN`, `BUFFER_FACEBOOK_ID`, `BUFFER_THREADS_ID`