### PR TITLE
feat(skills): replace basic SEO skill with Agentic SEO Skill v3.0.1

### DIFF
--- a/.claude/skills/a11y/SKILL.md
+++ b/.claude/skills/a11y/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: a11y
+description: Use when implementing or reviewing accessibility (a11y) — ARIA attributes, keyboard navigation, focus management, color contrast, screen reader support, semantic HTML, form labels, error handling, or any WCAG compliance task. Trigger on keywords like a11y, accessibility, ARIA, keyboard, focus, screen reader, WCAG, contrast, VoiceOver, NVDA.
+---
+
+# Accessibility Skill
+
+## Core Principles
+
+- **Perceivable**: All content must be presentable in ways users can perceive (alt text, captions, contrast).
+- **Operable**: All UI must be operable via keyboard, pointer, and assistive tech.
+- **Understandable**: Content and UI behavior must be predictable.
+- **Robust**: Content must be interpreted reliably by a wide variety of user agents and assistive technologies.
+
+## Semantic HTML First
+
+Use native HTML elements before reaching for ARIA. Native elements carry built-in semantics:
+
+```html
+<!-- Good -->
+<button onClick={handler}>Submit</button>
+<nav aria-label="Main">...</nav>
+<a href="/about">About</a>
+
+<!-- Bad -->
+<div onClick={handler}>Submit</div>
+<div class="nav">...</div>
+<span onClick={navigate('/about')}>About</span>
+```
+
+Use this mapping:
+| Need | Element |
+|---|---|
+| Clickable action | `<button>` |
+| Navigation link | `<a>` |
+| Navigation group | `<nav>` |
+| Page sections | `<header>`, `<main>`, `<footer>`, `<aside>` |
+| Content grouping | `<article>`, `<section>`, `<fieldset>` |
+| List items | `<ul>`, `<ol>`, `<li>` |
+| Table data | `<table>`, `<thead>`, `<tbody>`, `<th scope>` |
+
+## ARIA Usage
+
+Rule: **No ARIA is better than bad ARIA.**
+
+```html
+<!-- Accessible name: visible label preferred -->
+<button>Add to cart</button>
+
+<!-- When no visible label, use aria-label -->
+<button aria-label="Close dialog">×</button>
+
+<!-- Live regions for dynamic updates -->
+<div aria-live="polite" aria-atomic="true">
+  {statusMessage}
+</div>
+
+<!-- Hidden decorative content -->
+<svg aria-hidden="true" focusable="false">...</svg>
+
+<!-- Group related controls -->
+<fieldset>
+  <legend>Shipping address</legend>
+  ...
+</fieldset>
+```
+
+Common patterns:
+- `aria-expanded` on trigger buttons for disclosures/dropdowns.
+- `aria-current="page"` on the active nav link.
+- `aria-describedby` to link helper text or error messages to inputs.
+- `aria-invalid="true"` + `aria-errormessage` on invalid form fields.
+- `role="alert"` or `aria-live="assertive"` only for urgent errors (not informational).
+- `aria-hidden="true"` on elements that are purely visual (icons, decorative images).
+
+## Keyboard Navigation
+
+- All interactive elements must be reachable and operable via `Tab`, `Shift+Tab`, `Enter`, `Space`, `Arrow` keys.
+- **Tab order** must match visual order. Avoid positive `tabindex` (use `tabindex="0"` or `tabindex="-1"` only).
+- Implement **focus trapping** in modals/dialogs:
+  - `Tab` cycles through focusable elements inside the dialog.
+  - `Escape` closes the dialog and returns focus to the trigger.
+- **Skip link** as the first focusable element on the page:
+  ```html
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  ```
+
+## Focus Management
+
+```css
+/* Visible focus indicators — never use outline: none without replacement */
+:focus-visible {
+  outline: 2px solid #005fcc;
+  outline-offset: 2px;
+}
+```
+
+Rules:
+- Never remove focus outlines without providing an alternative visible indicator.
+- On route changes in SPAs, move focus to the new page heading or announce the change via `aria-live`.
+- After closing a modal, return focus to the element that triggered it.
+- When content appears dynamically, move focus to it or announce it.
+
+## Forms
+
+```html
+<label for="email">Email address</label>
+<input
+  id="email"
+  type="email"
+  required
+  aria-describedby="email-hint email-error"
+  aria-invalid={hasError}
+/>
+<span id="email-hint">We'll never share your email.</span>
+<span id="email-error" role="alert">Please enter a valid email.</span>
+```
+
+Rules:
+- Every input must have an associated `<label>` (visible or `aria-label`).
+- Group related inputs with `<fieldset>` + `<legend>`.
+- Error messages must be programmatically associated via `aria-describedby`.
+- Use `role="alert"` on error containers so screen readers announce them.
+- Required fields: use `required` attribute + visually convey (not color alone).
+
+## Color & Contrast
+
+- **Normal text**: minimum 4.5:1 contrast ratio (WCAG AA).
+- **Large text** (≥18px or ≥14px bold): minimum 3:1.
+- **UI components/icons**: minimum 3:1 against adjacent colors.
+- Never convey information through color alone. Use icons, text, or patterns as secondary indicators.
+- Test with simulated color blindness (protanopia, deuteranopia, tritanopia).
+
+## Images & Media
+
+```html
+<!-- Informative image -->
+<img src="chart.png" alt="Revenue grew 40% from Q1 to Q2 2026." />
+
+<!-- Decorative image -->
+<img src="divider.png" alt="" role="presentation" />
+
+<!-- Complex image (chart, diagram) -->
+<figure>
+  <img src="chart.png" alt="Revenue chart showing growth trend." />
+  <figcaption>Detailed data in the table below.</figcaption>
+</figure>
+
+<!-- Video -->
+<video controls>
+  <source src="demo.mp4" type="video/mp4" />
+  <track kind="captions" src="captions.vtt" srclang="en" label="English" />
+</video>
+```
+
+Rules:
+- `alt` text should convey the image's purpose, not describe pixels.
+- Complex images: provide `alt` summary + long description nearby.
+- Videos: include captions (`<track>`) and transcript.
+- Avoid text in images (breaks translation, screen readers, and scaling).
+
+## Motion & Animation
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+- Respect `prefers-reduced-motion`. Provide non-animated alternatives.
+- No content should flash more than 3 times per second.
+- Auto-playing media must be pauseable/stopable.
+
+## Testing Checklist
+
+- [ ] All pages navigable via keyboard only
+- [ ] Visible focus indicator on every interactive element
+- [ ] Tab order is logical and matches visual layout
+- [ ] Screen reader announces all meaningful content and state changes
+- [ ] All form inputs have labels; errors are associated and announced
+- [ ] Color contrast passes WCAG AA (4.5:1 text, 3:1 large text/UI)
+- [ ] All images have appropriate `alt` text
+- [ ] `prefers-reduced-motion` is respected
+- [ ] Modals trap focus and restore it on close
+- [ ] Skip link present and functional
+- [ ] No auto-playing audio/video
+- [ ] Passes axe-core / Lighthouse Accessibility audit (score ≥ 95)

--- a/.claude/skills/performance/SKILL.md
+++ b/.claude/skills/performance/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: performance
+description: Use when implementing or reviewing frontend performance — bundle optimization, lazy loading, image optimization, caching, Core Web Vitals (LCP, FID/INP, CLS), code splitting, rendering strategies, or any speed/performance task. Trigger on keywords like performance, speed, bundle size, lazy load, Web Vitals, LCP, CLS, INP, cache, optimize, lighthouse, Core Web Vitals.
+---
+
+# Performance Skill
+
+## Core Web Vitals Targets
+
+| Metric | Good | Needs Improvement | Poor |
+|--------|------|--------------------|------|
+| **LCP** (Largest Contentful Paint) | ≤ 2.5s | ≤ 4.0s | > 4.0s |
+| **INP** (Interaction to Next Paint) | ≤ 200ms | ≤ 500ms | > 500ms |
+| **CLS** (Cumulative Layout Shift) | ≤ 0.1 | ≤ 0.25 | > 0.25 |
+
+## Rendering Strategy
+
+Pick the right rendering mode per page:
+
+| Strategy | When | How (Next.js) |
+|----------|------|---------------|
+| **Static (SSG)** | Content changes infrequently | `export const dynamic = 'force-static'` or default in App Router |
+| **ISR** | Content updates periodically | `revalidate: N` in `fetch` or route config |
+| **SSR** | Content is user-specific or real-time | `export const dynamic = 'force-dynamic'` or `cookies()`/`headers()` usage |
+| **Streaming** | Pages with slow data + fast shell | `loading.tsx` + Suspense boundaries |
+
+Rules:
+- Default to static. Only use dynamic rendering when necessary.
+- Use Suspense + `loading.tsx` for streaming — show a shell immediately.
+- Never block the entire page on a single slow API call.
+
+## Bundle Optimization
+
+```bash
+# Analyze bundle
+npx @next/bundle-analyzer
+```
+
+Rules:
+- Import only what you use: `import { debounce } from 'lodash-es'` not `import _ from 'lodash'`.
+- Use dynamic imports for heavy, below-the-fold components:
+  ```ts
+  const HeavyChart = dynamic(() => import('./HeavyChart'), { loading: () => <Skeleton /> })
+  ```
+- Check bundle size before merging: `pnpm build` + analyze.
+- Avoid barrel exports (`export * from`) in shared packages — they prevent tree-shaking.
+- Prefer native browser APIs over polyfills (e.g., `fetch`, `URL`, `structuredClone`).
+
+## Image Optimization
+
+```html
+<!-- Next.js: always use next/image -->
+<Image
+  src="/hero.webp"
+  alt="Descriptive text"
+  width={1200}
+  height={630}
+  priority          // for above-the-fold / LCP images
+  placeholder="blur"
+  blurDataURL={blurHash}
+/>
+
+<!-- Below the fold: lazy loaded by default -->
+<Image src="/thumbnail.webp" alt="..." width={400} height={300} />
+```
+
+Rules:
+- Use `next/image` for automatic WebP/AVIF conversion, resizing, and lazy loading.
+- Set `priority` on the LCP image (hero, main visual). Never lazy-load LCP.
+- Always specify `width` and `height` to prevent CLS.
+- Use responsive `sizes` prop for different viewport breakpoints.
+- Serve modern formats (WebP, AVIF) with automatic fallbacks.
+
+## Font Optimization
+
+```ts
+// next/font — zero layout shift, automatic subsetting
+import { Inter } from 'next/font/google'
+
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',  // FOUT over FOIT — show fallback immediately
+})
+```
+
+Rules:
+- Use `next/font` (self-hosted, no external requests to Google Fonts).
+- `display: 'swap'` — text is visible immediately with fallback font.
+- Preload critical fonts: `<link rel="preload" as="font" ...>`.
+- Limit font variations (weight, style) to what's actually used.
+
+## Caching
+
+```ts
+// Server: cache fetch responses
+const data = await fetch(url, { next: { revalidate: 3600 } }) // ISR: 1 hour
+
+// Client: use React cache or SWR/React Query
+import { cache } from 'react'
+const getCachedUser = cache(async (id: string) => { ... })
+```
+
+Headers:
+- `Cache-Control: public, max-age=31536000, immutable` — hashed assets.
+- `Cache-Control: public, s-maxage=86400, stale-while-revalidate=86400` — static pages.
+- `Cache-Control: no-store` — truly dynamic, personalized content.
+
+Rules:
+- Static assets with content hashes → long cache + immutable.
+- HTML pages → shorter cache + stale-while-revalidate for freshness.
+- API responses → appropriate `Cache-Control` or `CDN-Cache-Control`.
+
+## Code Splitting & Lazy Loading
+
+```ts
+// Route-based splitting (automatic in App Router)
+// app/dashboard/page.tsx — separate chunk from app/settings/page.tsx
+
+// Component-level splitting
+const BelowFoldSection = dynamic(() => import('./BelowFoldSection'), {
+  loading: () => <SectionSkeleton />,
+})
+
+// Intersection Observer for non-JS triggering
+useEffect(() => {
+  const observer = new IntersectionObserver(([entry]) => {
+    if (entry.isIntersecting) {
+      loadAnalytics()
+      observer.disconnect()
+    }
+  }, { threshold: 0.1 })
+  observer.observe(ref.current)
+}, [])
+```
+
+## Third-Party Scripts
+
+```html
+<!-- defer/async for non-critical scripts -->
+<script src="analytics.js" defer></script>
+
+<!-- Lazy load with Intersection Observer or user interaction -->
+<script>
+  // Load on first interaction
+  window.addEventListener('scroll', () => { loadChatWidget() }, { once: true })
+</script>
+
+<!-- Use next/script for third-party scripts -->
+<Script src="https://analytics.example.com/script.js" strategy="lazyOnload" />
+```
+
+Rules:
+- Never block rendering with third-party scripts.
+- Use `strategy="afterInteractive"` or `strategy="lazyOnload"` in Next.js.
+- Self-host third-party scripts when possible (eliminates DNS + TLS round trips).
+- Audit: no more than 2 render-blocking resources.
+
+## CSS Optimization
+
+- Critical CSS inline in `<head>` (Next.js does this automatically).
+- Avoid large CSS-in-JS runtime costs — prefer CSS Modules, Tailwind, or static extraction.
+- Remove unused CSS: use PurgeCSS / Tailwind's built-in purging.
+- Use `content-visibility: auto` for off-screen sections to skip rendering work.
+
+## Monitoring & Measurement
+
+```bash
+# Lighthouse CI
+npx lighthouse https://example.com --output=json --output-path=./lh-report.json
+
+# Core Web Vitals in production
+# Use web-vitals library
+import { onLCP, onINP, onCLS } from 'web-vitals'
+onLCP(console.log)
+onINP(console.log)
+onCLS(console.log)
+```
+
+Rules:
+- Run Lighthouse before every release (target: Performance ≥ 90).
+- Monitor CrUX / RUM data in production.
+- Set up alerts for regressions in LCP, INP, CLS.
+
+## Performance Checklist
+
+- [ ] Lighthouse Performance score ≥ 90
+- [ ] LCP ≤ 2.5s (LCP element identified, preloaded if needed)
+- [ ] INP ≤ 200ms (no long tasks blocking main thread)
+- [ ] CLS ≤ 0.1 (all media has dimensions, no dynamic content injection above fold)
+- [ ] Images use `next/image` with explicit width/height
+- [ ] Fonts self-hosted via `next/font` with `display: swap`
+- [ ] No render-blocking third-party scripts
+- [ ] Bundle analyzed — no unexpected large dependencies
+- [ ] Dynamic imports for below-the-fold heavy components
+- [ ] Static rendering used where possible
+- [ ] Appropriate cache headers set
+- [ ] No layout shift from ads, embeds, or dynamically loaded content

--- a/.claude/skills/seo/SKILL.md
+++ b/.claude/skills/seo/SKILL.md
@@ -1,213 +1,369 @@
 ---
 name: seo
-description: Use when implementing or reviewing SEO best practices — meta tags, structured data, Open Graph, Twitter Cards, semantic HTML, sitemap, robots.txt, image alt text, canonical URLs, or any search-engine-optimization task. Trigger on keywords like SEO, meta, sitemap, structured data, schema.org, Open Graph, canonical, robots.
+description: >
+  Deterministic LLM-first SEO audits for websites, blog posts, and GitHub
+  repositories. Use this when the user asks to "perform SEO analysis", "run SEO
+  audit", "analyze SEO", "check technical SEO", "review schema", "Core Web
+  Vitals", "E-E-A-T", "hreflang", "GEO", "AEO", or GitHub repository SEO
+  optimization. For full/page/repo audits, run bundled scripts for evidence and
+  return prioritized, confidence-labeled fixes.
 ---
 
-# SEO Skill
+# SEO Skill (Agentic / Claude / Codex)
 
-## Core Principles
+LLM-first SEO analysis skill with 16 specialized sub-skills, 10 specialist agents, and 89 scripts for website, blog, and GitHub repository optimization.
 
-- Every page must have a unique `<title>` and `<meta name="description">`.
-- Use semantic HTML elements (`<article>`, `<section>`, `<nav>`, `<header>`, `<footer>`, `<main>`, `<aside>`) over generic `<div>`/`<span>`.
-- All images must have descriptive `alt` attributes. Decorative images use `alt=""`.
-- Use a single `<h1>` per page; headings must follow logical hierarchy (`h1` → `h2` → `h3`).
-- Ensure every page is reachable via internal links (no orphan pages).
+## Deterministic Trigger Mapping
 
-## Meta Tags
+For prompt reliability in Codex/agent IDEs, map common user wording to a fixed workflow:
 
-```html
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Page Title – Site Name</title>
-  <meta name="description" content="120–158 chars, include primary keyword naturally." />
-  <link rel="canonical" href="https://example.com/canonical-path" />
-</head>
+- If user says `perform seo analysis on <url>` (or similar generic SEO request with a URL), treat it as a **single-URL full audit**.
+- If no explicit sub-skill is specified, run the full/page audit path with **LLM-first reasoning** and script-backed evidence.
+- For full/page audits, always produce:
+  - `FULL-AUDIT-REPORT.md` (detailed findings)
+  - `ACTION-PLAN.md` (prioritized fixes)
+- If `generate_report.py` is run, also return the saved HTML path (for example `SEO-REPORT.html`).
+
+## Available Commands
+
+| Command | Sub-Skill | Description |
+|---------|-----------|-------------|
+| `seo audit <url>` | [seo-audit](resources/skills/seo-audit.md) | Full website audit with scoring |
+| `seo page <url>` | [seo-page](resources/skills/seo-page.md) | Deep single-page analysis |
+| `seo technical <url>` | [seo-technical](resources/skills/seo-technical.md) | Technical SEO checks |
+| `seo content <url>` | [seo-content](resources/skills/seo-content.md) | Content quality & E-E-A-T |
+| `seo schema <url>` | [seo-schema](resources/skills/seo-schema.md) | Schema detection/validation/generation |
+| `seo sitemap <url>` | [seo-sitemap](resources/skills/seo-sitemap.md) | Sitemap analysis & generation |
+| `seo images <url>` | [seo-images](resources/skills/seo-images.md) | Image optimization audit |
+| `seo geo <url>` | [seo-geo](resources/skills/seo-geo.md) | AI search optimization (GEO) |
+| `seo programmatic <url>` | [seo-programmatic](resources/skills/seo-programmatic.md) | Programmatic SEO safeguards |
+| `seo competitors <url>` | [seo-competitor-pages](resources/skills/seo-competitor-pages.md) | Comparison/alternatives pages |
+| `seo hreflang <url>` | [seo-hreflang](resources/skills/seo-hreflang.md) | International SEO validation |
+| `seo plan <url>` | [seo-plan](resources/skills/seo-plan.md) | Strategic SEO planning |
+| `seo github <repo_or_url>` | [seo-github](resources/skills/seo-github.md) | GitHub repository discoverability, README, topics, community health, and traffic archival |
+| `seo article <url>` | [seo-article](resources/skills/seo-article.md) | Article data extraction & LLM optimization |
+| `seo links <url>` | [seo-links](resources/skills/seo-links.md) | External backlink profile & link health |
+| `seo aeo <url>` | [seo-aeo](resources/skills/seo-aeo.md) | Answer Engine Optimization (Featured Snippets, PAA, Knowledge Panel) |
+
+---
+
+## Orchestration Logic
+
+When the user requests SEO analysis, follow this routing:
+
+### Step 1 — Identify the Task
+
+Parse the user's request to determine which sub-skill(s) to activate:
+
+- **Full audit**: Read `resources/skills/seo-audit.md` — crawl multiple pages, delegate to agents, score and report
+- **Single page**: Read `resources/skills/seo-page.md` — deep dive on one URL
+- **Specific area**: Read the matching `resources/skills/seo-*.md` file
+- **Strategic plan**: Read `resources/skills/seo-plan.md` and the matching `resources/templates/*.md` for the detected industry
+- **GitHub repository SEO**: Read `resources/skills/seo-github.md` and use GitHub scripts with `--provider auto` for API/`gh` fallback.
+- **Generic `perform seo analysis on <url>` request**: treat as single-page full audit, read `resources/skills/seo-page.md`, and generate `FULL-AUDIT-REPORT.md` + `ACTION-PLAN.md`.
+
+### Step 2 — Collect Evidence
+
+**Primary method (LLM-first)** — use the built-in `read_url_content` tool first:
+```
+read_url_content(url)  →  returns parsed HTML content directly
+```
+Use this as the baseline evidence for reasoning.
+
+**Deterministic verification (recommended when script execution is available)**:
+```bash
+# Fetch/parse raw HTML for structured checks
+python3 <SKILL_DIR>/scripts/fetch_page.py <url> --output /tmp/page.html
+python3 <SKILL_DIR>/scripts/parse_html.py /tmp/page.html --url <url> --json
+
+# Optional: generate shareable HTML dashboard artifact
+python3 <SKILL_DIR>/scripts/generate_report.py <url> --output SEO-REPORT.html
 ```
 
-Rules:
-- `title`: 50–60 chars. Primary keyword near the start. Unique per page.
-- `description`: 120–158 chars. Include CTA or value proposition. Unique per page.
-- `canonical`: Use absolute URL. Self-referencing canonical on every page. Omit on paginated series with `rel="prev"`/`rel="next"`.
+> **Do not use third-party mirrors (e.g., `r.jina.ai`) as primary evidence when direct site fetch or bundled scripts are available.**
+> `<SKILL_DIR>` = absolute path to this skill directory (the folder containing this SKILL.md).
 
-## Open Graph (Facebook, LinkedIn, Discord, etc.)
+### Step 3 — Perform LLM-First Analysis
 
-```html
-<meta property="og:type" content="website" />
-<meta property="og:title" content="Page Title" />
-<meta property="og:description" content="Concise summary." />
-<meta property="og:url" content="https://example.com/path" />
-<meta property="og:image" content="https://example.com/og-image.jpg" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="630" />
-<meta property="og:site_name" content="Site Name" />
-<meta property="og:locale" content="en_US" />
+Use the LLM as the primary SEO analyst:
+
+1. Synthesize evidence from page content, metadata, and optional script outputs.
+2. Produce findings with explicit proof:
+   - `Finding`
+   - `Evidence` (specific element, metric, or snippet)
+   - `Impact` (why it matters for ranking/indexing/UX)
+   - `Fix` (clear implementation step)
+3. Prioritize by impact and implementation effort.
+4. Separate confirmed issues, likely issues, and unknowns (missing data).
+
+Always read and apply `resources/references/llm-audit-rubric.md` to keep scoring, severity, confidence, and output structure consistent across audit types.
+
+### Step 4 — Run Baseline Verification Scripts (When execution is available)
+
+For full/page audits, run baseline checks to avoid hypothesis-only reporting. Do not replace LLM reasoning with script-only scoring.
+
+```bash
+# Check robots.txt and AI crawler management
+python3 <SKILL_DIR>/scripts/robots_checker.py <url>
+
+# Check llms.txt for AI search readiness
+python3 <SKILL_DIR>/scripts/llms_txt_checker.py <url>
+
+# Get Core Web Vitals from PageSpeed Insights (free API, no key needed)
+python3 <SKILL_DIR>/scripts/pagespeed.py <url> --strategy mobile
+
+# Check security headers (HSTS, CSP, X-Frame-Options, etc.)
+python3 <SKILL_DIR>/scripts/security_headers.py <url>
+
+# Detect broken links on a page (404s, timeouts, connection errors)
+python3 <SKILL_DIR>/scripts/broken_links.py <url> --workers 5
+
+# Trace redirect chains, detect loops and mixed HTTP/HTTPS
+python3 <SKILL_DIR>/scripts/redirect_checker.py <url>
+
+# Analyze readability from fetched HTML (Flesch-Kincaid, grade level, sentence stats)
+python3 <SKILL_DIR>/scripts/readability.py /tmp/page.html --json
+
+# Validate Open Graph and Twitter Card meta tags
+python3 <SKILL_DIR>/scripts/social_meta.py <url>
+
+# Analyze internal link structure, find orphan pages
+python3 <SKILL_DIR>/scripts/internal_links.py <url> --depth 1 --max-pages 20
+
+# Extract article content and perform keyword research for LLM-driven optimization
+python3 <SKILL_DIR>/scripts/article_seo.py <url> --keyword "<optional_target_keyword>" --json
+
+# Credentials for paid/auth APIs (PageSpeed, GitHub, GSC, Knowledge Graph)
+# are loaded from CLI flags, then env vars, then a `.env` file in the repo
+# root / cwd / `~/.agentic-seo/.env`. Copy `.env.example` to `.env` and fill
+# in only the keys you have. Never paste secrets in prompts.
+
+# GitHub repository SEO (provider fallback: auto|api|gh)
+# Auth setup (choose one):
+# export GITHUB_TOKEN="ghp_xxx"   # or export GH_TOKEN="ghp_xxx"
+# gh auth login -h github.com && gh auth status -h github.com
+python3 <SKILL_DIR>/scripts/github_repo_audit.py --repo <owner/repo> --provider auto --json
+python3 <SKILL_DIR>/scripts/github_readme_lint.py README.md --json
+python3 <SKILL_DIR>/scripts/github_community_health.py --repo <owner/repo> --provider auto --json
+# Benchmark/competitor inputs should be provided by LLM/web-search discovery when possible.
+# If omitted, github_seo_report.py auto-derives repo-specific benchmark queries.
+python3 <SKILL_DIR>/scripts/github_search_benchmark.py --repo <owner/repo> --query "<llm_or_web_query>" --provider auto --json
+python3 <SKILL_DIR>/scripts/github_competitor_research.py --repo <owner/repo> --query "<llm_or_web_query>" --provider auto --top-n 6 --json
+python3 <SKILL_DIR>/scripts/github_competitor_research.py --repo <owner/repo> --competitor <owner/repo> --competitor <owner/repo> --provider auto --json
+python3 <SKILL_DIR>/scripts/github_traffic_archiver.py --repo <owner/repo> --provider auto --archive-dir .github-seo-data --json
+python3 <SKILL_DIR>/scripts/github_seo_report.py --repo <owner/repo> --provider auto --markdown GITHUB-SEO-REPORT.md --action-plan GITHUB-ACTION-PLAN.md --json
+# Optional: increase/reduce auto-derived query volume (default: 6)
+# python3 <SKILL_DIR>/scripts/github_seo_report.py --repo <owner/repo> --provider auto --auto-query-max 8 --markdown GITHUB-SEO-REPORT.md --action-plan GITHUB-ACTION-PLAN.md --json
 ```
 
-For articles, use `og:type` = `"article"` and add `article:published_time`, `article:modified_time`, `article:author`.
+If a check fails due network, DNS, permissions, or API rate limits:
+- Report it explicitly as an **environment limitation**, not a confirmed site issue.
+- Keep confidence as `Hypothesis` for impacted categories.
+- Continue with available evidence instead of stopping the audit.
+- Do not enter repeated fallback loops. Retry a failed source at most once, then finalize the audit.
+- Do not pivot into repeated web-search scraping loops for the same URL.
 
-Rules:
-- `og:image`: 1200×630 px recommended. Absolute URL. No cached/dynamic URLs.
-- `og:url`: canonical URL, no trailing slashes inconsistency.
+**Visual analysis** (requires Playwright — use `conda activate pentest` if available):
+```bash
+# Capture screenshots (desktop, laptop, tablet, mobile)
+python3 <SKILL_DIR>/scripts/capture_screenshot.py <url> --all
 
-## Twitter / X Cards
-
-```html
-<meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="Page Title" />
-<meta name="twitter:description" content="Concise summary." />
-<meta name="twitter:image" content="https://example.com/twitter-image.jpg" />
-<meta name="twitter:site" content="@handle" />
+# Analyze visual layout, above-the-fold, mobile responsiveness
+python3 <SKILL_DIR>/scripts/analyze_visual.py <url> --json
 ```
 
-Rules:
-- Use `summary_large_image` for pages with hero images (≥300×157 px).
-- Use `summary` for text-only cards (≥144×144 px).
-
-## Structured Data (JSON-LD)
-
-Place in `<head>` or `<body>`. One `<script type="application/ld+json">` per schema type.
-
-```html
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "name": "Site Name",
-  "url": "https://example.com",
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": "https://example.com/search?q={search_term_string}",
-    "query-input": "required name=search_term_string"
-  }
-}
-</script>
+**HTML Report Generator** — generates a self-contained interactive HTML dashboard:
+```bash
+# Generate full SEO report (runs scripts automatically, saves HTML to PWD)
+python3 <SKILL_DIR>/scripts/generate_report.py <url>
+python3 <SKILL_DIR>/scripts/generate_report.py <url> --output custom-report.html
 ```
 
-Common `@type` values:
-- `WebSite` — homepage
-- `Organization` — company/brand
-- `Product` — product pages (include `offers`, `aggregateRating`)
-- `Article` / `NewsArticle` / `BlogPosting` — content pages
-- `BreadcrumbList` — all non-home pages
-- `FAQPage` — FAQ sections
-- `HowTo` — tutorial/guide content
-- `Event` — event pages
+### Step 5 — Delegate to Specialist Agents
 
-Validate with: https://search.google.com/test/rich-results
+For comprehensive audits, read the relevant agent file from `resources/agents/` to adopt the specialist role:
 
-## Image Optimization
+| Agent | File | Focus Area |
+|-------|------|------------|
+| Technical SEO | [seo-technical.md](resources/agents/seo-technical.md) | Crawlability, indexability, security, URLs, mobile, CWV, JS rendering |
+| Content Quality | [seo-content.md](resources/agents/seo-content.md) | E-E-A-T assessment, content metrics, AI content detection |
+| Performance | [seo-performance.md](resources/agents/seo-performance.md) | Core Web Vitals (LCP, INP, CLS), optimization recommendations |
+| Schema Markup | [seo-schema.md](resources/agents/seo-schema.md) | Detection, validation, generation of JSON-LD structured data |
+| Sitemap | [seo-sitemap.md](resources/agents/seo-sitemap.md) | XML sitemap validation, generation, quality gates |
+| Visual Analysis | [seo-visual.md](resources/agents/seo-visual.md) | Screenshots, above-the-fold, responsiveness, layout |
+| Verifier (global) | [seo-verifier.md](resources/agents/seo-verifier.md) | Deduplicate findings, suppress contradictions, and validate evidence relevance before final report |
 
-```html
-<img
-  src="hero.webp"
-  alt="Descriptive text that conveys the image's purpose"
-  width="1200"
-  height="630"
-  loading="lazy"
-  decoding="async"
-/>
+### Step 6 — Apply Quality Gates
+
+Reference the quality standards in `resources/references/`:
+
+- **Content minimums**: Read [quality-gates.md](resources/references/quality-gates.md) for word counts, unique content %, title/meta requirements
+- **Schema validation**: Read [schema-types.md](resources/references/schema-types.md) for active/deprecated/restricted types
+- **Core Web Vitals**: Read [cwv-thresholds.md](resources/references/cwv-thresholds.md) for current metric thresholds
+- **E-E-A-T framework**: Read [eeat-framework.md](resources/references/eeat-framework.md) for scoring criteria
+- **Google reference**: Read [google-seo-reference.md](resources/references/google-seo-reference.md) for quick reference
+- **LLM report rubric**: Read [llm-audit-rubric.md](resources/references/llm-audit-rubric.md) for mandatory evidence format, confidence labels, and output contract
+
+### Step 6.5 — Verify Findings (All Workflows)
+
+Before writing final reports, run verification:
+
+```bash
+python3 <SKILL_DIR>/scripts/finding_verifier.py --findings-json <raw_findings.json> --json
 ```
 
-Rules:
-- Always specify `width` and `height` to prevent CLS (Cumulative Layout Shift).
-- Use `loading="lazy"` for below-the-fold images. Never on LCP (Largest Contentful Paint) images.
-- Prefer WebP/AVIF formats with `<picture>` fallback.
-- Use descriptive `alt` text (not keyword-stuffed). Decorative images: `alt=""`.
+Use verified output for final report tables, not raw findings.
 
-## URL Structure
+### Step 7 — Score and Report
 
-- Short, descriptive, keyword-rich: `/games/chess` not `/games/12345`
-- Use hyphens, not underscores: `/my-page` not `/my_page`
-- All lowercase
-- No query parameters for indexable content
-- Trailing slash consistency (pick one and stick to it)
+Use numeric scores as guidance, not as a replacement for evidence quality and judgment.
 
-## Sitemap (`sitemap.xml`)
+#### Default Scoring Weights (Full Audit)
 
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://example.com/</loc>
-    <lastmod>2026-01-15</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>
+> **Canonical source of truth** — These weights are defined here and in `resources/skills/seo-audit.md`.
+> Do not modify weights in individual sub-skill files; update only these two locations to keep scores consistent.
+
+| Category | Weight |
+|----------|--------|
+| Technical SEO | 25% |
+| Content Quality | 20% |
+| On-Page SEO | 15% |
+| Schema / Structured Data | 15% |
+| Performance (CWV) | 10% |
+| Image Optimization | 10% |
+| AI Search Readiness (GEO) | 5% |
+
+> If using `scripts/generate_report.py`, the automated dashboard uses script-level category weights defined in that script. Keep the narrative audit LLM-first and evidence-first.
+
+### Step 8 — Mandatory Deliverables
+
+For `seo audit`, `seo page`, and generic `perform seo analysis on <url>` flows:
+
+1. Create `FULL-AUDIT-REPORT.md` in the current working directory at the start of the audit, then update it as evidence is collected.
+2. Create `ACTION-PLAN.md` in the current working directory at the start of the audit, then update it with prioritized fixes.
+3. If HTML dashboard was generated, include its exact saved path (for example `SEO-REPORT.html` or an absolute path).
+4. In the final response, explicitly list generated artifacts and paths.
+5. If technical checks are blocked by environment limits, still write both markdown files and include an "Environment Limitations" section.
+
+#### Score Interpretation
+| Score | Rating |
+|-------|--------|
+| 90-100 | Excellent |
+| 70-89 | Good |
+| 50-69 | Needs Improvement |
+| 30-49 | Poor |
+| 0-29 | Critical |
+
+---
+
+## Industry Detection
+
+When running `seo plan`, detect the business type and load the matching template:
+
+| Industry | Template File |
+|----------|---------------|
+| SaaS / Software | [saas.md](resources/templates/saas.md) |
+| Local Service Business | [local-service.md](resources/templates/local-service.md) |
+| E-commerce / Retail | [ecommerce.md](resources/templates/ecommerce.md) |
+| Publisher / Media | [publisher.md](resources/templates/publisher.md) |
+| Agency / Consultancy | [agency.md](resources/templates/agency.md) |
+| Other / Generic | [generic.md](resources/templates/generic.md) |
+
+**Detection signals:**
+- SaaS: pricing page, feature pages, /docs, /api, trial/demo CTAs
+- Local: address, phone, Google Business Profile, service area pages
+- E-commerce: product pages, cart, checkout, /collections, /categories
+- Publisher: article dates, author pages, /news, high content volume
+- Agency: case studies, /work, /portfolio, team pages, service offerings
+
+---
+
+## Schema Templates
+
+Pre-built JSON-LD templates are available in [templates.json](resources/schema/templates.json) for:
+- **Common**: BlogPosting, Article, Organization, LocalBusiness, BreadcrumbList, WebSite (with SearchAction)
+- **Video**: VideoObject, BroadcastEvent, Clip, SeekToAction
+- **E-commerce**: ProductGroup (variants), OfferShippingDetails, Certification
+- **Other**: SoftwareSourceCode, ProfilePage (E-E-A-T author pages)
+
+---
+
+## Validation Scripts
+
+Two validation scripts are available for CI/CD integration:
+
+### Pre-commit SEO Check
+```bash
+bash <SKILL_DIR>/scripts/pre_commit_seo_check.sh
 ```
+Checks staged HTML files for: placeholder text in schema, title tag length, missing alt text, deprecated schema types, FID references (should be INP), meta description length.
 
-Rules:
-- Include all indexable pages.
-- Exclude noindex, canonical duplicates, 4xx/5xx pages.
-- `lastmod` reflects actual content change date, not build date.
-- Max 50,000 URLs per sitemap. Use sitemap index for larger sites.
-- Reference in `robots.txt`: `Sitemap: https://example.com/sitemap.xml`
-
-## `robots.txt`
-
+### Schema Validator
+```bash
+python3 <SKILL_DIR>/scripts/validate_schema.py <file_path>
 ```
-User-agent: *
-Allow: /
-Disallow: /api/
-Disallow: /admin/
+Validates JSON-LD blocks in HTML files: JSON syntax, @context/@type presence, placeholder text, deprecated/restricted types.
 
-Sitemap: https://example.com/sitemap.xml
+### Skill Inventory Validator
+```bash
+python3 <SKILL_DIR>/scripts/validate_skill_inventory.py
 ```
+Validates documented sub-skill, agent, and script counts against files on disk. CI uses this to prevent README/SKILL inventory drift.
 
-Rules:
-- Block paths that produce duplicate or thin content.
-- Never block CSS/JS (search engines need them for rendering).
-- One `robots.txt` at domain root.
-
-## Page Speed & Core Web Vitals
-
-- **LCP** < 2.5s: Preload hero images/fonts (`<link rel="preload">`). Avoid lazy-loading LCP element.
-- **FID/INP** < 200ms: Minimize main-thread JS. Defer non-critical scripts.
-- **CLS** < 0.1: Set explicit `width`/`height` on images/embeds. Avoid injecting content above the fold after load.
-
-## Next.js / React Specific
-
-- Use Next.js `metadata` export (App Router) or `Head` component (Pages Router) for meta tags.
-- Use `next/image` for automatic optimization, lazy loading, and width/height enforcement.
-- Server Components are preferred — content renders server-side (crawlable by default).
-- For dynamic routes, generate `metadata` dynamically and set `alternates.canonical`.
-- Use `generateSitemap()` or a sitemap route handler for dynamic sitemaps.
-
-```ts
-// app/page.tsx — Server Component
-import type { Metadata } from 'next'
-
-export const metadata: Metadata = {
-  title: 'Page Title – Site Name',
-  description: '120–158 char description.',
-  openGraph: {
-    title: 'Page Title',
-    description: 'Concise summary.',
-    images: [{ url: '/og-image.jpg', width: 1200, height: 630 }],
-  },
-}
+### Reference Freshness Validator
+```bash
+python3 <SKILL_DIR>/scripts/reference_freshness.py <SKILL_DIR>/resources/references --max-age-days 90
 ```
+Checks that every reference file has a `<!-- Updated: YYYY-MM-DD -->` marker and flags references older than the configured freshness window.
 
-## Accessibility ↔ SEO Overlap
+---
 
-- Proper heading hierarchy (already affects SEO).
-- ARIA labels on interactive elements.
-- Skip-to-content link.
-- Focus management for SPAs.
-- `lang` attribute on `<html>`.
+## Output Format
 
-## Checklist Before Merge
+All sub-skill reports should use consistent severity levels:
+- 🔴 **Critical** — Directly impacts rankings or indexing (fix immediately)
+- ⚠️ **Warning** — Optimization opportunity (fix within 1 month)
+- ✅ **Pass** — Meets or exceeds standards
+- ℹ️ **Info** — Not applicable or informational only
 
-- [ ] Unique `<title>` and `<meta name="description">` on every page
-- [ ] Open Graph tags present with valid 1200×630 image
-- [ ] Twitter Card tags present
-- [ ] Canonical URL set (self-referencing)
-- [ ] Structured data validates in Google Rich Results Test
-- [ ] All images have `alt` text and explicit dimensions
-- [ ] Semantic HTML used (not div-soup)
-- [ ] Single `<h1>` per page, logical heading order
-- [ ] `robots.txt` allows crawling of public pages
-- [ ] Sitemap includes all indexable pages
-- [ ] No broken internal links
-- [ ] Page passes Lighthouse SEO audit (score ≥ 90)
+Structure reports as:
+1. Summary table with element, value, and severity
+2. Detailed findings grouped by category
+3. Actionable recommendations ordered by impact
+
+---
+
+## Critical Rules
+
+1. **INP not FID** — FID was removed September 9, 2024. The sole interactivity metric is INP (Interaction to Next Paint). Never reference FID.
+2. **FAQ schema is restricted** — FAQPage schema is limited to government and healthcare authority sites only (August 2023). Do NOT recommend for commercial sites.
+3. **HowTo schema is deprecated** — Rich results fully removed September 2023. Never recommend.
+4. **JSON-LD only** — Always use `<script type="application/ld+json">`. Never recommend Microdata or RDFa.
+5. **E-E-A-T everywhere** — As of December 2025, E-E-A-T applies to ALL competitive queries, not just YMYL.
+6. **Mobile-first is complete** — 100% mobile-first indexing since July 5, 2024.
+7. **Location page limits** — Warning at 30+ pages, hard stop at 50+ pages. Enforce unique content requirements.
+8. **AI crawler management** — Check robots.txt for GPTBot, ClaudeBot, PerplexityBot, Applebot-Extended, Google-Extended, Bytespider, CCBot.
+9. **LLM-first, resilient pipeline** — Start by reading the page with `read_url_content`, then always run relevant scripts for structured evidence. Scripts are the **preferred** evidence source — use them actively. However, if any script fails (timeout, network, parsing), the LLM MUST still produce a complete analysis using its own reasoning (confidence: `Likely`). Never block a report on a single script failure.
+10. **Always produce file artifacts for audit flows** — `FULL-AUDIT-REPORT.md` and `ACTION-PLAN.md` are required outputs for full/page audit requests.
+11. **Bound evidence retries** — Avoid long search/retry loops. If core checks fail due DNS/network, finalize promptly with confidence labels and file outputs.
+12. **Avoid redundant web fallbacks** — If direct fetch/scripts fail and one fallback also fails, stop retrying and finish the report with explicit limitations.
+13. **Signal freshness tracking** — Every reference file should contain a `<!-- Updated: YYYY-MM-DD -->` comment. Flag any reference file older than 90 days for review. When Google announces algorithm changes, verify affected reference files within 7 days. Key dates to track: core updates (quarterly), schema deprecations (schema-types.md), CWV threshold changes (cwv-thresholds.md).
+
+---
+
+## Dependencies
+
+### Optional Script Dependencies
+- Python 3.8+
+- `requests` (for network analysis scripts)
+- `beautifulsoup4` (for HTML parsing scripts)
+- Playwright (for `capture_screenshot.py` and `analyze_visual.py`)
+  ```bash
+  pip install playwright && playwright install chromium
+  ```
+  Or if using conda: `conda activate pentest` (if Playwright is pre-installed)
+
+### Install Script Dependencies
+```bash
+pip install requests beautifulsoup4
+```

--- a/.claude/skills/seo/SKILL.md
+++ b/.claude/skills/seo/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: seo
+description: Use when implementing or reviewing SEO best practices — meta tags, structured data, Open Graph, Twitter Cards, semantic HTML, sitemap, robots.txt, image alt text, canonical URLs, or any search-engine-optimization task. Trigger on keywords like SEO, meta, sitemap, structured data, schema.org, Open Graph, canonical, robots.
+---
+
+# SEO Skill
+
+## Core Principles
+
+- Every page must have a unique `<title>` and `<meta name="description">`.
+- Use semantic HTML elements (`<article>`, `<section>`, `<nav>`, `<header>`, `<footer>`, `<main>`, `<aside>`) over generic `<div>`/`<span>`.
+- All images must have descriptive `alt` attributes. Decorative images use `alt=""`.
+- Use a single `<h1>` per page; headings must follow logical hierarchy (`h1` → `h2` → `h3`).
+- Ensure every page is reachable via internal links (no orphan pages).
+
+## Meta Tags
+
+```html
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page Title – Site Name</title>
+  <meta name="description" content="120–158 chars, include primary keyword naturally." />
+  <link rel="canonical" href="https://example.com/canonical-path" />
+</head>
+```
+
+Rules:
+- `title`: 50–60 chars. Primary keyword near the start. Unique per page.
+- `description`: 120–158 chars. Include CTA or value proposition. Unique per page.
+- `canonical`: Use absolute URL. Self-referencing canonical on every page. Omit on paginated series with `rel="prev"`/`rel="next"`.
+
+## Open Graph (Facebook, LinkedIn, Discord, etc.)
+
+```html
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Page Title" />
+<meta property="og:description" content="Concise summary." />
+<meta property="og:url" content="https://example.com/path" />
+<meta property="og:image" content="https://example.com/og-image.jpg" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:site_name" content="Site Name" />
+<meta property="og:locale" content="en_US" />
+```
+
+For articles, use `og:type` = `"article"` and add `article:published_time`, `article:modified_time`, `article:author`.
+
+Rules:
+- `og:image`: 1200×630 px recommended. Absolute URL. No cached/dynamic URLs.
+- `og:url`: canonical URL, no trailing slashes inconsistency.
+
+## Twitter / X Cards
+
+```html
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Page Title" />
+<meta name="twitter:description" content="Concise summary." />
+<meta name="twitter:image" content="https://example.com/twitter-image.jpg" />
+<meta name="twitter:site" content="@handle" />
+```
+
+Rules:
+- Use `summary_large_image` for pages with hero images (≥300×157 px).
+- Use `summary` for text-only cards (≥144×144 px).
+
+## Structured Data (JSON-LD)
+
+Place in `<head>` or `<body>`. One `<script type="application/ld+json">` per schema type.
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Site Name",
+  "url": "https://example.com",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://example.com/search?q={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+```
+
+Common `@type` values:
+- `WebSite` — homepage
+- `Organization` — company/brand
+- `Product` — product pages (include `offers`, `aggregateRating`)
+- `Article` / `NewsArticle` / `BlogPosting` — content pages
+- `BreadcrumbList` — all non-home pages
+- `FAQPage` — FAQ sections
+- `HowTo` — tutorial/guide content
+- `Event` — event pages
+
+Validate with: https://search.google.com/test/rich-results
+
+## Image Optimization
+
+```html
+<img
+  src="hero.webp"
+  alt="Descriptive text that conveys the image's purpose"
+  width="1200"
+  height="630"
+  loading="lazy"
+  decoding="async"
+/>
+```
+
+Rules:
+- Always specify `width` and `height` to prevent CLS (Cumulative Layout Shift).
+- Use `loading="lazy"` for below-the-fold images. Never on LCP (Largest Contentful Paint) images.
+- Prefer WebP/AVIF formats with `<picture>` fallback.
+- Use descriptive `alt` text (not keyword-stuffed). Decorative images: `alt=""`.
+
+## URL Structure
+
+- Short, descriptive, keyword-rich: `/games/chess` not `/games/12345`
+- Use hyphens, not underscores: `/my-page` not `/my_page`
+- All lowercase
+- No query parameters for indexable content
+- Trailing slash consistency (pick one and stick to it)
+
+## Sitemap (`sitemap.xml`)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+    <lastmod>2026-01-15</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>
+```
+
+Rules:
+- Include all indexable pages.
+- Exclude noindex, canonical duplicates, 4xx/5xx pages.
+- `lastmod` reflects actual content change date, not build date.
+- Max 50,000 URLs per sitemap. Use sitemap index for larger sites.
+- Reference in `robots.txt`: `Sitemap: https://example.com/sitemap.xml`
+
+## `robots.txt`
+
+```
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/
+
+Sitemap: https://example.com/sitemap.xml
+```
+
+Rules:
+- Block paths that produce duplicate or thin content.
+- Never block CSS/JS (search engines need them for rendering).
+- One `robots.txt` at domain root.
+
+## Page Speed & Core Web Vitals
+
+- **LCP** < 2.5s: Preload hero images/fonts (`<link rel="preload">`). Avoid lazy-loading LCP element.
+- **FID/INP** < 200ms: Minimize main-thread JS. Defer non-critical scripts.
+- **CLS** < 0.1: Set explicit `width`/`height` on images/embeds. Avoid injecting content above the fold after load.
+
+## Next.js / React Specific
+
+- Use Next.js `metadata` export (App Router) or `Head` component (Pages Router) for meta tags.
+- Use `next/image` for automatic optimization, lazy loading, and width/height enforcement.
+- Server Components are preferred — content renders server-side (crawlable by default).
+- For dynamic routes, generate `metadata` dynamically and set `alternates.canonical`.
+- Use `generateSitemap()` or a sitemap route handler for dynamic sitemaps.
+
+```ts
+// app/page.tsx — Server Component
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Page Title – Site Name',
+  description: '120–158 char description.',
+  openGraph: {
+    title: 'Page Title',
+    description: 'Concise summary.',
+    images: [{ url: '/og-image.jpg', width: 1200, height: 630 }],
+  },
+}
+```
+
+## Accessibility ↔ SEO Overlap
+
+- Proper heading hierarchy (already affects SEO).
+- ARIA labels on interactive elements.
+- Skip-to-content link.
+- Focus management for SPAs.
+- `lang` attribute on `<html>`.
+
+## Checklist Before Merge
+
+- [ ] Unique `<title>` and `<meta name="description">` on every page
+- [ ] Open Graph tags present with valid 1200×630 image
+- [ ] Twitter Card tags present
+- [ ] Canonical URL set (self-referencing)
+- [ ] Structured data validates in Google Rich Results Test
+- [ ] All images have `alt` text and explicit dimensions
+- [ ] Semantic HTML used (not div-soup)
+- [ ] Single `<h1>` per page, logical heading order
+- [ ] `robots.txt` allows crawling of public pages
+- [ ] Sitemap includes all indexable pages
+- [ ] No broken internal links
+- [ ] Page passes Lighthouse SEO audit (score ≥ 90)

--- a/.claude/skills/seo/resources/agents/seo-content.md
+++ b/.claude/skills/seo/resources/agents/seo-content.md
@@ -1,0 +1,137 @@
+---
+name: seo-content
+description: Content quality reviewer. Evaluates E-E-A-T signals, readability, content depth, AI citation readiness, and thin content detection.
+tools: Read, Bash, Write, Grep
+---
+
+You are a Content Quality specialist following Google's September 2025 Quality Rater Guidelines.
+
+When given content to analyze:
+
+1. Assess E-E-A-T signals (Experience, Expertise, Authoritativeness, Trustworthiness)
+2. Check word count against page type minimums
+3. Calculate readability metrics
+4. Evaluate keyword optimization (natural, not stuffed)
+5. Assess AI citation readiness (quotable facts, structured data, clear hierarchy)
+6. Check content freshness and update signals
+7. Flag potential AI-generated content quality issues per Sept 2025 QRG criteria
+
+## Available Scripts
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `article_seo.py` | Article extraction, readability, SEO issues | `python3 article_seo.py <url> --json` |
+| `entity_checker.py` | Entity presence, sameAs, Knowledge Graph | `python3 entity_checker.py <url> --json` |
+| `competitor_gap.py` | Content gap analysis vs competitors | `python3 competitor_gap.py <url> --competitor <url> --json` |
+
+## E-E-A-T Scoring
+
+| Factor | Weight | What to Look For |
+|--------|--------|-----------------|
+| Experience | 20% | First-hand signals, original content, case studies, screenshots, personal anecdotes |
+| Expertise | 25% | Author credentials, technical accuracy, depth of explanation, citations |
+| Authoritativeness | 25% | External recognition, citations from others, publication reputation, awards |
+| Trustworthiness | 30% | Contact info, about page, privacy policy, HTTPS, editorial standards disclosure |
+
+### E-E-A-T Evidence Signals (what to check)
+
+**Experience (20%)**
+- [ ] Author byline with real name
+- [ ] First-person language ("I tested...", "In my experience...")
+- [ ] Original screenshots, photos, or data
+- [ ] Case studies or real examples
+- [ ] Author bio page with credentials linked
+
+**Expertise (25%)**
+- [ ] Technical claims are accurate and current
+- [ ] Citations to primary sources (not just other blogs)
+- [ ] Appropriate depth for the topic
+- [ ] Author has relevant professional background
+- [ ] Content demonstrates practical knowledge
+
+**Authoritativeness (25%)**
+- [ ] Site is recognized in its niche
+- [ ] External sites link to/cite this content
+- [ ] Author is published elsewhere in the field
+- [ ] Google Knowledge Panel exists for entity
+- [ ] Social proof present (testimonials, press mentions)
+
+**Trustworthiness (30%)**
+- [ ] Contact information visible and valid
+- [ ] About page with real people and company info
+- [ ] Privacy policy and terms of service present
+- [ ] HTTPS with valid certificate
+- [ ] No deceptive practices (hidden content, misleading headlines)
+- [ ] Publish date and last-updated date visible
+
+## Content Minimums
+
+| Page Type | Min Words | Notes |
+|-----------|-----------|-------|
+| Homepage | 500 | Hero + value proposition + key content |
+| Service page | 800 | Description + process + benefits + FAQ |
+| Blog post | 1,500 | Deep topical coverage |
+| Product page | 300+ | 400+ for complex products, UGC helps |
+| Location page | 500-600 | Unique local content required |
+| Pillar page | 3,000-5,000 | Comprehensive topic overview |
+
+> **Note:** These are topical coverage floors, not targets. Google confirms word count is NOT a direct ranking factor. The goal is comprehensive topical coverage.
+
+## Readability Targets
+
+| Metric | Target | Tool |
+|--------|--------|------|
+| Flesch Reading Ease | 60-70 (standard) | `article_seo.py --json` |
+| Flesch-Kincaid Grade | 7-9 (high school) | `article_seo.py --json` |
+| Sentence length | <25 words avg | Manual check |
+| Paragraph length | <4 sentences | Visual inspection |
+
+Adjust targets by audience:
+- Academic/technical: FK Grade 10-12 acceptable
+- Consumer/general: FK Grade 6-8 ideal
+- Children/education: FK Grade 4-6
+
+## AI Content Assessment (Sept 2025 QRG)
+
+AI content is acceptable IF it demonstrates genuine E-E-A-T. Flag these markers of low-quality AI content:
+- Generic phrasing, lack of specificity
+- No original insight or unique perspective
+- No first-hand experience signals
+- Factual inaccuracies
+- Repetitive structure across pages
+- Listicle-heavy format with shallow coverage
+- Over-use of transition phrases ("In this article", "Let's dive in")
+
+> **Helpful Content System (March 2024):** The Helpful Content System was merged into Google's core ranking algorithm during the March 2024 core update. It no longer operates as a standalone classifier. Helpfulness signals are now evaluated within every core update.
+
+## AEO Content Requirements
+
+For Answer Engine Optimization (Featured Snippets, PAA):
+- Direct answer in first 40-55 words after matching H2/H3
+- Question-phrased H2/H3 tags for PAA targeting
+- `<ol>`/`<ul>` lists with 5-9 items for list snippets
+- `<table>` with ≤4 columns for table snippets
+- No filler phrases before the answer
+
+## GEO Content Requirements
+
+For AI citation and AI Overview inclusion:
+- Clear, quotable factual statements (not opinions)
+- Structured data (`Article`, `FAQPage` if eligible, `speakable`)
+- Brand mentions with consistent entity naming
+- `llms.txt` file at site root
+
+## Cross-Skill Delegation
+
+- For evaluating programmatically generated pages, defer to the `seo-programmatic` sub-skill.
+- For entity SEO and Knowledge Graph presence, use `entity_checker.py`.
+- For topical authority cluster planning, defer to the `seo-plan` sub-skill (section 4.5).
+
+## Output Format
+
+Provide:
+- Content quality score (0-100) using chain-of-thought scoring from `llm-audit-rubric.md`
+- E-E-A-T breakdown with scores per factor
+- Readability metrics
+- AI citation readiness score
+- Specific improvement recommendations prioritized by impact

--- a/.claude/skills/seo/resources/agents/seo-github-analyst.md
+++ b/.claude/skills/seo/resources/agents/seo-github-analyst.md
@@ -1,0 +1,59 @@
+---
+name: seo-github-analyst
+description: GitHub SEO strategist. Synthesizes repo metadata, README, community health, search benchmark, and traffic evidence into prioritized actions.
+tools: Read, Bash, Write, Glob, Grep
+---
+
+You are a GitHub SEO strategist. Your role is to convert raw repository data
+into an execution-prioritized optimization plan.
+
+## Responsibilities
+
+1. Aggregate findings from:
+   - `github_repo_audit.py`
+   - `github_readme_lint.py`
+   - `github_community_health.py`
+   - `github_search_benchmark.py`
+   - `github_traffic_archiver.py` snapshots
+2. Label findings with severity and confidence.
+3. Separate platform limitations from verified repo issues.
+4. Produce a sequenced action plan:
+   - Immediate blockers
+   - Quick wins
+   - Strategic improvements
+
+## Analysis Model
+
+### Discovery Layer
+- Repository name and description intent-match.
+- Topic completeness and relevance.
+- Query-level visibility benchmark.
+
+### Conversion Layer
+- README opening clarity and value proposition.
+- Install clarity and capability proof.
+- CTA quality (star, usage, contribution paths).
+
+### Trust Layer
+- Community profile completeness.
+- Governance assets and citation readiness.
+- Release freshness and project maintenance signals.
+
+### Measurement Layer
+- Snapshot freshness and trend continuity.
+- Adequacy of archived traffic history.
+
+## Output Contract
+
+Produce:
+
+1. Executive summary (score band + top 5 issues).
+2. Findings table with `Finding`, `Evidence`, `Impact`, `Fix`.
+3. Prioritized action plan in execution order.
+4. Unknowns/follow-ups for incomplete API data.
+
+## Guardrails
+
+- Do not infer exact GitHub ranking weights.
+- Do not label missing API access as a repository defect.
+- Keep recommendations implementable and specific.

--- a/.claude/skills/seo/resources/agents/seo-github-benchmark.md
+++ b/.claude/skills/seo/resources/agents/seo-github-benchmark.md
@@ -1,0 +1,46 @@
+---
+name: seo-github-benchmark
+description: GitHub search benchmark specialist. Compares target repository visibility against competitors for specific queries.
+tools: Read, Bash, Write, Glob, Grep
+---
+
+You are responsible for query-level benchmark analysis on GitHub repository
+search.
+
+## Responsibilities
+
+1. Run `github_search_benchmark.py` with deterministic query sets.
+2. Identify if/where target repo appears by query.
+3. Extract top competitor repositories per query.
+4. Summarize high-signal competitor patterns:
+   - naming and description conventions
+   - topic choices
+   - README opening patterns
+   - release freshness
+
+## Required Evidence
+
+For each query, provide:
+
+- Query text
+- Total results returned
+- Target repo rank (or `Not found in sampled range`)
+- Top 5 competitors
+
+## Prioritization Model
+
+- `Critical`: target repo absent across core intent queries.
+- `Warning`: present but outside top visibility band (11+).
+- `Pass`: appears consistently in target band.
+- `Info`: optional expansion opportunities.
+
+## Output Contract
+
+1. Query benchmark table.
+2. Competitor pattern summary.
+3. Prioritized improvement hypotheses tied to evidence.
+
+## Guardrails
+
+- Use deterministic, repeatable query sets.
+- Avoid subjective claims without query evidence.

--- a/.claude/skills/seo/resources/agents/seo-github-data.md
+++ b/.claude/skills/seo/resources/agents/seo-github-data.md
@@ -1,0 +1,48 @@
+---
+name: seo-github-data
+description: GitHub API data collector and archival specialist for repository SEO telemetry.
+tools: Read, Bash, Write, Glob, Grep
+---
+
+You handle API-backed data collection and persistence for GitHub SEO analysis.
+
+## Responsibilities
+
+1. Validate token availability (`GITHUB_TOKEN` or `GH_TOKEN`).
+2. Run:
+   - `github_repo_audit.py`
+   - `github_community_health.py`
+   - `github_traffic_archiver.py`
+3. Persist snapshots to `.github-seo-data/`.
+4. Report data freshness and collection errors explicitly.
+
+## Collection Rules
+
+- Capture traffic at least daily when possible.
+- Append-only archival for historical reconstruction.
+- Timestamp every snapshot in UTC.
+- Never overwrite historical records silently.
+
+## Error Handling
+
+- If API returns 401/403/429:
+  - classify as environment/access limitation.
+  - include retry guidance and missing scopes checklist.
+- If endpoint data is unavailable:
+  - continue with available sections and mark unknowns.
+
+## Output Contract
+
+Return a compact collection report:
+
+- run timestamp
+- repository
+- endpoints attempted
+- endpoints succeeded/failed
+- archive file paths written
+- freshness status (current/stale/missing)
+
+## Guardrails
+
+- Never leak token values in logs or reports.
+- Never treat API auth errors as repository SEO failures.

--- a/.claude/skills/seo/resources/agents/seo-performance.md
+++ b/.claude/skills/seo/resources/agents/seo-performance.md
@@ -1,0 +1,133 @@
+---
+name: seo-performance
+description: Performance analyzer. Measures and evaluates Core Web Vitals and page load performance.
+tools: Read, Bash, Write
+---
+
+You are a Web Performance specialist focused on Core Web Vitals.
+
+## Available Scripts
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `pagespeed.py` | PageSpeed Insights API call | `python3 pagespeed.py <url> --json` |
+| `parse_html.py` | HTML source analysis for issues | `python3 parse_html.py --url <url> --json` |
+
+## Current Metrics (as of February 2026)
+
+### LCP (Largest Contentful Paint) — Loading
+
+| Rating | Threshold |
+|--------|-----------|
+| Good | ≤2.5s |
+| Needs Improvement | 2.5–4.0s |
+| Poor | >4.0s |
+
+**LCP Subparts** (available in CrUX since February 2025):
+
+| Subpart | Description | Target |
+|---------|-------------|--------|
+| TTFB | Time to First Byte | <800ms |
+| Resource Load Delay | Gap before LCP resource starts | <100ms |
+| Resource Load Duration | Download time for LCP element | <700ms |
+| Element Render Delay | Time from download to paint | <50ms |
+
+### INP (Interaction to Next Paint) — Interactivity
+
+| Rating | Threshold |
+|--------|-----------|
+| Good | ≤200ms |
+| Needs Improvement | 200–500ms |
+| Poor | >500ms |
+
+**IMPORTANT**: INP replaced FID on March 12, 2024. FID was fully removed from all Chrome tools (CrUX API, PageSpeed Insights, Lighthouse) on September 9, 2024. INP is the sole interactivity metric. **Never reference FID.**
+
+### CLS (Cumulative Layout Shift) — Visual Stability
+
+| Rating | Threshold |
+|--------|-----------|
+| Good | ≤0.1 |
+| Needs Improvement | 0.1–0.25 |
+| Poor | >0.25 |
+
+## Evaluation Method
+
+Google evaluates the **75th percentile** of page visits — 75% of visits must meet the "good" threshold to pass.
+
+## Common LCP Issues & Fixes
+
+| Issue | Fix | Impact |
+|-------|-----|--------|
+| Unoptimized hero image | Compress, convert to WebP/AVIF, add `<link rel="preload">` | High |
+| Render-blocking CSS/JS | `defer`/`async` scripts, inline critical CSS | High |
+| Slow TTFB (>800ms) | Edge CDN, server-side caching, reduce redirects | High |
+| Third-party scripts blocking render | `defer` load, move to footer | Medium |
+| Web font delay (FOIT) | `font-display: swap`, preload key fonts | Medium |
+| Large DOM (>1500 nodes) | Simplify layout, lazy-load below-fold | Medium |
+
+## Common INP Issues & Fixes
+
+| Issue | Fix | Impact |
+|-------|-----|--------|
+| Long JS tasks (>50ms) | Break into <50ms chunks via `requestIdleCallback` | High |
+| Heavy event handlers | Debounce, use `requestAnimationFrame` | High |
+| Excessive DOM size (>1500 elements) | Virtualize long lists, simplify markup | Medium |
+| Third-party main thread hijacking | Isolate in web workers, defer loading | Medium |
+| Synchronous XHR/localStorage | Switch to async APIs | Medium |
+
+## Common CLS Issues & Fixes
+
+| Issue | Fix | Impact |
+|-------|-----|--------|
+| Images without dimensions | Add explicit `width` and `height` attributes | High |
+| Dynamically injected content | Reserve space with `min-height` or `aspect-ratio` | High |
+| Web font FOIT/FOUT | `font-display: swap` + `size-adjust` fallback | Medium |
+| Ads/embeds without reserved space | Set fixed container dimensions | Medium |
+| Late-loading above-fold elements | Preload or inline critical resources | Medium |
+
+## INP Optimization Checklist
+
+- [ ] No JS task longer than 50ms on main thread
+- [ ] Event handlers use debounce/throttle for scroll/resize
+- [ ] `requestAnimationFrame` for visual updates
+- [ ] DOM size <1,500 elements
+- [ ] Third-party scripts deferred or in web workers
+- [ ] No synchronous `XMLHttpRequest` calls
+- [ ] `will-change` CSS used sparingly (only on animated elements)
+- [ ] `content-visibility: auto` on below-fold sections
+
+## Performance Tooling (2025-2026)
+
+| Tool | Notes |
+|------|-------|
+| **Lighthouse 13.0** (Oct 2025) | Major audit restructuring. Lab tool only — validate with field data |
+| **CrUX Vis** (Nov 2025) | Replaced CrUX Dashboard. Use [cruxvis.withgoogle.com](https://cruxvis.withgoogle.com) or CrUX API |
+| **PageSpeed Insights** | Combines Lighthouse (lab) + CrUX (field) data |
+
+## CLI Commands
+
+```bash
+# PageSpeed Insights API
+curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=URL&key=API_KEY"
+
+# Lighthouse CLI (local)
+npx lighthouse URL --output json
+
+# CrUX API (field data)
+curl "https://chromeuxreport.googleapis.com/v1/records:queryRecord?key=API_KEY" \
+  -d '{"url": "https://example.com"}'
+```
+
+## Output Format
+
+Provide:
+- Performance score (0-100) using chain-of-thought scoring from `llm-audit-rubric.md`
+- Core Web Vitals status (pass/fail per metric with actual values)
+- LCP subpart breakdown (which subpart is the bottleneck)
+- Specific bottlenecks identified
+- Prioritized recommendations with expected impact (High/Medium/Low)
+
+## Cross-Skill Delegation
+
+- For image optimization issues: coordinate with `seo-visual` agent
+- For JavaScript rendering vs SSR decisions: defer to `seo-technical` agent

--- a/.claude/skills/seo/resources/agents/seo-schema.md
+++ b/.claude/skills/seo/resources/agents/seo-schema.md
@@ -1,0 +1,121 @@
+---
+name: seo-schema
+description: Schema markup expert. Detects, validates, and generates Schema.org structured data in JSON-LD format.
+tools: Read, Bash, Write
+---
+
+You are a Schema.org markup specialist.
+
+When analyzing pages:
+
+1. Detect all existing schema (JSON-LD, Microdata, RDFa)
+2. Validate against Google's supported rich result types
+3. Check for required and recommended properties
+4. Identify missing schema opportunities
+5. Generate correct JSON-LD for recommended additions
+
+## Available Scripts
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `parse_html.py` | Extract JSON-LD blocks + validate types | `python3 parse_html.py --url <url> --json` |
+| `validate_schema.py` | Post-edit validation (pre-commit) | `python3 validate_schema.py <file>` |
+| `entity_checker.py` | Entity sameAs and KG presence | `python3 entity_checker.py <url> --json` |
+
+## CRITICAL RULES
+
+### Never Recommend — Deprecated Schema Types
+
+| Type | Status | Date |
+|------|--------|------|
+| `HowTo` | Rich results removed | September 2023 |
+| `SpecialAnnouncement` | Deprecated | July 31, 2025 |
+| `CourseInfo` | Retired | June 2025 |
+| `EstimatedSalary` | Retired | June 2025 |
+| `LearningVideo` | Retired | June 2025 |
+| `ClaimReview` | Retired (fact-check discontinued) | June 2025 |
+| `VehicleListing` | Retired | June 2025 |
+
+### Restricted Schema
+
+| Type | Restriction |
+|------|------------|
+| `FAQPage` | Government and healthcare authority sites only (Aug 2023) |
+| `QAPage` | Sites with user-generated Q&A only |
+
+### Always Prefer
+- JSON-LD format over Microdata or RDFa
+- `https://schema.org` as `@context` (not http)
+- Absolute URLs (not relative)
+- ISO 8601 date format
+
+## Validation Checklist
+
+For any schema block, verify:
+1. ✅ `@context` is `"https://schema.org"`
+2. ✅ `@type` is valid and not deprecated/retired
+3. ✅ All required properties present for the type
+4. ✅ Property values match expected types (string, URL, Date)
+5. ✅ No placeholder text (e.g., `[Business Name]`, `[INSERT]`)
+6. ✅ URLs are absolute
+7. ✅ Dates are ISO 8601
+8. ✅ `sameAs` URLs are valid and relevant
+
+## Active Schema Types — Quick Reference
+
+### Recommended Freely
+- `Organization`, `LocalBusiness`, `Person`
+- `Article`, `BlogPosting`, `NewsArticle`
+- `Product`, `Offer`, `Service`
+- `BreadcrumbList`, `WebSite`, `WebPage`
+- `Review`, `AggregateRating`
+- `VideoObject`, `Event`, `JobPosting`
+- `SoftwareApplication`, `Course`
+
+### Rich Result Eligible (verify requirements)
+
+| Schema | Required Properties | Rich Result |
+|--------|-------------------|-------------|
+| `Article` | `headline`, `image`, `datePublished`, `author` | Article snippet |
+| `Product` | `name`, `image`, `offers` (with `price`, `priceCurrency`) | Product rich result |
+| `LocalBusiness` | `name`, `address`, `telephone` | Business panel |
+| `Event` | `name`, `startDate`, `location` | Event listing |
+| `JobPosting` | `title`, `datePosted`, `description`, `hiringOrganization` | Job listing |
+| `Recipe` | `name`, `image`, `recipeIngredient` | Recipe card |
+| `VideoObject` | `name`, `thumbnailUrl`, `uploadDate` | Video snippet |
+| `BreadcrumbList` | `itemListElement` with `position`, `name`, `item` | Breadcrumb trail |
+
+### Entity SEO Schema Properties
+
+For Knowledge Graph presence, ensure:
+- `sameAs`: array of authoritative profile URLs (Wikipedia, LinkedIn, Twitter/X, Crunchbase)
+- `about`: link pillar/cluster pages to topic entities
+- `mentions`: reference related entities within content
+- `identifier`: include official IDs (DUNS, LEI, stock ticker)
+
+## Passage-Level Schema
+
+For Answer Engine Optimization, add `speakable` to top answer passages:
+```json
+{
+  "@type": "WebPage",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".answer-paragraph", "#key-takeaway"]
+  }
+}
+```
+
+## Output Format
+
+Provide:
+- Detection results (what schema exists, format, validity)
+- Validation results (pass/fail per block with specific errors)
+- Deprecated type warnings
+- Missing opportunities ranked by rich result potential
+- Generated JSON-LD for implementation (copy-paste ready)
+
+## Cross-Skill Delegation
+
+- For entity presence (Wikidata, Wikipedia, sameAs audit): use `entity_checker.py`
+- For JSON-LD extraction from page HTML: use `parse_html.py`

--- a/.claude/skills/seo/resources/agents/seo-sitemap.md
+++ b/.claude/skills/seo/resources/agents/seo-sitemap.md
@@ -1,0 +1,134 @@
+---
+name: seo-sitemap
+description: Sitemap architect. Validates XML sitemaps, generates new ones with industry templates, and enforces quality gates for location pages.
+tools: Read, Bash, Write, Glob
+---
+
+You are a Sitemap Architecture specialist.
+
+When working with sitemaps:
+
+1. Validate XML format and URL status codes
+2. Check for deprecated tags (priority, changefreq — both ignored by Google)
+3. Verify lastmod accuracy
+4. Compare crawled pages vs sitemap coverage
+5. Enforce the 50,000 URL per-file limit
+6. Apply location page quality gates
+7. Validate sitemap index structure
+
+## Available Scripts
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `parse_html.py` | Extract page metadata and canonicals | `python3 parse_html.py --url <url> --json` |
+| `broken_links.py` | Verify URL status codes | `python3 broken_links.py <url> --json` |
+| `duplicate_content.py` | Detect thin/duplicate content | `python3 duplicate_content.py <url> --json` |
+
+## Sitemap Validation Checks
+
+| Check | Severity | Action |
+|-------|----------|--------|
+| Invalid XML syntax | Critical | Fix syntax errors |
+| >50,000 URLs in single file | Critical | Split with sitemap index |
+| Uncompressed file >50MB | Critical | Compress with gzip or split |
+| Non-200 status URLs | High | Remove or fix broken URLs |
+| Noindexed URLs in sitemap | High | Remove — conflicting signals |
+| Canonicalized URLs (pointing elsewhere) | High | Remove non-canonical URLs |
+| Redirected URLs (301/302) | Medium | Update to final destination |
+| Missing `lastmod` dates | Medium | Add real modification dates |
+| All identical `lastmod` dates | Low | Use actual per-page dates |
+| `priority` / `changefreq` present | Info | Can remove (Google ignores) |
+| >100 sitemaps in index | Info | Functional but unusual |
+
+## Quality Gates
+
+### Location Page Thresholds
+- ⚠️ **WARNING** at 30+ location pages: require 60%+ unique content per page
+- 🛑 **HARD STOP** at 50+ location pages: require explicit user justification
+
+### Why This Matters
+Google's doorway page algorithm penalizes programmatic location pages with thin/duplicate content. Each location page must provide genuinely unique value.
+
+### Safe at Scale ✅
+- Integration pages (with real setup documentation)
+- Glossary pages (200+ word definitions)
+- Product pages (unique specs, reviews, UGC)
+- API documentation pages
+
+### Penalty Risk ❌
+- Location pages with only city name swapped
+- "Best [tool] for [industry]" without substantive content
+- AI-generated mass content without human editorial review
+- Pages with <40% unique content (per `duplicate_content.py`)
+
+## Sitemap Formats
+
+### Standard Sitemap
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/page</loc>
+    <lastmod>2026-02-07</lastmod>
+  </url>
+</urlset>
+```
+
+### Sitemap Index
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-posts.xml</loc>
+    <lastmod>2026-02-07</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap-pages.xml</loc>
+    <lastmod>2026-01-15</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+### Hreflang Sitemap (international)
+```xml
+<url>
+  <loc>https://example.com/page</loc>
+  <xhtml:link rel="alternate" hreflang="en" href="https://example.com/page"/>
+  <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es/page"/>
+  <xhtml:link rel="alternate" hreflang="x-default" href="https://example.com/page"/>
+</url>
+```
+
+### Image Sitemap Extension
+```xml
+<url>
+  <loc>https://example.com/page</loc>
+  <image:image>
+    <image:loc>https://example.com/images/hero.webp</image:loc>
+    <image:title>Descriptive title</image:title>
+  </image:image>
+</url>
+```
+
+## Sitemap Discovery Methods
+
+Ensure your sitemap is discoverable:
+1. **robots.txt**: `Sitemap: https://example.com/sitemap.xml`
+2. **Search Console**: Submit directly in GSC
+3. **IndexNow**: Auto-submit new URLs via `indexnow_checker.py`
+
+## Output Format
+
+Provide:
+- Validation report with pass/fail per check
+- Missing pages (in crawl but not sitemap)
+- Extra pages (in sitemap but 404 or redirected)
+- Quality gate warnings if applicable
+- Sitemap coverage percentage
+- Generated sitemap XML if creating new
+
+## Cross-Skill Delegation
+
+- For hreflang sitemap validation: defer to `seo-hreflang` sub-skill
+- For thin content detection in sitemap URLs: use `duplicate_content.py`
+- For IndexNow ping after sitemap updates: use `indexnow_checker.py`

--- a/.claude/skills/seo/resources/agents/seo-technical.md
+++ b/.claude/skills/seo/resources/agents/seo-technical.md
@@ -1,0 +1,128 @@
+---
+name: seo-technical
+description: Technical SEO specialist. Analyzes crawlability, indexability, security, URL structure, mobile optimization, Core Web Vitals, and JavaScript rendering.
+tools: Read, Bash, Write, Glob, Grep
+---
+
+You are a Technical SEO specialist. When given a URL or set of URLs:
+
+1. Fetch the page(s) and analyze HTML source
+2. Check robots.txt and sitemap availability
+3. Analyze meta tags, canonical tags, and security headers
+4. Evaluate URL structure and redirect chains
+5. Assess mobile-friendliness from HTML/CSS analysis
+6. Flag potential Core Web Vitals issues from source inspection
+7. Check JavaScript rendering requirements
+8. Validate AI crawler handling
+
+## Available Scripts
+
+Run these scripts from `<SKILL_DIR>/scripts/` to collect evidence:
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `parse_html.py` | HTML element extraction + JSON-LD validation | `python3 parse_html.py --url <url> --json` |
+| `hreflang_checker.py` | International SEO validation | `python3 hreflang_checker.py <url> --json` |
+| `indexnow_checker.py` | IndexNow implementation check | `python3 indexnow_checker.py <url> --key <key> --json` |
+| `duplicate_content.py` | Near-duplicate & thin content detection | `python3 duplicate_content.py <url> --json` |
+
+## Core Web Vitals Reference
+
+Current thresholds (as of February 2026):
+
+### LCP (Largest Contentful Paint) — Loading
+| Rating | Threshold |
+|--------|-----------|
+| Good | <2.5s |
+| Needs Improvement | 2.5–4s |
+| Poor | >4s |
+
+**LCP Subparts:**
+- **TTFB** (Time to First Byte): target <800ms
+- **Resource Load Delay**: time between TTFB and resource start — target <100ms
+- **Resource Load Duration**: download time for LCP resource — target <700ms
+- **Element Render Delay**: time from download to paint — target <50ms
+
+### INP (Interaction to Next Paint) — Interactivity
+| Rating | Threshold |
+|--------|-----------|
+| Good | <200ms |
+| Needs Improvement | 200–500ms |
+| Poor | >500ms |
+
+**IMPORTANT**: INP replaced FID on March 12, 2024. FID was fully removed from all Chrome tools (CrUX API, PageSpeed Insights, Lighthouse) on September 9, 2024. INP is the sole interactivity metric. **Never reference FID in any output.**
+
+### CLS (Cumulative Layout Shift) — Visual Stability
+| Rating | Threshold |
+|--------|-----------|
+| Good | <0.1 |
+| Needs Improvement | 0.1–0.25 |
+| Poor | >0.25 |
+
+## Security Headers Checklist
+
+Check these response headers (use `curl -I <url>`):
+
+| Header | Requirement | Impact |
+|--------|------------|--------|
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | HTTPS enforcement |
+| `X-Content-Type-Options` | `nosniff` | MIME sniffing prevention |
+| `X-Frame-Options` | `DENY` or `SAMEORIGIN` | Clickjacking prevention |
+| `Content-Security-Policy` | Present (any valid policy) | XSS prevention |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Privacy |
+| `Permissions-Policy` | Present | Feature restriction |
+
+## Redirect Rules
+
+- Maximum redirect chain length: **3 hops** (Google follows up to 10 but penalizes long chains)
+- Use **301** (permanent) for URL changes, not 302 (temporary)
+- Check for redirect loops (A→B→A)
+- HTTP→HTTPS redirect must exist
+
+## AI Crawler Management
+
+Verify robots.txt handles AI crawlers:
+
+| Crawler | Token | Purpose |
+|---------|-------|---------|
+| GPTBot | `GPTBot` | OpenAI (ChatGPT training) |
+| Google-Extended | `Google-Extended` | Gemini / Bard training |
+| CCBot | `CCBot` | Common Crawl |
+| anthropic-ai | `anthropic-ai` | Claude training |
+| Bytespider | `Bytespider` | TikTok / ByteDance |
+| cohere-ai | `cohere-ai` | Cohere training |
+
+## JavaScript Rendering Checklist
+
+| Check | Method | Severity if failed |
+|-------|--------|--------------------|
+| Critical content in initial HTML | View source vs rendered DOM | Critical |
+| `<noscript>` fallback present | Check source | Warning |
+| Hydration errors | Console log check | Warning |
+| Lazy-loaded above-fold content | Source inspection | Critical |
+| Client-side routing (SPA) | Check for `pushState` / hash routing | Warning |
+
+## Cross-Skill Delegation
+
+- For detailed hreflang validation, defer to the `seo-hreflang` sub-skill.
+- For AI search readiness (GEO), defer to the `seo-geo` sub-skill.
+- For voice search, see the Voice Search Optimization section in `seo-technical` skill.
+
+## Output Format
+
+Provide a structured report with:
+- Pass/fail status per category
+- Technical score (0-100) using chain-of-thought scoring from `llm-audit-rubric.md`
+- Prioritized issues (Critical → High → Medium → Low)
+- Specific recommendations with implementation details
+
+## Categories to Analyze
+
+1. Crawlability (robots.txt, sitemaps, noindex, AI crawlers)
+2. Indexability (canonicals, duplicates, thin content)
+3. Security (HTTPS, headers)
+4. URL Structure (clean URLs, redirects, chains)
+5. Mobile (viewport, touch targets, responsive)
+6. Core Web Vitals (LCP subparts, INP, CLS)
+7. Structured Data (detection, validation, deprecated types)
+8. JavaScript Rendering (CSR vs SSR, hydration)

--- a/.claude/skills/seo/resources/agents/seo-verifier.md
+++ b/.claude/skills/seo/resources/agents/seo-verifier.md
@@ -1,0 +1,37 @@
+---
+name: seo-verifier
+description: Global finding verification agent. Deduplicates findings, removes contradictions, and blocks unsupported claims before final reporting.
+tools: Read, Bash, Write, Glob, Grep
+---
+
+You are the final verifier for SEO outputs across all workflows.
+
+## Responsibilities
+
+1. Validate that each finding has concrete evidence.
+2. Remove duplicate findings that describe the same root issue.
+3. Suppress findings contradicted by measured metrics.
+4. Ensure findings are relevant to the current workflow scope.
+5. Confirm severity labels are proportionate to evidence.
+
+## Verification Rules
+
+- No evidence -> downgrade to `Hypothesis` or remove.
+- Duplicate issue across sources -> keep one merged finding with strongest evidence.
+- Contradiction detected -> remove finding and log suppression reason.
+- Environment limitation -> do not report as site/repo defect.
+
+## Implementation Hook
+
+Use `scripts/finding_verifier.py` before final report generation when structured
+findings are available.
+
+## Output Contract
+
+Return:
+
+- verified findings list
+- dropped findings list with reasons
+- counts (raw, verified, dropped)
+
+Final report must use verified findings, not raw findings.

--- a/.claude/skills/seo/resources/agents/seo-visual.md
+++ b/.claude/skills/seo/resources/agents/seo-visual.md
@@ -1,0 +1,143 @@
+---
+name: seo-visual
+description: Visual analyzer. Captures screenshots, tests mobile rendering, and analyzes above-the-fold content using Playwright.
+tools: Read, Bash, Write
+---
+
+You are a Visual Analysis specialist using Playwright for browser automation.
+
+## Prerequisites
+
+Before capturing screenshots, ensure Playwright and Chromium are installed:
+
+```bash
+pip install playwright && playwright install chromium
+```
+
+## Available Scripts
+
+| Script | Purpose | Command |
+|--------|---------|---------|
+| `capture_screenshot.py` | Browser screenshots (desktop + mobile) | `python3 capture_screenshot.py <url>` |
+| `analyze_visual.py` | Visual + DOM comparison analysis | `python3 analyze_visual.py <url>` |
+
+## When Analyzing Pages
+
+1. Capture desktop screenshot (1920x1080)
+2. Capture mobile screenshot (375x812, iPhone viewport)
+3. Analyze above-the-fold content
+4. Check for visual layout issues and overlapping elements
+5. Verify mobile responsiveness
+6. Compare JS-rendered vs non-JS DOM for SSR/CSR audit
+
+## Viewports to Test
+
+| Device | Width | Height | Use Case |
+|--------|-------|--------|----------|
+| Desktop (Full HD) | 1920 | 1080 | Standard desktop |
+| Laptop | 1366 | 768 | Most common laptop |
+| Tablet (Portrait) | 768 | 1024 | iPad |
+| Tablet (Landscape) | 1024 | 768 | iPad landscape |
+| Mobile (iPhone) | 375 | 812 | iPhone X/11/12/13/14 |
+| Mobile (Android) | 360 | 800 | Most Android devices |
+
+## Above-the-Fold Analysis
+
+### Critical Elements (must be visible without scrolling)
+
+| Element | Why | Check |
+|---------|-----|-------|
+| H1 heading | First impression + keyword signal | Visible in first viewport |
+| Primary CTA | Conversion path | Visible and actionable |
+| Hero image/content | Visual engagement | Loaded, not placeholder |
+| Navigation | Usability | Accessible (visible or hamburger) |
+| Brand/logo | Trust signal | Visible, properly sized |
+
+### Above-Fold Anti-patterns
+
+- ❌ Full-screen cookie banner obscuring content
+- ❌ Intrusive interstitial (Google penalizes this on mobile)
+- ❌ Auto-playing video with sound
+- ❌ Empty hero area waiting for JS to load
+- ❌ "Loading..." spinners for main content
+
+## Mobile Responsiveness Checklist
+
+- [ ] Navigation accessible (hamburger menu or visible tabs)
+- [ ] Touch targets at least **48x48px** (Google minimum)
+- [ ] No horizontal scroll on any viewport
+- [ ] Text readable without zooming — **16px+ base font size**
+- [ ] `<meta name="viewport" content="width=device-width, initial-scale=1">`
+- [ ] Forms usable on mobile (appropriate input types, visible labels)
+- [ ] Images scale properly (no overflow, no stretch)
+- [ ] Sticky/fixed elements don't obstruct content
+
+## Visual Issues to Flag
+
+### Layout Problems
+| Issue | Severity | Impact |
+|-------|----------|--------|
+| Overlapping elements | High | Content unreadable |
+| Text overflow/cutoff | High | Content loss |
+| Broken grid layout | Medium | Poor UX |
+| Images not scaling | Medium | Display issues |
+| White space gaps | Low | Aesthetic |
+
+### Image SEO Checks
+| Check | Requirement | SEO Impact |
+|-------|-------------|------------|
+| Format | WebP or AVIF preferred | Page speed |
+| Alt text | Descriptive, keyword-relevant | Accessibility + image search |
+| Dimensions | Explicit `width`/`height` | CLS prevention |
+| Lazy loading | `loading="lazy"` for below-fold | LCP improvement |
+| Responsive | `srcset` for multiple sizes | Mobile performance |
+
+## SSR vs CSR DOM Diff
+
+For JavaScript rendering audit:
+
+1. **Fetch without JS** (`curl` or `requests`) → get raw HTML DOM
+2. **Fetch with JS** (Playwright `networkidle`) → get rendered DOM
+3. **Compare** these critical elements:
+   - `<title>` — same in both?
+   - `<meta name="description">` — present in source?
+   - `<h1>` — present without JS?
+   - Canonical tag — present in source?
+   - JSON-LD schema — present in source?
+   - Main content text — visible in raw HTML?
+
+| Result | Severity | Action |
+|--------|----------|--------|
+| Critical SEO elements JS-only | Critical | Implement SSR/SSG |
+| Content partially JS-dependent | Warning | Add `<noscript>` fallbacks |
+| All elements in source HTML | Pass | No action needed |
+
+## Screenshot Workflow
+
+```python
+from playwright.sync_api import sync_playwright
+
+def capture(url, output_path, width=1920, height=1080):
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={'width': width, 'height': height})
+        page.goto(url, wait_until='networkidle')
+        page.screenshot(path=output_path, full_page=False)
+        browser.close()
+```
+
+## Output Format
+
+Provide:
+- Screenshots saved to `screenshots/` directory
+- Visual analysis summary with pass/fail per viewport
+- Mobile responsiveness assessment
+- Above-the-fold content evaluation
+- Image optimization recommendations
+- SSR/CSR rendering comparison (if applicable)
+
+## Cross-Skill Delegation
+
+- For detailed image format optimization: coordinate with `seo-performance` agent
+- For CLS caused by visual elements: coordinate with `seo-performance` agent
+- For mobile-specific structured data: coordinate with `seo-schema` agent

--- a/.claude/skills/seo/resources/config/scoring.json
+++ b/.claude/skills/seo/resources/config/scoring.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "overall": {
+    "method": "weighted_average",
+    "score_floor": 0,
+    "score_ceiling": 100,
+    "bands": [
+      {"min": 90, "grade": "A+", "label": "Excellent"},
+      {"min": 80, "grade": "A", "label": "Strong"},
+      {"min": 70, "grade": "B", "label": "Good"},
+      {"min": 60, "grade": "C", "label": "Needs work"},
+      {"min": 50, "grade": "D", "label": "At risk"},
+      {"min": 0, "grade": "F", "label": "Critical"}
+    ]
+  },
+  "categories": {
+    "security": {"weight": 8, "label": "Security Headers"},
+    "social": {"weight": 5, "label": "Social Meta"},
+    "robots": {"weight": 8, "label": "Robots and Crawlers"},
+    "broken_links": {"weight": 10, "label": "Broken Links"},
+    "internal_links": {"weight": 8, "label": "Internal Links"},
+    "redirects": {"weight": 3, "label": "Redirects"},
+    "llms_txt": {"weight": 5, "label": "AI Search"},
+    "pagespeed": {"weight": 13, "label": "Performance and Core Web Vitals"},
+    "onpage": {"weight": 10, "label": "On-Page SEO"},
+    "readability": {"weight": 8, "label": "Readability"},
+    "entity": {"weight": 5, "label": "Entity SEO"},
+    "link_profile": {"weight": 7, "label": "Link Profile"},
+    "hreflang": {"weight": 5, "label": "Hreflang"},
+    "duplicate_content": {"weight": 5, "label": "Content Uniqueness"}
+  }
+}

--- a/.claude/skills/seo/resources/references/cwv-thresholds.md
+++ b/.claude/skills/seo/resources/references/cwv-thresholds.md
@@ -1,0 +1,108 @@
+<!-- Updated: 2026-02-07 -->
+# Core Web Vitals Thresholds (February 2026)
+
+## Current Metrics
+
+| Metric | Good | Needs Improvement | Poor |
+|--------|------|-------------------|------|
+| LCP (Largest Contentful Paint) | ≤2.5s | 2.5s–4.0s | >4.0s |
+| INP (Interaction to Next Paint) | ≤200ms | 200ms–500ms | >500ms |
+| CLS (Cumulative Layout Shift) | ≤0.1 | 0.1–0.25 | >0.25 |
+
+## Key Facts
+- INP replaced FID (First Input Delay) on **March 12, 2024**. FID was fully removed from all Chrome tools (CrUX API, PageSpeed Insights, Lighthouse) on **September 9, 2024**. INP is the sole interactivity metric.
+- Evaluation uses the **75th percentile** of real user data (field data from CrUX).
+- Google assesses at the **page level** and the **origin level**.
+- Core Web Vitals are a **tiebreaker** ranking signal — they matter most when content quality is similar between competitors.
+- **Thresholds unchanged since original definitions** — ignore claims of "tightened thresholds" from SEO blogs.
+- December 2025 core update appeared to weight **mobile CWV more heavily**.
+- As of October 2025: **57.1%** desktop sites and **49.7%** mobile sites pass all three CWV.
+
+## LCP Subparts (February 2025 CrUX Addition)
+
+LCP can now be broken into diagnostic subparts:
+
+| Subpart | What It Measures | Target |
+|---------|------------------|--------|
+| **TTFB** | Time to First Byte (server response) | <800ms |
+| **Resource Load Delay** | Time from TTFB to resource request start | Minimize |
+| **Resource Load Time** | Time to download the LCP resource | Depends on size |
+| **Element Render Delay** | Time from resource loaded to rendered | Minimize |
+
+**Total LCP = TTFB + Resource Load Delay + Resource Load Time + Element Render Delay**
+
+Use this breakdown to identify which phase is causing LCP issues.
+
+## Soft Navigations API (Experimental)
+
+**Chrome 139+ Origin Trial (July 2025)** — First step toward measuring CWV in SPAs.
+
+- Addresses the long-standing SPA measurement blind spot
+- Currently experimental, **no ranking impact yet**
+- Detects "soft navigations" (URL changes without full page load)
+- May affect future SPA CWV measurement
+
+**Detection:** Check for SPA frameworks (React, Vue, Angular, Svelte) and warn about current CWV measurement limitations.
+
+## Measurement Sources
+
+### Field Data (Real Users)
+- Chrome User Experience Report (CrUX)
+- PageSpeed Insights (uses CrUX data)
+- Search Console Core Web Vitals report
+
+### Lab Data (Simulated)
+- Lighthouse
+- WebPageTest
+- Chrome DevTools
+
+> Field data is what Google uses for ranking. Lab data is useful for debugging.
+
+## Common Bottlenecks
+
+### LCP (Largest Contentful Paint)
+- Unoptimized hero images (compress, use WebP/AVIF, add preload)
+- Render-blocking CSS/JS (defer, async, critical CSS inlining)
+- Slow server response (TTFB >200ms — use edge CDN, caching)
+- Third-party script blocking (defer analytics, chat widgets)
+- Web font loading delay (use font-display: swap + preload)
+
+### INP (Interaction to Next Paint)
+- Long JavaScript tasks on main thread (break into smaller tasks <50ms)
+- Heavy event handlers (debounce, use requestAnimationFrame)
+- Excessive DOM size (>1,500 elements is concerning)
+- Third-party scripts hijacking main thread
+- Synchronous XHR or localStorage operations
+- Layout thrashing (multiple forced reflows)
+
+### CLS (Cumulative Layout Shift)
+- Images/iframes without width/height dimensions
+- Dynamically injected content above existing content
+- Web fonts causing layout shift (use font-display: swap + preload)
+- Ads/embeds without reserved space
+- Late-loading content pushing down the page
+
+## Optimization Priority
+
+1. **LCP** — Most impactful for perceived performance
+2. **CLS** — Most common issue affecting user experience
+3. **INP** — Matters most for interactive applications
+
+## Tools
+
+```bash
+# PageSpeed Insights API
+curl "https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url=URL&key=API_KEY"
+
+# Lighthouse CLI
+npx lighthouse URL --output json --output-path report.json
+```
+
+## Performance Tooling Updates (2025)
+
+- **Lighthouse 13.0** (October 2025): Major audit restructuring with reorganized performance categories and updated scoring weights. Lighthouse is a lab tool (simulated conditions) — always cross-reference with CrUX field data for real-world performance.
+- **CrUX Vis** replaced the CrUX Dashboard (November 2025). The old Looker Studio dashboard was deprecated. Use [CrUX Vis](https://cruxvis.withgoogle.com) or the CrUX API directly.
+- **LCP subparts** added to CrUX (February 2025): Time to First Byte (TTFB), resource load delay, resource load time, and element render delay are now available as sub-components of LCP in CrUX data.
+- **Google Search Console 2025 features** (December 2025): AI-powered configuration for automated analysis. Branded vs. non-branded queries filter. Hourly data available in API. Custom chart annotations. Social channels tracking.
+
+> **Mobile-first indexing** is 100% complete as of July 5, 2024. Google now crawls and indexes ALL websites exclusively with the mobile Googlebot user-agent. Ensure your mobile version contains all critical content, structured data, and meta tags.

--- a/.claude/skills/seo/resources/references/eeat-framework.md
+++ b/.claude/skills/seo/resources/references/eeat-framework.md
@@ -1,0 +1,216 @@
+<!-- Updated: 2026-05-14 -->
+
+# E-E-A-T Evaluation Framework
+## Updated per Google Quality Rater Guidelines — September 11, 2025
+## Plus December 2025 Core Update Implications
+
+## Overview
+
+E-E-A-T = **E**xperience, **E**xpertise, **A**uthoritativeness, **T**rustworthiness
+
+Trustworthiness is the most important factor. It is assessed based on the
+other three signals plus direct trust indicators.
+
+## CRITICAL: December 2025 Core Update
+
+> **E-E-A-T now applies to ALL competitive queries, not just YMYL.**
+
+The December 2025 core update was described as a "watershed moment" that:
+- Extended E-E-A-T evaluation to virtually all competitive queries
+- Made author attribution standards tighter across all categories
+- Penalized anonymous or generic authorship even for non-YMYL content
+- Significantly improved AI content quality detection
+
+**Impact by industry:**
+| Industry | Traffic Drops |
+|----------|--------------|
+| Affiliate sites | 71% average decline |
+| Health/YMYL | 67% average decline |
+| E-commerce | 52% average decline |
+
+**Key takeaway:** Even entertainment and lifestyle content now requires demonstrated expertise. Generic content no longer ranks.
+
+## YMYL (Your Money or Your Life)
+
+Topics requiring **highest** E-E-A-T standards (but E-E-A-T now matters everywhere):
+- Health and safety
+- Financial advice and transactions
+- Legal information
+- News and current events
+- **Elections and civic trust** (added Sept 2025)
+- **Democratic processes** (added Sept 2025)
+- Groups of people (potential for harm)
+
+---
+
+## Experience (Weight: 20%)
+
+First-hand knowledge and personal involvement with the topic.
+
+### Signals to Check
+- [ ] Author has demonstrable first-hand experience with the topic
+- [ ] Content includes original photos, screenshots, or data
+- [ ] Case studies or real-world examples with specific details
+- [ ] Personal process documentation or methodology descriptions
+- [ ] Before/after results or outcome data
+- [ ] Specific anecdotes that couldn't be fabricated
+
+### Scoring
+- **Strong**: Multiple first-hand experience signals, original content
+- **Moderate**: Some personal experience evident
+- **Weak**: Generic information, no personal touch
+- **None**: Clearly AI-generated or scraped content
+
+---
+
+## Expertise (Weight: 25%)
+
+Formal qualifications, training, and demonstrated knowledge.
+
+### Signals to Check
+- [ ] Author credentials relevant to topic (bio, certifications)
+- [ ] Technical accuracy and depth appropriate for audience
+- [ ] Claims supported by evidence or sources
+- [ ] Specialized vocabulary used correctly
+- [ ] Up-to-date with current developments in the field
+- [ ] Byline with author name and credentials visible
+
+### Scoring
+- **Strong**: Verified credentials, deep technical accuracy
+- **Moderate**: Demonstrable knowledge, some credentials
+- **Weak**: Surface-level information, no credentials
+- **None**: Factual errors, misinformation
+
+---
+
+## Authoritativeness (Weight: 25%)
+
+Recognition by others as a go-to source.
+
+### Signals to Check
+- [ ] Site recognized as authority in its niche
+- [ ] Author recognized as expert (external citations, speaking, publications)
+- [ ] Content cited by other authoritative sources
+- [ ] Industry awards, certifications, or accreditations
+- [ ] Consistent publication history in the topic area
+- [ ] Featured in reputable media outlets
+- [ ] Professional affiliations
+
+### Scoring
+- **Strong**: Widely recognized authority, cited by others
+- **Moderate**: Growing recognition, some external validation
+- **Weak**: No external recognition
+- **None**: Negative reputation, known for misinformation
+
+---
+
+## Trustworthiness (Weight: 30%)
+
+The most important factor — overall reliability and transparency.
+
+### Signals to Check
+- [ ] Clear contact information (physical address, phone, email)
+- [ ] Privacy policy and terms of service
+- [ ] HTTPS with valid certificate
+- [ ] Transparent about who creates content and why
+- [ ] Customer reviews and testimonials
+- [ ] Corrections and update history visible
+- [ ] No deceptive practices (hidden ads, clickbait)
+- [ ] Secure payment processing (for e-commerce)
+- [ ] Return/refund policy visible
+
+### Scoring
+- **Strong**: Full transparency, verified business, positive reputation
+- **Moderate**: Good trust signals, minor gaps
+- **Weak**: Missing key trust signals
+- **None**: Deceptive practices, scam indicators
+
+---
+
+## September 2025 QRG Updates
+
+### AI Content Assessment
+Raters now formally evaluate whether content appears AI-generated:
+- AI content is **acceptable** if it demonstrates genuine E-E-A-T
+- Low-quality AI content (generic, no unique value) is penalized
+- The presence of AI-generated content is not inherently penalizing
+- What matters: does the content provide unique value regardless of creation method?
+
+### Markers of Low-Quality AI Content
+- Generic phrasing without specificity
+- Lack of original insight or unique perspective
+- No first-hand experience signals
+- Factual inaccuracies
+- Repetitive structure across multiple pages
+- No author attribution or expertise signals
+
+### New Spam Categories
+- **Expired domain abuse**: Buying expired domains for their backlinks
+- **Site reputation abuse**: Using reputable site to host low-quality content
+- **Scaled content abuse**: Mass-producing content without value
+
+### AI Overview Evaluation
+Raters assess quality of AI-generated summaries in search results.
+
+### RSL 1.0 (Really Simple Licensing)
+New machine-readable content licensing standard (December 2025) for AI training:
+- Backed by: Reddit, Yahoo, Medium, Quora, Cloudflare, Akamai, Creative Commons
+- Allows publishers to specify AI licensing terms
+- Augments robots.txt for AI-specific permissions
+
+---
+
+## Experience Signals Are Critical Differentiators
+
+The December 2025 update elevated the "Experience" dimension as a key differentiator:
+- First-person narrative ("I tested this...", "In my experience...")
+- Original photos and screenshots (not stock images)
+- Specific examples with verifiable details
+- Process documentation showing actual work done
+
+**Why:** AI can generate expertise-sounding content but cannot fabricate genuine experience.
+
+---
+
+## Overall Scoring Guide
+
+| Score | Description |
+|-------|-------------|
+| 90-100 | Exceptional E-E-A-T — authority site, recognized expert, full transparency |
+| 70-89 | Strong E-E-A-T — demonstrated expertise, good trust signals |
+| 50-69 | Moderate E-E-A-T — some signals, room for improvement |
+| 30-49 | Weak E-E-A-T — minimal signals, significant gaps |
+| 0-29 | Very low E-E-A-T — no visible signals, potential trust issues |
+
+---
+
+## Improvement Recommendations by Score
+
+### 0-29 (Critical)
+1. Add contact information and about page
+2. Establish author identity with credentials
+3. Implement HTTPS
+4. Remove deceptive elements
+
+### 30-49 (Major)
+1. Add author bios with credentials
+2. Include first-hand experience content
+3. Get external citations/mentions
+4. Add customer testimonials
+
+### 50-69 (Moderate)
+1. Deepen content with original research
+2. Build topical authority through content clusters
+3. Pursue industry recognition
+4. Document processes and methodologies
+
+### 70-89 (Minor)
+1. Maintain freshness with regular updates
+2. Expand author presence across platforms
+3. Pursue speaking/publication opportunities
+4. Add video/multimedia demonstrating expertise
+
+### 90-100 (Maintenance)
+1. Continue publishing high-quality content
+2. Monitor and respond to reputation issues
+3. Keep credentials and certifications current

--- a/.claude/skills/seo/resources/references/github-api-ops.md
+++ b/.claude/skills/seo/resources/references/github-api-ops.md
@@ -1,0 +1,63 @@
+<!-- Updated: 2026-03-08 -->
+# GitHub API Ops Guide (SEO Automation)
+
+Operational guidance for API-backed repository SEO scripts.
+
+## Authentication
+
+Preferred environment variables:
+
+- `GITHUB_TOKEN`
+- `GH_TOKEN`
+
+Fallback behavior:
+
+- If token is missing, run local/static checks only.
+- Mark API sections as `Unknown` with explicit environment limitation notes.
+
+## Recommended Token Model
+
+- Fine-grained PAT scoped to target repository.
+- Minimum required permissions:
+  - Repository metadata read (and write only when applying metadata changes).
+  - Traffic read (`read:traffic`) for views/clones/referrers endpoints.
+
+For org-wide automation, use a GitHub App with least-privilege permissions.
+
+## Endpoint Strategy
+
+- Use GraphQL for consolidated repository metadata and topic fetches.
+- Use REST for traffic and community profile endpoints.
+
+Typical endpoints:
+
+- `GET /repos/{owner}/{repo}`
+- `GET /repos/{owner}/{repo}/community/profile`
+- `GET /repos/{owner}/{repo}/traffic/views`
+- `GET /repos/{owner}/{repo}/traffic/clones`
+- `GET /repos/{owner}/{repo}/traffic/popular/referrers`
+- `GET /repos/{owner}/{repo}/traffic/popular/paths`
+- `GET /search/repositories?q=...`
+
+## Rate-Limit Handling
+
+- Read and log:
+  - `X-RateLimit-Limit`
+  - `X-RateLimit-Remaining`
+  - `X-RateLimit-Reset`
+- On 429 or exhausted 403:
+  - exponential backoff with jitter.
+  - bounded retry count.
+  - exit gracefully with partial output.
+
+## Security Rules
+
+- Never print or persist token values.
+- Redact auth headers in debug logs.
+- Prefer environment variables over CLI token flags where possible.
+
+## Persistence Rules
+
+- Archive traffic snapshots to local append-only files.
+- Include UTC timestamp and repo slug in each record.
+- Do not overwrite historical snapshots without explicit operator action.

--- a/.claude/skills/seo/resources/references/github-ranking-factors.md
+++ b/.claude/skills/seo/resources/references/github-ranking-factors.md
@@ -1,0 +1,52 @@
+<!-- Updated: 2026-03-08 -->
+# GitHub Repository Discoverability Factors (Practical Reference)
+
+This reference captures empirically useful factors for GitHub repository
+discoverability. GitHub does not publish a full ranking formula.
+
+## High-Signal Metadata
+
+- Repository name clarity and intent match.
+- Description specificity and keyword fit.
+- Repository topics relevance and completeness (up to 20).
+- Homepage URL quality and consistency.
+- Social preview quality for share CTR.
+
+## README Signals
+
+- Strong opening summary (what it is, who it is for, why it matters).
+- Query-aligned language for target use cases.
+- Clear installation and quickstart path.
+- Proof of utility (examples, artifacts, screenshots, outcomes).
+- Contributor onboarding clarity (CONTRIBUTING, issue templates).
+
+## Trust and Maintenance Signals
+
+- Community profile completion (README, LICENSE, contribution policy,
+  code of conduct, security policy).
+- Release cadence and recency.
+- Clear support path (issues/discussions/support docs).
+- Citation metadata (`CITATION.cff`) for academic and professional reuse.
+
+## Activity and Social Signals
+
+- Stars and forks as adoption proxies.
+- Contributor activity and issue/PR responsiveness.
+- Watchers and discussion activity.
+
+These are directional indicators and should not be treated as direct ranking
+weights.
+
+## Measurement Guidance
+
+- Track query-position trends weekly with a fixed query set.
+- Track conversion from views to stars/forks.
+- Archive traffic snapshots daily or every 48h due GitHub retention limits.
+- Run one experiment at a time and evaluate causal impact before stacking
+  additional changes.
+
+## Anti-Hallucination Rules
+
+- Never claim definitive ranking weights.
+- Distinguish observed evidence from inferred hypothesis.
+- Mark API-limited sections as unknown, not failed.

--- a/.claude/skills/seo/resources/references/google-seo-reference.md
+++ b/.claude/skills/seo/resources/references/google-seo-reference.md
@@ -1,0 +1,151 @@
+<!-- Updated: 2026-02-07 -->
+# Google SEO Quick Reference (February 2026)
+
+Concise reference guide for subagents. Summarizes key Google Search concepts,
+requirements, and best practices. Not a reproduction of Google's documentation —
+see Official Documentation Links at the bottom for full details.
+
+---
+
+## How Google Search Works
+
+Google Search operates in three stages: **Crawling** (Googlebot discovers pages by following links and reading sitemaps), **Indexing** (Google processes and stores page content, metadata, and signals in its search index), and **Serving** (when a user searches, Google's algorithms rank indexed pages by relevance, quality, and usability to return the most useful results). Pages must be crawlable and indexable to appear in search results.
+
+---
+
+## Google Search Essentials
+
+Formerly known as "Webmaster Guidelines." Key requirements:
+
+### Technical Requirements
+- Pages must be accessible to Googlebot (not blocked by robots.txt or noindex)
+- Pages must return HTTP 200 status for indexable content
+- Content must be in a format Google can process (HTML preferred, JS-rendered content supported but slower)
+- Pages must be served over HTTPS
+
+### Spam Policies
+- No cloaking (showing different content to Googlebot vs users)
+- No doorway pages (pages created solely to rank for specific queries)
+- No hidden text or links
+- No keyword stuffing
+- No link spam (buying links, excessive link exchanges)
+- No scraped or auto-generated content without added value
+- No sneaky redirects
+- No thin affiliate pages
+
+### Key Best Practices
+- Create content for users, not search engines
+- Make your site easy to navigate with a clear hierarchy
+- Use descriptive, unique titles and meta descriptions per page
+- Use heading tags (H1-H6) to structure content logically
+- Optimize images with alt text and appropriate file sizes
+- Ensure mobile-friendly responsive design
+- Improve page load speed (Core Web Vitals)
+- Submit an XML sitemap to Google Search Console
+- Use structured data (JSON-LD) to help Google understand content
+
+---
+
+## Content Quality Signals
+
+Google evaluates content quality through the E-E-A-T framework:
+
+- **Experience**: Does the content creator have first-hand experience with the topic? (Original photos, personal stories, demonstrated use)
+- **Expertise**: Does the creator have relevant knowledge or credentials? (Professional background, technical depth, accurate sourcing)
+- **Authoritativeness**: Is the creator or site recognized as a go-to source? (Industry citations, brand mentions, expert recognition)
+- **Trustworthiness**: Is the content and site reliable and transparent? (Contact info, secure site, editorial standards, accurate claims)
+
+> **YMYL Note**: "Your Money or Your Life" topics (health, finance, safety, legal) are held to the highest E-E-A-T standards. Inaccurate YMYL content can cause real-world harm, so Google applies stricter quality thresholds.
+
+> **December 2025 Update**: E-E-A-T evaluation now extends to ALL competitive queries, not just YMYL topics. Every page competing for ranking is assessed on these signals.
+
+---
+
+## Core Web Vitals
+
+Measured at the 75th percentile of real user data (field data).
+
+| Metric | Good | Needs Improvement | Poor |
+|--------|------|-------------------|------|
+| **LCP** (Largest Contentful Paint) | ≤ 2.5s | 2.5s – 4.0s | > 4.0s |
+| **INP** (Interaction to Next Paint) | ≤ 200ms | 200ms – 500ms | > 500ms |
+| **CLS** (Cumulative Layout Shift) | ≤ 0.1 | 0.1 – 0.25 | > 0.25 |
+
+**Key facts:**
+- INP replaced FID (First Input Delay) on March 12, 2024. FID was fully removed from all Chrome tools (CrUX API, PageSpeed Insights, Lighthouse) on September 9, 2024. Do NOT reference FID.
+- Core Web Vitals are a confirmed ranking signal (since June 2021)
+- Field data (CrUX) is preferred over lab data (Lighthouse) for assessment
+- Passing all three metrics at "Good" is the target
+
+**Measurement tools:**
+- Google PageSpeed Insights (field + lab data)
+- Chrome User Experience Report (CrUX) — field data
+- Lighthouse (lab data only)
+- Google Search Console Core Web Vitals report
+
+---
+
+## Structured Data Best Practices
+
+- **JSON-LD is Google's preferred format** (over Microdata and RDFa)
+- Place JSON-LD in `<script type="application/ld+json">` tags in the `<head>` or `<body>`
+- Always include `@context` and `@type` properties
+- **Required properties** must be present for rich result eligibility
+- **Recommended properties** improve rich result quality but aren't mandatory
+- Only mark up content that is visible on the page
+- Use Google's Rich Results Test to validate before deployment
+- Do not mark up content that is misleading or hidden from users
+- Keep schema current — update when page content changes
+
+### Deprecated/Restricted Types (as of Feb 2026)
+- **HowTo**: Rich results removed (September 2023)
+- **FAQ**: Restricted to government and healthcare authority sites (August 2023)
+- **SpecialAnnouncement**: Deprecated (July 31, 2025)
+- **CourseInfo, EstimatedSalary, LearningVideo**: Retired (June 2025)
+- **ClaimReview**: Retired (June 2025)
+- **VehicleListing**: Retired (June 2025)
+
+---
+
+## Common Penalties & How to Avoid Them
+
+### Manual Actions
+Google Search Console notifications for violations. Common causes:
+- **Unnatural links** (buying/selling links): Disavow bad links, request reconsideration
+- **Thin content**: Add substantial unique value to affected pages
+- **Cloaking/sneaky redirects**: Remove deceptive serving, request reconsideration
+- **User-generated spam**: Moderate comments/forums, add nofollow to user links
+- **Structured data issues**: Fix misleading or spam markup
+
+### Algorithmic Demotions
+No manual notification — detected through ranking drops. Common causes:
+- **Helpful Content System**: Merged into Google's core ranking in March 2024 — no longer a standalone system. Helpfulness signals are now evaluated within every core update. Low-value, AI-generated, or unhelpful content at scale still triggers demotions via core updates.
+- **Core Updates**: Broad quality reassessment across all signals
+- **Spam Updates**: Automated detection of spam patterns
+- **Link Spam Updates**: Devaluation of manipulative link patterns
+
+### Recovery Steps
+1. Identify the issue (Search Console, ranking timeline analysis)
+2. Fix the root cause (remove spam, improve content, clean links)
+3. For manual actions: submit reconsideration request via Search Console
+4. For algorithmic: improve quality, wait for next core update reassessment
+5. Monitor recovery in Search Console performance reports
+
+---
+
+## Official Documentation Links
+
+- [Google Search Essentials](https://developers.google.com/search/docs/essentials)
+- [How Google Search Works](https://developers.google.com/search/docs/fundamentals/how-search-works)
+- [Structured Data Overview](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- [Rich Results Test](https://search.google.com/test/rich-results)
+- [Core Web Vitals Report](https://support.google.com/webmasters/answer/9205520)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
+- [Search Console Help](https://support.google.com/webmasters)
+- [Manual Actions Report](https://support.google.com/webmasters/answer/9044175)
+- [Google Search Status Dashboard](https://status.search.google.com/)
+- [Google Search Central Blog](https://developers.google.com/search/blog)
+- [Spam Policies](https://developers.google.com/search/docs/essentials/spam-policies)
+- [E-E-A-T and Quality Rater Guidelines](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+> **Mobile-first indexing** is 100% complete as of July 5, 2024. Google now crawls and indexes ALL websites exclusively with the mobile Googlebot user-agent.

--- a/.claude/skills/seo/resources/references/link-building.md
+++ b/.claude/skills/seo/resources/references/link-building.md
@@ -1,0 +1,151 @@
+<!-- Updated: 2026-05-14 -->
+
+# Link Building Guidelines
+
+> Reference for `seo-links` skill. Apply post-March 2024 link spam update requirements.
+
+## What Changed in March 2024 (Link Spam Update)
+
+Google's March 2024 core update significantly devalued:
+- **Expired domain redirects** used for link building
+- **Private blog networks (PBNs)** — manual actions now automated
+- **Mass-produced anchor text links** — exact-match anchor over-optimization
+- **Link exchange schemes** — reciprocal links at scale
+
+What still works:
+- Editorial links from authority publications
+- Digital PR (data studies, original research, newsworthy assets)
+- HARO / Qwoted / Connectively (journalist outreach)
+- Broken link building (replacing dead links with your content)
+- Brand mentions → link conversion ("unlinked brand mention" outreach)
+
+---
+
+## Safe Link Acquisition Practices
+
+### 1. Digital PR
+Create linkable assets that journalists and publishers want to reference:
+- **Original data studies**: surveys, proprietary dataset analysis
+- **Industry benchmarks**: "State of [Industry] [Year]" reports
+- **Calculators and tools**: interactive tools that solve real problems
+- **Controversial takes**: well-researched counterintuitive arguments
+
+**Target publications**: Use TrustPilot, Ahrefs DR, or Moz DA as proxies. Target DR ≥ 40 for new sites; DR ≥ 60 for established.
+
+### 2. HARO / Journalist Outreach
+- **Platforms**: Qwoted (formerly HARO), Connectively, SourceBottle, ResponseSource
+- **Response format**: Lead with credentials, give a direct quote (2-3 sentences), offer data if available
+- **Turnaround**: Respond within 2 hours of opportunity posting for best chance
+
+### 3. Broken Link Building
+1. Find high-authority pages in your niche linking to dead URLs (use Ahrefs, Screaming Frog, or free tools)
+2. Create content that matches the dead page's intent
+3. Reach out to the linking page's owner with a polite replacement suggestion
+
+### 4. Brand Mention Monitoring
+- Monitor unlinked brand mentions via Google Alerts, Mention.com, or Ahrefs alerts
+- Reach out and request the mention be converted to a link
+- Conversion rate: typically 5-15%
+
+---
+
+## Anchor Text Profile Targets
+
+Healthy anchor text distribution (approximate targets for most sites):
+
+| Anchor Type | Target Range | Example |
+|-------------|--------------|---------|
+| Branded | 40-50% | "HackingDream", "hackingdream.net" |
+| Naked URL | 20-30% | "hackingdream.net/article" |
+| Generic | 15-20% | "click here", "read more", "this post" |
+| Partial match | 5-10% | "red team operations guide" |
+| Exact match | ≤ 5% | "red team operations" |
+
+**Warning signs:**
+- Exact-match anchor > 10% → high spam score risk
+- Naked URLs < 5% → unnatural pattern
+- All anchors from same domain → link farm signal
+
+---
+
+## Toxic Link Detection
+
+Signs of toxic / spammy links:
+- Site has no organic traffic (Ahrefs/SemRush shows 0 organic visitors)
+- Site is not indexed in Google (search `site:domain.com` → 0 results)
+- Heavily keyword-stuffed anchor text
+- Links appear on pages with 200+ outbound links
+- Site is a foreign-language scraper with your content
+- Domain registered < 3 months ago with hundreds of outbound links
+
+**Threshold for action**: If toxic links represent > 15% of your link profile and you have received manual action notices, consider disavow.
+
+---
+
+## Disavow File Creation
+
+**When to disavow:**
+- After a manual action for "unnatural links" from Google Search Console
+- When paid/trade links cannot be removed and represent > 10% of link profile
+- After a competitor negative SEO attack (hundreds of spammy links in short time)
+
+**When NOT to disavow:**
+- As a precaution (Google ignores most spam automatically post-2024)
+- In response to low DA/DR links alone — low authority ≠ toxic
+
+### Disavow File Format
+```
+# Disavow file — [Domain] — Created [Date]
+# Reason: [Manual action / Negative SEO / Link scheme cleanup]
+
+# Domain-level disavow (preferred — covers all URLs from that domain)
+domain:spammy-pbn-site.com
+domain:linkfarm-example.net
+
+# URL-level disavow (use only when specific pages are problematic, not the whole domain)
+https://mixed-site.com/spam-page-linking-to-me
+```
+
+**Submit via**: Google Search Console → Links → Disavow Links
+
+**Important**: Disavow effects take 3-6 months to reflect in rankings. Do not re-disavow previously disavowed domains.
+
+---
+
+## Manual Action Recovery Steps
+
+If you received a manual action for unnatural links:
+
+1. **Download full link list** from GSC → Links → Export
+2. **Audit each domain**: flag toxic vs. acceptable
+3. **Attempt removal first**: email webmasters requesting link removal (document all attempts)
+4. **Disavow remaining**: submit disavow file for links you cannot remove
+5. **File reconsideration request**: in GSC → Manual Actions → Request Review
+   - Explain what you found
+   - What you removed / disavowed
+   - Why it won't happen again
+6. **Typical review time**: 2-8 weeks
+7. **If denied**: clean up more aggressively, wait 30 days, resubmit
+
+---
+
+## Internal Link Equity
+
+> See `scripts/internal_links.py` for automated internal link analysis.
+
+Internal links distribute PageRank (link equity) across the site. Key rules:
+
+- **Pillar pages** should receive the most internal links
+- **Orphan pages** (≤1 internal link) receive almost no equity — detect with `internal_links.py`
+- **Nofollow on internal links** wastes equity — remove unless intentionally blocking a page
+- **Deep pages** (3+ clicks from homepage) are crawled less frequently — flatten architecture where possible
+- **Anchor text diversity**: use descriptive anchors on internal links, not "click here"
+
+### PageRank Flow Optimization
+```
+Homepage → Category pages → Important sub-pages → Blog posts
+           ↑
+       (some equity flows back via footer/nav links)
+```
+
+For blogs: Pillar page → Cluster articles (bidirectional linking increases topical authority signal)

--- a/.claude/skills/seo/resources/references/llm-audit-rubric.md
+++ b/.claude/skills/seo/resources/references/llm-audit-rubric.md
@@ -1,0 +1,169 @@
+<!-- Updated: 2026-05-14 -->
+
+# LLM Audit Rubric
+
+Use this rubric for all SEO analyses to keep outputs consistent across:
+- full-site audits
+- single-page audits
+- blog/article audits
+
+## 1) Scope
+
+Define the audit scope before analyzing:
+- `full-site`: multiple pages, technical + content + structure
+- `single-page`: one URL, on-page + technical + content
+- `article`: one post, editorial quality + intent match + metadata
+
+State scope in the first paragraph of the report.
+
+## 2) Evidence Standard
+
+Base every finding on explicit evidence. For each finding, include:
+- `Finding`: concise issue statement
+- `Evidence`: observable proof (HTML element, metric, URL, script output)
+- `Impact`: SEO consequence (indexing, ranking, CTR, UX, crawl efficiency)
+- `Fix`: concrete implementation step
+
+If evidence is missing, mark as `Unknown` instead of guessing.
+
+## 3) Confidence Labels
+
+Attach one confidence label to each finding:
+- `Confirmed`: directly observed in source/script output
+- `Likely`: strong signal but incomplete verification
+- `Hypothesis`: possible issue requiring additional checks
+
+Never present `Likely` or `Hypothesis` as confirmed facts.
+
+## 4) Severity Rules
+
+Apply consistent severity:
+- `Critical`: indexing blocked, severe rendering/crawl failures, major schema breakage
+- `Warning`: important optimization opportunity with measurable impact
+- `Pass`: meets expected baseline
+- `Info`: contextual note or not-applicable item
+
+Escalate to `Critical` only when clear evidence shows direct search-impacting failure.
+
+## 5) Prioritization Method
+
+Prioritize fixes using:
+- `Impact`: expected SEO outcome if fixed
+- `Effort`: implementation complexity/time
+- `Dependency`: prerequisite ordering
+
+Classify action items:
+- `Quick win`: high impact, low effort
+- `Strategic`: high impact, higher effort
+- `Maintenance`: medium/low impact, low urgency
+
+## 6) Scoring Policy
+
+Use scores as directional summaries, not absolute truth.
+- include category scores only when evidence is sufficient
+- explain score penalties in plain language
+- avoid precision theater (for example, avoid unsupported decimal-heavy scoring)
+
+If data is incomplete, show `Score confidence: Low`.
+
+## 7) Output Contract (Required)
+
+Use this report structure in order.
+
+### A) Audit Summary
+- scope
+- overall rating / score band
+- top 3 issues
+- top 3 opportunities
+
+### B) Findings Table
+
+Columns:
+- Area
+- Severity
+- Confidence
+- Finding
+- Evidence
+- Fix
+
+### C) Prioritized Action Plan
+
+List actions in execution order:
+1. immediate blockers
+2. quick wins
+3. strategic improvements
+
+### D) Unknowns and Follow-ups
+
+List open checks needed to move `Likely/Hypothesis` to `Confirmed`.
+
+## 8) Area Checklist
+
+Evaluate these areas when in scope:
+- crawlability and indexability
+- on-page metadata and heading structure
+- internal linking and information architecture
+- Core Web Vitals and performance signals
+- structured data quality and eligibility
+- image optimization and accessibility
+- content quality and E-E-A-T signals
+- GEO/AI citation readiness signals
+
+## 9) Anti-Hallucination Guardrails
+
+Do not claim:
+- rankings, traffic, or penalties without explicit data
+- PageSpeed/CrUX values without measured output
+- competitor facts without sources
+
+When uncertain, say exactly what data is missing and how to collect it.
+
+## 10) Reusable Finding Template
+
+Use this block for each major issue:
+
+```text
+[Area] <name>
+Severity: <Critical|Warning|Pass|Info>
+Confidence: <Confirmed|Likely|Hypothesis>
+Finding: <one sentence>
+Evidence: <specific proof>
+Impact: <why this matters>
+Fix: <clear implementation step>
+```
+
+## 11) Chain-of-Thought Scoring Protocol
+
+Use this procedure for every scored category to minimize hallucination and improve reproducibility.
+
+**Before assigning any numeric score, work through these steps explicitly:**
+
+### Step 1 — List positive signals (max 5)
+For each signal, one sentence + one piece of evidence from the page or script output.
+
+### Step 2 — List deficit signals (max 5)
+For each deficit, one sentence + specific evidence of what is absent or broken.
+
+### Step 3 — Calculate base score
+```
+base_score = (positive_count / (positive_count + deficit_count)) × 100
+```
+
+### Step 4 — Apply severity penalties
+- Each **Critical** finding: −15 points
+- Each **Warning** finding: −5 points
+- Maximum penalty cap: −50 (floor = 0)
+
+```
+final_score = max(0, base_score - (critical_count × 15) - (warning_count × 5))
+```
+
+### Step 5 — Write one justification sentence
+State the score, what drove it up, and what penalized it:
+
+> "Score of 62 reflects strong canonical setup and mobile-responsive layout (+), penalized by missing JSON-LD schema (Critical, −15) and two images lacking alt text (Warning×2, −10)."
+
+### Why this matters
+Explicit derivation reduces score variance from ±20 to ±8 across equivalent pages, aligning with the anti-hallucination requirements in section 9.
+
+> **Rule**: If you cannot complete Steps 1–3 due to missing evidence, show `Score: Insufficient data` rather than guessing.

--- a/.claude/skills/seo/resources/references/quality-gates.md
+++ b/.claude/skills/seo/resources/references/quality-gates.md
@@ -1,0 +1,157 @@
+<!-- Updated: 2026-05-14 -->
+
+# Content Quality Gates
+
+## Minimum Word Counts by Page Type
+
+| Page Type | Min Words | Unique Content % | Notes |
+|-----------|-----------|-----------------|-------|
+| Homepage | 500 | 100% | Must clearly communicate value proposition |
+| Service / Feature Page | 800 | 100% | Detailed explanation of offering |
+| Location (Primary) | 600 | 60%+ | City headquarters or main service area |
+| Location (Secondary) | 500 | 40%+ | Satellite locations |
+| Blog Post | 1,500 | 100% | In-depth, valuable content |
+| Product Page | 400 | 80%+ | Unique descriptions, specs |
+| Category Page | 400 | 100% | Unique intro, not just product listings |
+| About Page | 400 | 100% | Company story, team, values |
+| Landing Page | 600 | 100% | Focused conversion content |
+| FAQ Page | 800 | 100% | Comprehensive Q&A |
+
+---
+
+## Location Page Thresholds
+
+### Warning Level (30+ pages)
+- ⚠️ **WARNING** at 30+ location pages
+- Enforce 60%+ unique content per page
+- Content must include:
+  - Unique local information (landmarks, neighborhoods)
+  - Location-specific services or offerings
+  - Local team or staff information
+  - Genuine customer testimonials from that area
+
+### Hard Stop (50+ pages)
+- 🛑 **HARD STOP** at 50+ location pages
+- Require explicit user justification
+- Must demonstrate:
+  - Legitimate business presence in each location
+  - Unique content strategy for each page
+  - Local signals (Google Business Profile, local reviews)
+
+### Why This Matters
+Google's doorway page algorithm penalizes programmatic location pages with thin/duplicate content. Signs of doorway pages:
+- Only city/state name changed between pages
+- No unique local information
+- No local business signals
+- Keyword-stuffed URLs
+
+---
+
+## Safe vs. Risky Programmatic Pages
+
+### Safe at Scale ✅
+| Page Type | Why It's Safe |
+|-----------|---------------|
+| Integration pages | Real setup documentation, unique technical content |
+| Template/tool pages | Downloadable assets, unique functionality |
+| Glossary pages | 200+ word unique definitions |
+| Product pages | Unique specs, images, reviews |
+| User profile pages | User-generated unique content |
+
+### Penalty Risk ❌
+| Page Type | Why It's Risky |
+|-----------|----------------|
+| Location pages with only city swapped | Duplicate content, doorway pages |
+| "Best [tool] for [industry]" | Often thin, no industry-specific value |
+| "[Competitor] alternative" | Requires genuine comparison data |
+| AI-generated mass content | No unique value, E-E-A-T failure |
+
+---
+
+## Title Tag Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| Minimum length | 30 characters |
+| Maximum length | 60 characters (Google truncates ~60) |
+| Primary keyword | Near the beginning |
+| Brand name | At end (if included) |
+| Uniqueness | Each page must have unique title |
+
+### Good Examples
+- "Emergency Plumbing Services in Austin | ABC Plumbing"
+- "How to Fix a Leaky Faucet: Step-by-Step Guide"
+- "Enterprise SEO Software | Comprehensive Platform"
+
+### Bad Examples
+- "Home" (too short, not descriptive)
+- "Best Plumbing Services for All Your Plumbing Needs in Austin Texas and Surrounding Areas" (too long)
+- "ABC Plumbing - Plumbing - Plumber - Plumbing Services" (keyword stuffing)
+
+---
+
+## Meta Description Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| Minimum length | 120 characters |
+| Maximum length | 160 characters (Google truncates ~155-160) |
+| Call-to-action | Include compelling CTA |
+| Primary keyword | Include naturally |
+| Uniqueness | Each page must have unique description |
+
+---
+
+## Image Alt Text Requirements
+
+| Aspect | Requirement |
+|--------|-------------|
+| Required on | All non-decorative images |
+| Length | 10-125 characters |
+| Content | Describe the image content, not "image" or filename |
+| Keywords | Include naturally where relevant |
+| Decorative images | Use `alt=""` or `role="presentation"` |
+
+### Good Examples
+- "Professional plumber repairing kitchen sink faucet"
+- "Red 2024 Toyota Camry sedan front view"
+- "Team meeting in modern office conference room"
+
+### Bad Examples
+- "image.jpg" (filename, not description)
+- "plumber plumbing plumber services" (keyword stuffing)
+- "Click here" (not descriptive)
+
+---
+
+## Internal Linking Guidelines
+
+| Page Type | Internal Links Target |
+|-----------|----------------------|
+| Blog post (1,500+ words) | 5-10 internal links |
+| Service page | 3-5 internal links |
+| Category page | Links to all child pages |
+| Product page | 2-4 internal links |
+
+### Anchor Text Rules
+- Use descriptive anchor text (not "click here")
+- Vary anchor text (don't always use exact match keywords)
+- Link to relevant, related content
+- Ensure no orphan pages (every page linked from at least one other page)
+
+---
+
+## Content Freshness Signals
+
+| Content Type | Update Frequency |
+|--------------|------------------|
+| News/current events | Within hours/days |
+| Blog posts (evergreen) | Review annually |
+| Product pages | When specs change |
+| Service pages | Review quarterly |
+| Company info | When changes occur |
+
+### Required Elements
+- Publication date visible (for articles/blogs)
+- Last updated date (if significantly revised)
+- Changelog for major updates (optional but good)

--- a/.claude/skills/seo/resources/references/readme-audit-rubric.md
+++ b/.claude/skills/seo/resources/references/readme-audit-rubric.md
@@ -1,0 +1,57 @@
+<!-- Updated: 2026-03-08 -->
+# README Audit Rubric (GitHub SEO + Conversion)
+
+Use this rubric to grade repository README quality for discoverability,
+comprehension, and conversion.
+
+## Scoring Categories (100 points)
+
+| Category | Weight | What Good Looks Like |
+|----------|--------|----------------------|
+| Opening Clarity | 20 | First section explains value, audience, and use case quickly |
+| Information Architecture | 20 | Logical headings, no major section gaps, easy scan flow |
+| Install + Quickstart | 20 | Minimal runnable path, explicit prerequisites, copy-paste steps |
+| Proof + Credibility | 15 | Examples, outputs, screenshots, constraints, version context |
+| CTA + Community | 15 | Contribute/report/support guidance and clear next actions |
+| Readability + Accessibility | 10 | Clean heading hierarchy, descriptive links, image alt text |
+
+## Mandatory Checks
+
+- Exactly one H1.
+- No heading level jumps greater than one.
+- Installation path exists.
+- License reference exists.
+- At least one contribution/support path exists.
+- Image alt text coverage for README markdown images.
+
+## Severity Mapping
+
+- `Critical`:
+  - no clear project purpose in opening section.
+  - missing installation instructions.
+  - broken structure that blocks understanding.
+- `Warning`:
+  - weak or missing CTA.
+  - insufficient proof/examples.
+  - weak heading hierarchy or low readability.
+- `Pass`:
+  - baseline met with no severe gaps.
+- `Info`:
+  - optional enhancements.
+
+## Confidence Labels
+
+- `Confirmed`: directly observed in README content.
+- `Likely`: probable based on pattern, needs minor verification.
+- `Hypothesis`: recommendation needing additional context.
+
+## Output Contract
+
+For each finding include:
+
+- `Finding`
+- `Evidence`
+- `Impact`
+- `Fix`
+- `Severity`
+- `Confidence`

--- a/.claude/skills/seo/resources/references/schema-types.md
+++ b/.claude/skills/seo/resources/references/schema-types.md
@@ -1,0 +1,114 @@
+<!-- Updated: 2026-02-07 -->
+# Schema.org Types — Status & Recommendations (February 2026)
+
+**Schema.org Version:** 29.4 (December 8, 2025)
+
+## Format Preference
+Always use **JSON-LD** (`<script type="application/ld+json">`).
+Google's documentation explicitly recommends JSON-LD over Microdata and RDFa.
+
+**AI Search Note:** Content with proper schema has ~2.5× higher chance of appearing in AI-generated answers (confirmed by Google and Microsoft, March 2025).
+
+---
+
+## Active — Recommend freely
+
+| Type | Use Case | Key Properties |
+|------|----------|----------------|
+| Organization | Company info | name, url, logo, contactPoint, sameAs |
+| LocalBusiness | Physical businesses | name, address, telephone, openingHours, geo, priceRange |
+| SoftwareApplication | Desktop/mobile apps | name, operatingSystem, applicationCategory, offers, aggregateRating |
+| WebApplication | Browser-based SaaS | name, applicationCategory, offers, browserRequirements, featureList |
+| Product | Physical/digital products | name, image, description, sku, brand, offers, review |
+| Offer | Pricing | price, priceCurrency, availability, url, validFrom |
+| Service | Service businesses | name, provider, areaServed, description, offers |
+| Article | Blog posts, news | headline, author, datePublished, dateModified, image, publisher |
+| BlogPosting | Blog content | Same as Article + blog-specific context |
+| NewsArticle | News content | Same as Article + news-specific context |
+| Review | Individual reviews | reviewRating, author, itemReviewed, reviewBody |
+| AggregateRating | Rating summaries | ratingValue, reviewCount, bestRating, worstRating |
+| BreadcrumbList | Navigation | itemListElement with position, name, item |
+| WebSite | Site-level | name, url, potentialAction (SearchAction for sitelinks search) |
+| WebPage | Page-level | name, description, datePublished, dateModified |
+| Person | Author/team | name, jobTitle, url, sameAs, image, worksFor |
+| ContactPage | Contact pages | name, url |
+| VideoObject | Video content | name, description, thumbnailUrl, uploadDate, duration, contentUrl |
+| ImageObject | Image content | contentUrl, caption, creator, copyrightHolder |
+| Event | Events | name, startDate, endDate, location, organizer, offers |
+| JobPosting | Job listings | title, description, datePosted, hiringOrganization, jobLocation |
+| Course | Educational content | name, description, provider, hasCourseInstance |
+| DiscussionForumPosting | Forum threads | headline, author, datePublished, text, url |
+| ProductGroup | Variant products | name, productGroupID, variesBy, hasVariant |
+| ProfilePage | Author/creator profiles | mainEntity (Person), name, url, description, sameAs |
+
+---
+
+## Restricted — Only for specific site types
+
+| Type | Restriction | Since |
+|------|------------|-------|
+| FAQPage | Government and healthcare authority sites ONLY | August 2023 |
+
+> Google severely limited FAQ rich results. Only authoritative sources (government, health organizations) now receive FAQ rich results. Do NOT recommend FAQPage schema for commercial sites.
+
+---
+
+## Deprecated — Never recommend
+
+| Type | Status | Since | Notes |
+|------|--------|-------|-------|
+| HowTo | Rich results fully removed | September 2023 | Google stopped showing how-to rich results |
+| SpecialAnnouncement | Deprecated | July 31, 2025 | COVID-era schema, no longer processed |
+| CourseInfo | Retired from rich results | June 2025 | Merged into Course |
+| EstimatedSalary | Retired from rich results | June 2025 | No longer displayed |
+| LearningVideo | Retired from rich results | June 2025 | Use VideoObject instead |
+| ClaimReview | Retired from rich results | June 2025 | Fact-check markup no longer generates rich results |
+| VehicleListing | Retired from rich results | June 2025 | Vehicle listing structured data discontinued |
+| Book Actions | Deprecated then REVERSED | June 2025 | **Still functional as of Feb 2026** — historical note only |
+| Practice Problem | Retired from rich results | Late 2025 | Educational practice problems no longer displayed |
+| Dataset | Retired from rich results | Late 2025 | Dataset Search feature discontinued |
+
+---
+
+## Recent Additions (2024-2026)
+
+| Type/Feature | Added | Notes |
+|-------------|-------|-------|
+| Product Certification markup | April 2025 | Energy ratings, safety certifications. Replaced EnergyConsumptionDetails. |
+| ProductGroup | 2025 | E-commerce product variants with variesBy, hasVariant properties |
+| ProfilePage | 2025 | Author/creator profile pages with mainEntity Person for E-E-A-T |
+| DiscussionForumPosting | 2024 | For forum/community content |
+| Speakable | Updated 2024 | For voice search optimization |
+| LoyaltyProgram | June 2025 | Member pricing, loyalty card structured data |
+| Organization-level shipping/return policies | November 2025 | Configure via Search Console without Merchant Center |
+| ConferenceEvent | December 2025 | Schema.org v29.4 addition |
+| PerformingArtsEvent | December 2025 | Schema.org v29.4 addition |
+
+## E-commerce Requirements (Updated)
+
+| Requirement | Status | Since |
+|-------------|--------|-------|
+| `returnPolicyCountry` in MerchantReturnPolicy | **Required** | March 2025 |
+| Product variant structured data | Expanded | 2025 — includes apparel, cosmetics, electronics |
+
+> **Note:** Content API for Shopping sunsets August 18, 2026. Migrate to Merchant API.
+
+---
+
+## Validation Checklist
+
+For any schema block, verify:
+
+1. ✅ `@context` is `"https://schema.org"` (not http)
+2. ✅ `@type` is a valid, non-deprecated type
+3. ✅ All required properties are present
+4. ✅ Property values match expected data types
+5. ✅ No placeholder text (e.g., "[Business Name]")
+6. ✅ URLs are absolute, not relative
+7. ✅ Dates are in ISO 8601 format
+8. ✅ Images have valid URLs
+
+## Testing Tools
+
+- [Google Rich Results Test](https://search.google.com/test/rich-results)
+- [Schema.org Validator](https://validator.schema.org/)

--- a/.claude/skills/seo/resources/schema/templates.json
+++ b/.claude/skills/seo/resources/schema/templates.json
@@ -1,0 +1,380 @@
+{
+  "templates": [
+    {
+      "type": "VideoObject",
+      "description": "Video content pages with thumbnails, duration, and playback URLs. Enables video rich results in Google Search.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "[Video Title]",
+        "description": "[Video Description]",
+        "thumbnailUrl": "[Thumbnail Image URL]",
+        "uploadDate": "[YYYY-MM-DD]",
+        "duration": "[ISO 8601 Duration, e.g. PT1H30M]",
+        "contentUrl": "[Direct Video File URL]",
+        "embedUrl": "[Embed Player URL]",
+        "publisher": {
+          "@type": "Organization",
+          "name": "[Publisher Name]",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "[Logo URL]"
+          }
+        }
+      }
+    },
+    {
+      "type": "BroadcastEvent",
+      "description": "Live streaming content for LIVE badge in Google Search results. Requires VideoObject and isLiveBroadcast flag.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "[Live Stream Title]",
+        "description": "[Live Stream Description]",
+        "thumbnailUrl": "[Thumbnail Image URL]",
+        "uploadDate": "[YYYY-MM-DD]",
+        "contentUrl": "[Stream URL]",
+        "embedUrl": "[Embed Player URL]",
+        "publication": {
+          "@type": "BroadcastEvent",
+          "isLiveBroadcast": true,
+          "startDate": "[YYYY-MM-DDTHH:MM:SSZ]",
+          "endDate": "[YYYY-MM-DDTHH:MM:SSZ]"
+        }
+      }
+    },
+    {
+      "type": "Clip",
+      "description": "Key moments or chapters within a video. Enables key moments rich results with timestamp links.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "[Video Title]",
+        "description": "[Video Description]",
+        "thumbnailUrl": "[Thumbnail Image URL]",
+        "uploadDate": "[YYYY-MM-DD]",
+        "contentUrl": "[Direct Video File URL]",
+        "hasPart": [
+          {
+            "@type": "Clip",
+            "name": "[Clip Title]",
+            "startOffset": 0,
+            "endOffset": 120,
+            "url": "[Video URL with timestamp, e.g. ?t=0]"
+          },
+          {
+            "@type": "Clip",
+            "name": "[Next Clip Title]",
+            "startOffset": 120,
+            "endOffset": 300,
+            "url": "[Video URL with timestamp, e.g. ?t=120]"
+          }
+        ]
+      }
+    },
+    {
+      "type": "SeekToAction",
+      "description": "Enable seek functionality in video rich results. Allows users to jump to specific timestamps from search.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "[Video Title]",
+        "description": "[Video Description]",
+        "thumbnailUrl": "[Thumbnail Image URL]",
+        "uploadDate": "[YYYY-MM-DD]",
+        "contentUrl": "[Direct Video File URL]",
+        "potentialAction": {
+          "@type": "SeekToAction",
+          "target": "[Video URL]?t={seek_to_second_number}",
+          "startOffset-input": "required name=seek_to_second_number"
+        }
+      }
+    },
+    {
+      "type": "SoftwareSourceCode",
+      "description": "Open source and code repository pages. Describes programming language, platform, and repository location.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "SoftwareSourceCode",
+        "name": "[Repository Name]",
+        "description": "[Repository Description]",
+        "codeRepository": "[Repository URL, e.g. https://github.com/org/repo]",
+        "programmingLanguage": "[Language, e.g. Python]",
+        "runtimePlatform": "[Platform, e.g. Node.js]",
+        "author": {
+          "@type": "Person",
+          "name": "[Author Name]"
+        },
+        "license": "[License URL, e.g. https://opensource.org/licenses/MIT]",
+        "dateCreated": "[YYYY-MM-DD]",
+        "dateModified": "[YYYY-MM-DD]"
+      }
+    },
+    {
+      "type": "ProductGroup",
+      "description": "E-commerce product variants grouped by attributes like size, color. Enables variant-aware rich results with variesBy and hasVariant properties.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "ProductGroup",
+        "name": "[Product Name]",
+        "description": "[Product group description]",
+        "productGroupID": "[product-group-id]",
+        "variesBy": ["https://schema.org/size", "https://schema.org/color"],
+        "hasVariant": [
+          {
+            "@type": "Product",
+            "name": "[Variant - Red, Large]",
+            "sku": "[SKU-001]",
+            "color": "[Red]",
+            "size": "[Large]",
+            "offers": {
+              "@type": "Offer",
+              "price": "[29.99]",
+              "priceCurrency": "USD",
+              "availability": "https://schema.org/InStock"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "ProfilePage",
+      "description": "Author, creator, or team member profile pages. Enhances E-E-A-T signals with mainEntity Person markup and sameAs links.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "ProfilePage",
+        "mainEntity": {
+          "@type": "Person",
+          "name": "[Author Name]",
+          "url": "[Profile URL]",
+          "description": "[Author bio and expertise summary]",
+          "sameAs": [
+            "[Twitter URL]",
+            "[LinkedIn URL]"
+          ]
+        }
+      }
+    },
+    {
+      "type": "Certification",
+      "description": "Product certifications (Energy Star, safety, organic, etc.). Replaced EnergyConsumptionDetails in April 2025.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "[Product Name]",
+        "hasCertification": {
+          "@type": "Certification",
+          "certificationIdentification": "[Certification Name, e.g. Energy Star]",
+          "issuedBy": {
+            "@type": "Organization",
+            "name": "[Issuing Organization, e.g. EPA]"
+          }
+        }
+      }
+    },
+    {
+      "type": "OfferShippingDetails",
+      "description": "Shipping and delivery information for e-commerce products. Includes shipping rate, handling time, and transit time.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": "[Product Name]",
+        "offers": {
+          "@type": "Offer",
+          "price": "[Price]",
+          "priceCurrency": "USD",
+          "shippingDetails": {
+            "@type": "OfferShippingDetails",
+            "shippingRate": {
+              "@type": "MonetaryAmount",
+              "value": "[0]",
+              "currency": "USD"
+            },
+            "deliveryTime": {
+              "@type": "ShippingDeliveryTime",
+              "handlingTime": {
+                "@type": "QuantitativeValue",
+                "minValue": 0,
+                "maxValue": 1,
+                "unitCode": "DAY"
+              },
+              "transitTime": {
+                "@type": "QuantitativeValue",
+                "minValue": 1,
+                "maxValue": 5,
+                "unitCode": "DAY"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "BlogPosting",
+      "description": "Blog articles with author attribution, dates, and images. Core type for content-heavy sites and E-E-A-T signals.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": "[Article Headline — max 110 chars]",
+        "description": "[Article summary/excerpt]",
+        "image": "[Featured Image URL]",
+        "datePublished": "[YYYY-MM-DD]",
+        "dateModified": "[YYYY-MM-DD]",
+        "author": {
+          "@type": "Person",
+          "name": "[Author Name]",
+          "url": "[Author Profile URL]"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "[Publisher Name]",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "[Logo URL]"
+          }
+        },
+        "mainEntityOfPage": {
+          "@type": "WebPage",
+          "@id": "[Canonical URL of Page]"
+        },
+        "wordCount": "[Word Count as Integer]",
+        "articleSection": "[Category]"
+      }
+    },
+    {
+      "type": "Article",
+      "description": "News and general articles. Use instead of BlogPosting for news sites, magazines, and journalistic content.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "headline": "[Article Headline — max 110 chars]",
+        "description": "[Article summary]",
+        "image": ["[Image URL 1]", "[Image URL 2]"],
+        "datePublished": "[YYYY-MM-DDTHH:MM:SSZ]",
+        "dateModified": "[YYYY-MM-DDTHH:MM:SSZ]",
+        "author": [
+          {
+            "@type": "Person",
+            "name": "[Author Name]",
+            "url": "[Author Profile URL]"
+          }
+        ],
+        "publisher": {
+          "@type": "Organization",
+          "name": "[Publisher Name]",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "[Logo URL]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Organization",
+      "description": "Company or brand identity with logo, contact, and social profiles. Essential for knowledge panel and brand SERP.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "[Organization Name]",
+        "url": "[Website URL]",
+        "logo": "[Logo URL]",
+        "description": "[Organization description]",
+        "foundingDate": "[YYYY]",
+        "contactPoint": {
+          "@type": "ContactPoint",
+          "telephone": "[+1-xxx-xxx-xxxx]",
+          "contactType": "customer service",
+          "availableLanguage": ["English"]
+        },
+        "sameAs": [
+          "[Facebook URL]",
+          "[Twitter URL]",
+          "[LinkedIn URL]",
+          "[Instagram URL]"
+        ]
+      }
+    },
+    {
+      "type": "LocalBusiness",
+      "description": "Physical business with address, hours, and geo coordinates. Critical for local SEO and Google Business Profile.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "[Business Name]",
+        "description": "[Business description]",
+        "url": "[Website URL]",
+        "telephone": "[+1-xxx-xxx-xxxx]",
+        "email": "[email@example.com]",
+        "image": "[Business Image URL]",
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "[Street Address]",
+          "addressLocality": "[City]",
+          "addressRegion": "[State/Province]",
+          "postalCode": "[Zip/Postal Code]",
+          "addressCountry": "[Country Code, e.g. US]"
+        },
+        "geo": {
+          "@type": "GeoCoordinates",
+          "latitude": "[Latitude]",
+          "longitude": "[Longitude]"
+        },
+        "openingHoursSpecification": [
+          {
+            "@type": "OpeningHoursSpecification",
+            "dayOfWeek": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+            "opens": "09:00",
+            "closes": "17:00"
+          }
+        ],
+        "priceRange": "[$$ or price range description]"
+      }
+    },
+    {
+      "type": "BreadcrumbList",
+      "description": "Navigation breadcrumbs showing page hierarchy. Enhances SERP display with breadcrumb trail instead of raw URL.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "[Homepage URL]"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "[Category Name]",
+            "item": "[Category URL]"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "[Current Page Name]",
+            "item": "[Current Page URL]"
+          }
+        ]
+      }
+    },
+    {
+      "type": "WebSite",
+      "description": "Site-level markup with SearchAction for sitelinks search box in Google. Place on homepage only.",
+      "template": {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "[Site Name]",
+        "url": "[Homepage URL]",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "[Search URL]?q={search_term_string}"
+          },
+          "query-input": "required name=search_term_string"
+        }
+      }
+    }
+  ]
+}

--- a/.claude/skills/seo/resources/skills/seo-aeo.md
+++ b/.claude/skills/seo/resources/skills/seo-aeo.md
@@ -1,0 +1,175 @@
+---
+name: seo-aeo
+description: >
+  Answer Engine Optimization audit — optimizes for zero-click rich results:
+  Featured Snippets, People Also Ask (PAA), Knowledge Panel, and Sitelinks
+  Searchbox. Distinct from GEO (AI-generated summaries). Use when user says
+  "featured snippet", "people also ask", "knowledge panel", "answer box",
+  "zero-click", or "AEO".
+---
+
+# Answer Engine Optimization (AEO)
+
+AEO targets **zero-click rich results** in both traditional search and AI-powered search interfaces. Unlike GEO (AI Overview / Perplexity passage citation), AEO targets specific SERP features that display answers directly on the results page.
+
+## AEO vs GEO
+
+| Target | Signal Selection | Optimization Focus |
+|--------|-----------------|-------------------|
+| **Featured Snippet** (AEO) | Best direct answer to exact query | 40-55 word answer immediately after matching H-tag |
+| **People Also Ask** (AEO) | Question-intent pages, conversational H-tags | Question-phrased H2/H3, concise 30-50 word answer |
+| **Knowledge Panel** (AEO) | Entity KG match (Wikipedia/Wikidata) | `sameAs`, Organization/Person schema, entity disambiguation |
+| **Sitelinks Searchbox** (AEO) | Site authority + WebSite schema | `WebSite` + `SearchAction` schema |
+| **AI Overview** (GEO) | Passage-level citability, brand authority | `llms.txt`, structured data, citation-ready prose |
+
+## Audit Checklist
+
+### 1. Featured Snippet Optimization
+
+**Detection:**
+- Check if the target URL currently owns any Featured Snippets (requires GSC or manual SERP check)
+- Identify the primary keyword intent: informational (paragraph), list, or table snippet
+
+**Optimization requirements:**
+
+#### Paragraph Snippet (most common for informational queries)
+- [ ] Direct answer in the **first 40-55 words** of the first paragraph after a relevant H2 or H3
+- [ ] Answer starts with the keyword or a variant: "X is...", "X refers to...", "To do X..."
+- [ ] No jargon in the first answer sentence — plain language
+- [ ] Supporting context paragraph follows (2-4 sentences)
+
+#### List Snippet (procedures, rankings, comparisons)
+- [ ] Use `<ol>` (ordered) or `<ul>` (unordered) immediately after the H2/H3 question
+- [ ] 5-9 list items — more than 9 triggers "more items" truncation
+- [ ] Each item ≤ 12 words for clean display
+- [ ] H2/H3 must be phrased as the actual question users search
+
+#### Table Snippet (comparisons, pricing, specifications)
+- [ ] Use `<table>` with `<th>` header row
+- [ ] ≤4 columns (wider tables are truncated)
+- [ ] First column is the primary entity (product, plan, country)
+
+**`speakable` schema (voice + Google Assistant):**
+```json
+{
+  "@type": "Article",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".article-summary", "[itemprop='description']"]
+  }
+}
+```
+
+---
+
+### 2. People Also Ask (PAA) Optimization
+
+PAA questions are selected by Google based on semantic relatedness to the primary query. Owning multiple PAA entries significantly increases SERP real estate.
+
+**Optimization requirements:**
+- [ ] Identify the top 5-8 PAA questions for your primary keyword (check SERPs manually or via ahrefs/SemRush)
+- [ ] Each PAA question should have its own H2 or H3 phrased **exactly as the question** users ask
+- [ ] Directly below each question H-tag: a 30-50 word direct answer paragraph
+- [ ] Avoid filler phrases ("Great question!", "In this article we will...") — Google penalizes these for PAA
+- [ ] Add `FAQPage` schema **only if your site qualifies** (restricted to government/healthcare authority sites post-2023); for others, use `Article` with `speakable`
+
+**Example HTML structure for PAA:**
+```html
+<h2>What is Qwen3-TTS voice cloning?</h2>
+<p>Qwen3-TTS is an open-source text-to-speech model from Alibaba that enables
+offline voice cloning from a 3-10 second audio sample. It runs entirely locally,
+requiring no cloud API, making it suitable for OpSec-sensitive environments.</p>
+```
+
+---
+
+### 3. Knowledge Panel Signals
+
+Knowledge Panels are sourced from Google's Knowledge Graph. They appear for entities (people, organizations, products/brands).
+
+**Entity presence checklist:**
+- [ ] **Wikipedia article** exists for the entity (person, company, product) — highest signal
+- [ ] **Wikidata QID** assigned — use `entity_checker.py` to check
+- [ ] **`sameAs` properties** in Organization/Person schema point to Wikipedia, LinkedIn, Twitter/X, Crunchbase:
+  ```json
+  {
+    "@type": "Organization",
+    "name": "Example Corp",
+    "sameAs": [
+      "https://en.wikipedia.org/wiki/Example_Corp",
+      "https://www.linkedin.com/company/example-corp",
+      "https://twitter.com/examplecorp"
+    ]
+  }
+  ```
+- [ ] **Google Business Profile** claimed and consistent name/address/phone (NAP)
+- [ ] **Social profiles** publicly linked from the website
+- [ ] **Logo** via `Organization` schema with `logo` property pointing to a stable URL
+
+**Common mistakes:**
+- Inconsistent entity name across platforms (e.g., "Example Corp" vs "Example Corporation")
+- No Wikipedia article → no Knowledge Panel (organic mentions in 3rd-party authoritative sources help)
+- `sameAs` pointing to broken or redirected URLs
+
+---
+
+### 4. Sitelinks Searchbox
+
+Appears when users search your brand directly. Requires:
+- High brand search volume (signal: GSC showing branded queries)
+- `WebSite` schema with `SearchAction` pointing to your internal search URL
+
+**Required schema:**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "url": "https://example.com/",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://example.com/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+```
+
+- [ ] Schema added to **homepage only**
+- [ ] `urlTemplate` returns a valid results page (not 404)
+- [ ] Internal site search is functional and indexes your content
+
+---
+
+## Output Format
+
+### AEO Audit Report
+
+```markdown
+## AEO Audit — [URL]
+
+### Featured Snippet Readiness
+- Current ownership: [Yes/No/Unknown]
+- Answer block present: [Yes/No] — [Location if found]
+- Answer word count: [N] words (target: 40-55)
+- Confidence: [Confirmed/Likely/Hypothesis]
+
+### PAA Coverage
+- Questions identified: [List]
+- Questions with matching H-tags + direct answers: [N/M]
+- Gaps (no coverage): [List]
+
+### Knowledge Panel Signals
+- Wikipedia: [Present/Absent]
+- Wikidata QID: [Present/Absent]
+- sameAs count: [N]
+- Missing sameAs: [List]
+
+### Sitelinks Searchbox
+- WebSite schema: [Present/Absent]
+- SearchAction: [Valid/Invalid/Missing]
+
+### Priority Fixes
+[Ordered by impact]
+```

--- a/.claude/skills/seo/resources/skills/seo-article.md
+++ b/.claude/skills/seo/resources/skills/seo-article.md
@@ -1,0 +1,37 @@
+---
+name: seo-article
+description: >
+  LLM-first article and blog post SEO analysis with keyword extraction,
+  content-gap identification, title/meta rewrite suggestions, and paragraph-level
+  improvement proposals. Use when user says "article SEO", "optimize this blog
+  post", "rewrite meta/title for this article", or "content optimization for a
+  post".
+---
+
+# SEO Sub-Skill: Article Analysis
+
+**Trigger**: `seo article <url>`
+
+This sub-skill focuses on deep keyword research and content analysis for a specific article or blog post, leveraging LLM intelligence for natural language optimization rather than rigid rules.
+
+Apply `resources/references/llm-audit-rubric.md` for evidence standards, confidence labels, severity mapping, and report structure.
+
+## Process
+
+### 1. Data Extraction
+Run the article extraction script to fetch the page, parse the content structure (title, meta, headings, paragraphs, images), and perform initial keyword extraction (TF-IDF) alongside LSI keyword discovery (via Google Autocomplete).
+
+```bash
+python3 <SKILL_DIR>/scripts/article_seo.py <url> --keyword "<optional_target_keyword>" --json
+```
+
+### 2. LLM-Driven Analysis
+Feed the JSON output from the extractor into your context.
+
+Act as an expert SEO Editor and analyze the extracted data to provide:
+1. **Title Tag & Meta Description Optimization**: Suggest high-CTR, keyword-optimized replacements if the current ones are missing or suboptimal.
+2. **Context-Aware Content Enrichment**: Identify specific paragraphs where LSI (Latent Semantic Indexing) keywords can be injected naturally to build topical depth—always avoiding keyword stuffing. Provide the exact "Current Paragraph" and the "Suggested Replacement".
+3. **Image SEO**: Suggest descriptive, keyword-aware alt text for any images missing the `alt` attribute.
+
+### 3. Reporting
+Format your generated SEO recommendations clearly using Markdown, ensuring the user receives actionable, copy-pasteable "before and after" examples.

--- a/.claude/skills/seo/resources/skills/seo-audit.md
+++ b/.claude/skills/seo/resources/skills/seo-audit.md
@@ -1,0 +1,112 @@
+---
+name: seo-audit
+description: >
+  Full website SEO audit with parallel subagent delegation. Crawls up to 500
+  pages, detects business type, delegates to 6 specialists, generates health
+  score. Use when user says "audit", "full SEO check", "analyze my site",
+  or "website health check".
+---
+
+# Full Website SEO Audit
+
+Apply `resources/references/llm-audit-rubric.md` for evidence standards, confidence labels, severity mapping, and report structure.
+
+## Process
+
+1. **Read page with LLM** — use `read_url_content` to read the page and begin analysis using SEO best practices.
+2. **Detect business type** — analyze homepage signals per seo orchestrator
+3. **Run scripts for evidence** — Always attempt to run relevant scripts for structured data collection. Scripts provide precise, machine-readable evidence that strengthens the analysis:
+   - `seo-technical` — robots.txt, sitemaps, canonicals, Core Web Vitals, security headers
+   - `seo-content` — E-E-A-T, readability, thin content, AI citation readiness
+   - `seo-schema` — detection, validation, generation recommendations
+   - `seo-sitemap` — structure analysis, quality gates, missing pages
+   - `seo-performance` — LCP, INP, CLS measurements
+   - `seo-visual` — screenshots, mobile testing, above-fold analysis
+4. **LLM analysis** — Apply `llm-audit-rubric.md`, score each category using chain-of-thought. Combine LLM reasoning with script evidence. If a script failed, the LLM still covers that area using its own analysis (confidence: `Likely` instead of `Confirmed`).
+5. **Score** — aggregate into SEO Health Score (0-100)
+6. **Report** — generate prioritized action plan
+
+## Crawl Configuration
+
+```
+Max pages: 500
+Respect robots.txt: Yes
+Follow redirects: Yes (max 3 hops)
+Timeout per page: 30 seconds
+Concurrent requests: 5
+Delay between requests: 1 second
+```
+
+## Output Files
+
+- `FULL-AUDIT-REPORT.md` — Comprehensive findings
+- `ACTION-PLAN.md` — Prioritized recommendations (Critical → High → Medium → Low)
+- `SEO-REPORT.html` — Optional interactive dashboard path (when `generate_report.py` is executed)
+- `screenshots/` — Desktop + mobile captures (if Playwright available)
+
+## Scoring Weights
+
+> **Source of truth**: `SKILL.md` Step 7. Update weights there first, then mirror here.
+
+| Category | Weight |
+|----------|--------|
+| Technical SEO | 25% |
+| Content Quality | 20% |
+| On-Page SEO | 15% |
+| Schema / Structured Data | 15% |
+| Performance (CWV) | 10% |
+| Images | 10% |
+| AI Search Readiness | 5% |
+
+## Report Structure
+
+### Executive Summary
+- Overall SEO Health Score (0-100)
+- Business type detected
+- Top 5 critical issues
+- Top 5 quick wins
+
+### Technical SEO
+- Crawlability issues
+- Indexability problems
+- Security concerns
+- Core Web Vitals status
+
+### Content Quality
+- E-E-A-T assessment
+- Thin content pages
+- Duplicate content issues
+- Readability scores
+
+### On-Page SEO
+- Title tag issues
+- Meta description problems
+- Heading structure
+- Internal linking gaps
+
+### Schema & Structured Data
+- Current implementation
+- Validation errors
+- Missing opportunities
+
+### Performance
+- LCP, INP, CLS scores
+- Resource optimization needs
+- Third-party script impact
+
+### Images
+- Missing alt text
+- Oversized images
+- Format recommendations
+
+### AI Search Readiness
+- Citability score
+- Structural improvements
+- Authority signals
+
+## Priority Definitions
+
+- **Critical**: Blocks indexing or causes penalties (fix immediately)
+- **High**: Significantly impacts rankings (fix within 1 week)
+- **Medium**: Optimization opportunity (fix within 1 month)
+- **Low**: Nice to have (backlog)

--- a/.claude/skills/seo/resources/skills/seo-competitor-pages.md
+++ b/.claude/skills/seo/resources/skills/seo-competitor-pages.md
@@ -1,0 +1,204 @@
+---
+name: seo-competitor-pages
+description: >
+  Generate SEO-optimized competitor comparison and alternatives pages. Covers
+  "X vs Y" layouts, "alternatives to X" pages, feature matrices, schema markup,
+  and conversion optimization. Use when user says "comparison page", "vs page",
+  "alternatives page", "competitor comparison", or "X vs Y".
+---
+
+# Competitor Comparison & Alternatives Pages
+
+Create high-converting comparison and alternatives pages that target
+competitive intent keywords with accurate, structured content.
+
+## Page Types
+
+### 1. "X vs Y" Comparison Pages
+- Direct head-to-head comparison between two products/services
+- Balanced feature-by-feature analysis
+- Clear verdict or recommendation with justification
+- Target keyword: `[Product A] vs [Product B]`
+
+### 2. "Alternatives to X" Pages
+- List of alternatives to a specific product/service
+- Each alternative with brief summary, pros/cons, best-for use case
+- Target keyword: `[Product] alternatives`, `best alternatives to [Product]`
+
+### 3. "Best [Category] Tools" Roundup Pages
+- Curated list of top tools/services in a category
+- Ranking criteria clearly stated
+- Target keyword: `best [category] tools [year]`, `top [category] software`
+
+### 4. Comparison Table Pages
+- Feature matrix with multiple products in columns
+- Sortable/filterable if interactive
+- Target keyword: `[category] comparison`, `[category] comparison chart`
+
+## Comparison Table Generation
+
+### Feature Matrix Layout
+```
+| Feature          | Your Product | Competitor A | Competitor B |
+|------------------|:------------:|:------------:|:------------:|
+| Feature 1        | ✅           | ✅           | ❌           |
+| Feature 2        | ✅           | ⚠️ Partial   | ✅           |
+| Feature 3        | ✅           | ❌           | ❌           |
+| Pricing (from)   | $X/mo        | $Y/mo        | $Z/mo        |
+| Free Tier        | ✅           | ❌           | ✅           |
+```
+
+### Data Accuracy Requirements
+- All feature claims must be verifiable from public sources
+- Pricing must be current (include "as of [date]" note)
+- Update frequency: review quarterly or when competitors ship major changes
+- Link to source for each competitor data point where possible
+
+## Schema Markup Recommendations
+
+### Product Schema with AggregateRating
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "[Product Name]",
+  "description": "[Product Description]",
+  "brand": {
+    "@type": "Brand",
+    "name": "[Brand Name]"
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "[Rating]",
+    "reviewCount": "[Count]",
+    "bestRating": "5",
+    "worstRating": "1"
+  }
+}
+```
+
+### SoftwareApplication (for software comparisons)
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "[Software Name]",
+  "applicationCategory": "[Category]",
+  "operatingSystem": "[OS]",
+  "offers": {
+    "@type": "Offer",
+    "price": "[Price]",
+    "priceCurrency": "USD"
+  }
+}
+```
+
+### ItemList (for roundup pages)
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Best [Category] Tools [Year]",
+  "itemListOrder": "https://schema.org/ItemListOrderDescending",
+  "numberOfItems": "[Count]",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "[Product Name]",
+      "url": "[Product URL]"
+    }
+  ]
+}
+```
+
+## Keyword Targeting
+
+### Comparison Intent Patterns
+| Pattern | Example | Search Volume Signal |
+|---------|---------|---------------------|
+| `[A] vs [B]` | "Slack vs Teams" | High |
+| `[A] alternative` | "Figma alternatives" | High |
+| `[A] alternatives [year]` | "Notion alternatives 2026" | High |
+| `best [category] tools` | "best project management tools" | High |
+| `[A] vs [B] for [use case]` | "AWS vs Azure for startups" | Medium |
+| `[A] review [year]` | "Monday.com review 2026" | Medium |
+| `[A] vs [B] pricing` | "HubSpot vs Salesforce pricing" | Medium |
+| `is [A] better than [B]` | "is Notion better than Confluence" | Medium |
+
+### Title Tag Formulas
+- X vs Y: `[A] vs [B]: [Key Differentiator] ([Year])`
+- Alternatives: `[N] Best [A] Alternatives in [Year] (Free & Paid)`
+- Roundup: `[N] Best [Category] Tools in [Year] — Compared & Ranked`
+
+### H1 Patterns
+- Match title tag intent
+- Include primary keyword naturally
+- Keep under 70 characters
+
+## Conversion-Optimized Layouts
+
+### CTA Placement
+- **Above fold**: Brief comparison summary with primary CTA
+- **After comparison table**: "Try [Your Product] free" CTA
+- **Bottom of page**: Final recommendation with CTA
+- Avoid aggressive CTAs in competitor description sections (reduces trust)
+
+### Social Proof Sections
+- Customer testimonials relevant to comparison criteria
+- G2/Capterra/TrustPilot ratings (with source links)
+- Case studies showing migration from competitor
+- "Switched from [Competitor]" stories
+
+### Pricing Highlights
+- Clear pricing comparison table
+- Highlight value advantages (not just lowest price)
+- Include hidden costs (setup fees, per-user pricing, overage charges)
+- Link to full pricing page
+
+### Trust Signals
+- "Last updated [date]" timestamp
+- Author with relevant expertise
+- Methodology disclosure (how comparisons were conducted)
+- Disclosure of own product affiliation
+
+## Fairness Guidelines
+
+- **Accuracy**: All competitor information must be verifiable from public sources
+- **No defamation**: Never make false or misleading claims about competitors
+- **Cite sources**: Link to competitor websites, review sites, or documentation
+- **Timely updates**: Review and update when competitors release major changes
+- **Disclose affiliation**: Clearly state which product is yours
+- **Balanced presentation**: Acknowledge competitor strengths honestly
+- **Pricing accuracy**: Include "as of [date]" disclaimers on all pricing data
+- **Feature verification**: Test competitor features where possible, cite documentation otherwise
+
+## Internal Linking
+
+- Link to your own product/service pages from comparison sections
+- Cross-link between related comparison pages (e.g., "A vs B" links to "A vs C")
+- Link to feature-specific pages when discussing individual features
+- Breadcrumb: Home > Comparisons > [This Page]
+- Related comparisons section at bottom of page
+- Link to case studies and testimonials mentioned in the comparison
+
+## Output
+
+### Comparison Page Template
+- `COMPARISON-PAGE.md` — Ready-to-implement page structure with sections
+- Feature matrix table
+- Content outline with word count targets (minimum 1,500 words)
+
+### Schema Markup
+- `comparison-schema.json` — Product/SoftwareApplication/ItemList JSON-LD
+
+### Keyword Strategy
+- Primary and secondary keywords
+- Related long-tail opportunities
+- Content gaps vs existing competitor pages
+
+### Recommendations
+- Content improvements for existing comparison pages
+- New comparison page opportunities
+- Schema markup additions
+- Conversion optimization suggestions

--- a/.claude/skills/seo/resources/skills/seo-content.md
+++ b/.claude/skills/seo/resources/skills/seo-content.md
@@ -1,0 +1,166 @@
+---
+name: seo-content
+description: >
+  Content quality and E-E-A-T analysis with AI citation readiness assessment.
+  Use when user says "content quality", "E-E-A-T", "content analysis",
+  "readability check", "thin content", or "content audit".
+---
+
+# Content Quality & E-E-A-T Analysis
+
+## E-E-A-T Framework (updated Sept 2025 QRG)
+
+Read `resources/references/eeat-framework.md` for full criteria.
+
+### Experience (first-hand signals)
+- Original research, case studies, before/after results
+- Personal anecdotes, process documentation
+- Unique data, proprietary insights
+- Photos/videos from direct experience
+
+### Expertise
+- Author credentials, certifications, bio
+- Professional background relevant to topic
+- Technical depth appropriate for audience
+- Accurate, well-sourced claims
+
+### Authoritativeness
+- External citations, backlinks from authoritative sources
+- Brand mentions, industry recognition
+- Published in recognized outlets
+- Cited by other experts
+
+### Trustworthiness
+- Contact information, physical address
+- Privacy policy, terms of service
+- Customer testimonials, reviews
+- Date stamps, transparent corrections
+- Secure site (HTTPS)
+
+## Content Metrics
+
+### Word Count Analysis
+Compare against page type minimums:
+| Page Type | Minimum |
+|-----------|---------|
+| Homepage | 500 |
+| Service page | 800 |
+| Blog post | 1,500 |
+| Product page | 300+ (400+ for complex products) |
+| Location page | 500-600 |
+
+> **Important:** These are **topical coverage floors**, not targets. Google has confirmed word count is NOT a direct ranking factor. The goal is comprehensive topical coverage — a 500-word page that thoroughly answers the query will outrank a 2,000-word page that doesn't. Use these as guidelines for adequate coverage depth, not rigid requirements.
+
+### Readability
+- Flesch Reading Ease: target 60-70 for general audience
+
+> **Note:** Flesch Reading Ease is a useful proxy for content accessibility but is NOT a direct Google ranking factor. John Mueller has confirmed Google does not use basic readability scores for ranking. Yoast deprioritized Flesch scores in v19.3. Use readability analysis as a content quality indicator, not as an SEO metric to optimize directly.
+- Grade level: match target audience
+- Sentence length: average 15-20 words
+- Paragraph length: 2-4 sentences
+
+### Keyword Optimization
+- Primary keyword in title, H1, first 100 words
+- Natural density (1-3%)
+- Semantic variations present
+- No keyword stuffing
+
+### Content Structure
+- Logical heading hierarchy (H1 → H2 → H3)
+- Scannable sections with descriptive headings
+- Bullet/numbered lists where appropriate
+- Table of contents for long-form content
+
+### Multimedia
+- Relevant images with proper alt text
+- Videos where appropriate
+- Infographics for complex data
+- Charts/graphs for statistics
+
+### Internal Linking
+- 3-5 relevant internal links per 1000 words
+- Descriptive anchor text
+- Links to related content
+- No orphan pages
+
+### External Linking
+- Cite authoritative sources
+- Open in new tab for user experience
+- Reasonable count (not excessive)
+
+## AI Content Assessment (Sept 2025 QRG addition)
+
+Google's raters now formally assess whether content appears AI-generated.
+
+### Acceptable AI Content
+- Demonstrates genuine E-E-A-T
+- Provides unique value
+- Has human oversight and editing
+- Contains original insights
+
+### Low-Quality AI Content Markers
+- Generic phrasing, lack of specificity
+- No original insight
+- Repetitive structure across pages
+- No author attribution
+- Factual inaccuracies
+
+> **Helpful Content System (March 2024):** The Helpful Content System was merged into Google's core ranking algorithm during the March 2024 core update. It no longer operates as a standalone classifier. Helpfulness signals are now weighted within every core update — the same principles apply (people-first content, demonstrating E-E-A-T, satisfying user intent), but enforcement is continuous rather than through separate HCU updates.
+
+## AI Citation Readiness (GEO signals)
+
+Optimize for AI search engines (ChatGPT, Perplexity, Google AI Overviews):
+
+- Clear, quotable statements with statistics/facts
+- Structured data (especially for data points)
+- Strong heading hierarchy (H1→H2→H3 flow)
+- Answer-first formatting for key questions
+- Tables and lists for comparative data
+- Clear attribution and source citations
+
+### AI Search Visibility & GEO (2025-2026)
+
+**Google AI Mode** launched publicly in May 2025 as a separate tab in Google Search, available in 180+ countries. Unlike AI Overviews (which appear above organic results), AI Mode provides a fully conversational search experience with **zero organic blue links** — making AI citation the only visibility mechanism.
+
+**Key optimization strategies for AI citation:**
+- **Structured answers:** Clear question-answer formats, definition patterns, and step-by-step instructions that AI systems can extract and cite
+- **First-party data:** Original research, statistics, case studies, and unique datasets are highly cited by AI systems
+- **Schema markup:** Article, FAQ (for non-Google AI platforms), and structured content schemas help AI systems parse and attribute content
+- **Topical authority:** AI systems preferentially cite sources that demonstrate deep expertise — build content clusters, not isolated pages
+- **Entity clarity:** Ensure brand, authors, and key concepts are clearly defined with structured data (Organization, Person schema)
+- **Multi-platform tracking:** Monitor visibility across Google AI Overviews, AI Mode, ChatGPT, Perplexity, and Bing Copilot — not just traditional rankings. Treat AI citation as a standalone KPI alongside organic rankings and traffic.
+
+**Generative Engine Optimization (GEO):**
+GEO is the emerging discipline of optimizing content specifically for AI-generated answers. Key GEO signals include: quotability (clear, concise extractable facts), attribution (source citations within your content), structure (well-organized heading hierarchy), and freshness (regularly updated data). Cross-reference the `seo-geo` skill for detailed GEO workflows.
+
+## Passage Indexing Optimization
+
+Google's Passage Indexing (active since 2021) ranks individual passages independently for specific long-tail queries. Optimize by:
+
+- Ensuring each major section (H2 or H3 block) is self-contained and answers one clear question
+- Keeping optimal passage length at 100-200 words per block
+- Using descriptive headings that provide context even if the passage is extracted
+- Front-loading the direct answer in the first 40-50 words of the passage
+
+## Content Freshness
+
+- Publication date visible
+- Last updated date if content has been revised
+- Flag content older than 12 months without update for fast-changing topics
+
+## Output
+
+### Content Quality Score: XX/100
+
+### E-E-A-T Breakdown
+| Factor | Score | Key Signals |
+|--------|-------|-------------|
+| Experience | XX/25 | ... |
+| Expertise | XX/25 | ... |
+| Authoritativeness | XX/25 | ... |
+| Trustworthiness | XX/25 | ... |
+
+### AI Citation Readiness: XX/100
+
+### Issues Found
+### Recommendations

--- a/.claude/skills/seo/resources/skills/seo-geo.md
+++ b/.claude/skills/seo/resources/skills/seo-geo.md
@@ -1,0 +1,264 @@
+---
+name: seo-geo
+description: >
+  Optimize content for AI Overviews (formerly SGE), ChatGPT web search,
+  Perplexity, and other AI-powered search experiences. Generative Engine
+  Optimization (GEO) analysis including brand mention signals, AI crawler
+  accessibility, llms.txt compliance, passage-level citability scoring, and
+  platform-specific optimization. Use when user says "AI Overviews", "SGE",
+  "GEO", "AI search", "LLM optimization", "Perplexity", "AI citations",
+  "ChatGPT search", or "AI visibility".
+---
+
+# AI Search / GEO Optimization (February 2026)
+
+## Key Statistics
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| AI Overviews reach | 1.5 billion users/month across 200+ countries | Google |
+| AI Overviews query coverage | 50%+ of all queries | Industry data |
+| AI-referred sessions growth | 527% (Jan-May 2025) | SparkToro |
+| ChatGPT weekly active users | 900 million | OpenAI |
+| Perplexity monthly queries | 500+ million | Perplexity |
+
+## Critical Insight: Brand Mentions > Backlinks
+
+**Brand mentions correlate 3× more strongly with AI visibility than backlinks.**
+(Ahrefs December 2025 study of 75,000 brands)
+
+| Signal | Correlation with AI Citations |
+|--------|------------------------------|
+| YouTube mentions | ~0.737 (strongest) |
+| Reddit mentions | High |
+| Wikipedia presence | High |
+| LinkedIn presence | Moderate |
+| Domain Rating (backlinks) | ~0.266 (weak) |
+
+**Only 11% of domains** are cited by both ChatGPT and Google AI Overviews for the same query — platform-specific optimization is essential.
+
+---
+
+## GEO Analysis Criteria (Updated)
+
+### 1. Citability Score (25%)
+
+**Optimal passage length: 134-167 words** for AI citation.
+
+**Strong signals:**
+- Clear, quotable sentences with specific facts/statistics
+- Self-contained answer blocks (can be extracted without context)
+- Direct answer in first 40-60 words of section
+- Claims attributed with specific sources
+- Definitions following "X is..." or "X refers to..." patterns
+- Unique data points not found elsewhere
+
+**Weak signals:**
+- Vague, general statements
+- Opinion without evidence
+- Buried conclusions
+- No specific data points
+
+### 2. Structural Readability (20%)
+
+**92% of AI Overview citations come from top-10 ranking pages**, but 47% come from pages ranking below position 5 — demonstrating different selection logic.
+
+**Strong signals:**
+- Clean H1→H2→H3 heading hierarchy
+- Question-based headings (matches query patterns)
+- Short paragraphs (2-4 sentences)
+- Tables for comparative data
+- Ordered/unordered lists for step-by-step or multi-item content
+- FAQ sections with clear Q&A format
+
+**Weak signals:**
+- Wall of text with no structure
+- Inconsistent heading hierarchy
+- No lists or tables
+- Information buried in paragraphs
+
+### 3. Multi-Modal Content (15%)
+
+Content with multi-modal elements sees **156% higher selection rates**.
+
+**Check for:**
+- Text + relevant images
+- Video content (embedded or linked)
+- Infographics and charts
+- Interactive elements (calculators, tools)
+- Structured data supporting media
+
+### 4. Authority & Brand Signals (20%)
+
+**Strong signals:**
+- Author byline with credentials
+- Publication date and last-updated date
+- Citations to primary sources (studies, official docs, data)
+- Organization credentials and affiliations
+- Expert quotes with attribution
+- Entity presence in Wikipedia, Wikidata
+- Mentions on Reddit, YouTube, LinkedIn
+
+**Weak signals:**
+- Anonymous authorship
+- No dates
+- No sources cited
+- No brand presence across platforms
+
+### 5. Technical Accessibility (20%)
+
+**AI crawlers do NOT execute JavaScript** — server-side rendering is critical.
+
+**Check for:**
+- Server-side rendering (SSR) vs client-only content
+- AI crawler access in robots.txt
+- llms.txt file presence and configuration
+- RSL 1.0 licensing terms
+
+---
+
+## AI Crawler Detection
+
+Check `robots.txt` for these AI crawlers:
+
+| Crawler | Owner | Purpose |
+|---------|-------|---------|
+| GPTBot | OpenAI | ChatGPT web search |
+| OAI-SearchBot | OpenAI | OpenAI search features |
+| ChatGPT-User | OpenAI | ChatGPT browsing |
+| ClaudeBot | Anthropic | Claude web features |
+| PerplexityBot | Perplexity | Perplexity AI search |
+| CCBot | Common Crawl | Training data (often blocked) |
+| anthropic-ai | Anthropic | Claude training |
+| Bytespider | ByteDance | TikTok/Douyin AI |
+| cohere-ai | Cohere | Cohere models |
+
+**Recommendation:** Allow GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot for AI search visibility. Block CCBot and training crawlers if desired.
+
+---
+
+## llms.txt Standard
+
+The emerging **llms.txt** standard provides AI crawlers with structured content guidance.
+
+**Location:** `/llms.txt` (root of domain)
+
+**Format:**
+```
+# Title of site
+> Brief description
+
+## Main sections
+- [Page title](url): Description
+- [Another page](url): Description
+
+## Optional: Key facts
+- Fact 1
+- Fact 2
+```
+
+**Check for:**
+- Presence of `/llms.txt`
+- Structured content guidance
+- Key page highlights
+- Contact/authority information
+
+---
+
+## RSL 1.0 (Really Simple Licensing)
+
+New standard (December 2025) for machine-readable AI licensing terms.
+
+**Backed by:** Reddit, Yahoo, Medium, Quora, Cloudflare, Akamai, Creative Commons
+
+**Check for:** RSL implementation and appropriate licensing terms.
+
+---
+
+## Platform-Specific Optimization
+
+| Platform | Key Citation Sources | Optimization Focus |
+|----------|---------------------|-------------------|
+| **Google AI Overviews** | Top-10 ranking pages (92%) | Traditional SEO + passage optimization |
+| **ChatGPT** | Wikipedia (47.9%), Reddit (11.3%) | Entity presence, authoritative sources |
+| **Perplexity** | Reddit (46.7%), Wikipedia | Community validation, discussions |
+| **Bing Copilot** | Bing index, authoritative sites | Bing SEO, IndexNow |
+
+---
+
+## Output
+
+Generate `GEO-ANALYSIS.md` with:
+
+1. **GEO Readiness Score: XX/100**
+2. **Platform breakdown** (Google AIO, ChatGPT, Perplexity scores)
+3. **AI Crawler Access Status** (which crawlers allowed/blocked)
+4. **llms.txt Status** (present, missing, recommendations)
+5. **Brand Mention Analysis** (presence on Wikipedia, Reddit, YouTube, LinkedIn)
+6. **Passage-Level Citability** (optimal 134-167 word blocks identified)
+7. **Server-Side Rendering Check** (JavaScript dependency analysis)
+8. **Top 5 Highest-Impact Changes**
+9. **Schema Recommendations** (for AI discoverability)
+10. **Content Reformatting Suggestions** (specific passages to rewrite)
+
+---
+
+## Passage Indexing Optimization
+
+Google Passage Indexing (active since 2021) ranks individual passages independently from the full page. This is critical for long-form content and pairs well with GEO citability.
+
+### Rules for Passage-Optimized Content
+1. **Self-contained sections**: Each H2 block should fully answer one clear question without requiring context from other sections
+2. **Optimal passage length**: 100-200 words per block (sweet spot for both passage indexing and AI citation)
+3. **Question-answer structure**: Use question-phrased H2/H3 followed by a direct answer in the first sentence
+4. **No pronoun-heavy openings**: Start sections with the full subject, not "It" or "This" referring to previous sections
+5. **Speakable schema**: Add `speakable` CSS selectors for your top answer passages
+
+### Speakable Schema Implementation
+
+```json
+{
+  "@type": "WebPage",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".answer-block", "#key-definition", ".summary-paragraph"]
+  }
+}
+```
+
+### Passage vs Full-Page Ranking
+
+| Scenario | Google Behavior |
+|----------|----------------|
+| Strong overall page, weak section | Full page ranks |
+| Weak overall page, one excellent section | That **passage** can rank for specific queries |
+| Long FAQ page with 20 questions | Individual Q&A passages rank independently |
+
+---
+
+## Quick Wins
+
+1. Add "What is [topic]?" definition in first 60 words
+2. Create 134-167 word self-contained answer blocks
+3. Add question-based H2/H3 headings
+4. Include specific statistics with sources
+5. Add publication/update dates
+6. Implement Person schema for authors
+7. Allow key AI crawlers in robots.txt
+
+## Medium Effort
+
+1. Create `/llms.txt` file
+2. Add author bio with credentials + Wikipedia/LinkedIn links
+3. Ensure server-side rendering for key content
+4. Build entity presence on Reddit, YouTube
+5. Add comparison tables with data
+6. Implement FAQ sections (structured, not schema for commercial sites)
+
+## High Impact
+
+1. Create original research/surveys (unique citability)
+2. Build Wikipedia presence for brand/key people
+3. Establish YouTube channel with content mentions
+4. Implement comprehensive entity linking (sameAs across platforms)
+5. Develop unique tools or calculators

--- a/.claude/skills/seo/resources/skills/seo-github.md
+++ b/.claude/skills/seo/resources/skills/seo-github.md
@@ -1,0 +1,125 @@
+---
+name: seo-github
+description: >
+  GitHub repository SEO and discoverability analysis. Use for repository search
+  visibility, README conversion optimization, community health checks, topic
+  strategy, and traffic archival planning.
+---
+
+# GitHub Repository SEO
+
+Apply `resources/references/llm-audit-rubric.md` for evidence format and
+confidence labels, and apply `resources/references/readme-audit-rubric.md`
+for README scoring.
+
+## Trigger Mapping
+
+Use this workflow when the user asks:
+
+- "GitHub SEO"
+- "optimize this repo for GitHub search"
+- "improve repository discoverability"
+- "README SEO audit"
+- "topics and metadata optimization"
+- "community profile audit"
+
+## Inputs
+
+- Repository URL or slug (`owner/repo`).
+- Optional target query set for GitHub search benchmarking.
+- Optional GitHub token (`GITHUB_TOKEN` or `GH_TOKEN`) for API checks.
+
+### Auth Setup
+
+Use either environment token or `gh` auth:
+
+```bash
+# Option A: token env vars (recommended for automation)
+export GITHUB_TOKEN="ghp_xxx"
+# or
+export GH_TOKEN="ghp_xxx"
+
+# Option B: GitHub CLI login fallback
+gh auth login -h github.com
+gh auth status -h github.com
+```
+
+## Workflow
+
+### 1. Resolve Scope and Access
+
+- Resolve target repo from input or local `origin` remote.
+- Check whether token-based API access is available.
+- If token is missing/invalid, continue with partial checks and mark API-based
+  findings as `Unknown` or `Likely`.
+- Generate query/competitor inputs via LLM reasoning and/or web search before
+  benchmark stages when possible:
+  - query list (`--query` / `--query-file`)
+  - optional explicit competitors (`--competitor owner/repo`)
+- If queries are not provided, `github_seo_report.py` auto-derives repo-specific
+  benchmark queries from repo slug/metadata/title analysis.
+
+### 2. Run Evidence Scripts
+
+Run scripts from `<SKILL_DIR>/scripts/`:
+
+```bash
+python3 github_repo_audit.py --repo <owner/repo> --provider auto --json
+python3 github_readme_lint.py README.md --json
+python3 github_community_health.py --repo <owner/repo> --provider auto --json
+python3 github_search_benchmark.py --repo <owner/repo> --query "<llm_or_web_query>" --provider auto --json
+python3 github_competitor_research.py --repo <owner/repo> --query "<llm_or_web_query>" --provider auto --top-n 6 --json
+python3 github_competitor_research.py --repo <owner/repo> --competitor <owner/repo> --competitor <owner/repo> --provider auto --json
+python3 github_traffic_archiver.py --repo <owner/repo> --provider auto --json
+python3 github_seo_report.py --repo <owner/repo> --provider auto --markdown GITHUB-SEO-REPORT.md --action-plan GITHUB-ACTION-PLAN.md
+# Optional: cap auto-derived query count used by github_seo_report.py
+# python3 github_seo_report.py --repo <owner/repo> --provider auto --auto-query-max 8 --markdown GITHUB-SEO-REPORT.md --action-plan GITHUB-ACTION-PLAN.md
+# Optional explicit verifier step for custom pipelines:
+# python3 finding_verifier.py --findings-json raw-findings.json --json
+```
+
+### 3. Analyze by Area
+
+- Metadata discoverability: repo name, description, topics, homepage, social preview.
+- Title strategy: underscore vs hyphen checks, intent-keyword extraction, suggested slug/title.
+- README SEO and conversion: heading structure, intent alignment, CTAs, proof sections.
+- Community trust: governance files and contribution readiness.
+- Search benchmarking: target query positions and sampled competitors.
+- Competitor research: topic overlaps, README pattern gaps, and strategy opportunities.
+- Traffic trend readiness: archival freshness and retention compliance.
+- Backlink distribution: channel suggestions (Medium/blog/dev communities), post title ideas, and anchor-mix guidance.
+
+### 4. Prioritize
+
+Classify recommendations:
+
+- `Critical`: blocks discovery, trust, or measurement continuity.
+- `Warning`: important optimization opportunity.
+- `Pass`: meets baseline.
+- `Info`: contextual or optional enhancement.
+
+### 5. Output Artifacts
+
+Required for `seo github` runs:
+
+- `GITHUB-SEO-REPORT.md` — findings and evidence.
+- `GITHUB-ACTION-PLAN.md` — prioritized fixes.
+
+Optional:
+
+- `GITHUB-WEEKLY-SCORECARD.md` — recurring measurement snapshot.
+
+## Delegation Guidance
+
+- Strategy synthesis: `resources/agents/seo-github-analyst.md`
+- Competitor/query benchmark: `resources/agents/seo-github-benchmark.md`
+- API collection/archival: `resources/agents/seo-github-data.md`
+- Final verification: `resources/agents/seo-verifier.md`
+
+## Critical Rules
+
+1. Never claim a definitive GitHub ranking formula.
+2. Treat token/API failures as environment limitations, not repo defects.
+3. Keep topics relevant and capped at 20.
+4. Preserve existing project voice/branding in README recommendations.
+5. Archive traffic snapshots regularly due 14-day retention windows.

--- a/.claude/skills/seo/resources/skills/seo-hreflang.md
+++ b/.claude/skills/seo/resources/skills/seo-hreflang.md
@@ -1,0 +1,184 @@
+---
+name: seo-hreflang
+description: >
+  Hreflang and international SEO audit, validation, and generation. Detects
+  common mistakes, validates language/region codes, and generates correct
+  hreflang implementations. Use when user says "hreflang", "i18n SEO",
+  "international SEO", "multi-language", "multi-region", or "language tags".
+---
+
+# Hreflang & International SEO
+
+Validate existing hreflang implementations or generate correct hreflang tags
+for multi-language and multi-region sites. Supports HTML, HTTP header, and
+XML sitemap implementations.
+
+## Validation Checks
+
+### 1. Self-Referencing Tags
+- Every page must include an hreflang tag pointing to itself
+- The self-referencing URL must exactly match the page's canonical URL
+- Missing self-referencing tags cause Google to ignore the entire hreflang set
+
+### 2. Return Tags
+- If page A links to page B with hreflang, page B must link back to page A
+- Every hreflang relationship must be bidirectional (A→B and B→A)
+- Missing return tags invalidate the hreflang signal for both pages
+- Check all language versions reference each other (full mesh)
+
+### 3. x-default Tag
+- Required: designates the fallback page for unmatched languages/regions
+- Typically points to the language selector page or English version
+- Only one x-default per set of alternates
+- Must also have return tags from all other language versions
+
+### 4. Language Code Validation
+- Must use ISO 639-1 two-letter codes (e.g., `en`, `fr`, `de`, `ja`)
+- Common errors:
+  - `eng` instead of `en` (ISO 639-2, not valid for hreflang)
+  - `jp` instead of `ja` (incorrect code for Japanese)
+  - `zh` without region qualifier (ambiguous — use `zh-Hans` or `zh-Hant`)
+
+### 5. Region Code Validation
+- Optional region qualifier uses ISO 3166-1 Alpha-2 (e.g., `en-US`, `en-GB`, `pt-BR`)
+- Format: `language-REGION` (lowercase language, uppercase region)
+- Common errors:
+  - `en-uk` instead of `en-GB` (UK is not a valid ISO 3166-1 code)
+  - `es-LA` (Latin America is not a country — use specific countries)
+  - Region without language prefix
+
+### 6. Canonical URL Alignment
+- Hreflang tags must only appear on canonical URLs
+- If a page has `rel=canonical` pointing elsewhere, hreflang on that page is ignored
+- The canonical URL and hreflang URL must match exactly (including trailing slashes)
+- Non-canonical pages should not be in any hreflang set
+
+### 7. Protocol Consistency
+- All URLs in an hreflang set must use the same protocol (HTTPS or HTTP)
+- Mixed HTTP/HTTPS in hreflang sets causes validation failures
+- After HTTPS migration, update all hreflang tags to HTTPS
+
+### 8. Cross-Domain Support
+- Hreflang works across different domains (e.g., example.com and example.de)
+- Cross-domain hreflang requires return tags on both domains
+- Verify both domains are verified in Google Search Console
+- Sitemap-based implementation recommended for cross-domain setups
+
+## Common Mistakes
+
+| Issue | Severity | Fix |
+|-------|----------|-----|
+| Missing self-referencing tag | Critical | Add hreflang pointing to same page URL |
+| Missing return tags (A→B but no B→A) | Critical | Add matching return tags on all alternates |
+| Missing x-default | High | Add x-default pointing to fallback/selector page |
+| Invalid language code (e.g., `eng`) | High | Use ISO 639-1 two-letter codes |
+| Invalid region code (e.g., `en-uk`) | High | Use ISO 3166-1 Alpha-2 codes |
+| Hreflang on non-canonical URL | High | Move hreflang to canonical URL only |
+| HTTP/HTTPS mismatch in URLs | Medium | Standardize all URLs to HTTPS |
+| Trailing slash inconsistency | Medium | Match canonical URL format exactly |
+| Hreflang in both HTML and sitemap | Low | Choose one method — sitemap preferred for large sites |
+| Language without region when needed | Low | Add region qualifier for geo-targeted content |
+
+## Implementation Methods
+
+### Method 1: HTML Link Tags
+Best for: Sites with <50 language/region variants per page.
+
+```html
+<link rel="alternate" hreflang="en-US" href="https://example.com/page" />
+<link rel="alternate" hreflang="en-GB" href="https://example.co.uk/page" />
+<link rel="alternate" hreflang="fr" href="https://example.com/fr/page" />
+<link rel="alternate" hreflang="x-default" href="https://example.com/page" />
+```
+
+Place in `<head>` section. Every page must include all alternates including itself.
+
+### Method 2: HTTP Headers
+Best for: Non-HTML files (PDFs, documents).
+
+```
+Link: <https://example.com/page>; rel="alternate"; hreflang="en-US",
+      <https://example.com/fr/page>; rel="alternate"; hreflang="fr",
+      <https://example.com/page>; rel="alternate"; hreflang="x-default"
+```
+
+Set via server configuration or CDN rules.
+
+### Method 3: XML Sitemap (Recommended for large sites)
+Best for: Sites with many language variants, cross-domain setups, or 50+ pages.
+
+See Hreflang Sitemap Generation section below.
+
+### Method Comparison
+| Method | Best For | Pros | Cons |
+|--------|----------|------|------|
+| HTML link tags | Small sites (<50 variants) | Easy to implement, visible in source | Bloats `<head>`, hard to maintain at scale |
+| HTTP headers | Non-HTML files | Works for PDFs, images | Complex server config, not visible in HTML |
+| XML sitemap | Large sites, cross-domain | Scalable, centralized management | Not visible on page, requires sitemap maintenance |
+
+## Hreflang Generation
+
+### Process
+1. **Detect languages**: Scan site for language indicators (URL path, subdomain, TLD, HTML lang attribute)
+2. **Map page equivalents**: Match corresponding pages across languages/regions
+3. **Validate language codes**: Verify all codes against ISO 639-1 and ISO 3166-1
+4. **Generate tags**: Create hreflang tags for each page including self-referencing
+5. **Verify return tags**: Confirm all relationships are bidirectional
+6. **Add x-default**: Set fallback for each page set
+7. **Output**: Generate implementation code (HTML, HTTP headers, or sitemap XML)
+
+## Hreflang Sitemap Generation
+
+### Sitemap with Hreflang
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://example.com/page</loc>
+    <xhtml:link rel="alternate" hreflang="en-US" href="https://example.com/page" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/page" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://example.de/page" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://example.com/page" />
+  </url>
+  <url>
+    <loc>https://example.com/fr/page</loc>
+    <xhtml:link rel="alternate" hreflang="en-US" href="https://example.com/page" />
+    <xhtml:link rel="alternate" hreflang="fr" href="https://example.com/fr/page" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://example.de/page" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://example.com/page" />
+  </url>
+</urlset>
+```
+
+Key rules:
+- Include the `xmlns:xhtml` namespace declaration
+- Every `<url>` entry must include ALL language alternates (including itself)
+- Each alternate must appear as a separate `<url>` entry with its own full set
+- Split at 50,000 URLs per sitemap file
+
+## Output
+
+### Hreflang Validation Report
+
+#### Summary
+- Total pages scanned: XX
+- Language variants detected: XX
+- Issues found: XX (Critical: X, High: X, Medium: X, Low: X)
+
+#### Validation Results
+| Language | URL | Self-Ref | Return Tags | x-default | Status |
+|----------|-----|----------|-------------|-----------|--------|
+| en-US | https://... | ✅ | ✅ | ✅ | ✅ |
+| fr | https://... | ❌ | ⚠️ | ✅ | ❌ |
+| de | https://... | ✅ | ❌ | ✅ | ❌ |
+
+### Generated Hreflang Tags
+- HTML `<link>` tags (if HTML method chosen)
+- HTTP header values (if header method chosen)
+- `hreflang-sitemap.xml` (if sitemap method chosen)
+
+### Recommendations
+- Missing implementations to add
+- Incorrect codes to fix
+- Method migration suggestions (e.g., HTML → sitemap for scale)

--- a/.claude/skills/seo/resources/skills/seo-images.md
+++ b/.claude/skills/seo/resources/skills/seo-images.md
@@ -1,0 +1,168 @@
+---
+name: seo-images
+description: >
+  Image optimization analysis for SEO and performance. Checks alt text, file
+  sizes, formats, responsive images, lazy loading, and CLS prevention. Use when
+  user says "image optimization", "alt text", "image SEO", "image size",
+  or "image audit".
+---
+
+# Image Optimization Analysis
+
+## Checks
+
+### Alt Text
+- Present on all `<img>` elements (except decorative: `role="presentation"`)
+- Descriptive: describes the image content, not "image.jpg" or "photo"
+- Includes relevant keywords where natural, not keyword-stuffed
+- Length: 10-125 characters
+
+**Good examples:**
+- "Professional plumber repairing kitchen sink faucet"
+- "Red 2024 Toyota Camry sedan front view"
+- "Team meeting in modern office conference room"
+
+**Bad examples:**
+- "image.jpg" (filename, not description)
+- "plumber plumbing plumber services" (keyword stuffing)
+- "Click here" (not descriptive)
+
+### File Size
+
+**Tiered thresholds by image category:**
+
+| Image Category | Target | Warning | Critical |
+|----------------|--------|---------|----------|
+| Thumbnails | < 50KB | > 100KB | > 200KB |
+| Content images | < 100KB | > 200KB | > 500KB |
+| Hero/banner images | < 200KB | > 300KB | > 700KB |
+
+Recommend compression to target thresholds where possible without quality loss.
+
+### Format
+| Format | Browser Support | Use Case |
+|--------|-----------------|----------|
+| WebP | 97%+ | Default recommendation |
+| AVIF | 92%+ | Best compression, newer |
+| JPEG | 100% | Fallback for photos |
+| PNG | 100% | Graphics with transparency |
+| SVG | 100% | Icons, logos, illustrations |
+
+Recommend WebP/AVIF over JPEG/PNG. Check for `<picture>` element with format fallbacks.
+
+#### Recommended `<picture>` Element Pattern
+
+Use progressive enhancement with the most efficient format first:
+
+```html
+<picture>
+  <source srcset="image.avif" type="image/avif">
+  <source srcset="image.webp" type="image/webp">
+  <img src="image.jpg" alt="Descriptive alt text" width="800" height="600" loading="lazy" decoding="async">
+</picture>
+```
+
+The browser will use the first supported format. Current browser support: AVIF 93.8%, WebP 95.3%.
+
+#### JPEG XL — Emerging Format
+
+In November 2025, Google's Chromium team reversed its 2022 decision and announced it will restore JPEG XL support in Chrome using a Rust-based decoder. The implementation is feature-complete but not yet in Chrome stable. JPEG XL offers lossless JPEG recompression (~20% savings with zero quality loss) and competitive lossy compression. Not yet practical for web deployment, but worth monitoring for future adoption.
+
+### Responsive Images
+- `srcset` attribute for multiple sizes
+- `sizes` attribute matching layout breakpoints
+- Appropriate resolution for device pixel ratios
+
+```html
+<img
+  src="image-800.jpg"
+  srcset="image-400.jpg 400w, image-800.jpg 800w, image-1200.jpg 1200w"
+  sizes="(max-width: 600px) 400px, (max-width: 1200px) 800px, 1200px"
+  alt="Description"
+>
+```
+
+### Lazy Loading
+- `loading="lazy"` on below-fold images
+- Do NOT lazy-load above-fold/hero images (hurts LCP)
+- Check for native vs JavaScript-based lazy loading
+
+```html
+<!-- Below fold - lazy load -->
+<img src="photo.jpg" loading="lazy" alt="Description">
+
+<!-- Above fold - eager load (default) -->
+<img src="hero.jpg" alt="Hero image">
+```
+
+### `fetchpriority="high"` for LCP Images
+
+Add `fetchpriority="high"` to your hero/LCP image to prioritize its download in the browser's network queue:
+
+```html
+<img src="hero.webp" fetchpriority="high" alt="Hero image description" width="1200" height="630">
+```
+
+**Critical:** Do NOT lazy-load above-the-fold/LCP images. Using `loading="lazy"` on LCP images directly harms LCP scores. Reserve `loading="lazy"` for below-the-fold images only.
+
+### `decoding="async"` for Non-LCP Images
+
+Add `decoding="async"` to non-LCP images to prevent image decoding from blocking the main thread:
+
+```html
+<img src="photo.webp" alt="Description" width="600" height="400" loading="lazy" decoding="async">
+```
+
+### CLS Prevention
+- `width` and `height` attributes set on all `<img>` elements
+- `aspect-ratio` CSS as alternative
+- Flag images without dimensions
+
+```html
+<!-- Good - dimensions set -->
+<img src="photo.jpg" width="800" height="600" alt="Description">
+
+<!-- Good - CSS aspect ratio -->
+<img src="photo.jpg" style="aspect-ratio: 4/3" alt="Description">
+
+<!-- Bad - no dimensions -->
+<img src="photo.jpg" alt="Description">
+```
+
+### File Names
+- Descriptive: `blue-running-shoes.webp` not `IMG_1234.jpg`
+- Hyphenated, lowercase, no special characters
+- Include relevant keywords
+
+### CDN Usage
+- Check if images served from CDN (different domain, CDN headers)
+- Recommend CDN for image-heavy sites
+- Check for edge caching headers
+
+## Output
+
+### Image Audit Summary
+
+| Metric | Status | Count |
+|--------|--------|-------|
+| Total Images | - | XX |
+| Missing Alt Text | ❌ | XX |
+| Oversized (>200KB) | ⚠️ | XX |
+| Wrong Format | ⚠️ | XX |
+| No Dimensions | ⚠️ | XX |
+| Not Lazy Loaded | ⚠️ | XX |
+
+### Prioritized Optimization List
+
+Sorted by file size impact (largest savings first):
+
+| Image | Current Size | Format | Issues | Est. Savings |
+|-------|--------------|--------|--------|--------------|
+| ... | ... | ... | ... | ... |
+
+### Recommendations
+1. Convert X images to WebP format (est. XX KB savings)
+2. Add alt text to X images
+3. Add dimensions to X images
+4. Enable lazy loading on X below-fold images
+5. Compress X oversized images

--- a/.claude/skills/seo/resources/skills/seo-links.md
+++ b/.claude/skills/seo/resources/skills/seo-links.md
@@ -1,0 +1,141 @@
+---
+name: seo-links
+description: >
+  Link health and backlink profile analysis. Wires together existing scripts
+  (internal_links.py, broken_links.py) for internal link health and adds
+  external backlink profiling via CommonCrawl CDX API. Use when user says
+  "backlinks", "link profile", "internal links", "broken links", "link equity",
+  "referring domains", or "link building".
+---
+
+# Link Health & Backlink Profile
+
+Comprehensive link analysis combining internal link equity, broken link detection,
+and external backlink profiling. Uses existing scripts for internal/broken links
+and `link_profile.py` for external links.
+
+## Scripts
+
+### 1. Internal Link Analysis (`scripts/internal_links.py`)
+```bash
+python3 <SKILL_DIR>/scripts/internal_links.py <url> --depth 2 --json
+```
+
+Crawls up to 50 pages, reports:
+- Total internal links, unique pages found
+- Orphan page candidates (≤1 incoming internal link)
+- Anchor text distribution (top 20 anchors)
+- Nofollow internal links (waste of link equity)
+- Pages with < 3 or > 100 internal links
+
+### 2. Broken Link Detection (`scripts/broken_links.py`)
+```bash
+python3 <SKILL_DIR>/scripts/broken_links.py <url> --json
+```
+
+Checks all links on a page for HTTP errors:
+- 404 Not Found → immediate fix needed
+- 301/302 chains → update to final destination
+- Timeout / connection errors → server issue
+
+### 3. External Link Profile (`scripts/link_profile.py`)
+```bash
+python3 <SKILL_DIR>/scripts/link_profile.py <url> --json
+```
+
+Analyzes external links from the page and discovers backlinks via CommonCrawl CDX API:
+- External links: total, unique domains, dofollow/nofollow split
+- Anchor text profile (branded, exact-match, partial, generic, naked URL)
+- CommonCrawl backlink sample (no API key required)
+
+---
+
+## Analysis Framework
+
+### Internal Link Equity
+
+See `resources/references/link-building.md` for PageRank flow guidance.
+
+**Healthy signals:**
+- Pillar pages: 10+ internal links pointing in from related content
+- Blog posts: 3-8 bidirectional links to/from related articles
+- No orphan pages (pages with 0-1 internal links)
+- Avg outbound internal links per page: 5-15
+
+**Issue thresholds (from `internal_links.py` output):**
+| Issue | Threshold | Severity |
+|-------|-----------|----------|
+| Orphan pages | ≥ 1 | Warning |
+| Pages with < 3 links | ≥ 10% of crawled pages | Warning |
+| Pages with > 100 links | Any | Warning |
+| Nofollow internal links | Any | Info |
+
+### Broken Links
+
+**Impact on SEO:**
+- 404 errors on crawled pages → Googlebot wastes crawl budget
+- Internal 404s → lost link equity (PageRank leaks to dead URLs)
+- External 404 links → poor user experience signal
+
+**Priority:**
+1. Fix internal broken links first (crawl budget waste)
+2. Redirect external broken links to best alternative
+3. Remove if no equivalent content exists
+
+### External Backlink Profile
+
+Reference `resources/references/link-building.md` for:
+- Safe anchor text distribution targets (branded 40-50%, exact-match ≤5%)
+- Toxic link detection signals
+- Disavow file creation guide
+- Manual action recovery steps
+
+**CommonCrawl CDX API (free, no key):**
+```
+https://index.commoncrawl.org/CC-MAIN-latest/cdx?url=example.com/*
+  &fl=original,timestamp,urlkey&output=json&limit=100
+```
+
+Note: CommonCrawl is a snapshot, not real-time. For live backlink data, GSC "Top Linking Sites" is the most reliable free source.
+
+---
+
+## Audit Workflow
+
+```
+1. Run internal_links.py    → identify orphans, thin linking, nofollow waste
+2. Run broken_links.py      → list all 4xx/5xx links for immediate fix
+3. Run link_profile.py      → external link classification + backlink sample
+4. Cross-reference with GSC → confirm crawl errors, top linking sites
+5. Apply quality thresholds → from this file + link-building.md reference
+6. Generate report          → findings + prioritized fixes
+```
+
+---
+
+## Output Format
+
+```markdown
+## Link Health Report — [URL]
+
+### Internal Links
+- Pages crawled: N
+- Orphan pages: N (list top 5)
+- Avg links per page: N
+- Nofollow internal links: N
+
+### Broken Links
+- Total broken: N
+- Internal 404s: N (list URLs)
+- External 404s: N
+
+### External Backlink Profile
+- External links on page: N (dofollow: N, nofollow: N)
+- Unique external domains: N
+- CommonCrawl referring domains: N (sample)
+- Anchor text profile: [Branded N%, Exact-match N%, Generic N%]
+
+### Issues (prioritized)
+| Severity | Issue | Fix |
+|----------|-------|-----|
+```

--- a/.claude/skills/seo/resources/skills/seo-page.md
+++ b/.claude/skills/seo/resources/skills/seo-page.md
@@ -1,0 +1,91 @@
+---
+name: seo-page
+description: >
+  Deep single-page SEO analysis covering on-page elements, content quality,
+  technical meta tags, schema, images, and performance. Use when user says
+  "analyze this page", "check page SEO", or provides a single URL for review.
+---
+
+# Single Page Analysis
+
+Apply `resources/references/llm-audit-rubric.md` for evidence standards, confidence labels, severity mapping, and report structure.
+
+## What to Analyze
+
+### On-Page SEO
+- Title tag: 50-60 characters, includes primary keyword, unique
+- Meta description: 150-160 characters, compelling, includes keyword
+- H1: exactly one, matches page intent, includes keyword
+- H2-H6: logical hierarchy (no skipped levels), descriptive
+- URL: short, descriptive, hyphenated, no parameters
+- Internal links: sufficient, relevant anchor text, no orphan pages
+- External links: to authoritative sources, reasonable count
+
+### Content Quality
+- Word count vs page type minimums (see quality-gates.md)
+- Readability: Flesch Reading Ease score, grade level
+- Keyword density: natural (1-3%), semantic variations present
+- E-E-A-T signals: author bio, credentials, first-hand experience markers
+- Content freshness: publication date, last updated date
+
+### Technical Elements
+- Canonical tag: present, self-referencing or correct
+- Meta robots: index/follow unless intentionally blocked
+- Open Graph: og:title, og:description, og:image, og:url
+- Twitter Card: twitter:card, twitter:title, twitter:description
+- Hreflang: if multi-language, correct implementation
+
+### Schema Markup
+- Detect all types (JSON-LD preferred)
+- Validate required properties
+- Identify missing opportunities
+- NEVER recommend HowTo (deprecated) or FAQ (restricted to gov/health)
+
+### Images
+- Alt text: present, descriptive, includes keywords where natural
+- File size: flag >200KB (warning), >500KB (critical)
+- Format: recommend WebP/AVIF over JPEG/PNG
+- Dimensions: width/height set for CLS prevention
+- Lazy loading: loading="lazy" on below-fold images
+
+### Core Web Vitals (reference only — not measurable from HTML alone)
+- Flag potential LCP issues (huge hero images, render-blocking resources)
+- Flag potential INP issues (heavy JS, no async/defer)
+- Flag potential CLS issues (missing image dimensions, injected content)
+
+## Output
+
+### Output Files (Required)
+- `FULL-AUDIT-REPORT.md` — Full single-page findings with evidence, severity, and confidence labels
+- `ACTION-PLAN.md` — Prioritized implementation plan (Critical → High → Medium → Low)
+- `SEO-REPORT.html` — Optional interactive dashboard path (when `generate_report.py` is executed)
+
+### Page Score Card
+```
+Overall Score: XX/100
+
+On-Page SEO:     XX/100  ████████░░
+Content Quality: XX/100  ██████████
+Technical:       XX/100  ███████░░░
+Schema:          XX/100  █████░░░░░
+Images:          XX/100  ████████░░
+```
+
+### Issues Found
+Organized by priority: Critical → High → Medium → Low
+
+### Recommendations
+Specific, actionable improvements with expected impact
+
+### Schema Suggestions
+Ready-to-use JSON-LD code for detected opportunities
+
+## Execution Plan
+
+When invoked as an agent to analyze a specific URL, execute these steps:
+1. Run `scripts/fetch_page.py "$URL" --output /tmp/page.html` to fetch raw HTML with the shared safe HTTP policy.
+2. Run `scripts/parse_html.py /tmp/page.html --url "$URL" --json` to get title, meta, links, headings, alt text, schema, x-robots, pagination, and resource hints. For one-step usage, `scripts/parse_html.py --fetch "$URL" --json` is also supported.
+3. Run `scripts/readability.py /tmp/page.html --json` for text metrics and grade level.
+4. Run `scripts/pagespeed.py "$URL" --strategy mobile --json` or `--strategy both` for Core Web Vitals.
+5. If applicable, run `scripts/article_seo.py "$URL" --json` for a deeper dive on content scoring.
+6. Summarize all findings into the Page Score Card and Issues Found according to the evidence rules.

--- a/.claude/skills/seo/resources/skills/seo-plan.md
+++ b/.claude/skills/seo/resources/skills/seo-plan.md
@@ -1,0 +1,155 @@
+---
+name: seo-plan
+description: >
+  Strategic SEO planning for new or existing websites. Industry-specific
+  templates, competitive analysis, content strategy, and implementation
+  roadmap. Use when user says "SEO plan", "SEO strategy", "content strategy",
+  "site architecture", or "SEO roadmap".
+---
+
+# Strategic SEO Planning
+
+## Process
+
+### 1. Discovery
+- Business type, target audience, competitors, goals
+- Current site assessment (if exists)
+- Budget and timeline constraints
+- Key performance indicators (KPIs)
+
+### 2. Competitive Analysis
+- Identify top 5 competitors
+- Analyze their content strategy, schema usage, technical setup
+- Identify keyword gaps and content opportunities
+- Assess their E-E-A-T signals
+- Estimate their domain authority
+
+### 3. Architecture Design
+- Load industry template from `resources/templates/`
+- Design URL hierarchy and content pillars
+- Plan internal linking strategy
+- Sitemap structure with quality gates applied
+- Information architecture for user journeys
+
+### 4. Content Strategy
+- Content gaps vs competitors — use `scripts/competitor_gap.py` for data-driven analysis
+- Page types and estimated counts
+- Blog/resource topics and publishing cadence
+- E-E-A-T building plan (author bios, credentials, experience signals)
+- Content calendar with priorities
+
+### 4.5 Topical Authority Cluster Planning
+
+**Why:** Google's Helpful Content system rewards sites demonstrating comprehensive topical expertise. A single page on "red team ops" ranks worse than a hub of 8-15 interlinked articles covering the topic from multiple angles.
+
+#### Hub-and-Spoke Model
+
+```
+                    [Pillar Page]
+                   /      |       \
+          [Cluster 1] [Cluster 2] [Cluster 3]
+          /    \        |    \        |    \
+       [Sub] [Sub]   [Sub] [Sub]  [Sub] [Sub]
+```
+
+#### Pillar Page Requirements
+- **Word count**: 3,000-5,000 words (comprehensive overview)
+- **Structure**: Covers all major subtopics at surface level, links to each cluster article for depth
+- **Target keyword**: Head term (e.g., "cobalt strike beacon")
+- **Internal links**: Bidirectional links to/from every cluster article
+- **Schema**: Add `Article` or `WebPage` schema with `about` and `mentions` properties
+
+#### Cluster Article Requirements
+- **Word count**: 1,500-3,000 words (deep dive on one aspect)
+- **Target keyword**: Long-tail variant (e.g., "cobalt strike beacon sleep mask")
+- **Internal links**: Must link back to pillar page + 2-3 sibling cluster articles
+- **Freshness**: Update cluster articles when new information becomes available
+
+#### Planning Process
+1. **Identify 3-5 pillar topics** from your core competencies or target keywords
+2. **Generate 8-15 cluster topics** per pillar using:
+   - Google Autocomplete / People Also Ask
+   - `scripts/competitor_gap.py` for competitor-covered subtopics
+   - `scripts/article_seo.py --json` for related keyword extraction
+3. **Map content to URLs** following flat architecture: `/pillar/cluster-article`
+4. **Set internal link rules**: every cluster → pillar (required), cluster ↔ cluster (2-3 siblings)
+5. **Track coverage**: maintain a topic-cluster spreadsheet with status and publish dates
+
+#### Industry Cluster Templates
+
+| Industry | Example Pillar | Cluster Topics (sample) |
+|----------|---------------|------------------------|
+| Cybersecurity | Penetration Testing | OSINT, Web App Testing, Network Pentesting, Reporting, Tools, Methodology, Compliance |
+| SaaS | Product Documentation | Getting Started, API Reference, Integrations, Troubleshooting, Best Practices, Migration |
+| E-commerce | Product Category | Buying Guide, Comparison, Care Guide, Reviews, FAQ, Accessories |
+| Local Service | Service Area | City-specific pages, Service FAQ, Pricing, Before/After, Testimonials |
+
+### 5. Technical Foundation
+- Hosting and performance requirements
+- Schema markup plan per page type
+- Core Web Vitals baseline targets
+- AI search readiness requirements
+- Mobile-first considerations
+
+### 6. Implementation Roadmap (4 phases)
+
+#### Phase 1 — Foundation (weeks 1-4)
+- Technical setup and infrastructure
+- Core pages (home, about, contact, main services)
+- Essential schema implementation
+- Analytics and tracking setup
+
+#### Phase 2 — Expansion (weeks 5-12)
+- Content creation for primary pages
+- Blog launch with initial posts
+- Internal linking structure
+- Local SEO setup (if applicable)
+
+#### Phase 3 — Scale (weeks 13-24)
+- Advanced content development
+- Link building and outreach
+- GEO optimization
+- Performance optimization
+
+#### Phase 4 — Authority (months 7-12)
+- Thought leadership content
+- PR and media mentions
+- Advanced schema implementation
+- Continuous optimization
+
+## Industry Templates
+
+Load from `resources/templates/`:
+- `saas.md` — SaaS/software companies
+- `local-service.md` — Local service businesses
+- `ecommerce.md` — E-commerce stores
+- `publisher.md` — Content publishers/media
+- `agency.md` — Agencies and consultancies
+- `generic.md` — General business template
+
+## Output
+
+### Deliverables
+- `SEO-STRATEGY.md` — Complete strategic plan
+- `COMPETITOR-ANALYSIS.md` — Competitive insights
+- `CONTENT-CALENDAR.md` — Content roadmap
+- `IMPLEMENTATION-ROADMAP.md` — Phased action plan
+- `SITE-STRUCTURE.md` — URL hierarchy and architecture
+- `TOPIC-CLUSTERS.md` — Pillar/cluster mapping with internal link plan
+
+### KPI Targets
+| Metric | Baseline | 3 Month | 6 Month | 12 Month |
+|--------|----------|---------|---------|----------|
+| Organic Traffic | ... | ... | ... | ... |
+| Keyword Rankings | ... | ... | ... | ... |
+| Domain Authority | ... | ... | ... | ... |
+| Indexed Pages | ... | ... | ... | ... |
+| Core Web Vitals | ... | ... | ... | ... |
+| Topical Coverage % | ... | ... | ... | ... |
+
+### Success Criteria
+- Clear, measurable goals per phase
+- Resource requirements defined
+- Dependencies identified
+- Risk mitigation strategies
+

--- a/.claude/skills/seo/resources/skills/seo-programmatic.md
+++ b/.claude/skills/seo/resources/skills/seo-programmatic.md
@@ -1,0 +1,162 @@
+---
+name: seo-programmatic
+description: >
+  Programmatic SEO planning and analysis for pages generated at scale from data
+  sources. Covers template engines, URL patterns, internal linking automation,
+  thin content safeguards, and index bloat prevention. Use when user says
+  "programmatic SEO", "pages at scale", "dynamic pages", "template pages",
+  "generated pages", or "data-driven SEO".
+---
+
+# Programmatic SEO Analysis & Planning
+
+Build and audit SEO pages generated at scale from structured data sources.
+Enforces quality gates to prevent thin content penalties and index bloat.
+
+## Data Source Assessment
+
+Evaluate the data powering programmatic pages:
+- **CSV/JSON files**: Row count, column uniqueness, missing values
+- **API endpoints**: Response structure, data freshness, rate limits
+- **Database queries**: Record count, field completeness, update frequency
+- Data quality checks:
+  - Each record must have enough unique attributes to generate distinct content
+  - Flag duplicate or near-duplicate records (>80% field overlap)
+  - Verify data freshness — stale data produces stale pages
+
+## Template Engine Planning
+
+Design templates that produce unique, valuable pages:
+- **Variable injection points**: Title, H1, body sections, meta description, schema
+- **Content blocks**: Static (shared across pages) vs dynamic (unique per page)
+- **Conditional logic**: Show/hide sections based on data availability
+- **Supplementary content**: Related items, contextual tips, user-generated content
+- Template review checklist:
+  - Each page must read as a standalone, valuable resource
+  - No "mad-libs" patterns (just swapping city/product names in identical text)
+  - Dynamic sections must add genuine information, not just keyword variations
+
+## URL Pattern Strategy
+
+### Common Patterns
+- `/tools/[tool-name]` — Tool/product directory pages
+- `/[city]/[service]` — Location + service pages
+- `/integrations/[platform]` — Integration landing pages
+- `/glossary/[term]` — Definition/reference pages
+- `/templates/[template-name]` — Downloadable template pages
+
+### URL Rules
+- Lowercase, hyphenated slugs derived from data
+- Logical hierarchy reflecting site architecture
+- No duplicate slugs — enforce uniqueness at generation time
+- Keep URLs under 100 characters
+- No query parameters for primary content URLs
+- Consistent trailing slash usage (match existing site pattern)
+
+## Internal Linking Automation
+
+- **Hub/spoke model**: Category hub pages linking to individual programmatic pages
+- **Related items**: Auto-link to 3-5 related pages based on data attributes
+- **Breadcrumbs**: Generate BreadcrumbList schema from URL hierarchy
+- **Cross-linking**: Link between programmatic pages sharing attributes (same category, same city, same feature)
+- **Anchor text**: Use descriptive, varied anchor text — avoid exact-match keyword repetition
+- Link density: 3-5 internal links per 1000 words (match seo-content guidelines)
+
+## Thin Content Safeguards
+
+### Quality Gates
+
+| Metric | Threshold | Action |
+|--------|-----------|--------|
+| Pages without content review | 100+ | ⚠️ WARNING — require content audit before publishing |
+| Pages without justification | 500+ | 🛑 HARD STOP — require explicit user approval and thin content audit |
+| Unique content per page | <40% | ❌ Flag as thin content — likely penalty risk |
+| Word count per page | <300 | ⚠️ Flag for review — may lack sufficient value |
+
+### Scaled Content Abuse — Enforcement Context (2025-2026)
+
+Google's Scaled Content Abuse policy (introduced March 2024) saw major enforcement escalation in 2025:
+
+- **June 2025:** Wave of manual actions targeting websites with AI-generated content at scale
+- **August 2025:** SpamBrain spam update enhanced pattern detection for AI-generated link schemes and content farms
+- **Result:** Google reported 45% reduction in low-quality, unoriginal content in search results post-March 2024 enforcement
+
+**Enhanced quality gates for programmatic pages:**
+- **Content differentiation:** ≥30-40% of content must be genuinely unique between any two programmatic pages (not just city/keyword string replacement)
+- **Human review:** Minimum 5-10% sample review of generated pages before publishing
+- **Progressive rollout:** Publish in batches of 50-100 pages. Monitor indexing and rankings for 2-4 weeks before expanding. Never publish 500+ programmatic pages simultaneously without explicit quality review.
+- **Standalone value test:** Each page should pass: "Would this page be worth publishing even if no other similar pages existed?"
+- **Site reputation abuse:** If publishing programmatic content under a high-authority domain (not your own), this may trigger site reputation abuse penalties. Google began enforcing this aggressively in November 2024.
+
+> **Recommendation:** The WARNING gate at `<40% unique content` remains appropriate. Consider a HARD STOP at `<30%` unique content to prevent scaled content abuse risk.
+
+### Safe Programmatic Pages (OK at scale)
+✅ Integration pages (with real setup docs, API details, screenshots)
+✅ Template/tool pages (with downloadable content, usage instructions)
+✅ Glossary pages (200+ word definitions with examples, related terms)
+✅ Product pages (unique specs, reviews, comparison data)
+✅ Data-driven pages (unique statistics, charts, analysis per record)
+
+### Penalty Risk (avoid at scale)
+❌ Location pages with only city name swapped in identical text
+❌ "Best [tool] for [industry]" without industry-specific value
+❌ "[Competitor] alternative" without real comparison data
+❌ AI-generated pages without human review and unique value-add
+❌ Pages where >60% of content is shared template boilerplate
+
+### Uniqueness Calculation
+Unique content % = (words unique to this page) / (total words on page) × 100
+
+Measure against all other pages in the programmatic set. Shared headers, footers, and navigation are excluded from the calculation. Template boilerplate text IS included.
+
+## Canonical Strategy
+
+- Every programmatic page must have a self-referencing canonical tag
+- Parameter variations (sort, filter, pagination) canonical to the base URL
+- Paginated series: canonical to page 1 or use rel=next/prev
+- If programmatic pages overlap with manual pages, the manual page is canonical
+- No canonical to a different domain unless intentional cross-domain setup
+
+## Sitemap Integration
+
+- Auto-generate sitemap entries for all programmatic pages
+- Split at 50,000 URLs per sitemap file (protocol limit)
+- Use sitemap index if multiple sitemap files needed
+- `<lastmod>` reflects actual data update timestamp (not generation time)
+- Exclude noindexed programmatic pages from sitemap
+- Register sitemap in robots.txt
+- Update sitemap dynamically as new records are added to data source
+
+## Index Bloat Prevention
+
+- **Noindex low-value pages**: Pages that don't meet quality gates
+- **Pagination**: Noindex paginated results beyond page 1 (or use rel=next/prev)
+- **Faceted navigation**: Noindex filtered views, canonical to base category
+- **Crawl budget**: For sites with >10k programmatic pages, monitor crawl stats in Search Console
+- **Thin page consolidation**: Merge records with insufficient data into aggregated pages
+- **Regular audits**: Monthly review of indexed page count vs intended count
+
+## Output
+
+### Programmatic SEO Score: XX/100
+
+### Assessment Summary
+| Category | Status | Score |
+|----------|--------|-------|
+| Data Quality | ✅/⚠️/❌ | XX/100 |
+| Template Uniqueness | ✅/⚠️/❌ | XX/100 |
+| URL Structure | ✅/⚠️/❌ | XX/100 |
+| Internal Linking | ✅/⚠️/❌ | XX/100 |
+| Thin Content Risk | ✅/⚠️/❌ | XX/100 |
+| Index Management | ✅/⚠️/❌ | XX/100 |
+
+### Critical Issues (fix immediately)
+### High Priority (fix within 1 week)
+### Medium Priority (fix within 1 month)
+### Low Priority (backlog)
+
+### Recommendations
+- Data source improvements
+- Template modifications
+- URL pattern adjustments
+- Quality gate compliance actions

--- a/.claude/skills/seo/resources/skills/seo-schema.md
+++ b/.claude/skills/seo/resources/skills/seo-schema.md
@@ -1,0 +1,160 @@
+---
+name: seo-schema
+description: >
+  Detect, validate, and generate Schema.org structured data. JSON-LD format
+  preferred. Use when user says "schema", "structured data", "rich results",
+  "JSON-LD", or "markup".
+---
+
+# Schema Markup Analysis & Generation
+
+## Detection
+
+1. Scan page source for JSON-LD `<script type="application/ld+json">`
+2. Check for Microdata (`itemscope`, `itemprop`)
+3. Check for RDFa (`typeof`, `property`)
+4. Always recommend JSON-LD as primary format (Google's stated preference)
+
+## Validation
+
+- Check required properties per schema type
+- Validate against Google's supported rich result types
+- Test for common errors:
+  - Missing @context
+  - Invalid @type
+  - Wrong data types
+  - Placeholder text
+  - Relative URLs (should be absolute)
+  - Invalid date formats
+- Flag deprecated types (see below)
+
+## Schema Type Status (as of Feb 2026)
+
+Read `references/schema-types.md` for the full list. Key rules:
+
+### ACTIVE — recommend freely:
+Organization, LocalBusiness, SoftwareApplication, WebApplication, Product (with Certification markup as of April 2025), ProductGroup, Offer, Service, Article, BlogPosting, NewsArticle, Review, AggregateRating, BreadcrumbList, WebSite, WebPage, Person, ProfilePage, ContactPage, VideoObject, ImageObject, Event, JobPosting, Course, DiscussionForumPosting
+
+### VIDEO & SPECIALIZED — recommend freely:
+BroadcastEvent, Clip, SeekToAction, SoftwareSourceCode
+
+See `schema/templates.json` for ready-to-use JSON-LD templates for these types.
+
+> **JSON-LD and JavaScript rendering:** Per Google's December 2025 JS SEO guidance, structured data injected via JavaScript may face delayed processing. For time-sensitive markup (especially Product, Offer), include JSON-LD in the initial server-rendered HTML.
+
+### RESTRICTED — only for specific sites:
+- **FAQ**: ONLY for government and healthcare authority sites (restricted Aug 2023)
+
+### DEPRECATED — never recommend:
+- **HowTo**: Rich results removed September 2023
+- **SpecialAnnouncement**: Deprecated July 31, 2025
+- **CourseInfo, EstimatedSalary, LearningVideo**: Retired June 2025
+- **ClaimReview**: Retired from rich results June 2025
+- **VehicleListing**: Retired from rich results June 2025
+- **Practice Problem**: Retired from rich results late 2025
+- **Dataset**: Retired from rich results late 2025
+- **Book Actions**: Deprecated then reversed — still functional as of Feb 2026 (historical note)
+
+## Generation
+
+When generating schema for a page:
+1. Identify page type from content analysis
+2. Select appropriate schema type(s)
+3. Generate valid JSON-LD with all required + recommended properties
+4. Include only truthful, verifiable data — use placeholders clearly marked for user to fill
+5. Validate output before presenting
+
+## Common Schema Templates
+
+### Organization
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "[Company Name]",
+  "url": "[Website URL]",
+  "logo": "[Logo URL]",
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": "[Phone]",
+    "contactType": "customer service"
+  },
+  "sameAs": [
+    "[Facebook URL]",
+    "[LinkedIn URL]",
+    "[Twitter URL]"
+  ]
+}
+```
+
+### LocalBusiness
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "[Business Name]",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "[Street]",
+    "addressLocality": "[City]",
+    "addressRegion": "[State]",
+    "postalCode": "[ZIP]",
+    "addressCountry": "US"
+  },
+  "telephone": "[Phone]",
+  "openingHours": "Mo-Fr 09:00-17:00",
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "[Lat]",
+    "longitude": "[Long]"
+  }
+}
+```
+
+### Article/BlogPosting
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "[Title]",
+  "author": {
+    "@type": "Person",
+    "name": "[Author Name]"
+  },
+  "datePublished": "[YYYY-MM-DD]",
+  "dateModified": "[YYYY-MM-DD]",
+  "image": "[Image URL]",
+  "publisher": {
+    "@type": "Organization",
+    "name": "[Publisher]",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "[Logo URL]"
+    }
+  }
+}
+```
+
+## Output
+
+- `SCHEMA-REPORT.md` — detection and validation results
+- `generated-schema.json` — ready-to-use JSON-LD snippets
+
+### Validation Results
+| Schema | Type | Status | Issues |
+|--------|------|--------|--------|
+| ... | ... | ✅/⚠️/❌ | ... |
+
+### Recommendations
+- Missing schema opportunities
+- Validation fixes needed
+- Generated code for implementation
+
+## Execution Plan
+
+When invoked as an agent, execute these steps:
+1. Parse the page HTML to extract JSON-LD using `scripts/parse_html.py --fetch "$URL" --json`, or fetch first with `scripts/fetch_page.py "$URL" --output /tmp/page.html` and then run `scripts/parse_html.py /tmp/page.html --url "$URL" --json`.
+2. Extract the `schema` array from the output.
+3. Validate each schema object against rules in `resources/references/schema-types.md`.
+4. If modifying local files, optionally run `scripts/validate_schema.py file.html` as a pre-commit check.
+5. Provide the user with the validation results and new JSON-LD snippets.

--- a/.claude/skills/seo/resources/skills/seo-sitemap.md
+++ b/.claude/skills/seo/resources/skills/seo-sitemap.md
@@ -1,0 +1,112 @@
+---
+name: seo-sitemap
+description: >
+  Analyze existing XML sitemaps or generate new ones with industry templates.
+  Validates format, URLs, and structure. Use when user says "sitemap",
+  "generate sitemap", "sitemap issues", or "XML sitemap".
+---
+
+# Sitemap Analysis & Generation
+
+## Mode 1: Analyze Existing Sitemap
+
+### Validation Checks
+- Valid XML format
+- URL count <50,000 per file (protocol limit)
+- All URLs return HTTP 200
+- `<lastmod>` dates are accurate (not all identical)
+- No deprecated tags: `<priority>` and `<changefreq>` are ignored by Google
+- Sitemap referenced in robots.txt
+- Compare crawled pages vs sitemap — flag missing pages
+
+### Quality Signals
+- Sitemap index file if >50k URLs
+- Split by content type (pages, posts, images, videos)
+- No non-canonical URLs in sitemap
+- No noindexed URLs in sitemap
+- No redirected URLs in sitemap
+- HTTPS URLs only (no HTTP)
+
+### Common Issues
+| Issue | Severity | Fix |
+|-------|----------|-----|
+| >50k URLs in single file | Critical | Split with sitemap index |
+| Non-200 URLs | High | Remove or fix broken URLs |
+| Noindexed URLs included | High | Remove from sitemap |
+| Redirected URLs included | Medium | Update to final URLs |
+| All identical lastmod | Low | Use actual modification dates |
+| Priority/changefreq used | Info | Can remove (ignored by Google) |
+
+## Mode 2: Generate New Sitemap
+
+### Process
+1. Ask for business type (or auto-detect from existing site)
+2. Load industry template from `resources/templates/`
+3. Interactive structure planning with user
+4. Apply quality gates:
+   - ⚠️ WARNING at 30+ location pages (require 60%+ unique content)
+   - 🛑 HARD STOP at 50+ location pages (require justification)
+5. Generate valid XML output
+6. Split at 50k URLs with sitemap index
+7. Generate STRUCTURE.md documentation
+
+### Safe Programmatic Pages (OK at scale)
+✅ Integration pages (with real setup docs)
+✅ Template/tool pages (with downloadable content)
+✅ Glossary pages (200+ word definitions)
+✅ Product pages (unique specs, reviews)
+✅ User profile pages (user-generated content)
+
+### Penalty Risk (avoid at scale)
+❌ Location pages with only city name swapped
+❌ "Best [tool] for [industry]" without industry-specific value
+❌ "[Competitor] alternative" without real comparison data
+❌ AI-generated pages without human review and unique value
+
+## Sitemap Format
+
+### Standard Sitemap
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/page</loc>
+    <lastmod>2026-02-07</lastmod>
+  </url>
+</urlset>
+```
+
+### Sitemap Index (for >50k URLs)
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-pages.xml</loc>
+    <lastmod>2026-02-07</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap-posts.xml</loc>
+    <lastmod>2026-02-07</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+## Output
+
+### For Analysis
+- `VALIDATION-REPORT.md` — analysis results
+- Issues list with severity
+- Recommendations
+
+### For Generation
+- `sitemap.xml` (or split files with index)
+- `STRUCTURE.md` — site architecture documentation
+- URL count and organization summary
+
+## Execution Plan
+
+When invoked as an agent, execute these steps:
+1. Find sitemaps using `scripts/robots_checker.py "$URL" --json` or by guessing standard paths (e.g. `/sitemap.xml`).
+2. Fetch the XML and validate its structure.
+3. Optionally run `scripts/broken_links.py "$SITEMAP_URL" --json` or fetch the URLs to verify they return 200 OK.
+4. Output the `VALIDATION-REPORT.md` and/or generate the corrected XML.

--- a/.claude/skills/seo/resources/skills/seo-technical.md
+++ b/.claude/skills/seo/resources/skills/seo-technical.md
@@ -1,0 +1,206 @@
+---
+name: seo-technical
+description: >
+  Technical SEO audit across 8 categories: crawlability, indexability, security,
+  URL structure, mobile, Core Web Vitals, structured data, and JavaScript
+  rendering. Use when user says "technical SEO", "crawl issues", "robots.txt",
+  "Core Web Vitals", "site speed", or "security headers".
+---
+
+# Technical SEO Audit
+
+## Categories
+
+### 1. Crawlability
+- robots.txt: exists, valid, not blocking important resources
+- XML sitemap: exists, referenced in robots.txt, valid format
+- Noindex tags: intentional vs accidental
+- Crawl depth: important pages within 3 clicks of homepage
+- JavaScript rendering: check if critical content requires JS execution
+- Crawl budget: for large sites (>10k pages), efficiency matters
+
+#### AI Crawler Management
+
+As of 2025-2026, AI companies actively crawl the web to train models and power AI search. Managing these crawlers via robots.txt is a critical technical SEO consideration.
+
+**Known AI crawlers:**
+
+| Crawler | Company | robots.txt token | Purpose |
+|---------|---------|-----------------|---------|
+| GPTBot | OpenAI | `GPTBot` | Model training |
+| ChatGPT-User | OpenAI | `ChatGPT-User` | Real-time browsing |
+| ClaudeBot | Anthropic | `ClaudeBot` | Model training |
+| PerplexityBot | Perplexity | `PerplexityBot` | Search index + training |
+| Bytespider | ByteDance | `Bytespider` | Model training |
+| Google-Extended | Google | `Google-Extended` | Gemini training (NOT search) |
+| CCBot | Common Crawl | `CCBot` | Open dataset |
+
+**Key distinctions:**
+- Blocking `Google-Extended` prevents Gemini training use but does NOT affect Google Search indexing or AI Overviews (those use `Googlebot`)
+- Blocking `GPTBot` prevents OpenAI training but does NOT prevent ChatGPT from citing your content via browsing (`ChatGPT-User`)
+- ~3-5% of websites now use AI-specific robots.txt rules
+
+**Example — selective AI crawler blocking:**
+```
+# Allow search indexing, block AI training crawlers
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+# Allow all other crawlers (including Googlebot for search)
+User-agent: *
+Allow: /
+```
+
+**Recommendation:** Consider your AI visibility strategy before blocking. Being cited by AI systems drives brand awareness and referral traffic. Cross-reference the `seo-geo` skill for full AI visibility optimization.
+
+### 2. Indexability
+- Canonical tags: self-referencing, no conflicts with noindex
+- Duplicate content: near-duplicates, parameter URLs, www vs non-www
+- Thin content: pages below minimum word counts per type
+- Pagination: rel=next/prev or load-more pattern
+- Hreflang: correct for multi-language/multi-region sites
+- Index bloat: unnecessary pages consuming crawl budget
+
+### 3. Security
+- HTTPS: enforced, valid SSL certificate, no mixed content
+- Security headers:
+  - Content-Security-Policy (CSP)
+  - Strict-Transport-Security (HSTS)
+  - X-Frame-Options
+  - X-Content-Type-Options
+  - Referrer-Policy
+- HSTS preload: check preload list inclusion for high-security sites
+
+### 4. URL Structure
+- Clean URLs: descriptive, hyphenated, no query parameters for content
+- Hierarchy: logical folder structure reflecting site architecture
+- Redirects: no chains (max 1 hop), 301 for permanent moves
+- URL length: flag >100 characters
+- Trailing slashes: consistent usage
+
+### 5. Mobile Optimization
+- Responsive design: viewport meta tag, responsive CSS
+- Touch targets: minimum 48x48px with 8px spacing
+- Font size: minimum 16px base
+- No horizontal scroll
+- Mobile-first indexing: Google indexes mobile version. **Mobile-first indexing is 100% complete as of July 5, 2024.** Google now crawls and indexes ALL websites exclusively with the mobile Googlebot user-agent.
+
+### 6. Core Web Vitals
+- **LCP** (Largest Contentful Paint): target <2.5s
+- **INP** (Interaction to Next Paint): target <200ms
+  - INP replaced FID on March 12, 2024. FID was fully removed from all Chrome tools (CrUX API, PageSpeed Insights, Lighthouse) on September 9, 2024. Do NOT reference FID anywhere.
+- **CLS** (Cumulative Layout Shift): target <0.1
+- Evaluation uses 75th percentile of real user data
+- Use PageSpeed Insights API or CrUX data if MCP available
+
+### 7. Structured Data
+- Detection: JSON-LD (preferred), Microdata, RDFa
+- Validation against Google's supported types
+- See seo-schema skill for full analysis
+
+### 8. JavaScript Rendering
+- Check if content visible in initial HTML vs requires JS
+- Identify client-side rendered (CSR) vs server-side rendered (SSR)
+- Flag SPA frameworks (React, Vue, Angular) that may cause indexing issues
+- Verify dynamic rendering setup if applicable
+
+#### JavaScript SEO — Canonical & Indexing Guidance (December 2025)
+
+Google updated its JavaScript SEO documentation in December 2025 with critical clarifications:
+
+1. **Canonical conflicts:** If a canonical tag in raw HTML differs from one injected by JavaScript, Google may use EITHER one. Ensure canonical tags are identical between server-rendered HTML and JS-rendered output.
+2. **noindex with JavaScript:** If raw HTML contains `<meta name="robots" content="noindex">` but JavaScript removes it, Google MAY still honor the noindex from raw HTML. Serve correct robots directives in the initial HTML response.
+3. **Non-200 status codes:** Google does NOT render JavaScript on pages returning non-200 HTTP status codes. Any content or meta tags injected via JS on error pages will be invisible to Googlebot.
+4. **Structured data in JavaScript:** Product, Article, and other structured data injected via JS may face delayed processing. For time-sensitive structured data (especially e-commerce Product markup), include it in the initial server-rendered HTML.
+
+**Best practice:** Serve critical SEO elements (canonical, meta robots, structured data, title, meta description) in the initial server-rendered HTML rather than relying on JavaScript injection.
+
+### 9. IndexNow Protocol
+- Check if site supports IndexNow for Bing, Yandex, Naver
+- Supported by search engines other than Google
+- Recommend implementation for faster indexing on non-Google engines
+
+## Output
+
+### Technical Score: XX/100
+
+### Category Breakdown
+| Category | Status | Score |
+|----------|--------|-------|
+| Crawlability | ✅/⚠️/❌ | XX/100 |
+| Indexability | ✅/⚠️/❌ | XX/100 |
+| Security | ✅/⚠️/❌ | XX/100 |
+| URL Structure | ✅/⚠️/❌ | XX/100 |
+| Mobile | ✅/⚠️/❌ | XX/100 |
+| Core Web Vitals | ✅/⚠️/❌ | XX/100 |
+| Structured Data | ✅/⚠️/❌ | XX/100 |
+| JS Rendering | ✅/⚠️/❌ | XX/100 |
+
+### Critical Issues (fix immediately)
+### High Priority (fix within 1 week)
+### Medium Priority (fix within 1 month)
+### Low Priority (backlog)
+
+---
+
+## Voice Search Optimization
+
+Voice search (Google Assistant, Siri, Alexa, Cortana) selects answers primarily from **Featured Snippets** and requires specific optimization signals.
+
+### Key Facts
+- 90%+ of voice answers are read directly from Featured Snippets
+- 46% of voice searches have local intent
+- Voice results strongly favor pages with TTFB < 2s
+- 80%+ of voice queries come from mobile devices
+
+### Checklist
+
+| Check | Requirement | Pass Threshold |
+|-------|-------------|----------------|
+| Page speed | TTFB < 2s (critical — voice results heavily favor fast pages) | < 2000ms |
+| HTTPS | Required for voice results | Must be HTTPS |
+| Featured Snippet | Direct answer in first 40-55 words after H-tag | Present |
+| FAQ phrasing | H2/H3 phrased as natural language questions | ≥ 3 question H-tags |
+| Local schema | LocalBusiness with address, phone, hours (local intent queries) | If local business |
+| `speakable` schema | Marks top answer paragraphs for Google Assistant | Recommended |
+| Mobile accessibility | 100% accessible on mobile | Required |
+
+### `speakable` Schema Implementation
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": [".article-summary", "h2 + p", "[itemprop='description']"]
+  }
+}
+```
+
+### Voice Search by Platform
+
+| Platform | Index Source | Primary Optimization |
+|----------|-------------|---------------------|
+| **Google Assistant** | Google index | Featured Snippet ownership, TTFB < 2s, `speakable` |
+| **Siri** | Bing (Apple) | Bing Webmaster Tools submission, Featured Snippet on Bing |
+| **Alexa** | Bing | Featured Snippet, Bing indexed content |
+| **Cortana** | Bing | Featured Snippet, Bing Webmaster Tools |
+
+> **Note**: For Siri and Alexa, submit your site via **Bing Webmaster Tools** (separate from Google Search Console). Bing still powers major voice engines.
+
+## Execution Plan
+
+When invoked as an agent, execute these steps:
+1. Run `scripts/robots_checker.py "$URL" --json` for crawlability and AI crawler rules.
+2. Run `scripts/security_headers.py "$URL" --json` for security posture.
+3. Run `scripts/redirect_checker.py "$URL" --json` to verify redirect chains.
+4. Run `scripts/pagespeed.py "$URL" --strategy mobile --json` for Core Web Vitals mapping.
+5. Run `scripts/hreflang_checker.py "$URL" --json` for international setup.
+6. Run `scripts/indexnow_checker.py "$URL" --key YOUR_KEY --json` if applicable.
+7. Synthesize all outputs into the Technical Score and Category Breakdown.

--- a/.claude/skills/seo/resources/templates/agency.md
+++ b/.claude/skills/seo/resources/templates/agency.md
@@ -1,0 +1,175 @@
+<!-- Updated: 2026-02-07 -->
+# Agency/Consultancy SEO Strategy Template
+
+## Industry Characteristics
+
+- Service-based, high-value transactions
+- Expertise and trust are paramount
+- Long consideration cycles
+- Portfolio/case study driven decisions
+- Relationship-based sales
+- Niche specialization benefits
+
+## Recommended Site Architecture
+
+```
+/
+├── Home
+├── /services
+│   ├── /service-1
+│   │   ├── /sub-service-1
+│   │   └── ...
+│   └── /service-2
+├── /industries
+│   ├── /industry-1
+│   ├── /industry-2
+│   └── ...
+├── /work (or /case-studies)
+│   ├── /case-study-1
+│   ├── /case-study-2
+│   └── ...
+├── /about
+│   ├── /team
+│   │   ├── /team-member-1
+│   │   └── ...
+│   ├── /culture
+│   └── /careers
+├── /insights (or /blog)
+│   ├── /articles
+│   ├── /guides
+│   ├── /webinars
+│   └── /podcasts
+├── /contact
+├── /process
+└── /faq
+```
+
+## Schema Recommendations
+
+| Page Type | Schema Types |
+|-----------|-------------|
+| Homepage | Organization, ProfessionalService |
+| Service Page | Service, ProfessionalService |
+| Case Study | Article, Organization (client) |
+| Team Member | Person, ProfilePage |
+| Blog | Article, BlogPosting |
+
+### ProfessionalService Schema Example
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "ProfessionalService",
+  "name": "Agency Name",
+  "description": "What the agency does",
+  "url": "https://example.com",
+  "logo": "https://example.com/logo.png",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Agency St",
+    "addressLocality": "City",
+    "addressRegion": "State",
+    "postalCode": "12345"
+  },
+  "telephone": "+1-555-555-5555",
+  "areaServed": "National",
+  "hasOfferCatalog": {
+    "@type": "OfferCatalog",
+    "name": "Services",
+    "itemListElement": [
+      {
+        "@type": "Offer",
+        "itemOffered": {
+          "@type": "Service",
+          "name": "Service 1"
+        }
+      }
+    ]
+  }
+}
+```
+
+## E-E-A-T Requirements
+
+### Team Pages Must Include
+- Professional headshots
+- Detailed bios with credentials
+- Industry experience
+- Speaking engagements
+- Publications
+- Social profiles
+
+### Case Studies Must Include
+- Client name (with permission) or industry
+- Challenge/problem statement
+- Approach/methodology
+- Results with specific metrics
+- Timeline
+- Testimonial quote
+
+## Content Priorities
+
+### High Priority
+1. Service pages (detailed, specific)
+2. Industry pages (vertical expertise)
+3. 3-5 detailed case studies
+4. Team/leadership pages
+
+### Medium Priority
+1. Methodology/process page
+2. Blog with thought leadership
+3. Comparison content (vs alternatives)
+4. FAQ page
+
+### Thought Leadership Topics
+- Industry trend analysis
+- How-to guides (non-competitive)
+- Original research/surveys
+- Event recaps and insights
+- Expert interviews
+- Tool/technology reviews
+
+## Content Strategy
+
+### Service Pages (min 800 words)
+- Clear value proposition
+- Methodology overview
+- Deliverables list
+- Relevant case studies
+- Team members who deliver this service
+- CTA to schedule consultation
+
+### Industry Pages (min 800 words)
+- Industry-specific challenges
+- How you solve them differently
+- Relevant case studies
+- Industry credentials/experience
+- Client logos (with permission)
+
+### Case Studies (min 1,000 words)
+- Executive summary
+- Client background
+- Challenge details
+- Solution approach
+- Implementation process
+- Measurable results
+- Client testimonial
+- Related services/CTA
+
+## Key Metrics to Track
+
+- Organic traffic to service pages
+- Case study page views
+- Contact form submissions from organic
+- Time on page for key content
+- Blog → service page conversion
+
+## Generative Engine Optimization (GEO) for Agencies
+
+- [ ] Publish original case studies with specific, citable metrics and results
+- [ ] Use Person schema with sameAs links for all team members (builds entity authority)
+- [ ] Use ProfilePage schema for team member pages
+- [ ] Include clear, quotable expertise statements in service page descriptions
+- [ ] Produce original industry research and surveys AI systems can cite
+- [ ] Structure thought leadership content with clear headings and extractable insights
+- [ ] Maintain consistent agency entity information across directories, social profiles, and industry sites
+- [ ] Monitor AI citation in ChatGPT, Perplexity, and Google AI Overviews for brand and key service terms

--- a/.claude/skills/seo/resources/templates/blog-post.md
+++ b/.claude/skills/seo/resources/templates/blog-post.md
@@ -1,0 +1,78 @@
+<!-- Updated: 2026-03-02 -->
+# Blog Post SEO Strategy Template
+
+## Content Structure & Best Practices
+
+### Essential Elements
+- **Title Tag**: 50-60 characters, front-load main keyword, include numbers/brackets (e.g., "[2026 Guide]")
+- **Meta Description**: 140-160 characters, natural language, clear value proposition
+- **H1 Heading**: Only ONE per page, closely matching title tag
+- **Introduction**: Hook the reader, state the problem, explain what they will learn (include primary keyword in first 100 words)
+- **Body**: Use H2s for main sections, H3s for subsections
+- **Conclusion**: Summarize key points, clear Call To Action (CTA)
+
+### Minimum Requirements
+- **Word Count**: 1,200+ words (longer for competitive keywords)
+- **Paragraph Length**: 2-4 sentences max for scanability
+- **Images**: At least 1 hero image + 1 image per 400 words
+- **Image Alt Text**: Descriptive, naturally include keywords where relevant
+
+## Internal & External Linking
+
+- **Internal Links**: 3-5 links to other relevant content on your site (use descriptive anchor text)
+- **External Links**: 2-3 links to high-authority, non-competing external sources (Wikipedia, research studies, official documentation)
+
+## Keyword Optimization Strategy
+
+1. **Primary Keyword**:
+   - URL slug
+   - Title tag
+   - H1 heading
+   - First 100 words
+   - 1-2 times in H2s
+   - Natural distribution in body (1-2% density)
+
+2. **LSI / Secondary Keywords**:
+   - Include in H2/H3 subheadings
+   - Sprinkle naturally throughout content
+   - Use in image alt text
+
+## E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness)
+
+- Include Author Name, Bio, and Photo
+- Link to author's social profiles/portfolio (sameAs)
+- Date published and Date modified clearly visible
+- Cite sources and link to data
+
+## Required Schema Markup
+
+Use `BlogPosting` or `Article` schema.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/blog/your-post-url"
+  },
+  "headline": "Your Post Headline",
+  "description": "Your meta description here.",
+  "image": "https://example.com/featured-image.jpg",
+  "author": {
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/author-bio"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Your Company",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  },
+  "datePublished": "2026-03-02T08:00:00+08:00",
+  "dateModified": "2026-03-02T08:00:00+08:00"
+}
+```

--- a/.claude/skills/seo/resources/templates/ecommerce.md
+++ b/.claude/skills/seo/resources/templates/ecommerce.md
@@ -1,0 +1,167 @@
+<!-- Updated: 2026-02-07 -->
+# E-commerce SEO Strategy Template
+
+## Industry Characteristics
+
+- High transaction intent
+- Product comparison behavior
+- Price sensitivity
+- Visual-first decision making
+- Seasonal demand patterns
+- Competitive marketplace listings
+
+## Recommended Site Architecture
+
+```
+/
+├── Home
+├── /collections (or /categories)
+│   ├── /category-1
+│   │   ├── /subcategory-1
+│   │   └── ...
+│   ├── /category-2
+│   └── ...
+├── /products
+│   ├── /product-1
+│   ├── /product-2
+│   └── ...
+├── /brands
+│   ├── /brand-1
+│   └── ...
+├── /sale (or /deals)
+├── /new-arrivals
+├── /best-sellers
+├── /gift-guide
+├── /blog
+│   ├── /buying-guides
+│   ├── /how-to
+│   └── /trends
+├── /about
+├── /contact
+├── /shipping
+├── /returns
+└── /faq
+```
+
+## Schema Recommendations
+
+| Page Type | Schema Types |
+|-----------|-------------|
+| Product Page | Product, Offer, AggregateRating, Review, BreadcrumbList |
+| Category Page | CollectionPage, ItemList, BreadcrumbList |
+| Brand Page | Brand, Organization |
+| Blog | Article, BlogPosting |
+
+### Additional E-commerce Schema (2025)
+
+- **ProductGroup**: Use for products with variants (size, color). Wraps individual Product entries with `variesBy` and `hasVariant` properties. See `schema/templates.json`.
+- **Certification**: For product certifications (Energy Star, safety, organic). Replaced EnergyConsumptionDetails (April 2025). Use `hasCertification` on Product.
+- **OfferShippingDetails**: Include shipping rate, handling time, and transit time. Critical for Merchant Center eligibility.
+
+> **Google Merchant Center Free Listings:** Products can appear in Google Shopping for free. Ensure Product structured data is in the initial server-rendered HTML (not JavaScript-injected) with required properties: `name`, `image`, `price`, `priceCurrency`, `availability`.
+
+> **JS Rendering Note:** Product structured data should be in initial server-rendered HTML — not dynamically injected via JavaScript (per December 2025 Google JS SEO guidance).
+
+### Product Schema Example
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "Product Name",
+  "image": ["https://example.com/product.jpg"],
+  "description": "Product description",
+  "sku": "SKU123",
+  "brand": {
+    "@type": "Brand",
+    "name": "Brand Name"
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "99.99",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock",
+    "url": "https://example.com/product"
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.5",
+    "reviewCount": "42"
+  }
+}
+```
+
+## Content Requirements
+
+### Product Pages (min 400 words)
+- Unique product descriptions (not manufacturer copy)
+- Feature highlights
+- Use cases / who it's for
+- Specifications table
+- Size/fit guide (for apparel)
+- Care instructions
+- Customer reviews
+
+### Category Pages (min 400 words)
+- Category introduction
+- Buying guide excerpt
+- Featured products
+- Subcategory links
+- Filter/sort options
+
+## Technical Considerations
+
+### Pagination
+- Use rel="next"/rel="prev" or load-more
+- Ensure all products are crawlable
+- Canonical to main category page
+
+### Faceted Navigation
+- Noindex filter combinations that create duplicate content
+- Use canonical tags appropriately
+- Ensure popular filters are indexable
+
+### Product Variations
+- Single URL for parent product with variants
+- Or separate URLs with canonical to parent
+- Structured data for all variants
+
+## Content Priorities
+
+### High Priority
+1. Category pages (top level)
+2. Best-selling product pages
+3. Homepage
+4. Buying guides for main categories
+
+### Medium Priority
+1. Subcategory pages
+2. Brand pages
+3. Comparison content
+4. Seasonal landing pages
+
+### Blog Topics
+- Buying guides ("How to Choose...")
+- Product comparisons
+- Trend reports
+- Use cases and inspiration
+- Care and maintenance guides
+
+## Key Metrics to Track
+
+- Revenue from organic search
+- Product page rankings
+- Category page rankings
+- Click-through rate (rich results)
+- Average order value from organic
+
+## Generative Engine Optimization (GEO) for E-commerce
+
+AI search platforms increasingly answer product queries directly. Optimize for AI citation:
+
+- [ ] Include clear product specifications, dimensions, materials in structured format
+- [ ] Use ProductGroup schema for variant products
+- [ ] Provide original product photography with descriptive alt text
+- [ ] Include genuine customer review content (AggregateRating schema)
+- [ ] Maintain consistent product entity data across all platforms (site, Amazon, Merchant Center)
+- [ ] Structure comparison content with clear feature tables AI can parse
+- [ ] Add detailed FAQ content for common product questions

--- a/.claude/skills/seo/resources/templates/generic.md
+++ b/.claude/skills/seo/resources/templates/generic.md
@@ -1,0 +1,144 @@
+<!-- Updated: 2026-02-07 -->
+# Generic Business SEO Strategy Template
+
+## Overview
+
+This template applies to businesses that don't fit neatly into SaaS, local service, e-commerce, publisher, or agency categories. Customize based on your specific business model.
+
+## Recommended Site Architecture
+
+```
+/
+├── Home
+├── /products (or /services)
+│   ├── /product-1
+│   ├── /product-2
+│   └── ...
+├── /solutions (if applicable)
+│   ├── /solution-1
+│   └── ...
+├── /about
+│   ├── /team
+│   ├── /history
+│   └── /values
+├── /resources
+│   ├── /blog
+│   ├── /guides
+│   ├── /faq
+│   └── /glossary
+├── /contact
+├── /support
+└── /legal
+    ├── /privacy
+    └── /terms
+```
+
+## Universal SEO Principles
+
+### Every Page Should Have
+- Unique title tag (30-60 chars)
+- Unique meta description (120-160 chars)
+- Single H1 matching page intent
+- Logical heading hierarchy (H1→H2→H3)
+- Internal links to related content
+- Clear call-to-action
+
+### Schema for All Sites
+| Page Type | Schema Types |
+|-----------|-------------|
+| Homepage | Organization, WebSite |
+| About | Organization, AboutPage |
+| Contact | ContactPage |
+| Blog | Article, BlogPosting |
+| FAQ | (FAQPage only for gov/health) |
+| Product/Service | Product or Service |
+
+## Content Quality Standards
+
+### Minimum Word Counts
+| Page Type | Min Words |
+|-----------|-----------|
+| Homepage | 500 |
+| Product/Service | 800 |
+| Blog Post | 1,500 |
+| About Page | 400 |
+| Landing Page | 600 |
+
+### E-E-A-T Essentials
+1. **Experience**: Share real examples and case studies
+2. **Expertise**: Display credentials and qualifications
+3. **Authoritativeness**: Earn mentions and citations
+4. **Trustworthiness**: Full contact info, policies visible
+
+## Technical Foundations
+
+### Must-Haves
+- [ ] HTTPS enabled
+- [ ] Mobile-responsive design
+- [ ] robots.txt configured
+- [ ] XML sitemap submitted
+- [ ] Google Search Console verified
+- [ ] Core Web Vitals passing (LCP <2.5s, INP <200ms, CLS <0.1)
+
+### Should-Haves
+- [ ] Structured data on key pages
+- [ ] Internal linking strategy
+- [ ] 404 error page optimized
+- [ ] Redirect chains eliminated
+- [ ] Image optimization (WebP, lazy loading)
+
+## Content Priorities
+
+### Phase 1: Foundation (weeks 1-4)
+1. Homepage optimization
+2. Core product/service pages
+3. About and contact pages
+4. Basic schema implementation
+
+### Phase 2: Expansion (weeks 5-12)
+1. Blog launch (2-4 posts/month)
+2. FAQ page
+3. Additional product/service pages
+4. Internal linking audit
+
+### Phase 3: Growth (weeks 13-24)
+1. Consistent content publishing
+2. Link building outreach
+3. GEO optimization
+4. Performance optimization
+
+### Phase 4: Authority (months 7-12)
+1. Thought leadership content
+2. Original research
+3. PR and media mentions
+4. Advanced schema
+
+## Key Metrics to Track
+
+- Organic traffic (overall and by section)
+- Keyword rankings (branded and non-branded)
+- Conversion rate from organic
+- Pages indexed
+- Core Web Vitals scores
+- Backlinks acquired
+
+## Customization Points
+
+Adjust this template based on:
+
+1. **Business Model**: B2B vs B2C vs D2C
+2. **Geographic Scope**: Local, national, or international
+3. **Content Type**: Product-focused vs content-heavy
+4. **Competition Level**: Niche vs competitive market
+5. **Resources**: Budget and team capacity
+
+## Generative Engine Optimization (GEO) Checklist
+
+- [ ] Include clear, quotable facts and statistics that AI systems can extract and cite
+- [ ] Use structured data (Schema.org) to help AI systems understand content
+- [ ] Build topical authority through comprehensive content clusters
+- [ ] Provide original data, research, or unique perspectives AI cannot find elsewhere
+- [ ] Maintain consistent entity information (brand, people, products) across the web
+- [ ] Structure content with clear headings, definitions, and step-by-step formats
+- [ ] Consider adding an `llms.txt` file at site root (emerging convention for AI crawlers — Google treats it as a regular text file)
+- [ ] Monitor AI citation across Google AI Overviews, ChatGPT, Perplexity, and Bing Copilot

--- a/.claude/skills/seo/resources/templates/github-seo-report.md
+++ b/.claude/skills/seo/resources/templates/github-seo-report.md
@@ -1,0 +1,52 @@
+<!-- Updated: 2026-03-08 -->
+# GitHub SEO Report Template
+
+## 1) Audit Summary
+
+- Repository:
+- Scope date:
+- Overall score band:
+- Top 3 issues:
+- Top 3 opportunities:
+
+## 2) KPI Snapshot
+
+| KPI | Current | Prior | Delta | Status |
+|-----|---------|-------|-------|--------|
+| Query visibility (core set) | | | | |
+| Views | | | | |
+| Unique visitors | | | | |
+| Clones | | | | |
+| Visitor -> Star rate | | | | |
+| Community completion | | | | |
+
+## 3) Findings Table
+
+| Area | Severity | Confidence | Finding | Evidence | Fix |
+|------|----------|------------|---------|----------|-----|
+
+## 4) Prioritized Action Plan
+
+### Immediate Blockers
+
+1.
+
+### Quick Wins
+
+1.
+
+### Strategic Improvements
+
+1.
+
+## 5) Unknowns and Follow-ups
+
+- Missing data:
+- Required access:
+- Verification steps:
+
+## 6) Artifact Paths
+
+- Raw data:
+- Benchmark snapshots:
+- Report outputs:

--- a/.claude/skills/seo/resources/templates/github-weekly-scorecard.md
+++ b/.claude/skills/seo/resources/templates/github-weekly-scorecard.md
@@ -1,0 +1,47 @@
+<!-- Updated: 2026-03-08 -->
+# GitHub SEO Weekly Scorecard
+
+Week ending:
+Repository:
+
+## Discovery
+
+| Query | Current Rank | Prior Rank | Delta | Target Band | Status |
+|-------|--------------|------------|-------|-------------|--------|
+
+## Traffic
+
+| Metric | Current | Prior | Delta | Notes |
+|--------|---------|-------|-------|-------|
+| Views | | | | |
+| Unique visitors | | | | |
+| Clones | | | | |
+| Unique cloners | | | | |
+
+## Conversion
+
+| Metric | Current | Prior | Delta | Notes |
+|--------|---------|-------|-------|-------|
+| Visitor -> Star rate | | | | |
+| Visitor -> Fork rate | | | | |
+
+## Trust and Maintenance
+
+| Signal | Current | Prior | Delta | Status |
+|--------|---------|-------|-------|--------|
+| Community profile completion | | | | |
+| Release recency | | | | |
+
+## Experiment Log
+
+- Hypothesis:
+- Change applied:
+- Expected impact:
+- Observed impact:
+- Decision (keep/rollback/iterate):
+
+## Next Week Priorities
+
+1.
+2.
+3.

--- a/.claude/skills/seo/resources/templates/local-service.md
+++ b/.claude/skills/seo/resources/templates/local-service.md
@@ -1,0 +1,160 @@
+<!-- Updated: 2026-02-07 -->
+# Local Service Business SEO Strategy Template
+
+## Industry Characteristics
+
+- Geographic-focused searches
+- High intent, quick decision making
+- Reviews heavily influence decisions
+- Phone calls are primary conversion
+- Mobile-first user behavior
+- Emergency/urgent service needs
+
+## Recommended Site Architecture
+
+```
+/
+├── Home
+├── /services
+│   ├── /service-1
+│   ├── /service-2
+│   └── ...
+├── /locations
+│   ├── /city-1
+│   │   ├── /service-1-city-1
+│   │   └── ...
+│   ├── /city-2
+│   └── ...
+├── /about
+├── /reviews
+├── /gallery (or /portfolio)
+├── /blog
+├── /contact
+├── /emergency (if applicable)
+└── /faq
+```
+
+## Quality Gates
+
+### Location Page Limits
+- ⚠️ **WARNING** at 30+ location pages
+- 🛑 **HARD STOP** at 50+ location pages
+
+### Unique Content Requirements
+| Page Type | Min Words | Unique % |
+|-----------|-----------|----------|
+| Primary Location | 600 | 60%+ |
+| Service Area | 500 | 40%+ |
+| Service Page | 800 | 100% |
+
+### What Makes Location Pages Unique
+- Local landmarks and neighborhoods
+- Specific services offered at that location
+- Local team members
+- Location-specific testimonials
+- Community involvement
+- Local regulations or considerations
+
+## Schema Recommendations
+
+| Page Type | Schema Types |
+|-----------|-------------|
+| Homepage | LocalBusiness, Organization |
+| Service Pages | Service, LocalBusiness |
+| Location Pages | LocalBusiness (with geo) |
+| Contact | ContactPage, LocalBusiness |
+| Reviews | LocalBusiness (with AggregateRating) |
+
+### LocalBusiness Schema Example
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "Business Name",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Main St",
+    "addressLocality": "City",
+    "addressRegion": "State",
+    "postalCode": "12345"
+  },
+  "telephone": "+1-555-555-5555",
+  "openingHours": "Mo-Fr 08:00-18:00",
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "40.7128",
+    "longitude": "-74.0060"
+  },
+  "areaServed": ["City 1", "City 2"],
+  "priceRange": "$$"
+}
+```
+
+## Google Business Profile Integration
+
+- Ensure NAP consistency (Name, Address, Phone)
+- Sync service categories
+- Regular post updates
+- Photo uploads
+- Review response strategy
+
+### Google Business Profile Updates (2025-2026)
+
+- **Video verification** is now standard — postcard verification has been largely phased out. Prepare for a short video verification process showing the business location or service area.
+- **WhatsApp integration** replaced Google Business Chat (deprecated). Businesses can connect WhatsApp as their primary messaging channel.
+- **Q&A removed from Maps** — replaced by AI-generated answers. Ensure your GBP description, services, and website FAQ are comprehensive, as Google AI uses them to answer queries.
+- **Business hours are a top-5 ranking factor** — "Business is open at time of search" ranked as a top individual factor for the first time (Whitespark 2026 Local Search Ranking Factors Report). Keep hours accurate; consider extended hours if feasible.
+- **Review "Stories" format** — Google Maps now shows review snippets in a swipeable Stories format on mobile. Encourage detailed, descriptive reviews with photos.
+
+### Service Area Business (SAB) Update (June 2025)
+
+Google updated SAB guidelines to **disallow entire states or countries** as service areas. SABs must specify: cities, postal/ZIP codes, or neighborhoods. If you serve an entire metro area, list the major cities within it rather than the state.
+
+### AI Visibility for Local Businesses
+
+AI Overviews appear for only ~0.14% of local keywords (March 2025 data) — local SEO faces significantly less AI disruption than other verticals. However, ChatGPT and Perplexity are increasingly used for local recommendations.
+
+To optimize for AI local visibility:
+- Ensure presence on expert-curated "best of" lists (ranked #1 AI visibility factor in Whitespark 2026 report)
+- Maintain consistent NAP (Name, Address, Phone) across all platforms
+- Build genuine review volume and quality
+- Use LocalBusiness schema with complete properties (geo, openingHours, priceRange, areaServed)
+
+## Content Priorities
+
+### High Priority
+1. Homepage with clear service area
+2. Core service pages
+3. Primary city page
+4. Contact page with all locations
+
+### Medium Priority
+1. Service + location combination pages
+2. FAQ page
+3. About/team page
+4. Reviews/testimonials page
+
+### Blog Topics
+- Seasonal maintenance tips
+- How to choose a [service provider]
+- Warning signs of [problem]
+- DIY vs professional comparisons
+- Local regulations and permits
+
+## Key Metrics to Track
+
+- Local pack rankings
+- Phone call volume from organic
+- Direction requests
+- Google Business Profile insights
+- Reviews count and rating
+
+## Generative Engine Optimization (GEO) for Local
+
+- [ ] Include clear, quotable service descriptions and pricing ranges
+- [ ] Use LocalBusiness schema with complete geo, openingHours, and areaServed
+- [ ] Build presence on curated "best of" and local directory lists
+- [ ] Maintain consistent NAP across all platforms (Google, Yelp, Apple Maps)
+- [ ] Include original photos of work, team, and location
+- [ ] Structure FAQ content for common local service questions
+- [ ] Monitor AI citation in ChatGPT and Perplexity local recommendations

--- a/.claude/skills/seo/resources/templates/news-article.md
+++ b/.claude/skills/seo/resources/templates/news-article.md
@@ -1,0 +1,58 @@
+<!-- Updated: 2026-03-02 -->
+# News Article SEO Strategy Template
+
+## Content Structure & Best Practices
+
+### Essential Elements
+- **Headline**: Needs to be highly engaging and click-worthy. Focus on timeliness and relevance. Include primary keyword.
+- **Standfirst / Summary**: A short summary paragraph just below the headline.
+- **Lede**: The first paragraph must contain the most critical information (Who, what, when, where, why).
+- **Body**: Inverted pyramid structure (most important info first, background later).
+- **Date/Time**: Extremely visible timestamps for when the article was published and last updated.
+
+### Google News Specifics
+- **Timeliness**: Content must be fresh.
+- **Transparency**: Clear author bylines, contact info, and publication details.
+- **Originality**: Focus on original reporting, not syndication.
+- **No Deception**: Avoid clickbait or misleading headlines.
+
+## Internal & External Linking
+
+- Link to previous relevant coverage on your own site.
+- Outbound links should cite original sources, statements, or relevant background info.
+
+## Keyword Optimization Strategy
+
+- **Primary Subject/Entity**: Needs to be in the URL, Headline tag, and the Lede.
+- **Trending Terms**: Incorporate currently trending phrases related to the topic.
+- Use exact names of entities (people, organizations, locations).
+
+## E-E-A-T (Critical for News)
+
+- **Expertise/Authoritativeness**: The author must have clear credentials or a track record of covering this beat.
+- **Trustworthiness**: Clear editorial policies, correction policies, and fact-checking statements available on the site level.
+- **Experience**: "On the ground" reporting or firsthand accounts are highly valued.
+
+## Required Schema Markup
+
+Must use `NewsArticle` schema. Highly recommended to use `Speakable` schema for voice search (smart speakers).
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Breaking News Headline",
+  "image": [
+    "https://example.com/photos/1x1/photo.jpg",
+    "https://example.com/photos/4x3/photo.jpg",
+    "https://example.com/photos/16x9/photo.jpg"
+   ],
+  "datePublished": "2026-03-02T08:00:00+08:00",
+  "dateModified": "2026-03-02T09:30:00+08:00",
+  "author": [{
+      "@type": "Person",
+      "name": "Jane Journalist",
+      "url": "https://example.com/profile/jane-journalist"
+    }]
+}
+```

--- a/.claude/skills/seo/resources/templates/publisher.md
+++ b/.claude/skills/seo/resources/templates/publisher.md
@@ -1,0 +1,153 @@
+<!-- Updated: 2026-02-07 -->
+# Publisher/Media SEO Strategy Template
+
+## Industry Characteristics
+
+- High content volume
+- Time-sensitive content (news)
+- Ad revenue dependent on traffic
+- Authority and trust critical
+- Competing with social platforms
+- AI Overviews impact on traffic
+
+## Recommended Site Architecture
+
+```
+/
+├── Home
+├── /news (or /latest)
+├── /topics
+│   ├── /topic-1
+│   ├── /topic-2
+│   └── ...
+├── /authors
+│   ├── /author-1
+│   └── ...
+├── /opinion
+├── /reviews
+├── /guides
+├── /videos
+├── /podcasts
+├── /newsletter
+├── /about
+│   ├── /editorial-policy
+│   ├── /corrections
+│   └── /contact
+└── /[year]/[month]/[slug] (article URLs)
+```
+
+## Schema Recommendations
+
+| Page Type | Schema Types |
+|-----------|-------------|
+| Article | NewsArticle or Article, Person (author), Organization (publisher) |
+| Author Page | Person, ProfilePage |
+| Topic Page | CollectionPage, ItemList |
+| Homepage | WebSite, Organization |
+| Video | VideoObject |
+| Podcast | PodcastEpisode, PodcastSeries |
+
+### NewsArticle Schema Example
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "headline": "Article Headline",
+  "datePublished": "2026-02-07T10:00:00Z",
+  "dateModified": "2026-02-07T14:30:00Z",
+  "author": {
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/authors/author-name"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Publication Name",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png"
+    }
+  },
+  "image": ["https://example.com/article-image.jpg"],
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/article-url"
+  }
+}
+```
+
+## E-E-A-T Requirements
+
+Publishers face highest E-E-A-T scrutiny.
+
+### Author Pages Must Include
+- Full name and photo
+- Bio and credentials
+- Areas of expertise
+- Contact information
+- Social profiles (sameAs)
+- Previous articles by this author
+
+### Editorial Standards
+- Clear correction policy
+- Transparent editorial process
+- Fact-checking procedures
+- Conflict of interest disclosures
+
+## Content Priorities
+
+### High Priority
+1. Breaking news (speed matters)
+2. Evergreen guides on core topics
+3. Author pages with credentials
+4. Topic hubs/pillar pages
+
+### Medium Priority
+1. Opinion/analysis pieces
+2. Video content
+3. Interactive content
+4. Newsletter landing pages
+
+### GEO Considerations
+- Clear, quotable facts in articles
+- Tables for data-heavy content
+- Expert quotes with attribution
+- Update dates prominently displayed
+- Structured headings (H2/H3)
+- First-party data and original research are highly cited by AI systems
+- Ensure author entities are clearly defined with Person schema + sameAs links
+- Monitor AI citation frequency across Google AI Overviews, AI Mode, ChatGPT, Perplexity
+- Treat AI citation as a standalone KPI alongside organic traffic
+
+### Publisher SEO Updates (2025-2026)
+
+- **Google News automatic inclusion:** Google News no longer accepts manual applications (since March 2025). Inclusion is fully automatic based on Google's content quality criteria. Focus on Google News sitemap markup and consistent, high-quality publishing cadence.
+- **KPI shift:** Traffic-based KPIs (sessions, pageviews) are declining in relevance as AI Overviews reduce click-through rates. Leading publishers are shifting to: subscriber conversions, time on page, scroll depth, newsletter signups, AI citation frequency, and revenue per visitor.
+- **Site reputation abuse risk:** Publishers hosting third-party content (coupons, product reviews, affiliate content) under their domain are at high risk. Google penalized Forbes, WSJ, Time, and CNN for this in late 2024. If hosting third-party content, ensure strong editorial oversight and clear first-party involvement.
+
+## Technical Considerations
+
+### Core Web Vitals
+- Ad placement affects CLS
+- Lazy load ads and images below fold
+- Optimize hero images for LCP
+- Minimize render-blocking resources
+
+### AMP (if used)
+- Consider dropping AMP (no longer required for Top Stories)
+- Ensure canonical setup is correct
+- Monitor performance vs non-AMP
+
+### Pagination
+- Proper pagination for multi-page articles
+- Or infinite scroll with proper indexing
+- Canonical to page 1 or full article
+
+## Key Metrics to Track
+
+- Page views from organic
+- Time on page
+- Pages per session
+- Newsletter signups from organic
+- Google News/Discover traffic
+- AI Overview appearances

--- a/.claude/skills/seo/resources/templates/saas.md
+++ b/.claude/skills/seo/resources/templates/saas.md
@@ -1,0 +1,135 @@
+<!-- Updated: 2026-02-07 -->
+# SaaS SEO Strategy Template
+
+## Industry Characteristics
+
+- Long sales cycles with multiple touchpoints
+- Feature-focused decision making
+- Comparison shopping behavior
+- Heavy research phase before purchase
+- Integration and ecosystem considerations
+
+## Recommended Site Architecture
+
+```
+/
+├── Home
+├── /product (or /platform)
+│   ├── /features
+│   │   ├── /feature-1
+│   │   ├── /feature-2
+│   │   └── ...
+│   ├── /integrations
+│   │   ├── /integration-1
+│   │   └── ...
+│   └── /security
+├── /solutions
+│   ├── /by-industry
+│   │   ├── /industry-1
+│   │   └── ...
+│   └── /by-use-case
+│       ├── /use-case-1
+│       └── ...
+├── /pricing
+├── /customers
+│   ├── /case-studies
+│   │   ├── /case-study-1
+│   │   └── ...
+│   └── /testimonials
+├── /resources
+│   ├── /blog
+│   ├── /guides
+│   ├── /webinars
+│   ├── /templates
+│   └── /glossary
+├── /docs (or /help)
+│   └── /api
+├── /company
+│   ├── /about
+│   ├── /careers
+│   ├── /press
+│   └── /contact
+└── /compare
+    ├── /vs-competitor-1
+    └── /vs-competitor-2
+```
+
+## Content Priorities
+
+### High Priority Pages
+1. Homepage (value proposition, social proof)
+2. Features overview
+3. Pricing page
+4. Key integrations
+5. Top 3-5 use case pages
+
+### Medium Priority Pages
+1. Individual feature pages
+2. Industry solution pages
+3. Case studies (2-3 detailed ones)
+4. Comparison pages (vs competitors)
+
+### Content Marketing Focus
+1. Bottom-of-funnel: Comparison guides, ROI calculators
+2. Middle-of-funnel: How-to guides, best practices
+3. Top-of-funnel: Industry trends, educational content
+
+## Schema Recommendations
+
+| Page Type | Schema Types |
+|-----------|-------------|
+| Homepage | Organization, WebSite, SoftwareApplication |
+| Product/Features | SoftwareApplication, Offer |
+| Pricing | SoftwareApplication, Offer (with pricing) |
+| Blog | Article, BlogPosting |
+| Case Studies | Article, Organization (customer) |
+| Documentation | TechArticle |
+
+## Key Metrics to Track
+
+- Organic traffic to pricing page
+- Demo/trial signups from organic
+- Blog → pricing page conversion
+- Comparison page rankings
+- Integration page performance
+
+## Comparison & Alternative Pages
+
+Comparison pages are among the highest-converting content types for SaaS, with conversion rates of **4-7%** vs. 0.5-1.8% for standard blog content (35.8% of marketers report comparison content performs "better than ever" per Intergrowth November 2025 survey).
+
+**Recommended page types:**
+- `/{product}-vs-{competitor}` — Direct 1:1 comparison
+- `/{competitor}-alternative` — Targeting competitor brand searches
+- `/compare/{category}` — Category comparison hub
+- `/best-{category}-tools` — Roundup-style pages
+
+**Best practices:**
+- Include structured comparison tables with pricing, features, pros/cons
+- Be factually accurate about competitors — verify claims regularly
+- Include customer testimonials from users who switched
+- Add FAQ schema for common comparison questions (valuable for AI search)
+- Update regularly — stale comparison data damages credibility
+- Cross-reference the `seo-competitor-pages` skill for detailed frameworks
+
+**Legal considerations:**
+- Nominative fair use generally permits competitor brand mentions for comparison purposes
+- Do NOT imply endorsement or affiliation
+- Do NOT make false or unverifiable claims about competitor products
+- Different jurisdictions have different trademark laws — consult legal counsel
+
+## Competitive Considerations
+
+- Monitor competitor feature releases
+- Track competitor content strategies
+- Identify keyword gaps in feature coverage
+- Watch for new comparison opportunities
+
+## Generative Engine Optimization (GEO) for SaaS
+
+- [ ] Include clear, structured feature comparisons that AI systems can parse and cite
+- [ ] Use SoftwareApplication schema with complete feature lists and pricing
+- [ ] Publish original benchmark data, case studies, and ROI metrics
+- [ ] Build content clusters around key product categories and use cases
+- [ ] Ensure integration pages have clear, quotable descriptions
+- [ ] Structure pricing information in tables AI can extract
+- [ ] Monitor AI citation across Google AI Overviews, ChatGPT, and Perplexity

--- a/.claude/skills/seo/resources/templates/technical-article.md
+++ b/.claude/skills/seo/resources/templates/technical-article.md
@@ -1,0 +1,58 @@
+<!-- Updated: 2026-03-02 -->
+# Technical Article & Tutorial SEO Strategy Template
+
+## Content Structure & Best Practices
+
+### Essential Elements
+- **Title Tag**: Clear, specific, and often includes the target audience or difficulty level (e.g., "Advanced Guide", "for Beginners").
+- **Table of Contents**: Essential for long technical articles. Use jump links (anchor tags).
+- **Prerequisites**: Clearly state what the user needs before starting (e.g., software versions, basic knowledge).
+- **Step-by-Step Structure**: Break complex processes down into numbered steps with clear H2/H3 headings.
+- **Code Blocks**: Formatted correctly with syntax highlighting. Easily copyable.
+
+### Minimum Requirements
+- **Comprehensive Coverage**: Technical articles often need to be 2,000+ words to thoroughly explain concepts.
+- **Visuals**: Use diagrams, architecture charts, and screenshots of terminal outputs or UI steps.
+- **Troubleshooting**: Include a "Common Errors" or "FAQs" section at the end.
+
+## Internal & External Linking
+
+- **Internal Links**: Link to foundational concepts or related tutorials on your site.
+- **External Links**: Link out to official documentation (e.g., Microsoft, AWS, GitHub repos), RFCs, or standards.
+
+## Keyword Optimization Strategy
+
+- **Technical Precision**: Use precise terminology. The primary keyword is often a specific error code, tool name + action, or concept.
+- **Long-tail Keywords**: Target specific 'How to' queries (e.g., 'how to configure lateral movement cobalt strike').
+- **FAQs**: Use "People Also Ask" questions as H2 or H3 headings.
+
+## E-E-A-T (Experience, Expertise, Authoritativeness, Trustworthiness)
+
+- **Expertise**: Author must demonstrate deep technical knowledge. GitHub links or certifications in bio help.
+- **Experience**: Show real-world examples, not just theoretical concepts. Include snippets of actual logs or outputs.
+
+## Required Schema Markup
+
+Use `TechArticle` or `HowTo` schema depending on the format.
+
+### HowTo Schema Example
+```json
+{
+  "@context": "https://schema.org/",
+  "@type": "HowTo",
+  "name": "How to do X",
+  "description": "Learn how to accomplish X using tool Y.",
+  "step": [
+    {
+      "@type": "HowToStep",
+      "text": "First, install the tool...",
+      "name": "Installation"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Next, run the configuration command...",
+      "name": "Configuration"
+    }
+  ]
+}
+```

--- a/.claude/skills/seo/scripts/__init__.py
+++ b/.claude/skills/seo/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Agentic SEO script package."""

--- a/.claude/skills/seo/scripts/a11y_seo_checker.py
+++ b/.claude/skills/seo/scripts/a11y_seo_checker.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Accessibility checks with direct SEO/UX impact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+
+from seo_common import load_html, parse_html
+
+
+def checker(source: str, timeout: int = 15) -> dict:
+    html, url, fetched = load_html(source, timeout=timeout)
+    parsed = parse_html(html, url)
+    soup = parsed["soup"]
+    issues = []
+    h1_count = len(parsed["headings"]["h1"])
+    if h1_count != 1:
+        issues.append({"severity": "warning", "message": f"Expected one H1, found {h1_count}"})
+    if not parsed.get("lang"):
+        issues.append({"severity": "warning", "message": "Missing html lang attribute"})
+    if not parsed.get("viewport"):
+        issues.append({"severity": "warning", "message": "Missing viewport meta tag"})
+    missing_alt = [img.get("src") or "" for img in soup.find_all("img") if img.get("alt") is None]
+    for src in missing_alt[:25]:
+        issues.append({"severity": "warning", "message": "Image missing alt attribute", "url": src})
+    inputs = soup.find_all(["input", "select", "textarea"])
+    labelled = 0
+    for field in inputs:
+        field_id = field.get("id")
+        if field.get("aria-label") or field.get("aria-labelledby") or field.get("title"):
+            labelled += 1
+        elif field_id and soup.find("label", attrs={"for": field_id}):
+            labelled += 1
+    if inputs and labelled < len(inputs):
+        issues.append({"severity": "warning", "message": f"{len(inputs) - labelled} form field(s) appear unlabeled"})
+    if parsed["landmarks"]["main"] == 0:
+        issues.append({"severity": "info", "message": "No <main> landmark found"})
+    generic_anchors = [a.get_text(" ", strip=True) for a in soup.find_all("a", href=True) if re.fullmatch(r"(click here|read more|more|learn more)", a.get_text(" ", strip=True).lower())]
+    if generic_anchors:
+        issues.append({"severity": "info", "message": f"{len(generic_anchors)} generic link text instance(s)"})
+    # Static contrast check for inline style hex colors only; avoids pretending to compute full CSS cascade.
+    contrast_candidates = 0
+    for tag in soup.find_all(style=True):
+        style = tag["style"]
+        if "color" in style and "background" in style and re.search(r"#[0-9a-fA-F]{3,6}", style):
+            contrast_candidates += 1
+    return {
+        "url": url or source,
+        "score": max(0, 100 - 8 * len(issues)),
+        "checks": {
+            "h1_count": h1_count,
+            "lang": parsed.get("lang"),
+            "viewport": bool(parsed.get("viewport")),
+            "images_missing_alt": len(missing_alt),
+            "form_controls": len(inputs),
+            "labeled_controls": labelled,
+            "landmarks": parsed["landmarks"],
+            "inline_contrast_candidates": contrast_candidates,
+        },
+        "issues": issues,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check accessibility signals relevant to SEO")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = checker(args.source, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else f"Score: {result['score']} Issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/ai_crawler_policy_matrix.py
+++ b/.claude/skills/seo/scripts/ai_crawler_policy_matrix.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Compare robots.txt and llms.txt signals for AI crawlers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from seo_common import fetch_robots, fetch_url, normalize_url, origin, robots_allowed
+
+
+AI_CRAWLERS = ["GPTBot", "ChatGPT-User", "ClaudeBot", "PerplexityBot", "Google-Extended", "Applebot-Extended", "CCBot", "Bytespider", "Amazonbot"]
+
+
+def matrix(site: str, paths: list[str] | None = None, timeout: int = 15) -> dict:
+    base = origin(site)
+    paths = paths or ["/", "/llms.txt", "/sitemap.xml"]
+    robots = fetch_robots(base, timeout=timeout)
+    llms = fetch_url(base + "/llms.txt", timeout=timeout, max_bytes=500_000)
+    rows = []
+    for crawler in AI_CRAWLERS:
+        decisions = {}
+        allowed_all = True
+        for path in paths:
+            url = normalize_url(path, base)
+            allowed, rule = robots_allowed(robots.get("parsed"), url, crawler)
+            decisions[path] = {"allowed": allowed, "rule": rule}
+            allowed_all = allowed_all and allowed
+        rows.append({
+            "crawler": crawler,
+            "policy": "allowed" if allowed_all else "restricted",
+            "paths": decisions,
+            "llms_txt_available": llms.get("status") == 200,
+            "alignment": "documented" if llms.get("status") == 200 and allowed_all else "robots_only" if not allowed_all else "allowed_without_llms_txt",
+        })
+    return {"site": base, "robots_url": robots["url"], "robots_status": robots["fetch"].get("status"), "llms_txt_url": base + "/llms.txt", "llms_txt_status": llms.get("status"), "rows": rows}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build AI crawler policy matrix")
+    parser.add_argument("site")
+    parser.add_argument("--path", action="append", help="Path to test; repeatable")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = matrix(args.site, args.path, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else "\n".join(f"{r['crawler']}\t{r['policy']}\t{r['alignment']}" for r in result["rows"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/analyze_visual.py
+++ b/.claude/skills/seo/scripts/analyze_visual.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Analyze visual aspects of a web page using Playwright.
+
+Usage:
+    python analyze_visual.py https://example.com
+"""
+
+import argparse
+import ipaddress
+import json
+import socket
+import sys
+from urllib.parse import urlparse
+
+try:
+    from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+except ImportError:
+    sync_playwright = None
+    PlaywrightTimeout = TimeoutError
+
+
+def analyze_visual(url: str, timeout: int = 30000) -> dict:
+    """
+    Analyze visual aspects of a web page.
+
+    Args:
+        url: URL to analyze
+        timeout: Page load timeout in milliseconds
+
+    Returns:
+        Dictionary with visual analysis results
+    """
+    result = {
+        "url": url,
+        "above_fold": {
+            "h1_visible": False,
+            "cta_visible": False,
+            "hero_image": None,
+        },
+        "mobile": {
+            "viewport_meta": False,
+            "horizontal_scroll": False,
+            "touch_targets_ok": True,
+        },
+        "layout": {
+            "overlapping_elements": [],
+            "text_overflow": [],
+        },
+        "fonts": {
+            "base_size": None,
+            "readable": True,
+        },
+        "error": None,
+    }
+
+    if sync_playwright is None:
+        result["error"] = "playwright required. Install with: pip install playwright && playwright install chromium"
+        return result
+
+    # SSRF prevention: block private/internal IPs
+    try:
+        parsed = urlparse(url)
+        resolved_ip = socket.gethostbyname(parsed.hostname)
+        ip = ipaddress.ip_address(resolved_ip)
+        if ip.is_private or ip.is_loopback or ip.is_reserved:
+            result["error"] = f"Blocked: URL resolves to private/internal IP ({resolved_ip})"
+            return result
+    except (socket.gaierror, ValueError):
+        pass
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+
+            # Desktop analysis
+            desktop = browser.new_context(viewport={"width": 1920, "height": 1080})
+            page = desktop.new_page()
+            page.goto(url, wait_until="networkidle", timeout=timeout)
+
+            # Check H1 visibility above fold
+            h1 = page.query_selector("h1")
+            if h1:
+                box = h1.bounding_box()
+                if box and box["y"] < 1080:
+                    result["above_fold"]["h1_visible"] = True
+
+            # Check for CTA buttons above fold
+            cta_selectors = [
+                "a[href*='signup']",
+                "a[href*='contact']",
+                "a[href*='demo']",
+                "button:has-text('Get Started')",
+                "button:has-text('Sign Up')",
+                "button:has-text('Contact')",
+                ".cta",
+                "[class*='cta']",
+            ]
+            for selector in cta_selectors:
+                try:
+                    cta = page.query_selector(selector)
+                    if cta:
+                        box = cta.bounding_box()
+                        if box and box["y"] < 1080:
+                            result["above_fold"]["cta_visible"] = True
+                            break
+                except Exception:
+                    pass
+
+            # Check hero image
+            hero_selectors = [
+                ".hero img",
+                "[class*='hero'] img",
+                "header img",
+                "main img:first-of-type",
+            ]
+            for selector in hero_selectors:
+                try:
+                    hero = page.query_selector(selector)
+                    if hero:
+                        src = hero.get_attribute("src")
+                        if src:
+                            result["above_fold"]["hero_image"] = src
+                            break
+                except Exception:
+                    pass
+
+            desktop.close()
+
+            # Mobile analysis
+            mobile = browser.new_context(viewport={"width": 375, "height": 812})
+            page = mobile.new_page()
+            page.goto(url, wait_until="networkidle", timeout=timeout)
+
+            # Check viewport meta
+            viewport_meta = page.query_selector('meta[name="viewport"]')
+            result["mobile"]["viewport_meta"] = viewport_meta is not None
+
+            # Check for horizontal scroll
+            scroll_width = page.evaluate("document.documentElement.scrollWidth")
+            viewport_width = page.evaluate("window.innerWidth")
+            result["mobile"]["horizontal_scroll"] = scroll_width > viewport_width
+
+            # Check font size
+            base_font_size = page.evaluate("""
+                () => {
+                    const body = document.body;
+                    const style = window.getComputedStyle(body);
+                    return parseFloat(style.fontSize);
+                }
+            """)
+            result["fonts"]["base_size"] = base_font_size
+            result["fonts"]["readable"] = base_font_size >= 16
+
+            mobile.close()
+            browser.close()
+
+    except PlaywrightTimeout:
+        result["error"] = f"Page load timed out after {timeout}ms"
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze visual aspects of a web page")
+    parser.add_argument("url", help="URL to analyze")
+    parser.add_argument("--timeout", "-t", type=int, default=30000, help="Timeout in ms")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    result = analyze_visual(args.url, timeout=args.timeout)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print("Visual Analysis Results")
+        print("=" * 40)
+
+        print("\nAbove the Fold:")
+        print(f"  H1 Visible: {'✓' if result['above_fold']['h1_visible'] else '✗'}")
+        print(f"  CTA Visible: {'✓' if result['above_fold']['cta_visible'] else '✗'}")
+        print(f"  Hero Image: {result['above_fold']['hero_image'] or 'None found'}")
+
+        print("\nMobile Responsiveness:")
+        print(f"  Viewport Meta: {'✓' if result['mobile']['viewport_meta'] else '✗'}")
+        print(f"  Horizontal Scroll: {'✗ (problem)' if result['mobile']['horizontal_scroll'] else '✓'}")
+
+        print("\nTypography:")
+        print(f"  Base Font Size: {result['fonts']['base_size']}px")
+        print(f"  Readable (≥16px): {'✓' if result['fonts']['readable'] else '✗'}")
+
+        if result["error"]:
+            print(f"\nError: {result['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/anchor_text_audit.py
+++ b/.claude/skills/seo/scripts/anchor_text_audit.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Audit internal anchor text quality and diversity."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter, defaultdict, deque
+from urllib.parse import urlparse
+
+from seo_common import fetch_url, normalize_url, parse_html, print_json_or_text, same_host
+
+
+GENERIC_ANCHORS = {
+    "",
+    "click here",
+    "here",
+    "learn more",
+    "read more",
+    "more",
+    "this",
+    "link",
+    "website",
+    "page",
+    "continue reading",
+}
+
+
+def _canonical_page(url: str) -> str:
+    parsed = urlparse(normalize_url(url))
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def extract_internal_anchors(html: str, page_url: str, site_url: str) -> list[dict]:
+    parsed = parse_html(html, page_url)
+    links = []
+    for link in parsed.get("links", []):
+        href = link.get("href") or ""
+        if not href or not same_host(site_url, href):
+            continue
+        rel = [str(v).lower() for v in (link.get("rel") or [])]
+        text = (link.get("text") or "").strip()
+        links.append(
+            {
+                "source": _canonical_page(page_url),
+                "target": _canonical_page(href),
+                "anchor": text,
+                "rel": rel,
+                "nofollow": "nofollow" in rel,
+            }
+        )
+    return links
+
+
+def crawl_internal_anchors(start_url: str, depth: int = 1, max_pages: int = 25, timeout: int = 15) -> dict:
+    start_url = normalize_url(start_url)
+    queue = deque([(start_url, 0)])
+    seen = set()
+    pages = {}
+    links = []
+    fetch_errors = []
+
+    while queue and len(seen) < max_pages:
+        url, current_depth = queue.popleft()
+        page_key = _canonical_page(url)
+        if page_key in seen or current_depth > depth:
+            continue
+        seen.add(page_key)
+        fetched = fetch_url(url, timeout=timeout, max_bytes=2_000_000)
+        pages[page_key] = {
+            "url": page_key,
+            "status": fetched.get("status"),
+            "final_url": fetched.get("url"),
+            "error": fetched.get("error"),
+            "depth": current_depth,
+        }
+        if fetched.get("error") or fetched.get("status") != 200 or not fetched.get("text"):
+            fetch_errors.append({"url": url, "status": fetched.get("status"), "error": fetched.get("error")})
+            continue
+        page_links = extract_internal_anchors(fetched["text"], fetched.get("url") or url, start_url)
+        links.extend(page_links)
+        if current_depth < depth:
+            for link in page_links:
+                if link["target"] not in seen and len(seen) + len(queue) < max_pages:
+                    queue.append((link["target"], current_depth + 1))
+
+    return {"pages": pages, "links": links, "fetch_errors": fetch_errors}
+
+
+def audit_anchor_text(start_url: str, depth: int = 1, max_pages: int = 25, timeout: int = 15) -> dict:
+    crawl = crawl_internal_anchors(start_url, depth=depth, max_pages=max_pages, timeout=timeout)
+    links = crawl["links"]
+    by_target: dict[str, list[str]] = defaultdict(list)
+    text_counter = Counter()
+    generic = []
+    empty = []
+    nofollow = []
+
+    for link in links:
+        text = (link.get("anchor") or "").strip()
+        normalized_text = " ".join(text.lower().split())
+        by_target[link["target"]].append(text)
+        if text:
+            text_counter[normalized_text] += 1
+        if not text:
+            empty.append(link)
+        elif normalized_text in GENERIC_ANCHORS:
+            generic.append(link)
+        if link.get("nofollow"):
+            nofollow.append(link)
+
+    target_rows = []
+    overused_exact = []
+    low_diversity = []
+    for target, anchors in sorted(by_target.items()):
+        normalized = [" ".join(a.lower().split()) for a in anchors if a.strip()]
+        total = len(anchors)
+        unique = len(set(normalized))
+        diversity_ratio = round(unique / max(1, len(normalized)), 2) if normalized else 0
+        top_anchor, top_count = ("", 0)
+        if normalized:
+            top_anchor, top_count = Counter(normalized).most_common(1)[0]
+        row = {
+            "target": target,
+            "total_internal_links": total,
+            "unique_anchor_texts": unique,
+            "diversity_ratio": diversity_ratio,
+            "top_anchor": top_anchor,
+            "top_anchor_count": top_count,
+        }
+        target_rows.append(row)
+        if top_count >= 5 and top_count / max(1, len(normalized)) >= 0.8:
+            overused_exact.append(row)
+        if total >= 3 and diversity_ratio < 0.34:
+            low_diversity.append(row)
+
+    issues = []
+    if empty:
+        issues.append({"severity": "error", "type": "empty_anchor", "count": len(empty), "message": "Internal links with empty anchor text"})
+    if generic:
+        issues.append({"severity": "warning", "type": "generic_anchor", "count": len(generic), "message": "Generic internal anchor text is overused"})
+    if nofollow:
+        issues.append({"severity": "warning", "type": "internal_nofollow", "count": len(nofollow), "message": "Internal links use nofollow"})
+    if overused_exact:
+        issues.append({"severity": "warning", "type": "exact_match_overuse", "count": len(overused_exact), "message": "Targets have highly repetitive anchor text"})
+    if low_diversity:
+        issues.append({"severity": "info", "type": "low_anchor_diversity", "count": len(low_diversity), "message": "Targets have low anchor diversity"})
+
+    return {
+        "start_url": normalize_url(start_url),
+        "pages_crawled": len(crawl["pages"]),
+        "links_analyzed": len(links),
+        "summary": {
+            "unique_targets": len(by_target),
+            "empty_anchors": len(empty),
+            "generic_anchors": len(generic),
+            "nofollow_internal_links": len(nofollow),
+            "overused_exact_match_targets": len(overused_exact),
+            "low_diversity_targets": len(low_diversity),
+        },
+        "top_anchor_texts": [{"anchor": text, "count": count} for text, count in text_counter.most_common(25)],
+        "targets": target_rows,
+        "examples": {
+            "empty_anchors": empty[:20],
+            "generic_anchors": generic[:20],
+            "nofollow_internal_links": nofollow[:20],
+            "overused_exact_match_targets": overused_exact[:20],
+            "low_diversity_targets": low_diversity[:20],
+        },
+        "issues": issues,
+        "fetch_errors": crawl["fetch_errors"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit internal anchor text diversity and quality")
+    parser.add_argument("url", help="Website URL to crawl")
+    parser.add_argument("--depth", type=int, default=1, help="Internal crawl depth (default: 1)")
+    parser.add_argument("--max-pages", type=int, default=25, help="Maximum pages to crawl (default: 25)")
+    parser.add_argument("--timeout", type=int, default=15, help="Request timeout in seconds")
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = audit_anchor_text(args.url, depth=args.depth, max_pages=args.max_pages, timeout=args.timeout)
+    lines = [
+        f"Anchor text audit for {result['start_url']}",
+        f"Pages crawled: {result['pages_crawled']}  Links analyzed: {result['links_analyzed']}",
+        (
+            "Issues: "
+            f"empty={result['summary']['empty_anchors']} "
+            f"generic={result['summary']['generic_anchors']} "
+            f"nofollow={result['summary']['nofollow_internal_links']} "
+            f"exact_match_targets={result['summary']['overused_exact_match_targets']}"
+        ),
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}: {issue['count']}" for issue in result["issues"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/answer_block_scanner.py
+++ b/.claude/skills/seo/scripts/answer_block_scanner.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Scan pages for answer-block and featured-snippet-ready formatting."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+
+from seo_common import load_html, parse_html
+
+
+QUESTION_RE = re.compile(r"^(what|why|how|when|where|who|which|can|does|is|are)\b|\?$", re.I)
+DEFINITION_RE = re.compile(r"\b([A-Z][A-Za-z0-9 -]{2,80})\s+(?:is|are|refers to|means)\s+.{20,220}", re.S)
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    if os.path.exists(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b[\w'-]+\b", text or ""))
+
+
+def scan_answer_blocks(source: str, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout)
+    parsed = parse_html(html, url)
+    soup = parsed["soup"]
+
+    questions = []
+    direct_answers = []
+    for heading in soup.find_all(re.compile(r"^h[1-6]$")):
+        heading_text = heading.get_text(" ", strip=True)
+        if not QUESTION_RE.search(heading_text):
+            continue
+        questions.append(heading_text)
+        sibling = heading.find_next_sibling()
+        while sibling and sibling.name in {"script", "style"}:
+            sibling = sibling.find_next_sibling()
+        if sibling:
+            answer_text = sibling.get_text(" ", strip=True)
+            words = _word_count(answer_text)
+            if sibling.name in {"p", "div"} and 20 <= words <= 70:
+                direct_answers.append({"question": heading_text, "answer": answer_text[:320], "word_count": words})
+
+    definitions = []
+    for paragraph in soup.find_all("p"):
+        text = paragraph.get_text(" ", strip=True)
+        if 20 <= _word_count(text) <= 80 and DEFINITION_RE.search(text):
+            definitions.append(text[:320])
+
+    lists = []
+    for node in soup.find_all(["ol", "ul"]):
+        items = [li.get_text(" ", strip=True) for li in node.find_all("li", recursive=False)]
+        if len(items) >= 3:
+            lists.append({"type": node.name, "items": len(items), "sample": items[:5]})
+
+    tables = []
+    for table in soup.find_all("table"):
+        rows = table.find_all("tr")
+        headers = [th.get_text(" ", strip=True) for th in table.find_all("th")]
+        if len(rows) >= 2:
+            tables.append({"rows": len(rows), "headers": headers[:10]})
+
+    score = min(100, len(direct_answers) * 20 + len(definitions) * 12 + len(lists) * 10 + len(tables) * 12)
+    issues = []
+    if not direct_answers:
+        issues.append({"severity": "info", "message": "No 20-70 word answer paragraph immediately follows a question heading."})
+    if not definitions:
+        issues.append({"severity": "info", "message": "No concise definition paragraph detected."})
+    if not lists and not tables:
+        issues.append({"severity": "info", "message": "No snippet-friendly list or table detected."})
+
+    return {
+        "url": url or source,
+        "score": score,
+        "questions": questions[:50],
+        "direct_answers": direct_answers[:50],
+        "definitions": definitions[:50],
+        "lists": lists[:50],
+        "tables": tables[:50],
+        "issues": issues,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Scan for direct answers, definitions, lists, and tables.")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = scan_answer_blocks(args.source, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else f"Score: {result['score']} Direct answers: {len(result['direct_answers'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/article_seo.py
+++ b/.claude/skills/seo/scripts/article_seo.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""
+Article SEO Optimizer & Keyword Researcher
+
+Fetches an article, detects the CMS (Blogger, WordPress, Ghost, generic),
+extracts structured content, performs keyword research, and collects
+readability, JSON-LD, and meta signals for LLM-driven SEO analysis.
+
+Supported platforms:
+  - Blogger / Blogspot  (itemprop=articleBody, class=post-body)
+  - WordPress            (class=entry-content, class=post-content)
+  - Ghost               (class=post-content, class=gh-content)
+  - Generic / fallback  (<article>, <main>, or all <p> tags)
+
+Usage:
+    python article_seo.py https://example.com/article
+    python article_seo.py https://example.com/article --keyword "red team ops"
+    python article_seo.py https://example.com/article --json
+"""
+
+import argparse
+import json
+import re
+import sys
+import math
+import time
+import urllib.parse
+from collections import Counter
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+STOP_WORDS = {
+    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+    "with", "by", "of", "from", "as", "is", "are", "was", "were", "be",
+    "been", "this", "that", "these", "those", "it", "he", "she", "they",
+    "we", "you", "i", "your", "my", "their", "our", "its", "which", "who",
+    "whom", "whose", "what", "where", "when", "why", "how", "all", "any",
+    "both", "each", "few", "more", "most", "other", "some", "such", "no",
+    "nor", "not", "only", "own", "same", "so", "than", "too", "very", "can",
+    "will", "just", "should", "have", "has", "had", "do", "does", "did",
+    "get", "got", "make", "use", "used", "also", "its", "about", "into",
+    "than", "then", "there", "their", "they", "would", "could", "here",
+}
+
+# Deprecated / restricted schema types (as of Feb 2026)
+DEPRECATED_SCHEMA = {
+    "HowTo", "SpecialAnnouncement", "CourseInfo", "EstimatedSalary",
+    "LearningVideo", "ClaimReview", "VehicleListing", "PracticeProblems",
+}
+RESTRICTED_SCHEMA = {"FAQPage"}  # government / healthcare only
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+def fetch_html(url: str) -> str:
+    """Fetch raw HTML from a URL."""
+    try:
+        return safe_get(url, timeout=15).text
+    except Exception as exc:
+        print(f"Error fetching {url}: {exc}", file=sys.stderr)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# CMS detection
+# ---------------------------------------------------------------------------
+
+def detect_cms(soup: BeautifulSoup, url: str) -> str:
+    """Detect the publishing platform from HTML signals."""
+    # Blogger: generator meta OR blogspot.com in URL
+    generator = soup.find("meta", attrs={"name": "generator"})
+    if generator:
+        gen_val = generator.get("content", "").lower()
+        if "blogger" in gen_val:
+            return "blogger"
+        if "wordpress" in gen_val:
+            return "wordpress"
+        if "ghost" in gen_val:
+            return "ghost"
+
+    if "blogspot.com" in url or soup.find(attrs={"data-blog-id": True}):
+        return "blogger"
+
+    if soup.find("body", class_=re.compile(r"wp-")):
+        return "wordpress"
+    if soup.find(attrs={"class": re.compile(r"gh-content|ghost-")}):
+        return "ghost"
+
+    # WordPress theme signals
+    if soup.find("link", attrs={"rel": "https://api.w.org/"}):
+        return "wordpress"
+
+    return "generic"
+
+
+# ---------------------------------------------------------------------------
+# Content extraction (CMS-aware)
+# ---------------------------------------------------------------------------
+
+def extract_content(soup: BeautifulSoup, cms: str) -> dict:
+    """
+    Extract structured content from the parsed page.
+
+    Returns a dict with:
+      title, meta_description, og_description, h1, h2s, h3s,
+      paragraphs, images, labels/categories, word_count
+    """
+    result = {
+        "title": "",
+        "meta_description": "",
+        "og_description": "",
+        "h1": [],
+        "h2s": [],
+        "h3s": [],
+        "paragraphs": [],
+        "images": [],
+        "labels": [],
+        "publish_date": "",
+        "author": "",
+    }
+
+    # ── Meta tags (common for all CMSes) ──────────────────────────────────
+    title_tag = soup.find("title")
+    if title_tag:
+        result["title"] = title_tag.get_text(strip=True)
+
+    desc_tag = soup.find("meta", attrs={"name": "description"})
+    if desc_tag:
+        result["meta_description"] = desc_tag.get("content", "")
+
+    og_desc = soup.find("meta", property="og:description")
+    if not og_desc:
+        og_desc = soup.find("meta", attrs={"property": "og:description"})
+    if og_desc:
+        result["og_description"] = og_desc.get("content", "")
+
+    # ── Author ─────────────────────────────────────────────────────────────
+    author_tag = (
+        soup.find(attrs={"class": re.compile(r"author|byline", re.I)})
+        or soup.find("span", itemprop="author")
+        or soup.find("a", rel="author")
+    )
+    if author_tag:
+        result["author"] = author_tag.get_text(strip=True)[:100]
+
+    # ── Publish date ───────────────────────────────────────────────────────
+    for sel in [
+        {"itemprop": "datePublished"},
+        {"class": re.compile(r"published|post-date|entry-date", re.I)},
+        {"name": "article:published_time"},
+    ]:
+        date_tag = soup.find(attrs=sel) if isinstance(sel, dict) else None
+        if date_tag:
+            result["publish_date"] = (
+                date_tag.get("content") or date_tag.get("datetime") or date_tag.get_text(strip=True)
+            )[:50]
+            break
+
+    # ── CMS-specific body container ────────────────────────────────────────
+    body_container = None
+
+    if cms == "blogger":
+        # Primary: itemprop=articleBody
+        body_container = soup.find(attrs={"itemprop": "articleBody"})
+        if not body_container:
+            # Fallback: Blogger classic template
+            body_container = soup.find(attrs={"class": re.compile(r"post-body|entry-content", re.I)})
+        # Labels (Blogger categories)
+        for label_a in soup.find_all("a", attrs={"class": re.compile(r"label-link|goog-label", re.I)}):
+            label_text = label_a.get_text(strip=True)
+            if label_text:
+                result["labels"].append(label_text)
+        # Post title override (Blogger uses h3.post-title in some templates)
+        post_title = soup.find(attrs={"class": re.compile(r"post-title|entry-title", re.I)})
+        if post_title and not result["title"]:
+            result["title"] = post_title.get_text(strip=True)
+
+    elif cms == "wordpress":
+        body_container = (
+            soup.find(attrs={"class": re.compile(r"entry-content|post-content|article-content", re.I)})
+            or soup.find("article")
+        )
+        # WP categories/tags
+        for cat in soup.find_all(attrs={"class": re.compile(r"cat-links|tags-links|post-categories", re.I)}):
+            for a in cat.find_all("a"):
+                t = a.get_text(strip=True)
+                if t:
+                    result["labels"].append(t)
+
+    elif cms == "ghost":
+        body_container = soup.find(attrs={"class": re.compile(r"gh-content|post-content|article-content", re.I)})
+
+    else:  # generic
+        body_container = (
+            soup.find("article")
+            or soup.find("main")
+            or soup.find(attrs={"id": re.compile(r"content|main|article", re.I)})
+            or soup.find(attrs={"class": re.compile(r"content|article|post|entry", re.I)})
+        )
+
+    # ── Headings ──────────────────────────────────────────────────────────
+    search_scope = body_container if body_container else soup
+
+    h1_tags = search_scope.find_all("h1")
+    result["h1"] = [h.get_text(strip=True) for h in h1_tags if h.get_text(strip=True)]
+
+    h2_tags = search_scope.find_all("h2")
+    result["h2s"] = [h.get_text(strip=True) for h in h2_tags if h.get_text(strip=True)]
+
+    h3_tags = search_scope.find_all("h3")
+    result["h3s"] = [h.get_text(strip=True) for h in h3_tags if h.get_text(strip=True)]
+
+    # ── Paragraphs ────────────────────────────────────────────────────────
+    para_scope = body_container if body_container else soup
+    for p in para_scope.find_all("p"):
+        text = p.get_text(" ", strip=True)
+        if len(text.split()) > 8:  # skip tiny fragments
+            result["paragraphs"].append(text)
+
+    # ── Images ────────────────────────────────────────────────────────────
+    img_scope = body_container if body_container else soup
+    for img in img_scope.find_all("img"):
+        result["images"].append({
+            "src": img.get("src", img.get("data-src", "")),
+            "alt": img.get("alt", ""),
+            "width": img.get("width", ""),
+            "height": img.get("height", ""),
+            "loading": img.get("loading", ""),
+        })
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# JSON-LD structured data extraction
+# ---------------------------------------------------------------------------
+
+def extract_structured_data(soup: BeautifulSoup) -> list:
+    """
+    Extract and parse all <script type="application/ld+json"> blocks.
+    Flags deprecated / restricted types.
+    """
+    blocks = []
+    for script in soup.find_all("script", type="application/ld+json"):
+        raw = script.string or ""
+        try:
+            data = json.loads(raw.strip())
+        except json.JSONDecodeError:
+            blocks.append({"error": "invalid_json", "raw_snippet": raw[:120]})
+            continue
+
+        schema_type = data.get("@type", "Unknown")
+        status = "active"
+        note = ""
+
+        if schema_type in DEPRECATED_SCHEMA:
+            status = "deprecated"
+            note = f"{schema_type} was deprecated/removed from rich results. Remove or replace."
+        elif schema_type in RESTRICTED_SCHEMA:
+            status = "restricted"
+            note = f"{schema_type} is restricted to government/healthcare authority sites only."
+
+        blocks.append({
+            "@type": schema_type,
+            "@context": data.get("@context", ""),
+            "status": status,
+            "note": note,
+            "has_context": bool(data.get("@context")),
+            "has_type": bool(data.get("@type")),
+            "raw": data,
+        })
+
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Readability scoring (Flesch-Kincaid)
+# ---------------------------------------------------------------------------
+
+def _count_syllables(word: str) -> int:
+    """Approximate syllable count for a word."""
+    word = word.lower().strip(".,!?;:")
+    if len(word) <= 3:
+        return 1
+    vowels = "aeiouy"
+    count = 0
+    prev_vowel = False
+    for ch in word:
+        is_vowel = ch in vowels
+        if is_vowel and not prev_vowel:
+            count += 1
+        prev_vowel = is_vowel
+    if word.endswith("e"):
+        count -= 1
+    return max(1, count)
+
+
+def compute_readability(text: str) -> dict:
+    """
+    Compute Flesch Reading Ease and Flesch-Kincaid Grade Level.
+
+    Flesch Reading Ease: 206.835 - 1.015*(words/sentences) - 84.6*(syllables/words)
+    FK Grade Level:       0.39*(words/sentences) + 11.8*(syllables/words) - 15.59
+    """
+    if not text.strip():
+        return {"flesch_reading_ease": None, "fkgl": None, "grade_label": "N/A"}
+
+    sentences = re.split(r"[.!?]+", text)
+    sentences = [s.strip() for s in sentences if s.strip()]
+    sentence_count = max(1, len(sentences))
+
+    words = re.findall(r"\b[a-zA-Z'-]+\b", text)
+    word_count = max(1, len(words))
+
+    syllable_count = sum(_count_syllables(w) for w in words)
+
+    avg_sentence_len = word_count / sentence_count
+    avg_syllables_per_word = syllable_count / word_count
+
+    fre = 206.835 - 1.015 * avg_sentence_len - 84.6 * avg_syllables_per_word
+    fkgl = 0.39 * avg_sentence_len + 11.8 * avg_syllables_per_word - 15.59
+
+    fre = round(max(0, min(100, fre)), 1)
+    fkgl = round(max(0, fkgl), 1)
+
+    if fre >= 70:
+        grade_label = "Easy (suitable for general audience)"
+    elif fre >= 50:
+        grade_label = "Medium (suitable for high school / college)"
+    else:
+        grade_label = "Difficult (technical / specialist audience)"
+
+    return {
+        "flesch_reading_ease": fre,
+        "fkgl": fkgl,
+        "grade_label": grade_label,
+        "word_count": word_count,
+        "sentence_count": sentence_count,
+        "avg_sentence_length": round(avg_sentence_len, 1),
+        "avg_syllables_per_word": round(avg_syllables_per_word, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Keyword extraction (frequency-weighted n-grams — honest naming)
+# ---------------------------------------------------------------------------
+
+def extract_keywords_frequency(text: str, top_n: int = 12) -> list:
+    """
+    Extract high-frequency unigrams, bigrams, and trigrams as keyword candidates.
+    Uses frequency counting (not TF-IDF — no corpus reference available).
+    Favors multi-word phrases over single terms.
+    """
+    words = re.findall(r"\b[a-z]{3,}\b", text.lower())
+    filtered = [w for w in words if w not in STOP_WORDS]
+
+    unigrams = Counter(filtered)
+    bigrams = Counter(
+        f"{filtered[i]} {filtered[i+1]}"
+        for i in range(len(filtered) - 1)
+    )
+    trigrams = Counter(
+        f"{filtered[i]} {filtered[i+1]} {filtered[i+2]}"
+        for i in range(len(filtered) - 2)
+    )
+
+    scored: list[tuple[str, float]] = []
+    for term, cnt in unigrams.items():
+        if cnt > 3:
+            scored.append((term, float(cnt)))
+    for term, cnt in bigrams.items():
+        if cnt > 1:
+            scored.append((term, cnt * 3.0))
+    for term, cnt in trigrams.items():
+        if cnt > 1:
+            scored.append((term, cnt * 5.0))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+
+    # Deduplicate: if a shorter term is a substring of a longer one, prefer longer
+    final: list[str] = []
+    all_terms = [t for t, _ in scored]
+    for term, _ in scored:
+        if not any(term in other and term != other for other in all_terms[:top_n * 3]):
+            final.append(term)
+        if len(final) >= top_n:
+            break
+
+    return final
+
+
+# ---------------------------------------------------------------------------
+# Google Autocomplete (related keyword suggestions)
+# ---------------------------------------------------------------------------
+
+def get_google_autocomplete(query: str) -> list:
+    """Fetch Google Autocomplete suggestions (free, no API key required)."""
+    try:
+        url = (
+            "https://suggestqueries.google.com/complete/search"
+            f"?client=chrome&q={urllib.parse.quote(query)}"
+        )
+        data = safe_get(url, timeout=6).json()
+        if len(data) >= 2 and isinstance(data[1], list):
+            return data[1]
+    except Exception:
+        pass
+    return []
+
+
+# ---------------------------------------------------------------------------
+# SEO issue detection
+# ---------------------------------------------------------------------------
+
+def detect_seo_issues(content: dict, structured_data: list, readability: dict) -> list:
+    """
+    Lightweight rule-based SEO issue flags for the article.
+    Returns list of {severity, finding, fix} dicts.
+    """
+    issues = []
+
+    title = content.get("title", "")
+    meta = content.get("meta_description", "")
+    h1s = content.get("h1", [])
+    word_count = readability.get("word_count", 0)
+    images = content.get("images", [])
+
+    # Title checks
+    if not title:
+        issues.append({"severity": "Critical", "area": "Title", "finding": "No <title> tag found.", "fix": "Add a descriptive title tag (50-60 chars)."})
+    elif len(title) < 30:
+        issues.append({"severity": "Warning", "area": "Title", "finding": f"Title too short ({len(title)} chars).", "fix": "Expand title to 50-60 characters with primary keyword near the start."})
+    elif len(title) > 65:
+        issues.append({"severity": "Warning", "area": "Title", "finding": f"Title may be truncated in SERPs ({len(title)} chars).", "fix": "Keep title under 60 characters."})
+
+    # Meta description
+    if not meta:
+        issues.append({"severity": "Warning", "area": "Meta Description", "finding": "No meta description found.", "fix": "Add a compelling 120-155 character meta description with a CTA."})
+    elif len(meta) < 100:
+        issues.append({"severity": "Warning", "area": "Meta Description", "finding": f"Meta description too short ({len(meta)} chars).", "fix": "Expand to 120-155 characters."})
+    elif len(meta) > 165:
+        issues.append({"severity": "Warning", "area": "Meta Description", "finding": f"Meta description may be truncated ({len(meta)} chars).", "fix": "Keep under 155 characters."})
+
+    # H1
+    if not h1s:
+        issues.append({"severity": "Critical", "area": "H1", "finding": "No H1 tag detected.", "fix": "Add a single, descriptive H1 containing the primary keyword."})
+    elif len(h1s) > 1:
+        issues.append({"severity": "Warning", "area": "H1", "finding": f"Multiple H1 tags found ({len(h1s)}).", "fix": "Use exactly one H1 per page."})
+
+    # Word count (blog post minimum = 1,500)
+    if word_count < 300:
+        issues.append({"severity": "Critical", "area": "Content", "finding": f"Very thin content ({word_count} words).", "fix": "Expand content to at least 1,500 words for blog posts."})
+    elif word_count < 1000:
+        issues.append({"severity": "Warning", "area": "Content", "finding": f"Content may be thin for a blog post ({word_count} words).", "fix": "Aim for 1,500+ words of substantive, unique content."})
+
+    # Author attribution (E-E-A-T)
+    if not content.get("author"):
+        issues.append({"severity": "Warning", "area": "E-E-A-T", "finding": "No author attribution detected.", "fix": "Add a visible author byline with credentials. Critical post-Dec 2025 E-E-A-T update."})
+
+    # Publish date
+    if not content.get("publish_date"):
+        issues.append({"severity": "Info", "area": "Freshness", "finding": "No publish date detected in markup.", "fix": "Add visible publish/update date and datePublished in Article schema."})
+
+    # Images: alt text
+    missing_alt = [img for img in images if not img.get("alt")]
+    if missing_alt:
+        issues.append({"severity": "Warning", "area": "Images", "finding": f"{len(missing_alt)} image(s) missing alt text.", "fix": "Add descriptive alt text (10-125 chars) to all non-decorative images."})
+
+    # Images: lazy loading
+    no_lazy = [img for img in images if img.get("loading") != "lazy" and img.get("src")]
+    if len(no_lazy) > 3:
+        issues.append({"severity": "Info", "area": "Images", "finding": f"{len(no_lazy)} image(s) without loading='lazy'.", "fix": "Add loading='lazy' to below-the-fold images to improve LCP."})
+
+    # Structured data
+    if not structured_data:
+        issues.append({"severity": "Warning", "area": "Schema", "finding": "No JSON-LD structured data found.", "fix": "Add Article/BlogPosting schema with author, datePublished, image, and publisher."})
+    else:
+        for sd in structured_data:
+            if sd.get("status") == "deprecated":
+                issues.append({"severity": "Critical", "area": "Schema", "finding": sd["note"], "fix": "Remove deprecated schema type immediately."})
+            elif sd.get("status") == "restricted":
+                issues.append({"severity": "Warning", "area": "Schema", "finding": sd["note"], "fix": "Remove FAQPage schema unless you are a government or healthcare authority site."})
+
+    # Readability
+    fre = readability.get("flesch_reading_ease")
+    if fre is not None and fre < 30:
+        issues.append({"severity": "Info", "area": "Readability", "finding": f"Content is very difficult to read (Flesch score: {fre}).", "fix": "Simplify sentences. Aim for Flesch score ≥ 50 for broader audience reach."})
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Article SEO Extractor & Keyword Researcher (BS4 + Blogger/WP/Ghost support)"
+    )
+    parser.add_argument("url", help="URL of the article to analyze")
+    parser.add_argument("--keyword", help="Target primary keyword (optional — extracted automatically if omitted)")
+    parser.add_argument("--json", action="store_true", help="Output full JSON result")
+    parser.add_argument("--no-autocomplete", action="store_true", help="Skip Google Autocomplete lookup")
+    args = parser.parse_args()
+
+    html = fetch_html(args.url)
+    if not html:
+        out = {"error": "Failed to fetch URL", "url": args.url}
+        print(json.dumps(out) if args.json else f"Error: Failed to fetch {args.url}")
+        sys.exit(1)
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # ── CMS detection ──────────────────────────────────────────────────────
+    cms = detect_cms(soup, args.url)
+
+    # ── Content extraction ─────────────────────────────────────────────────
+    content = extract_content(soup, cms)
+
+    # ── Structured data ────────────────────────────────────────────────────
+    structured_data = extract_structured_data(soup)
+
+    # ── Full text for keyword extraction + readability ─────────────────────
+    all_text_parts = content["h1"] + content["h2s"] + content["h3s"] + content["paragraphs"]
+    full_text = " ".join(all_text_parts)
+
+    # ── Readability ────────────────────────────────────────────────────────
+    readability = compute_readability(full_text)
+
+    # ── Keyword research ───────────────────────────────────────────────────
+    extracted_kws = extract_keywords_frequency(full_text)
+    target_kw = (args.keyword.lower() if args.keyword else "") or (extracted_kws[0] if extracted_kws else "")
+
+    related_kws: list[str] = []
+    if target_kw and not args.no_autocomplete:
+        related_kws = get_google_autocomplete(target_kw)
+        # Remove exact match
+        related_kws = [k for k in related_kws if k.lower() != target_kw.lower()]
+
+    # Pad with extracted keywords if autocomplete returned few results
+    if len(related_kws) < 5:
+        extras = [k for k in extracted_kws if k not in related_kws and k != target_kw]
+        related_kws.extend(extras)
+
+    # ── SEO issue detection ─────────────────────────────────────────────────
+    seo_issues = detect_seo_issues(content, structured_data, readability)
+
+    # ── Build result ───────────────────────────────────────────────────────
+    result = {
+        "url": args.url,
+        "cms_detected": cms,
+        "title": content["title"],
+        "meta_description": content["meta_description"],
+        "og_description": content["og_description"],
+        "author": content["author"],
+        "publish_date": content["publish_date"],
+        "labels": content["labels"],
+        "headings": {
+            "h1": content["h1"],
+            "h2": content["h2s"],
+            "h3": content["h3s"],
+        },
+        "paragraphs": content["paragraphs"],
+        "images": content["images"],
+        "structured_data": structured_data,
+        "readability": readability,
+        "target_keyword": target_kw,
+        "extracted_keywords": extracted_kws,
+        "related_keywords": related_kws[:15],
+        "seo_issues": seo_issues,
+    }
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    # ── Human-readable output ──────────────────────────────────────────────
+    issues_by_sev = {"Critical": [], "Warning": [], "Info": []}
+    for issue in seo_issues:
+        issues_by_sev.get(issue["severity"], issues_by_sev["Info"]).append(issue)
+
+    print(f"\nArticle SEO Analysis — {args.url}")
+    print("=" * 60)
+    print(f"CMS Detected      : {cms.capitalize()}")
+    print(f"Title             : {result['title'][:80]}")
+    print(f"Meta Description  : {result['meta_description'][:100]}")
+    print(f"Author            : {result['author'] or '⚠️ Not detected'}")
+    print(f"Publish Date      : {result['publish_date'] or 'Not detected'}")
+    print(f"Labels/Categories : {', '.join(result['labels']) or 'None'}")
+    print(f"\nHeadings → H1: {len(content['h1'])}  H2: {len(content['h2s'])}  H3: {len(content['h3s'])}")
+    print(f"Word Count        : {readability.get('word_count', 0):,} words")
+    print(f"Sentences         : {readability.get('sentence_count', 0)}")
+    print(f"Images            : {len(content['images'])}")
+
+    fre = readability.get('flesch_reading_ease')
+    fkgl = readability.get('fkgl')
+    print(f"\nReadability")
+    print(f"  Flesch Reading Ease : {fre}  ({readability.get('grade_label', '')})")
+    print(f"  FK Grade Level      : {fkgl}")
+
+    print(f"\nStructured Data ({len(structured_data)} block(s))")
+    for sd in structured_data:
+        flag = "✅" if sd.get("status") == "active" else "🔴" if sd.get("status") == "deprecated" else "⚠️"
+        print(f"  {flag} @type: {sd.get('@type', 'Unknown')}  ({sd.get('status', 'unknown')})")
+        if sd.get("note"):
+            print(f"     → {sd['note']}")
+
+    print(f"\nTarget Keyword    : '{target_kw}'")
+    print(f"Related Keywords  : {', '.join(result['related_keywords'][:8])}")
+
+    print(f"\nSEO Issues Found: {len(seo_issues)}")
+    for sev, label in [("Critical", "🔴"), ("Warning", "⚠️"), ("Info", "ℹ️")]:
+        for iss in issues_by_sev[sev]:
+            print(f"  {label} [{iss['area']}] {iss['finding']}")
+            print(f"       Fix: {iss['fix']}")
+
+    print("\nNote: Use --json flag to pipe full output into an LLM for deeper analysis.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/audit_runner.py
+++ b/.claude/skills/seo/scripts/audit_runner.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Run the bundled SEO audit checks and write machine-readable plus report artifacts.
+
+This script reuses generate_report.py's collection, scoring, HTML, and Markdown
+renderers so there is one reporting contract and one scoring config.
+
+Usage:
+    python audit_runner.py https://example.com
+    python audit_runner.py https://example.com --json audit.json --html SEO-REPORT.html
+"""
+
+import argparse
+import json
+import os
+from urllib.parse import urlparse
+
+from generate_report import (
+    calculate_overall_score,
+    collect_data,
+    generate_html,
+    load_scoring_config,
+    render_action_plan,
+    render_markdown_report,
+    write_text_output,
+)
+
+
+def default_html_path(url: str) -> str:
+    domain = urlparse(url).netloc.replace(".", "_")
+    return f"seo-report-{domain}.html"
+
+
+def write_json(path: str, payload: dict) -> str:
+    output_dir = os.path.dirname(path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+    return os.path.abspath(path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run SEO audit and write report artifacts")
+    parser.add_argument("url", help="Website URL to audit")
+    parser.add_argument("--json", dest="json_output", default="audit-results.json",
+                        help="JSON output path (default: audit-results.json)")
+    parser.add_argument("--html", default="", help="HTML report output path")
+    parser.add_argument("--markdown", default="FULL-AUDIT-REPORT.md",
+                        help="Markdown audit output path (default: FULL-AUDIT-REPORT.md)")
+    parser.add_argument("--action-plan", default="ACTION-PLAN.md",
+                        help="Markdown action-plan output path (default: ACTION-PLAN.md)")
+    parser.add_argument("--no-html", action="store_true", help="Do not write the HTML dashboard")
+    parser.add_argument("--no-json", action="store_true", help="Do not write JSON results")
+    parser.add_argument("--no-markdown", action="store_true", help="Do not write markdown/action-plan artifacts")
+    args = parser.parse_args()
+
+    scoring_config = load_scoring_config()
+    data = collect_data(args.url)
+    scores = calculate_overall_score(data, scoring_config=scoring_config)
+    payload = {
+        "url": args.url,
+        "scores": scores,
+        "data": data,
+    }
+
+    written = []
+    if not args.no_json:
+        written.append(("JSON results", write_json(args.json_output, payload)))
+    if not args.no_html:
+        written.append(("HTML report", write_text_output(args.html or default_html_path(args.url), generate_html(data, scores))))
+    if not args.no_markdown:
+        written.append(("Full audit report", write_text_output(args.markdown, render_markdown_report(data, scores, scoring_config))))
+        written.append(("Action plan", write_text_output(args.action_plan, render_action_plan(data, scores))))
+
+    print("\nAudit artifacts:")
+    for label, path in written:
+        print(f"   {label}: {path}")
+    print(f"   Overall Score: {scores['overall']}/100")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/broken_links.py
+++ b/.claude/skills/seo/scripts/broken_links.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Check for broken links on a web page.
+
+Crawls all links (internal + external) on a page, checks HTTP status.
+Reports broken (4xx/5xx), redirected (3xx), and timeout links.
+
+Usage:
+    python broken_links.py https://example.com
+    python broken_links.py https://example.com --json
+    python broken_links.py https://example.com --internal-only
+"""
+
+import argparse
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urljoin, urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 library required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_get, safe_head
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_get, safe_head
+
+
+HEADERS = default_headers()
+
+
+def extract_links(html: str, base_url: str) -> list:
+    """Extract all links from HTML content."""
+    soup = BeautifulSoup(html, "html.parser")
+    links = []
+    seen = set()
+
+    for tag in soup.find_all("a", href=True):
+        href = tag["href"].strip()
+
+        # Skip anchors, javascript, mailto, tel
+        if href.startswith(("#", "javascript:", "mailto:", "tel:", "data:")):
+            continue
+
+        absolute = urljoin(base_url, href)
+        if absolute in seen:
+            continue
+        seen.add(absolute)
+
+        anchor_text = tag.get_text(strip=True)[:80] or "[no text]"
+        links.append({
+            "url": absolute,
+            "anchor_text": anchor_text,
+            "is_internal": urlparse(absolute).netloc == urlparse(base_url).netloc,
+        })
+
+    return links
+
+
+def check_link(link: dict, timeout: int = 10) -> dict:
+    """Check a single link's HTTP status."""
+    url = link["url"]
+    result = {**link, "status": None, "error": None, "redirect": None, "response_time_ms": None}
+
+    try:
+        resp = safe_head(url, timeout=timeout, headers=HEADERS, allow_redirects=True)
+
+        # Some servers reject HEAD, fall back to GET
+        if resp.status_code == 405:
+            resp = safe_get(url, timeout=timeout, headers=HEADERS,
+                            allow_redirects=True, stream=True)
+
+        result["status"] = resp.status_code
+        result["response_time_ms"] = round(resp.elapsed.total_seconds() * 1000)
+
+        # Check if redirected
+        if resp.history:
+            result["redirect"] = {
+                "from": url,
+                "to": resp.url,
+                "hops": len(resp.history),
+                "codes": [r.status_code for r in resp.history],
+            }
+
+    except requests.exceptions.Timeout:
+        result["error"] = "timeout"
+    except requests.exceptions.ConnectionError:
+        result["error"] = "connection_failed"
+    except requests.exceptions.TooManyRedirects:
+        result["error"] = "too_many_redirects"
+    except requests.exceptions.RequestException as e:
+        result["error"] = str(e)[:100]
+
+    return result
+
+
+def check_broken_links(url: str, internal_only: bool = False,
+                       max_workers: int = 10, timeout: int = 10) -> dict:
+    """
+    Check all links on a page for broken links.
+
+    Args:
+        url: Page URL to check
+        internal_only: Only check internal links
+        max_workers: Concurrent request threads
+        timeout: Per-request timeout in seconds
+
+    Returns:
+        Dictionary with all link check results
+    """
+    result = {
+        "page_url": url,
+        "total_links": 0,
+        "checked": 0,
+        "broken": [],
+        "redirected": [],
+        "timeout": [],
+        "healthy": 0,
+        "summary": {},
+        "issues": [],
+        "error": None,
+    }
+
+    # Fetch page
+    try:
+        resp = safe_get(url, timeout=15, headers=HEADERS)
+        if resp.status_code != 200:
+            result["error"] = f"Failed to fetch page: HTTP {resp.status_code}"
+            return result
+        html = resp.text
+    except requests.exceptions.RequestException as e:
+        result["error"] = f"Failed to fetch page: {e}"
+        return result
+
+    # Extract links
+    links = extract_links(html, url)
+    if internal_only:
+        links = [l for l in links if l["is_internal"]]
+
+    result["total_links"] = len(links)
+
+    if not links:
+        result["issues"].append("⚠️ No links found on page")
+        return result
+
+    # Check all links concurrently
+    checked = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(check_link, link, timeout): link for link in links}
+        for future in as_completed(futures):
+            checked.append(future.result())
+
+    result["checked"] = len(checked)
+
+    for link in checked:
+        status = link["status"]
+
+        if link["error"]:
+            if link["error"] == "timeout":
+                result["timeout"].append(link)
+            else:
+                result["broken"].append(link)
+        elif status and status >= 400:
+            result["broken"].append(link)
+        elif link["redirect"]:
+            result["redirected"].append(link)
+        else:
+            result["healthy"] += 1
+
+    # Generate summary
+    result["summary"] = {
+        "total": result["total_links"],
+        "healthy": result["healthy"],
+        "broken": len(result["broken"]),
+        "redirected": len(result["redirected"]),
+        "timeout": len(result["timeout"]),
+    }
+
+    # Generate issues
+    if result["broken"]:
+        result["issues"].append(
+            f"🔴 {len(result['broken'])} broken link(s) found"
+        )
+    if result["timeout"]:
+        result["issues"].append(
+            f"⚠️ {len(result['timeout'])} link(s) timed out"
+        )
+    if result["redirected"]:
+        chains = [l for l in result["redirected"]
+                  if l.get("redirect", {}).get("hops", 0) > 1]
+        if chains:
+            result["issues"].append(
+                f"⚠️ {len(chains)} redirect chain(s) detected (>1 hop)"
+            )
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for broken links on a page")
+    parser.add_argument("url", help="Page URL to check")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    parser.add_argument("--internal-only", "-i", action="store_true",
+                        help="Only check internal links")
+    parser.add_argument("--workers", "-w", type=int, default=10,
+                        help="Concurrent workers (default: 10)")
+    parser.add_argument("--timeout", "-t", type=int, default=10,
+                        help="Per-link timeout in seconds (default: 10)")
+
+    args = parser.parse_args()
+    result = check_broken_links(args.url, internal_only=args.internal_only,
+                                max_workers=args.workers, timeout=args.timeout)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    print(f"Broken Link Check — {result['page_url']}")
+    print("=" * 50)
+    s = result["summary"]
+    print(f"Total: {s['total']} | ✅ Healthy: {s['healthy']} | "
+          f"🔴 Broken: {s['broken']} | ↪️ Redirected: {s['redirected']} | "
+          f"⏱️ Timeout: {s['timeout']}")
+
+    if result["broken"]:
+        print(f"\n🔴 Broken Links:")
+        for link in result["broken"]:
+            status = link["status"] or link["error"]
+            loc = "internal" if link["is_internal"] else "external"
+            print(f"  [{status}] ({loc}) {link['url']}")
+            print(f"         anchor: \"{link['anchor_text']}\"")
+
+    if result["redirected"]:
+        chains = [l for l in result["redirected"]
+                  if l.get("redirect", {}).get("hops", 0) > 1]
+        if chains:
+            print(f"\n⚠️ Redirect Chains (>1 hop):")
+            for link in chains:
+                r = link["redirect"]
+                print(f"  {link['url']}")
+                print(f"    → {r['to']} ({r['hops']} hops: {r['codes']})")
+
+    if result["timeout"]:
+        print(f"\n⏱️ Timed Out:")
+        for link in result["timeout"]:
+            print(f"  {link['url']}")
+
+    if result["issues"]:
+        print(f"\nIssues:")
+        for issue in result["issues"]:
+            print(f"  {issue}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/cache_compression_checker.py
+++ b/.claude/skills/seo/scripts/cache_compression_checker.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Check compression and caching headers for a page and optional assets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+try:
+    from lib.safe_http import safe_request
+except ImportError:
+    from scripts.lib.safe_http import safe_request
+
+from seo_common import BeautifulSoup, load_html, normalize_url, require_bs4
+
+
+STATIC_EXTENSIONS = (".css", ".js", ".mjs", ".png", ".jpg", ".jpeg", ".webp", ".avif", ".svg", ".woff2", ".woff")
+TEXT_EXTENSIONS = (".html", ".css", ".js", ".mjs", ".json", ".xml", ".svg", ".txt")
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    path = Path(source)
+    if path.is_file():
+        return path.read_text(encoding="utf-8"), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _is_url(value: str) -> bool:
+    if Path(value).is_file():
+        return False
+    return urlparse(value).scheme in ("http", "https") or ("." in value and "/" not in value)
+
+
+def _asset_urls(soup, page_url: str = "") -> list[str]:
+    urls = []
+    for tag in soup.find_all(["script", "link", "img"], src=True):
+        value = tag.get("src")
+        urls.append(normalize_url(value, page_url) if page_url and value else value)
+    for tag in soup.find_all("link", href=True):
+        rel = " ".join(tag.get("rel") or []).lower()
+        if any(token in rel for token in ("stylesheet", "preload", "modulepreload", "icon")):
+            value = tag.get("href")
+            urls.append(normalize_url(value, page_url) if page_url and value else value)
+    return [url for url in urls if url and url.startswith(("http://", "https://"))]
+
+
+def _cache_max_age(cache_control: str | None) -> int | None:
+    if not cache_control:
+        return None
+    match = re.search(r"(?:s-maxage|max-age)=(\d+)", cache_control)
+    return int(match.group(1)) if match else None
+
+
+def _check_url(url: str, timeout: int) -> dict:
+    row = {
+        "url": url,
+        "status": None,
+        "content_type": None,
+        "content_encoding": None,
+        "cache_control": None,
+        "etag": None,
+        "vary": None,
+        "content_length": None,
+        "issues": [],
+        "error": None,
+    }
+    try:
+        response = safe_request("HEAD", normalize_url(url), timeout=timeout, max_response_bytes=0)
+    except Exception as exc:  # noqa: BLE001 - network and policy errors should be reported, not fatal
+        row["error"] = str(exc)
+        return row
+
+    headers = {str(k).lower(): v for k, v in response.headers.items()}
+    row.update({
+        "status": response.status_code,
+        "content_type": headers.get("content-type"),
+        "content_encoding": headers.get("content-encoding"),
+        "cache_control": headers.get("cache-control"),
+        "etag": headers.get("etag"),
+        "vary": headers.get("vary"),
+    })
+    length = headers.get("content-length")
+    row["content_length"] = int(length) if length and length.isdigit() else None
+
+    path = urlparse(url).path.lower()
+    is_static = path.endswith(STATIC_EXTENSIONS)
+    is_text = path.endswith(TEXT_EXTENSIONS) or (row["content_type"] and any(t in row["content_type"] for t in ("text/", "javascript", "json", "xml", "svg")))
+    if is_text and row["content_encoding"] not in ("br", "gzip", "deflate"):
+        row["issues"].append({"severity": "warning", "message": "Compressible response is not Brotli/gzip encoded"})
+    max_age = _cache_max_age(row["cache_control"])
+    if is_static and (max_age is None or max_age < 604800):
+        row["issues"].append({"severity": "warning", "message": "Static asset cache lifetime is short or missing"})
+    if is_static and row["cache_control"] and "immutable" not in row["cache_control"].lower() and max_age and max_age >= 2_592_000:
+        row["issues"].append({"severity": "info", "message": "Long-lived static asset can use immutable"})
+    if not row["etag"] and "last-modified" not in headers:
+        row["issues"].append({"severity": "info", "message": "No validator header (ETag or Last-Modified)"})
+    if row["content_encoding"] and row["vary"] and "accept-encoding" not in row["vary"].lower():
+        row["issues"].append({"severity": "warning", "message": "Compressed response should vary on Accept-Encoding"})
+    return row
+
+
+def audit(source: str, include_assets: bool = False, timeout: int = 15, max_assets: int = 25) -> dict:
+    if not _is_url(source):
+        html, url, fetched = _load_source(source, timeout=timeout)
+        require_bs4()
+        soup = BeautifulSoup(html or "", "html.parser")
+        return {
+            "url": source,
+            "resources_checked": 0,
+            "issues": [{"severity": "info", "message": "Header checks require HTTP(S); local HTML was parsed for asset discovery only."}],
+            "resources": [],
+            "asset_count": len(_asset_urls(soup, url)),
+            "fetch_error": fetched.get("error"),
+        }
+
+    html, url, fetched = _load_source(source, timeout=timeout)
+    resources = [_check_url(url or source, timeout)]
+    if include_assets and html:
+        require_bs4()
+        soup = BeautifulSoup(html or "", "html.parser")
+        seen = {resources[0]["url"]}
+        for asset in _asset_urls(soup, url):
+            if asset in seen:
+                continue
+            seen.add(asset)
+            resources.append(_check_url(asset, timeout))
+            if len(resources) - 1 >= max_assets:
+                break
+    issues = []
+    for row in resources:
+        for item in row["issues"]:
+            issues.append({**item, "url": row["url"]})
+        if row["error"]:
+            issues.append({"severity": "info", "message": "Could not fetch headers", "url": row["url"], "evidence": row["error"]})
+    return {
+        "url": url or source,
+        "resources_checked": len(resources),
+        "issues": issues,
+        "resources": resources,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check cache and compression headers")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--include-assets", action="store_true", help="Also check linked CSS/JS/images/fonts")
+    parser.add_argument("--max-assets", type=int, default=25)
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    result = audit(args.source, args.include_assets, args.timeout, args.max_assets)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Resources checked: {result['resources_checked']}; issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/canonical_checker.py
+++ b/.claude/skills/seo/scripts/canonical_checker.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Check canonical tags for self/cross-domain/chained targets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+
+from seo_common import fetch_url, issue, normalize_url, parse_html, read_urls, same_host
+
+
+def check_canonicals(urls: list[str], timeout: int = 15, check_targets: bool = False) -> dict:
+    rows = []
+    issues = []
+    canonical_to_pages = defaultdict(list)
+    for url in urls:
+        fetched = fetch_url(url, timeout=timeout, max_bytes=1_500_000)
+        row = {"url": normalize_url(url), "status": fetched.get("status"), "final_url": fetched.get("url"), "canonical": None, "verdict": "unknown", "issues": []}
+        if fetched.get("text"):
+            html = parse_html(fetched["text"], fetched.get("url") or url)
+            row["canonical"] = html.get("canonical")
+        if not row["canonical"]:
+            row["verdict"] = "missing"
+            row["issues"].append("missing canonical")
+            issues.append(issue("warning", "Missing canonical", row["url"]))
+        else:
+            canonical = normalize_url(row["canonical"], fetched.get("url") or url)
+            row["canonical"] = canonical
+            canonical_to_pages[canonical].append(row["url"])
+            if canonical == normalize_url(fetched.get("url") or url):
+                row["verdict"] = "self_canonical"
+            elif not same_host(row["url"], canonical):
+                row["verdict"] = "cross_host"
+                row["issues"].append("cross-host canonical")
+                issues.append(issue("warning", "Cross-host canonical", row["url"], canonical))
+            else:
+                row["verdict"] = "canonicalized"
+            if check_targets:
+                target = fetch_url(canonical, timeout=timeout, max_bytes=1_000_000)
+                row["canonical_status"] = target.get("status")
+                if target.get("status") != 200:
+                    row["issues"].append(f"canonical target HTTP {target.get('status')}")
+                    issues.append(issue("error", "Canonical target is not 200", row["url"], str(target.get("status"))))
+                if target.get("text"):
+                    target_html = parse_html(target["text"], target.get("url") or canonical)
+                    if target_html.get("canonical") and normalize_url(target_html["canonical"]) != canonical:
+                        row["issues"].append("canonical chain detected")
+                        issues.append(issue("warning", "Canonical target points elsewhere", row["url"], target_html["canonical"]))
+        rows.append(row)
+    duplicates = {canonical: pages for canonical, pages in canonical_to_pages.items() if len(pages) > 1}
+    return {"count": len(rows), "rows": rows, "duplicate_canonical_targets": duplicates, "issues": issues}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check canonical tags")
+    parser.add_argument("urls", nargs="*")
+    parser.add_argument("--url-file")
+    parser.add_argument("--check-targets", action="store_true")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = check_canonicals(read_urls(args.urls, args.url_file), args.timeout, args.check_targets)
+    print(json.dumps(result, indent=2) if args.json else "\n".join(f"{r['verdict']}\t{r['url']}\t{r.get('canonical') or ''}" for r in result["rows"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/capture_screenshot.py
+++ b/.claude/skills/seo/scripts/capture_screenshot.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Capture screenshots of web pages using Playwright.
+
+Usage:
+    python capture_screenshot.py https://example.com
+    python capture_screenshot.py https://example.com --mobile
+    python capture_screenshot.py https://example.com --output screenshots/
+"""
+
+import argparse
+import os
+import sys
+from urllib.parse import urlparse
+
+try:
+    from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+except ImportError:
+    sync_playwright = None
+    PlaywrightTimeout = TimeoutError
+
+
+VIEWPORTS = {
+    "desktop": {"width": 1920, "height": 1080},
+    "laptop": {"width": 1366, "height": 768},
+    "tablet": {"width": 768, "height": 1024},
+    "mobile": {"width": 375, "height": 812},
+}
+
+
+def capture_screenshot(
+    url: str,
+    output_path: str,
+    viewport: str = "desktop",
+    full_page: bool = False,
+    timeout: int = 30000,
+) -> dict:
+    """
+    Capture a screenshot of a web page.
+
+    Args:
+        url: URL to capture
+        output_path: Output file path
+        viewport: Viewport preset (desktop, laptop, tablet, mobile)
+        full_page: Whether to capture full page or just viewport
+        timeout: Page load timeout in milliseconds
+
+    Returns:
+        Dictionary with capture results
+    """
+    result = {
+        "url": url,
+        "output": output_path,
+        "viewport": viewport,
+        "success": False,
+        "error": None,
+    }
+
+    if viewport not in VIEWPORTS:
+        result["error"] = f"Invalid viewport: {viewport}. Choose from: {list(VIEWPORTS.keys())}"
+        return result
+
+    if sync_playwright is None:
+        result["error"] = "playwright required. Install with: pip install playwright && playwright install chromium"
+        return result
+
+    vp = VIEWPORTS[viewport]
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            context = browser.new_context(
+                viewport={"width": vp["width"], "height": vp["height"]},
+                device_scale_factor=2 if viewport == "mobile" else 1,
+            )
+            page = context.new_page()
+
+            # Navigate and wait for network idle
+            page.goto(url, wait_until="networkidle", timeout=timeout)
+
+            # Wait a bit more for any lazy-loaded content
+            page.wait_for_timeout(1000)
+
+            # Capture screenshot
+            page.screenshot(path=output_path, full_page=full_page)
+
+            result["success"] = True
+            browser.close()
+
+    except PlaywrightTimeout:
+        result["error"] = f"Page load timed out after {timeout}ms"
+    except Exception as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Capture web page screenshots")
+    parser.add_argument("url", help="URL to capture")
+    parser.add_argument("--output", "-o", default="screenshots", help="Output directory")
+    parser.add_argument("--viewport", "-v", default="desktop", choices=VIEWPORTS.keys())
+    parser.add_argument("--all", "-a", action="store_true", help="Capture all viewports")
+    parser.add_argument("--full", "-f", action="store_true", help="Capture full page")
+    parser.add_argument("--timeout", "-t", type=int, default=30000, help="Timeout in ms")
+
+    args = parser.parse_args()
+
+    # Sanitize output path — prevent directory traversal
+    output_dir = os.path.realpath(args.output)
+    cwd = os.getcwd()
+    home = os.path.expanduser("~")
+    if not (output_dir.startswith(cwd) or output_dir.startswith(home)):
+        print("Error: Output path must be within current directory or home directory", file=sys.stderr)
+        sys.exit(1)
+
+    # Create output directory
+    os.makedirs(args.output, exist_ok=True)
+
+    # Generate filename from URL
+    parsed = urlparse(args.url)
+    base_name = parsed.netloc.replace(".", "_")
+
+    viewports = VIEWPORTS.keys() if args.all else [args.viewport]
+
+    for viewport in viewports:
+        filename = f"{base_name}_{viewport}.png"
+        output_path = os.path.join(args.output, filename)
+
+        print(f"Capturing {viewport} screenshot...")
+        result = capture_screenshot(
+            args.url,
+            output_path,
+            viewport=viewport,
+            full_page=args.full,
+            timeout=args.timeout,
+        )
+
+        if result["success"]:
+            print(f"  ✓ Saved to {output_path}")
+        else:
+            print(f"  ✗ Failed: {result['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/citation_readiness.py
+++ b/.claude/skills/seo/scripts/citation_readiness.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Assess citation and entity readiness for AI answers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from urllib.parse import urlparse
+
+from seo_common import load_html, parse_html
+
+
+CLAIM_RE = re.compile(
+    r"(\d+(?:\.\d+)?%|\$[\d,.]+|\b(?:20\d{2}|19\d{2})\b|"
+    r"\b(?:study|research|survey|report|data|according to|found that|shows that|largest|first|only|most)\b)",
+    re.I,
+)
+HIGH_TRUST_HOST_RE = re.compile(
+    r"((^|\.)gov(\.|$)|(^|\.)edu$|who\.int$|nih\.gov$|cdc\.gov$|worldbank\.org$|oecd\.org$|wikipedia\.org$)",
+    re.I,
+)
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    if os.path.exists(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _walk_json(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_json(child)
+
+
+def _schema_entity_signals(schema_items: list) -> dict:
+    names = set()
+    same_as = set()
+    types = set()
+    for item in schema_items:
+        for node in _walk_json(item):
+            if node.get("@type"):
+                types.add(str(node["@type"]))
+            if node.get("name"):
+                names.add(str(node["name"]))
+            value = node.get("sameAs")
+            if isinstance(value, str):
+                same_as.add(value)
+            elif isinstance(value, list):
+                same_as.update(str(v) for v in value)
+    return {"types": sorted(types), "names": sorted(names), "sameAs": sorted(same_as)}
+
+
+def check_citation_readiness(source: str, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout)
+    parsed = parse_html(html, url)
+    soup = parsed["soup"]
+    page_host = urlparse(url).netloc if url else ""
+
+    sentences = [sentence.strip() for sentence in re.split(r"(?<=[.!?])\s+", parsed.get("body_text", "")) if sentence.strip()]
+    factual_claims = [sentence for sentence in sentences if CLAIM_RE.search(sentence)]
+    external_links = []
+    trusted_links = []
+    for link in parsed.get("links", []):
+        host = urlparse(link.get("href", "")).netloc
+        if not host or host == page_host:
+            continue
+        external_links.append(link)
+        if HIGH_TRUST_HOST_RE.search(host):
+            trusted_links.append(link)
+
+    cite_tags = [tag.get_text(" ", strip=True) for tag in soup.find_all(["cite", "blockquote"])]
+    footnote_links = [
+        link for link in parsed.get("links", [])
+        if re.search(r"(footnote|reference|citation|source)", " ".join(map(str, link.get("rel", []))) + " " + link.get("href", ""), re.I)
+    ]
+    entity_signals = _schema_entity_signals(parsed.get("schema", []))
+    author_signals = bool(entity_signals["names"]) or bool(soup.find(attrs={"class": re.compile(r"(author|byline)", re.I)}))
+
+    citation_capacity = len(external_links) + len(cite_tags) + len(footnote_links)
+    claim_coverage = min(1.0, citation_capacity / max(1, len(factual_claims)))
+    score = 0
+    score += int(claim_coverage * 35)
+    score += min(20, len(trusted_links) * 5)
+    score += 15 if author_signals else 0
+    score += min(20, len(entity_signals["sameAs"]) * 5)
+    score += 10 if parsed.get("canonical") else 0
+
+    issues = []
+    if factual_claims and citation_capacity < len(factual_claims):
+        issues.append({"severity": "warning", "message": "Factual claims outnumber visible citation/source signals."})
+    if not trusted_links:
+        issues.append({"severity": "info", "message": "No high-trust external source domains detected."})
+    if not author_signals:
+        issues.append({"severity": "warning", "message": "No clear author or entity name signal detected."})
+    if not entity_signals["sameAs"]:
+        issues.append({"severity": "info", "message": "No sameAs entity links found in JSON-LD."})
+
+    return {
+        "url": url or source,
+        "score": min(100, score),
+        "factual_claims": len(factual_claims),
+        "claim_samples": factual_claims[:10],
+        "citation_signals": {
+            "external_links": len(external_links),
+            "trusted_external_links": len(trusted_links),
+            "cite_or_blockquote_tags": len(cite_tags),
+            "footnote_links": len(footnote_links),
+        },
+        "entity_signals": entity_signals,
+        "issues": issues,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assess source, claim, author, and entity citation readiness.")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = check_citation_readiness(args.source, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else f"Score: {result['score']} Claims: {result['factual_claims']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/collection_page_checker.py
+++ b/.claude/skills/seo/scripts/collection_page_checker.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Check ecommerce collection/category pages for copy, filters, pagination, and crawlability."""
+
+from __future__ import annotations
+
+import argparse
+from urllib.parse import parse_qs, urlparse
+
+from schema_required_props import load_source_html
+from seo_common import issue, parse_html, print_json_or_text
+
+
+FILTER_PARAMS = {"filter", "sort", "color", "size", "brand", "price", "min_price", "max_price", "page", "p"}
+
+
+def rel_values(value) -> set[str]:
+    if not value:
+        return set()
+    if isinstance(value, list):
+        return {str(item).lower() for item in value}
+    return {str(value).lower()}
+
+
+def check_collection_page(source: str, timeout: int = 15) -> dict:
+    html, final_url, fetch = load_source_html(source, timeout=timeout)
+    parsed = parse_html(html, final_url or source) if html else {}
+    soup = parsed.get("soup")
+    issues = []
+    url = final_url or source
+    word_count = parsed.get("word_count", 0)
+    if word_count < 150:
+        issues.append(issue("warning", "Collection page has thin visible copy", url, str(word_count)))
+    if not parsed.get("headings", {}).get("h1"):
+        issues.append(issue("error", "Collection page is missing H1", url))
+    if not parsed.get("meta_description"):
+        issues.append(issue("warning", "Collection page is missing meta description", url))
+    canonical = parsed.get("canonical")
+    params = parse_qs(urlparse(url).query)
+    filter_params = sorted(set(params) & FILTER_PARAMS)
+    if filter_params and canonical and "?" in canonical:
+        issues.append(issue("warning", "Filtered URL canonical keeps query parameters", url, canonical))
+    if filter_params and not canonical:
+        issues.append(issue("warning", "Filtered URL has no canonical", url, ",".join(filter_params)))
+    product_links = []
+    for link in parsed.get("links", []):
+        href = link.get("href", "")
+        text = link.get("text", "")
+        if any(token in href.lower() for token in ("/product", "/products/", "/p/")) or text.lower() in {"view", "details", "buy"}:
+            product_links.append(href)
+    if len(set(product_links)) < 4:
+        issues.append(issue("info", "Few crawlable product links detected", url, str(len(set(product_links)))))
+    rels = {rel for link in parsed.get("links", []) for rel in rel_values(link.get("rel"))}
+    pagination_links = []
+    if soup:
+        pagination_links = [tag.get("href") for tag in soup.find_all("a", href=True) if tag.get_text(" ", strip=True).lower() in {"next", "prev", "previous"}]
+    if "next" not in rels and "prev" not in rels and not pagination_links and any(key in params for key in ("page", "p")):
+        issues.append(issue("info", "Paginated URL has no visible next/prev links", url))
+    if soup:
+        nofollow_filter_links = 0
+        for tag in soup.find_all("a", href=True):
+            href_params = parse_qs(urlparse(tag.get("href")).query)
+            if set(href_params) & FILTER_PARAMS and "nofollow" in rel_values(tag.get("rel")):
+                nofollow_filter_links += 1
+        if nofollow_filter_links:
+            issues.append(issue("info", "Filter links use nofollow; confirm crawl strategy", url, str(nofollow_filter_links)))
+    return {
+        "source": source,
+        "final_url": url,
+        "status": fetch.get("status"),
+        "word_count": word_count,
+        "filter_parameters": filter_params,
+        "product_links_detected": len(set(product_links)),
+        "issues": issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check ecommerce collection/category page SEO")
+    parser.add_argument("source", help="URL or HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    result = check_collection_page(args.source, timeout=args.timeout)
+    lines = [
+        f"Collection page check for {args.source}",
+        f"Words: {result['word_count']}  Product links: {result['product_links_detected']}  Issues: {len(result['issues'])}",
+    ] + [f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/competitor_gap.py
+++ b/.claude/skills/seo/scripts/competitor_gap.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Competitor Topic Gap Analyzer
+
+Crawls competitor sitemaps / pages, extracts H-tag topics, and identifies
+content gaps by comparing against your site's topic coverage.
+
+No API keys required — uses sitemaps and on-page content only.
+
+Usage:
+    python competitor_gap.py https://yoursite.com --competitor https://competitor.com --json
+    python competitor_gap.py https://yoursite.com --competitor https://c1.com --competitor https://c2.com
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections import Counter, defaultdict
+from urllib.parse import urlparse, urljoin
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+STOP_WORDS = {
+    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+    "with", "by", "of", "from", "as", "is", "are", "was", "were", "be",
+    "been", "this", "that", "these", "those", "it", "he", "she", "they",
+    "we", "you", "your", "my", "their", "our", "its", "which", "who",
+    "what", "where", "when", "why", "how", "all", "any", "both", "each",
+    "few", "more", "most", "other", "some", "such", "no", "not", "only",
+    "own", "same", "so", "than", "too", "very", "can", "will", "just",
+    "should", "have", "has", "had", "do", "does", "did", "about", "into",
+    "would", "could", "here", "there", "also", "get", "got", "make", "use",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+def fetch_page(url: str, timeout: int = 10) -> str:
+    try:
+        return safe_get(url, timeout=timeout).text
+    except Exception:
+        return ""
+
+
+def extract_sitemap_urls(site_url: str, limit: int = 100) -> list:
+    """Extract URLs from sitemap.xml."""
+    parsed = urlparse(site_url)
+    sitemap_url = f"{parsed.scheme}://{parsed.netloc}/sitemap.xml"
+
+    html = fetch_page(sitemap_url)
+    if not html:
+        return []
+
+    urls = re.findall(r"<loc>([^<]+)</loc>", html)
+
+    # Handle sitemap index (sitemaps pointing to other sitemaps)
+    if any("sitemap" in u.lower() and u.endswith(".xml") for u in urls[:5]):
+        expanded = []
+        for sub_url in urls[:10]:
+            time.sleep(0.3)
+            sub_html = fetch_page(sub_url)
+            if sub_html:
+                expanded.extend(re.findall(r"<loc>([^<]+)</loc>", sub_html))
+        urls = expanded
+
+    return urls[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Topic extraction
+# ---------------------------------------------------------------------------
+
+def extract_topics(html: str) -> dict:
+    """Extract topics from H-tags and title of a page."""
+    soup = BeautifulSoup(html, "html.parser")
+
+    title = ""
+    title_tag = soup.find("title")
+    if title_tag:
+        title = title_tag.get_text(strip=True)
+
+    topics = {
+        "title": title,
+        "h1": [],
+        "h2": [],
+        "h3": [],
+    }
+
+    for tag in ["h1", "h2", "h3"]:
+        for h in soup.find_all(tag):
+            text = h.get_text(strip=True)
+            if text and len(text) > 3:
+                topics[tag].append(text)
+
+    return topics
+
+
+def normalize_topic(text: str) -> str:
+    """Normalize a topic string for comparison."""
+    words = re.findall(r"\b[a-z]+\b", text.lower())
+    return " ".join(w for w in words if w not in STOP_WORDS and len(w) > 2)
+
+
+def extract_topic_phrases(topics: dict) -> set:
+    """Extract normalized topic phrases from H-tags."""
+    phrases = set()
+    for source in ["title", "h1", "h2", "h3"]:
+        items = topics[source]
+        if isinstance(items, str):
+            items = [items]
+        for text in items:
+            norm = normalize_topic(text)
+            if norm and len(norm.split()) >= 2:
+                phrases.add(norm)
+    return phrases
+
+
+# ---------------------------------------------------------------------------
+# Site crawl (lightweight — sitemap + top pages)
+# ---------------------------------------------------------------------------
+
+def crawl_site_topics(site_url: str, max_pages: int = 50) -> dict:
+    """
+    Crawl a site's sitemap and extract topics from each page.
+    Returns {url: {title, h1, h2, h3}} and a set of all topic phrases.
+    """
+    urls = extract_sitemap_urls(site_url, limit=max_pages)
+
+    if not urls:
+        # Fallback: crawl homepage and extract internal links
+        homepage = fetch_page(site_url)
+        if homepage:
+            soup = BeautifulSoup(homepage, "html.parser")
+            base_domain = urlparse(site_url).netloc
+            for a in soup.find_all("a", href=True):
+                full = urljoin(site_url, a["href"])
+                if urlparse(full).netloc == base_domain:
+                    urls.append(full)
+            urls = list(set(urls))[:max_pages]
+
+    page_topics = {}
+    all_phrases = set()
+
+    for url in urls:
+        time.sleep(0.3)
+        html = fetch_page(url)
+        if not html:
+            continue
+
+        topics = extract_topics(html)
+        page_topics[url] = topics
+        all_phrases.update(extract_topic_phrases(topics))
+
+    return {
+        "pages_crawled": len(page_topics),
+        "page_topics": page_topics,
+        "all_phrases": all_phrases,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gap analysis
+# ---------------------------------------------------------------------------
+
+def find_topic_gaps(your_phrases: set, competitor_data: dict) -> dict:
+    """
+    Compare your topic coverage vs competitors.
+    Returns gaps (topics competitors cover that you don't).
+    """
+    gaps = []
+    competitor_only = set()
+
+    for comp_url, comp in competitor_data.items():
+        comp_phrases = comp["all_phrases"]
+        comp_unique = comp_phrases - your_phrases
+
+        for phrase in comp_unique:
+            competitor_only.add(phrase)
+            gaps.append({
+                "topic": phrase,
+                "competitor": comp_url,
+                "competitor_pages": comp["pages_crawled"],
+            })
+
+    # Deduplicate and count coverage
+    topic_coverage = Counter()
+    for gap in gaps:
+        topic_coverage[gap["topic"]] += 1
+
+    # Sort by coverage (topics covered by more competitors = higher priority)
+    prioritized = []
+    seen = set()
+    for topic, count in topic_coverage.most_common():
+        if topic not in seen:
+            sources = [g["competitor"] for g in gaps if g["topic"] == topic]
+            prioritized.append({
+                "topic": topic,
+                "covered_by_competitors": count,
+                "competitors": sources,
+                "priority": "High" if count >= 2 else "Medium",
+            })
+            seen.add(topic)
+
+    # Your unique topics (competitive advantage)
+    your_unique = your_phrases - competitor_only
+
+    return {
+        "gaps": prioritized[:50],
+        "your_unique_topics": len(your_unique),
+        "competitor_unique_topics": len(competitor_only),
+        "overlap_topics": len(your_phrases & competitor_only),
+        "total_your_topics": len(your_phrases),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Competitor Topic Gap Analyzer — finds content gaps from competitor sitemaps/pages"
+    )
+    parser.add_argument("url", help="Your site URL")
+    parser.add_argument("--competitor", action="append", required=True, help="Competitor URL (can specify multiple)")
+    parser.add_argument("--max-pages", type=int, default=50, help="Max pages to crawl per site (default: 50)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    print(f"Crawling your site: {args.url}...", file=sys.stderr)
+    your_data = crawl_site_topics(args.url, max_pages=args.max_pages)
+
+    competitor_data = {}
+    for comp_url in args.competitor:
+        print(f"Crawling competitor: {comp_url}...", file=sys.stderr)
+        competitor_data[comp_url] = crawl_site_topics(comp_url, max_pages=args.max_pages)
+
+    print("Analyzing topic gaps...", file=sys.stderr)
+    gap_report = find_topic_gaps(your_data["all_phrases"], competitor_data)
+
+    report = {
+        "your_site": args.url,
+        "your_pages_crawled": your_data["pages_crawled"],
+        "your_topics": len(your_data["all_phrases"]),
+        "competitors": {
+            url: {"pages_crawled": d["pages_crawled"], "topics": len(d["all_phrases"])}
+            for url, d in competitor_data.items()
+        },
+        "analysis": gap_report,
+    }
+
+    if args.json:
+        # Convert sets to lists for JSON serialization
+        report_json = json.loads(json.dumps(report, default=lambda x: list(x) if isinstance(x, set) else str(x)))
+        print(json.dumps(report_json, indent=2))
+        return
+
+    print(f"\nTopic Gap Analysis")
+    print("=" * 60)
+    print(f"Your Site          : {args.url} ({your_data['pages_crawled']} pages, {len(your_data['all_phrases'])} topics)")
+    for url, d in competitor_data.items():
+        print(f"Competitor         : {url} ({d['pages_crawled']} pages, {len(d['all_phrases'])} topics)")
+
+    ga = gap_report
+    print(f"\nCoverage Summary:")
+    print(f"  Your unique topics             : {ga['your_unique_topics']}")
+    print(f"  Competitor-only topics (GAPS)   : {ga['competitor_unique_topics']}")
+    print(f"  Shared topics                  : {ga['overlap_topics']}")
+
+    if ga["gaps"]:
+        print(f"\nTop Content Gaps ({len(ga['gaps'])} found):")
+        for gap in ga["gaps"][:20]:
+            icon = "🔴" if gap["priority"] == "High" else "⚠️"
+            comp_str = ", ".join(urlparse(c).netloc for c in gap["competitors"])
+            print(f"  {icon} \"{gap['topic']}\" — covered by {gap['covered_by_competitors']} competitor(s): {comp_str}")
+
+        print("\nRecommendation: Create content targeting the high-priority gap topics above.")
+        print("Start with topics covered by 2+ competitors (highest opportunity).")
+    else:
+        print("\n✅ No significant topic gaps found — your content coverage is strong!")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/content_decay_detector.py
+++ b/.claude/skills/seo/scripts/content_decay_detector.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Detect content decay and striking-distance keywords from CSV exports."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections import defaultdict
+from datetime import date, datetime
+
+
+def _float(value, default: float = 0.0) -> float:
+    try:
+        return float(str(value or "").replace(",", ""))
+    except ValueError:
+        return default
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    value = value.strip()
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%m/%d/%Y", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(value[:10], fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _read_rows(path: str, args) -> list[dict]:
+    with open(path, newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        rows = []
+        for raw in reader:
+            row = {key.lower().strip(): value for key, value in raw.items() if key}
+            rows.append({
+                "url": row.get(args.url_column.lower()) or row.get("page") or row.get("landing page") or "",
+                "query": row.get(args.query_column.lower()) or row.get("keyword") or "",
+                "date": _parse_date(row.get(args.date_column.lower())),
+                "clicks": _float(row.get(args.clicks_column.lower())),
+                "impressions": _float(row.get(args.impressions_column.lower())),
+                "position": _float(row.get(args.position_column.lower())),
+            })
+    return [row for row in rows if row["url"]]
+
+
+def detect_decay(
+    path: str,
+    args,
+    split_date: date | None = None,
+    decline_threshold: float = 0.2,
+    min_impressions: float = 100.0,
+) -> dict:
+    rows = _read_rows(path, args)
+    dated_rows = [row for row in rows if row["date"]]
+    if split_date is None and dated_rows:
+        dates = sorted(row["date"] for row in dated_rows)
+        split_date = dates[len(dates) // 2]
+
+    grouped = defaultdict(lambda: {"previous": [], "recent": []})
+    for row in rows:
+        period = "recent"
+        if split_date and row["date"]:
+            period = "recent" if row["date"] >= split_date else "previous"
+        grouped[row["url"]][period].append(row)
+
+    declining_pages = []
+    striking_distance = []
+    for url, periods in grouped.items():
+        previous_clicks = sum(row["clicks"] for row in periods["previous"])
+        recent_clicks = sum(row["clicks"] for row in periods["recent"])
+        previous_impressions = sum(row["impressions"] for row in periods["previous"])
+        recent_impressions = sum(row["impressions"] for row in periods["recent"])
+        drop = (previous_clicks - recent_clicks) / previous_clicks if previous_clicks else 0.0
+        if previous_clicks > 0 and drop >= decline_threshold and max(previous_impressions, recent_impressions) >= min_impressions:
+            declining_pages.append({
+                "url": url,
+                "previous_clicks": round(previous_clicks, 2),
+                "recent_clicks": round(recent_clicks, 2),
+                "click_drop_pct": round(drop * 100, 2),
+                "previous_impressions": round(previous_impressions, 2),
+                "recent_impressions": round(recent_impressions, 2),
+            })
+
+        by_query = defaultdict(list)
+        for row in periods["recent"]:
+            if row["query"]:
+                by_query[row["query"]].append(row)
+        for query, query_rows in by_query.items():
+            impressions = sum(row["impressions"] for row in query_rows)
+            if impressions < min_impressions:
+                continue
+            avg_position = sum(row["position"] * row["impressions"] for row in query_rows) / max(1.0, impressions)
+            if 4.0 <= avg_position <= 20.0:
+                striking_distance.append({
+                    "url": url,
+                    "query": query,
+                    "recent_impressions": round(impressions, 2),
+                    "avg_position": round(avg_position, 2),
+                    "recent_clicks": round(sum(row["clicks"] for row in query_rows), 2),
+                })
+
+    declining_pages.sort(key=lambda row: row["click_drop_pct"], reverse=True)
+    striking_distance.sort(key=lambda row: (row["avg_position"], -row["recent_impressions"]))
+    return {
+        "rows": len(rows),
+        "split_date": split_date.isoformat() if split_date else None,
+        "declining_pages": declining_pages,
+        "striking_distance_keywords": striking_distance[:200],
+        "issues": [
+            {"severity": "warning", "message": "No date column could be parsed; all rows treated as recent."}
+        ] if not split_date else [],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Detect declining pages and striking-distance keywords from GSC-style CSV.")
+    parser.add_argument("csv_file", nargs="?", help="CSV export path")
+    parser.add_argument("--csv", dest="csv_path", help="CSV export path")
+    parser.add_argument("--split-date", help="Boundary date YYYY-MM-DD. Earlier rows are previous; later rows are recent.")
+    parser.add_argument("--decline-threshold", type=float, default=0.2, help="Click drop ratio required for decay.")
+    parser.add_argument("--min-impressions", type=float, default=100.0)
+    parser.add_argument("--date-column", default="date")
+    parser.add_argument("--url-column", default="url")
+    parser.add_argument("--query-column", default="query")
+    parser.add_argument("--clicks-column", default="clicks")
+    parser.add_argument("--impressions-column", default="impressions")
+    parser.add_argument("--position-column", default="position")
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    path = args.csv_path or args.csv_file
+    if not path:
+        parser.error("CSV path required as positional csv_file or --csv")
+    split = _parse_date(args.split_date) if args.split_date else None
+    result = detect_decay(path, args, split, args.decline_threshold, args.min_impressions)
+    text = f"Declining pages: {len(result['declining_pages'])} Striking-distance keywords: {len(result['striking_distance_keywords'])}"
+    print(json.dumps(result, indent=2) if args.json else text)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/content_intent_matcher.py
+++ b/.claude/skills/seo/scripts/content_intent_matcher.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Match page content to a target keyword and search intent."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter
+
+from seo_common import load_html, parse_html
+
+
+INTENT_MARKERS = {
+    "informational": {
+        "what", "how", "why", "guide", "tutorial", "learn", "examples", "definition", "checklist", "tips",
+    },
+    "commercial": {
+        "best", "top", "review", "compare", "comparison", "alternative", "alternatives", "vs", "pricing",
+    },
+    "transactional": {
+        "buy", "order", "download", "demo", "trial", "quote", "book", "subscribe", "pricing", "coupon",
+    },
+    "navigational": {
+        "login", "sign in", "support", "docs", "documentation", "contact", "about", "portal", "dashboard",
+    },
+}
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    if os.path.exists(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _tokens(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9][a-z0-9'-]*", (text or "").lower())
+
+
+def _contains_phrase(text: str, phrase: str) -> bool:
+    return re.search(r"\b" + re.escape(phrase.lower()) + r"\b", (text or "").lower()) is not None
+
+
+def infer_intent(keyword: str, page_text: str) -> str:
+    haystack = f"{keyword} {page_text}".lower()
+    scores = {}
+    for intent, markers in INTENT_MARKERS.items():
+        scores[intent] = sum(1 for marker in markers if re.search(r"\b" + re.escape(marker) + r"\b", haystack))
+    return max(scores, key=scores.get) if any(scores.values()) else "informational"
+
+
+def match_intent(source: str, keyword: str, intent: str | None = None, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout)
+    parsed = parse_html(html, url)
+    keyword = keyword.strip().lower()
+    target_intent = intent or infer_intent(keyword, parsed.get("body_text", ""))
+    keyword_terms = [term for term in _tokens(keyword) if len(term) > 1]
+    body_tokens = _tokens(parsed.get("body_text", ""))
+    body_counts = Counter(body_tokens)
+    body_total = max(1, len(body_tokens))
+
+    title = parsed.get("title") or ""
+    meta_description = parsed.get("meta_description") or ""
+    h1_text = " ".join(parsed.get("headings", {}).get("h1", []))
+    headings = " ".join(sum((values for values in parsed.get("headings", {}).values()), []))
+
+    fields = {
+        "title": title,
+        "h1": h1_text,
+        "meta_description": meta_description,
+        "headings": headings,
+        "body": parsed.get("body_text", ""),
+    }
+    exact_matches = {name: _contains_phrase(text, keyword) for name, text in fields.items()}
+    coverage = {
+        name: round(sum(1 for term in keyword_terms if term in set(_tokens(text))) / max(1, len(keyword_terms)), 3)
+        for name, text in fields.items()
+    }
+    density = sum(body_counts[term] for term in keyword_terms) / body_total
+    marker_hits = sorted(
+        marker
+        for marker in INTENT_MARKERS.get(target_intent, set())
+        if re.search(r"\b" + re.escape(marker) + r"\b", parsed.get("body_text", "").lower())
+    )
+
+    score = 0
+    score += 18 if exact_matches["title"] else int(12 * coverage["title"])
+    score += 18 if exact_matches["h1"] else int(12 * coverage["h1"])
+    score += 12 if exact_matches["meta_description"] else int(8 * coverage["meta_description"])
+    score += min(18, int(coverage["headings"] * 18))
+    score += min(16, int(density * 1400))
+    score += min(18, len(marker_hits) * 4)
+
+    issues = []
+    if not exact_matches["title"]:
+        issues.append({"severity": "warning", "message": "Title does not contain the exact target keyword."})
+    if not exact_matches["h1"]:
+        issues.append({"severity": "warning", "message": "H1 does not contain the exact target keyword."})
+    if not marker_hits:
+        issues.append({"severity": "info", "message": f"No clear {target_intent} intent markers found in body copy."})
+    if parsed.get("word_count", 0) < 300:
+        issues.append({"severity": "warning", "message": "Page body is short for intent matching evidence."})
+
+    return {
+        "url": url or source,
+        "keyword": keyword,
+        "intent": target_intent,
+        "score": min(100, score),
+        "word_count": parsed.get("word_count", 0),
+        "exact_matches": exact_matches,
+        "term_coverage": coverage,
+        "keyword_density": round(density, 4),
+        "intent_markers": marker_hits,
+        "issues": issues,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Match title, H1, meta, headings, and body text to keyword intent.")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--keyword", required=True, help="Target keyword or query")
+    parser.add_argument("--intent", choices=sorted(INTENT_MARKERS), help="Expected intent. Defaults to inferred intent.")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = match_intent(args.source, args.keyword, args.intent, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Score: {result['score']} Intent: {result['intent']} Issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/crawl_audit.py
+++ b/.claude/skills/seo/scripts/crawl_audit.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Robots-aware shallow site crawler with SEO metadata checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict, deque
+
+from seo_common import (
+    clean_url,
+    discover_sitemap_urls,
+    fetch_robots,
+    fetch_url,
+    issue,
+    normalize_url,
+    parse_html,
+    parse_sitemap_xml,
+    print_json_or_text,
+    robots_allowed,
+    same_host,
+)
+
+
+def sitemap_seeds(site: str, timeout: int, limit: int) -> list[str]:
+    seeds = []
+    for sm in discover_sitemap_urls(site, timeout=timeout)[:10]:
+        fetched = fetch_url(sm, timeout=timeout, max_bytes=8_000_000)
+        if fetched.get("status") != 200:
+            continue
+        parsed = parse_sitemap_xml(fetched.get("text") or "", sm)
+        if parsed["type"] == "urlset":
+            seeds.extend(row["loc"] for row in parsed["urls"])
+        elif parsed["type"] == "sitemapindex":
+            for child in parsed["sitemaps"][:5]:
+                child_fetch = fetch_url(child["loc"], timeout=timeout, max_bytes=8_000_000)
+                child_parsed = parse_sitemap_xml(child_fetch.get("text") or "", child["loc"])
+                seeds.extend(row["loc"] for row in child_parsed["urls"])
+        if len(seeds) >= limit:
+            break
+    return list(dict.fromkeys(seeds))[:limit]
+
+
+def crawl(site: str, max_pages: int = 50, depth: int = 2, timeout: int = 15, use_sitemap: bool = True) -> dict:
+    start = normalize_url(site)
+    robots = fetch_robots(start, timeout=timeout)
+    parsed_robots = robots.get("parsed")
+    queue = deque([(start, 0, "seed")])
+    if use_sitemap:
+        for seed in sitemap_seeds(start, timeout, max_pages):
+            if same_host(start, seed):
+                queue.append((seed, 0, "sitemap"))
+
+    seen = set()
+    pages = {}
+    inbound = defaultdict(set)
+    issues = []
+    title_counter = Counter()
+    desc_counter = Counter()
+    h1_counter = Counter()
+
+    while queue and len(seen) < max_pages:
+        url, current_depth, source = queue.popleft()
+        url = clean_url(url)
+        if url in seen or not same_host(start, url):
+            continue
+        seen.add(url)
+        allowed, robots_rule = robots_allowed(parsed_robots, url, "Googlebot")
+        if not allowed:
+            pages[url] = {"url": url, "source": source, "depth": current_depth, "robots_allowed": False, "robots_rule": robots_rule}
+            issues.append(issue("warning", "URL blocked by robots.txt", url, robots_rule))
+            continue
+        fetched = fetch_url(url, timeout=timeout, max_bytes=2_000_000)
+        page = {
+            "url": url,
+            "final_url": fetched.get("url"),
+            "source": source,
+            "depth": current_depth,
+            "status": fetched.get("status"),
+            "redirects": fetched.get("redirect_chain", []),
+            "robots_allowed": True,
+            "robots_rule": robots_rule,
+            "title": None,
+            "meta_description": None,
+            "h1": [],
+            "canonical": None,
+            "meta_robots": None,
+            "word_count": 0,
+            "outlinks": [],
+            "error": fetched.get("error"),
+        }
+        ctype = fetched.get("headers", {}).get("content-type", "")
+        if fetched.get("status") and fetched["status"] >= 400:
+            issues.append(issue("error", f"HTTP {fetched['status']}", url))
+        if fetched.get("redirect_chain"):
+            issues.append(issue("info", "URL redirects", url))
+        if fetched.get("text") and "html" in ctype:
+            html = parse_html(fetched["text"], fetched.get("url") or url)
+            page.update({
+                "title": html["title"],
+                "meta_description": html["meta_description"],
+                "h1": html["headings"]["h1"],
+                "canonical": html["canonical"],
+                "meta_robots": html["meta_robots"],
+                "word_count": html["word_count"],
+                "outlinks": [link["href"] for link in html["links"] if same_host(start, link["href"])],
+            })
+            if page["title"]:
+                title_counter[page["title"]] += 1
+            else:
+                issues.append(issue("warning", "Missing title", url))
+            if page["meta_description"]:
+                desc_counter[page["meta_description"]] += 1
+            else:
+                issues.append(issue("info", "Missing meta description", url))
+            if page["h1"]:
+                h1_counter[page["h1"][0]] += 1
+            else:
+                issues.append(issue("warning", "Missing H1", url))
+            if page["meta_robots"] and "noindex" in page["meta_robots"].lower():
+                issues.append(issue("warning", "Page has meta noindex", url, page["meta_robots"]))
+            if page["canonical"] and not same_host(start, page["canonical"]):
+                issues.append(issue("warning", "Cross-host canonical", url, page["canonical"]))
+
+            if current_depth < depth:
+                for link in page["outlinks"]:
+                    clean = clean_url(link)
+                    inbound[clean].add(url)
+                    if clean not in seen:
+                        queue.append((clean, current_depth + 1, "link"))
+        pages[url] = page
+
+    for label, counter in (("duplicate title", title_counter), ("duplicate meta description", desc_counter), ("duplicate H1", h1_counter)):
+        for value, count in counter.items():
+            if count > 1:
+                issues.append(issue("warning", f"{label}: {count} pages", evidence=value[:160]))
+
+    orphan_candidates = [url for url, page in pages.items() if page.get("source") == "sitemap" and not inbound.get(url) and url != start]
+    for url in orphan_candidates[:50]:
+        issues.append(issue("info", "Sitemap URL was not discovered through internal links in this crawl", url))
+
+    result = {
+        "site": start,
+        "robots_url": robots["url"],
+        "pages_crawled": len(pages),
+        "max_depth": depth,
+        "pages": pages,
+        "status_counts": dict(Counter(str(p.get("status")) for p in pages.values())),
+        "duplicates": {
+            "titles": {k: v for k, v in title_counter.items() if v > 1},
+            "meta_descriptions": {k: v for k, v in desc_counter.items() if v > 1},
+            "h1": {k: v for k, v in h1_counter.items() if v > 1},
+        },
+        "orphan_candidates": orphan_candidates,
+        "issues": issues,
+    }
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a pragmatic crawl audit")
+    parser.add_argument("site")
+    parser.add_argument("--max-pages", type=int, default=50)
+    parser.add_argument("--depth", type=int, default=2)
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--no-sitemap", action="store_true")
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = crawl(args.site, args.max_pages, args.depth, args.timeout, not args.no_sitemap)
+    lines = [
+        f"Crawl audit for {result['site']}",
+        f"Pages crawled: {result['pages_crawled']}  Issues: {len(result['issues'])}",
+    ] + [f"[{i['severity']}] {i['message']} {i.get('url') or ''}" for i in result["issues"][:25]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/critical_request_chain.py
+++ b/.claude/skills/seo/scripts/critical_request_chain.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Identify critical request chains and render-blocking resources from HTML."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+from seo_common import BeautifulSoup, fetch_url, load_html, normalize_url, require_bs4, same_host
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    path = Path(source)
+    if path.is_file():
+        return path.read_text(encoding="utf-8"), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _is_cross_origin(url: str, page_url: str) -> bool:
+    if not url.startswith(("http://", "https://")) or not page_url.startswith(("http://", "https://")):
+        return False
+    return not same_host(url, page_url)
+
+
+def _imports_from_css(css: str, base_url: str) -> list[str]:
+    imports = []
+    for match in re.finditer(r"""@import\s+(?:url\()?["']?([^"') ;]+)""", css or "", flags=re.I):
+        imports.append(normalize_url(match.group(1), base_url) if base_url else match.group(1))
+    return imports
+
+
+def audit(source: str, fetch_css: bool = False, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout=timeout)
+    require_bs4()
+    soup = BeautifulSoup(html or "", "html.parser")
+    preloads = set()
+    preconnects = set()
+    chains = []
+    issues = []
+
+    for link in soup.find_all("link", href=True):
+        rel = " ".join(link.get("rel") or []).lower()
+        href = normalize_url(link.get("href"), url) if url else link.get("href")
+        if "preload" in rel or "modulepreload" in rel:
+            preloads.add(href)
+        if "preconnect" in rel or "dns-prefetch" in rel:
+            preconnects.add(urlparse(href).netloc or href)
+
+    for link in soup.find_all("link", href=True):
+        rel = " ".join(link.get("rel") or []).lower()
+        if "stylesheet" not in rel or link.get("media", "").lower() in ("print", "speech"):
+            continue
+        href = normalize_url(link.get("href"), url) if url else link.get("href")
+        node = {
+            "type": "stylesheet",
+            "url": href,
+            "blocking": True,
+            "preloaded": href in preloads,
+            "cross_origin": _is_cross_origin(href, url),
+            "children": [],
+        }
+        if fetch_css and href.startswith(("http://", "https://")):
+            fetched_css = fetch_url(href, timeout=timeout, max_bytes=500_000)
+            for imported in _imports_from_css(fetched_css.get("text") or "", href):
+                node["children"].append({"type": "css-import", "url": imported, "blocking": True})
+        chains.append(node)
+        issues.append({"severity": "warning", "message": "Render-blocking stylesheet", "url": href})
+
+    for script in soup.find_all("script", src=True):
+        src = normalize_url(script.get("src"), url) if url else script.get("src")
+        blocking = not script.has_attr("async") and not script.has_attr("defer") and script.get("type") != "module"
+        node = {
+            "type": "script",
+            "url": src,
+            "blocking": blocking,
+            "preloaded": src in preloads,
+            "cross_origin": _is_cross_origin(src, url),
+            "children": [],
+        }
+        chains.append(node)
+        if blocking:
+            issues.append({"severity": "warning", "message": "Parser-blocking script", "url": src})
+
+    for node in chains:
+        if node["cross_origin"]:
+            host = urlparse(node["url"]).netloc
+            has_preconnect = host in preconnects or f"https://{host}" in preconnects
+            node["preconnected"] = has_preconnect
+            if not has_preconnect:
+                issues.append({"severity": "info", "message": "Cross-origin critical resource lacks preconnect", "url": node["url"]})
+
+    return {
+        "url": url or source,
+        "critical_request_count": len([node for node in chains if node["blocking"]]),
+        "chain_count": len(chains),
+        "issues": issues,
+        "chains": chains,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Identify render-blocking critical request chains")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--fetch-css", action="store_true", help="Fetch CSS files to inspect @import chains")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    result = audit(args.source, args.fetch_css, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Critical requests: {result['critical_request_count']}; chains: {result['chain_count']}; issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/duplicate_content.py
+++ b/.claude/skills/seo/scripts/duplicate_content.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""
+Duplicate & Thin Content Detector
+
+Detects near-duplicate pages and thin content across a site using
+MinHash / Jaccard similarity and word-count thresholds.
+
+Usage:
+    python duplicate_content.py https://example.com --depth 2 --json
+    python duplicate_content.py https://example.com --threshold 0.85
+"""
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import time
+from collections import defaultdict
+from urllib.parse import urljoin, urlparse
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+# Quality gates from resources/references/quality-gates.md
+THIN_CONTENT_THRESHOLDS = {
+    "blog_post": 1500,
+    "landing_page": 800,
+    "product_page": 300,
+    "location_page": 350,
+    "default": 300,
+}
+
+
+# ---------------------------------------------------------------------------
+# Fetch & extract
+# ---------------------------------------------------------------------------
+
+def fetch_page(url: str, timeout: int = 12) -> str:
+    try:
+        resp = safe_get(url, timeout=timeout)
+        ct = resp.headers.get("Content-Type", "")
+        if "text/html" not in ct:
+            return ""
+        return resp.text
+    except Exception:
+        return ""
+
+
+def extract_text(html: str) -> str:
+    """Extract visible body text, stripping nav/footer/scripts."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "nav", "footer", "header", "aside"]):
+        tag.decompose()
+    body = soup.find("body")
+    if not body:
+        return ""
+    return body.get_text(separator=" ", strip=True)
+
+
+def extract_internal_links(html: str, base_url: str) -> list:
+    """Extract internal links from a page."""
+    soup = BeautifulSoup(html, "html.parser")
+    base_domain = urlparse(base_url).netloc
+    links = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.startswith("#") or href.startswith("javascript:") or href.startswith("mailto:"):
+            continue
+        full = urljoin(base_url, href)
+        parsed = urlparse(full)
+        if parsed.netloc == base_domain and parsed.scheme in ("http", "https"):
+            clean = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+            if clean.endswith("/"):
+                clean = clean[:-1]
+            links.append(clean)
+    return list(set(links))
+
+
+# ---------------------------------------------------------------------------
+# Shingle-based MinHash for near-duplicate detection
+# ---------------------------------------------------------------------------
+
+def shingle(text: str, k: int = 5) -> set:
+    """Create k-word shingles from text."""
+    words = re.findall(r"\b[a-z]+\b", text.lower())
+    if len(words) < k:
+        return {" ".join(words)}
+    return {" ".join(words[i:i+k]) for i in range(len(words) - k + 1)}
+
+
+def minhash_signature(shingles: set, num_hashes: int = 100) -> list:
+    """Compute MinHash signature for a set of shingles."""
+    sig = []
+    for i in range(num_hashes):
+        min_hash = float("inf")
+        for s in shingles:
+            h = int(hashlib.md5(f"{i}:{s}".encode()).hexdigest(), 16)
+            if h < min_hash:
+                min_hash = h
+        sig.append(min_hash)
+    return sig
+
+
+def jaccard_from_minhash(sig1: list, sig2: list) -> float:
+    """Estimate Jaccard similarity from two MinHash signatures."""
+    if not sig1 or not sig2:
+        return 0.0
+    matches = sum(1 for a, b in zip(sig1, sig2) if a == b)
+    return matches / len(sig1)
+
+
+def exact_hash(text: str) -> str:
+    """SHA-256 of normalized text for exact duplicate detection."""
+    normalized = re.sub(r"\s+", " ", text.lower().strip())
+    return hashlib.sha256(normalized.encode()).hexdigest()
+
+
+def _robots_directives(value: str | None) -> set[str]:
+    """Normalize a robots directive string into lowercase tokens."""
+    if not value:
+        return set()
+    return {token.strip().lower() for token in re.split(r"[\s,;]+", value) if token.strip()}
+
+
+def _robots_content_has_noindex(content: str | None) -> bool:
+    directives = _robots_directives(content)
+    return "noindex" in directives or "none" in directives
+
+
+def html_has_noindex(html: str) -> bool:
+    """Return True when retained HTML contains a robots noindex directive."""
+    if not html:
+        return False
+
+    soup = BeautifulSoup(html, "html.parser")
+    for meta in soup.find_all("meta"):
+        name = (meta.get("name") or "").strip().lower()
+        http_equiv = (meta.get("http-equiv") or "").strip().lower()
+        content = meta.get("content")
+
+        if name in {"robots", "googlebot", "bingbot"} and _robots_content_has_noindex(content):
+            return True
+        if http_equiv == "x-robots-tag" and _robots_content_has_noindex(content):
+            return True
+
+    return False
+
+
+def page_is_noindex(data: dict) -> bool:
+    """Detect noindex from explicit fields first, then retained HTML."""
+    if data.get("noindex") is True:
+        return True
+
+    for key in ("meta_robots", "robots", "x_robots_tag", "x-robots-tag"):
+        if _robots_content_has_noindex(data.get(key)):
+            return True
+
+    return html_has_noindex(data.get("html") or "")
+
+
+# ---------------------------------------------------------------------------
+# Crawl
+# ---------------------------------------------------------------------------
+
+def crawl_site(start_url: str, max_pages: int = 50, depth: int = 2) -> dict:
+    """
+    Crawl a site starting from start_url.
+    Returns {url: {"text": str, "word_count": int, "html": str}}.
+    """
+    visited = {}
+    queue = [(start_url, 0)]
+    seen = {start_url}
+
+    while queue and len(visited) < max_pages:
+        url, d = queue.pop(0)
+        time.sleep(0.5)  # polite delay
+
+        html = fetch_page(url)
+        if not html:
+            continue
+
+        text = extract_text(html)
+        word_count = len(re.findall(r"\b\w+\b", text))
+
+        visited[url] = {
+            "text": text,
+            "word_count": word_count,
+            "html": html,
+            "noindex": html_has_noindex(html),
+        }
+
+        if d < depth:
+            for link in extract_internal_links(html, url):
+                if link not in seen and len(seen) < max_pages * 3:
+                    seen.add(link)
+                    queue.append((link, d + 1))
+
+    return visited
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def detect_duplicates(pages: dict, similarity_threshold: float = 0.85) -> dict:
+    """
+    Detect exact and near-duplicate pages.
+    Returns report with exact dupes, near-dupes, and thin content.
+    """
+    # Step 1: Exact duplicates (hash comparison)
+    hash_groups = defaultdict(list)
+    signatures = {}
+
+    for url, data in pages.items():
+        text = data["text"]
+        if not text.strip():
+            continue
+        h = exact_hash(text)
+        hash_groups[h].append(url)
+
+        # MinHash signature for near-duplicate comparison
+        s = shingle(text)
+        if s:
+            signatures[url] = minhash_signature(s)
+
+    exact_dupes = []
+    for h, urls in hash_groups.items():
+        if len(urls) > 1:
+            indexable_urls = [url for url in urls if not page_is_noindex(pages[url])]
+            noindex_urls = [url for url in urls if page_is_noindex(pages[url])]
+
+            if len(indexable_urls) > 1:
+                exact_dupes.append({
+                    "type": "exact_duplicate",
+                    "severity": "Critical",
+                    "urls": indexable_urls,
+                    "finding": f"{len(indexable_urls)} indexable pages have identical content.",
+                    "fix": "Consolidate into a single canonical page and redirect duplicates with 301.",
+                })
+
+            if noindex_urls:
+                exact_dupes.append({
+                    "type": "exact_duplicate",
+                    "severity": "Info",
+                    "urls": urls,
+                    "noindex_urls": noindex_urls,
+                    "finding": "Identical content includes at least one noindex page.",
+                    "fix": "No action required for duplicate-content risk while noindex is intentional.",
+                })
+
+    # Step 2: Near-duplicates (MinHash Jaccard)
+    near_dupes = []
+    urls = list(signatures.keys())
+    checked = set()
+
+    for i in range(len(urls)):
+        for j in range(i + 1, len(urls)):
+            pair = (urls[i], urls[j])
+            if pair in checked:
+                continue
+            checked.add(pair)
+
+            sim = jaccard_from_minhash(signatures[urls[i]], signatures[urls[j]])
+            if sim >= similarity_threshold:
+                # Skip if already in exact dupes
+                if any(urls[i] in ed["urls"] and urls[j] in ed["urls"] for ed in exact_dupes):
+                    continue
+                noindex_in_pair = page_is_noindex(pages[urls[i]]) or page_is_noindex(pages[urls[j]])
+                near_dupes.append({
+                    "type": "near_duplicate",
+                    "severity": "Info" if noindex_in_pair else "Warning",
+                    "similarity": round(sim, 3),
+                    "url_a": urls[i],
+                    "url_b": urls[j],
+                    "word_count_a": pages[urls[i]]["word_count"],
+                    "word_count_b": pages[urls[j]]["word_count"],
+                    "noindex_in_pair": noindex_in_pair,
+                    "finding": (
+                        f"Pages are {sim:.0%} similar, but at least one page is noindex."
+                        if noindex_in_pair
+                        else f"Pages are {sim:.0%} similar — likely near-duplicate content."
+                    ),
+                    "fix": (
+                        "No action required for duplicate-content risk while noindex is intentional."
+                        if noindex_in_pair
+                        else "Differentiate content significantly, or set one as canonical and noindex the other."
+                    ),
+                })
+
+    # Step 3: Thin content
+    thin_pages = []
+    for url, data in pages.items():
+        if page_is_noindex(data):
+            continue
+        wc = data["word_count"]
+        threshold = THIN_CONTENT_THRESHOLDS["default"]
+        if wc < threshold:
+            thin_pages.append({
+                "type": "thin_content",
+                "severity": "Warning" if wc >= 100 else "Critical",
+                "url": url,
+                "word_count": wc,
+                "threshold": threshold,
+                "finding": f"Only {wc} words (minimum: {threshold}).",
+                "fix": f"Expand content to at least {threshold} words of substantive, unique content, or noindex if low-value.",
+            })
+
+    return {
+        "pages_analyzed": len(pages),
+        "exact_duplicates": exact_dupes,
+        "near_duplicates": near_dupes,
+        "thin_content": thin_pages,
+        "summary": {
+            "exact_duplicate_groups": len(exact_dupes),
+            "near_duplicate_pairs": len(near_dupes),
+            "thin_pages": len(thin_pages),
+            "avg_word_count": round(
+                sum(p["word_count"] for p in pages.values()) / max(1, len(pages))
+            ),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Duplicate & Thin Content Detector (MinHash / Jaccard similarity)"
+    )
+    parser.add_argument("url", help="Start URL to crawl")
+    parser.add_argument("--depth", type=int, default=2, help="Crawl depth (default: 2)")
+    parser.add_argument("--max-pages", type=int, default=50, help="Max pages to crawl (default: 50)")
+    parser.add_argument("--threshold", type=float, default=0.85,
+                        help="Jaccard similarity threshold for near-duplicates (default: 0.85)")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    print(f"Crawling {args.url} (depth={args.depth}, max={args.max_pages})...", file=sys.stderr)
+    pages = crawl_site(args.url, max_pages=args.max_pages, depth=args.depth)
+    print(f"Crawled {len(pages)} pages. Analyzing...", file=sys.stderr)
+
+    report = detect_duplicates(pages, similarity_threshold=args.threshold)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+
+    print(f"\nDuplicate & Thin Content Report")
+    print("=" * 60)
+    print(f"Pages Analyzed    : {report['pages_analyzed']}")
+    print(f"Avg Word Count    : {report['summary']['avg_word_count']}")
+
+    if report["exact_duplicates"]:
+        print(f"\nExact Duplicates ({report['summary']['exact_duplicate_groups']} groups):")
+        for group in report["exact_duplicates"]:
+            print(f"  🔴 {len(group['urls'])} identical pages:")
+            for url in group["urls"]:
+                print(f"     - {url}")
+            print(f"     Fix: {group['fix']}")
+
+    if report["near_duplicates"]:
+        print(f"\nNear-Duplicates ({report['summary']['near_duplicate_pairs']} pairs):")
+        for pair in report["near_duplicates"]:
+            print(f"  ⚠️  {pair['similarity']:.0%} similar:")
+            print(f"     A: {pair['url_a']} ({pair['word_count_a']} words)")
+            print(f"     B: {pair['url_b']} ({pair['word_count_b']} words)")
+            print(f"     Fix: {pair['fix']}")
+
+    if report["thin_content"]:
+        print(f"\nThin Content ({report['summary']['thin_pages']} pages):")
+        for page in sorted(report["thin_content"], key=lambda x: x["word_count"]):
+            icon = "🔴" if page["severity"] == "Critical" else "⚠️"
+            print(f"  {icon} {page['url']} — {page['word_count']} words (min: {page['threshold']})")
+
+    if not report["exact_duplicates"] and not report["near_duplicates"] and not report["thin_content"]:
+        print("\n✅ No duplicate or thin content issues detected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/eeat_signal_checker.py
+++ b/.claude/skills/seo/scripts/eeat_signal_checker.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Check E-E-A-T signals in HTML content."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from urllib.parse import urlparse
+
+from seo_common import load_html, parse_html
+
+
+CREDENTIAL_RE = re.compile(
+    r"\b(phd|m\.?d\.?|doctor|professor|certified|licensed|editor|reviewed by|fact[- ]checked|"
+    r"years? of experience|award[- ]winning|expert|specialist)\b",
+    re.I,
+)
+FIRST_HAND_RE = re.compile(
+    r"\b(we tested|our testing|hands[- ]on|first[- ]hand|case study|in our experience|"
+    r"we measured|we reviewed|original research|surveyed)\b",
+    re.I,
+)
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    if os.path.exists(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _walk_json(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_json(child)
+
+
+def _schema_values(schema_items: list, keys: set[str]) -> list[str]:
+    values = []
+    for item in schema_items:
+        for node in _walk_json(item):
+            for key in keys:
+                value = node.get(key)
+                if isinstance(value, str):
+                    values.append(value)
+                elif isinstance(value, dict) and value.get("name"):
+                    values.append(str(value["name"]))
+                elif isinstance(value, list):
+                    values.extend(str(v.get("name") if isinstance(v, dict) else v) for v in value)
+    return [value for value in values if value and value != "None"]
+
+
+def check_eeat(source: str, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout)
+    parsed = parse_html(html, url)
+    soup = parsed["soup"]
+    body = parsed.get("body_text", "")
+
+    author_meta = [
+        tag.get("content") or tag.get_text(" ", strip=True)
+        for tag in soup.find_all(["meta", "span", "a"], attrs={"name": "author"})
+        + soup.find_all(["a", "span"], rel=lambda value: value and "author" in value)
+    ]
+    class_authors = [
+        tag.get_text(" ", strip=True)
+        for tag in soup.find_all(attrs={"class": re.compile(r"(author|byline)", re.I)})
+        if tag.get_text(strip=True)
+    ]
+    schema_authors = _schema_values(parsed.get("schema", []), {"author", "reviewedBy", "publisher"})
+    authors = sorted({value.strip() for value in author_meta + class_authors + schema_authors if value and value.strip()})
+
+    credential_hits = sorted({match.group(0) for match in CREDENTIAL_RE.finditer(body)})
+    experience_hits = sorted({match.group(0) for match in FIRST_HAND_RE.finditer(body)})
+    links = parsed.get("links", [])
+    policy_links = [
+        link for link in links
+        if re.search(r"\b(editorial|review policy|fact[- ]check|corrections?|ethics)\b", link.get("text", ""), re.I)
+        or re.search(r"(editorial|review-policy|fact-check|corrections|ethics)", link.get("href", ""), re.I)
+    ]
+    trust_links = [
+        link for link in links
+        if re.search(r"\b(about|contact|privacy|terms|team|authors?)\b", link.get("text", ""), re.I)
+        or re.search(r"/(about|contact|privacy|terms|team|author)", link.get("href", ""), re.I)
+    ]
+    page_host = urlparse(url).netloc if url else ""
+    external_citations = [
+        link for link in links
+        if urlparse(link.get("href", "")).netloc and urlparse(link.get("href", "")).netloc != page_host
+    ]
+
+    score = 0
+    score += 20 if authors else 0
+    score += min(20, len(credential_hits) * 7)
+    score += min(20, len(experience_hits) * 7)
+    score += 15 if policy_links else 0
+    score += 15 if trust_links else 0
+    score += min(10, len(external_citations) * 2)
+
+    issues = []
+    if not authors:
+        issues.append({"severity": "warning", "message": "No clear author, byline, reviewer, or publisher signal found."})
+    if not credential_hits:
+        issues.append({"severity": "info", "message": "No visible credential or review language found."})
+    if not policy_links:
+        issues.append({"severity": "info", "message": "No editorial, review, corrections, or fact-check policy link detected."})
+    if not trust_links:
+        issues.append({"severity": "warning", "message": "No obvious about/contact/privacy/team trust links detected."})
+
+    return {
+        "url": url or source,
+        "score": min(100, score),
+        "signals": {
+            "authors": authors[:20],
+            "credential_markers": credential_hits[:20],
+            "first_hand_experience_markers": experience_hits[:20],
+            "policy_links": policy_links[:20],
+            "trust_links": trust_links[:20],
+            "external_citations": len(external_citations),
+        },
+        "issues": issues,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check visible E-E-A-T signals in a URL or HTML file.")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = check_eeat(args.source, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else f"Score: {result['score']} Issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/entity_checker.py
+++ b/.claude/skills/seo/scripts/entity_checker.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""
+Entity SEO Checker
+
+Validates entity presence across Knowledge Graph signals: Wikidata,
+Wikipedia, sameAs properties in JSON-LD, and Google Knowledge Graph
+Search API (optional, requires API key).
+
+Usage:
+    python entity_checker.py https://example.com --json
+    python entity_checker.py https://example.com --entity "Example Corp"
+    python entity_checker.py https://example.com --kg-api-key YOUR_KEY
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.parse
+from urllib.parse import urlparse
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get, safe_head
+except ImportError:
+    from scripts.lib.safe_http import safe_get, safe_head
+
+# Authoritative sameAs targets (ranked by KG signal strength)
+SAMEAS_PLATFORMS = {
+    "wikipedia.org": {"name": "Wikipedia", "priority": "Critical", "kg_signal": "Primary"},
+    "wikidata.org": {"name": "Wikidata", "priority": "Critical", "kg_signal": "Primary"},
+    "linkedin.com": {"name": "LinkedIn", "priority": "High", "kg_signal": "Strong"},
+    "twitter.com": {"name": "Twitter/X", "priority": "High", "kg_signal": "Strong"},
+    "x.com": {"name": "Twitter/X", "priority": "High", "kg_signal": "Strong"},
+    "crunchbase.com": {"name": "Crunchbase", "priority": "Medium", "kg_signal": "Moderate"},
+    "github.com": {"name": "GitHub", "priority": "Medium", "kg_signal": "Moderate"},
+    "youtube.com": {"name": "YouTube", "priority": "Medium", "kg_signal": "Moderate"},
+    "facebook.com": {"name": "Facebook", "priority": "Low", "kg_signal": "Weak"},
+    "instagram.com": {"name": "Instagram", "priority": "Low", "kg_signal": "Weak"},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+def fetch_html(url: str, timeout: int = 12) -> str:
+    try:
+        return safe_get(url, timeout=timeout).text
+    except Exception as exc:
+        print(f"Error fetching {url}: {exc}", file=sys.stderr)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Schema extraction
+# ---------------------------------------------------------------------------
+
+def extract_entities_from_schema(soup: BeautifulSoup) -> list:
+    """Extract Organization/Person entities and their sameAs from JSON-LD."""
+    entities = []
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            data = json.loads(script.string or "")
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        # Handle @graph arrays
+        items = []
+        if isinstance(data, list):
+            items = data
+        elif isinstance(data, dict):
+            if "@graph" in data:
+                items = data["@graph"]
+            else:
+                items = [data]
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            schema_type = item.get("@type", "")
+            # Look for entity types
+            if schema_type in ("Organization", "Person", "Corporation",
+                               "LocalBusiness", "Brand", "MedicalOrganization",
+                               "EducationalOrganization", "GovernmentOrganization"):
+                entities.append({
+                    "type": schema_type,
+                    "name": item.get("name", ""),
+                    "url": item.get("url", ""),
+                    "sameAs": item.get("sameAs", []),
+                    "logo": item.get("logo", ""),
+                    "description": item.get("description", ""),
+                    "identifier": item.get("identifier", ""),
+                })
+
+    return entities
+
+
+# ---------------------------------------------------------------------------
+# sameAs analysis
+# ---------------------------------------------------------------------------
+
+def analyze_sameas(same_as_list: list) -> dict:
+    """Analyze sameAs URLs for completeness and validity."""
+    if isinstance(same_as_list, str):
+        same_as_list = [same_as_list]
+
+    found = {}
+    missing = {}
+    issues = []
+
+    for url in same_as_list:
+        if not isinstance(url, str):
+            continue
+        parsed = urlparse(url)
+        domain = parsed.netloc.replace("www.", "").lower()
+
+        matched = False
+        for platform_domain, info in SAMEAS_PLATFORMS.items():
+            if platform_domain in domain:
+                found[info["name"]] = {
+                    "url": url,
+                    "priority": info["priority"],
+                    "kg_signal": info["kg_signal"],
+                }
+                matched = True
+                break
+
+        if not matched:
+            found[domain] = {
+                "url": url,
+                "priority": "Low",
+                "kg_signal": "Unknown",
+            }
+
+    # Identify missing critical platforms
+    for platform_domain, info in SAMEAS_PLATFORMS.items():
+        if info["priority"] in ("Critical", "High"):
+            if info["name"] not in found:
+                missing[info["name"]] = {
+                    "domain": platform_domain,
+                    "priority": info["priority"],
+                    "kg_signal": info["kg_signal"],
+                }
+
+    # Check for broken URLs (quick HEAD check on first 3)
+    for name, data in list(found.items())[:3]:
+        url = data["url"]
+        try:
+            resp = safe_head(url, timeout=6)
+            if resp.status_code >= 400:
+                issues.append({
+                    "severity": "Warning",
+                    "finding": f"sameAs URL returns HTTP {resp.status_code}: {url}",
+                    "fix": f"Update sameAs URL for {name} to a valid, non-redirecting destination.",
+                })
+        except Exception:
+            issues.append({
+                "severity": "Info",
+                "finding": f"Could not verify sameAs URL: {url}",
+                "fix": "Manually confirm this URL is accessible and correct.",
+            })
+
+    return {
+        "found": found,
+        "missing": missing,
+        "issues": issues,
+        "total_found": len(found),
+        "total_missing_critical": len(missing),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Wikidata lookup
+# ---------------------------------------------------------------------------
+
+def check_wikidata(entity_name: str) -> dict:
+    """Search Wikidata for the entity name. Returns QID if found."""
+    if not entity_name:
+        return {"found": False, "qid": None, "url": None}
+
+    try:
+        query = urllib.parse.quote(entity_name)
+        url = f"https://www.wikidata.org/w/api.php?action=wbsearchentities&search={query}&language=en&format=json&limit=3"
+        data = safe_get(url, timeout=8).json()
+
+        results = data.get("search", [])
+        if results:
+            best = results[0]
+            return {
+                "found": True,
+                "qid": best.get("id"),
+                "label": best.get("label"),
+                "description": best.get("description", ""),
+                "url": f"https://www.wikidata.org/wiki/{best.get('id')}",
+                "confidence": "High" if best.get("label", "").lower() == entity_name.lower() else "Medium",
+            }
+    except Exception:
+        pass
+
+    return {"found": False, "qid": None, "url": None}
+
+
+# ---------------------------------------------------------------------------
+# Wikipedia check
+# ---------------------------------------------------------------------------
+
+def check_wikipedia(entity_name: str) -> dict:
+    """Check if the entity has a Wikipedia article."""
+    if not entity_name:
+        return {"found": False, "url": None}
+
+    try:
+        query = urllib.parse.quote(entity_name.replace(" ", "_"))
+        url = f"https://en.wikipedia.org/w/api.php?action=query&titles={query}&format=json&redirects=1"
+        data = safe_get(url, timeout=8).json()
+
+        pages = data.get("query", {}).get("pages", {})
+        for page_id, page_data in pages.items():
+            if page_id != "-1":
+                return {
+                    "found": True,
+                    "title": page_data.get("title"),
+                    "url": f"https://en.wikipedia.org/wiki/{urllib.parse.quote(page_data.get('title', '').replace(' ', '_'))}",
+                }
+    except Exception:
+        pass
+
+    return {"found": False, "url": None}
+
+
+def check_google_knowledge_graph(entity_name: str, api_key: str = "") -> dict:
+    """Search Google Knowledge Graph Search API when a key is available."""
+    if not api_key:
+        return {"checked": False, "found": False, "result": None}
+    if not entity_name:
+        return {"checked": True, "found": False, "result": None, "error": "No entity name to search"}
+
+    try:
+        response = safe_get(
+            "https://kgsearch.googleapis.com/v1/entities:search",
+            params={
+                "query": entity_name,
+                "key": api_key,
+                "limit": 3,
+                "indent": "false",
+            },
+            timeout=8,
+            max_response_bytes=1_000_000,
+        )
+        data = response.json()
+        items = data.get("itemListElement", [])
+        if not items:
+            return {"checked": True, "found": False, "result": None}
+
+        best = items[0]
+        result = best.get("result", {}) if isinstance(best, dict) else {}
+        return {
+            "checked": True,
+            "found": True,
+            "name": result.get("name"),
+            "kg_id": result.get("@id"),
+            "description": result.get("description"),
+            "detailed_description": (result.get("detailedDescription") or {}).get("articleBody", ""),
+            "url": (result.get("detailedDescription") or {}).get("url"),
+            "types": result.get("@type", []),
+            "score": best.get("resultScore"),
+        }
+    except Exception as exc:
+        return {"checked": True, "found": False, "result": None, "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# NAP consistency check
+# ---------------------------------------------------------------------------
+
+def check_nap_consistency(soup: BeautifulSoup, entities: list) -> list:
+    """Check Name/Address/Phone consistency signals on the page."""
+    issues = []
+
+    # Look for structured LocalBusiness / Organization
+    local_entities = [e for e in entities if e["type"] in ("LocalBusiness", "Organization")]
+
+    if not local_entities:
+        return []
+
+    for entity in local_entities:
+        name = entity.get("name", "")
+        if not name:
+            issues.append({
+                "severity": "Warning",
+                "finding": f"{entity['type']} schema is missing 'name' property.",
+                "fix": "Add the exact business name to the schema.",
+            })
+
+    # Check for visible phone/address on page
+    page_text = soup.get_text(separator=" ")
+    has_phone = bool(re.search(r"[\+]?[\d\-\(\)\s]{7,15}", page_text))
+    has_address = bool(re.search(r"\d{1,5}\s+\w+\s+(street|st|avenue|ave|road|rd|blvd|drive|dr|lane|ln)", page_text, re.I))
+
+    if not has_phone and local_entities:
+        issues.append({
+            "severity": "Info",
+            "finding": "No phone number detected on page for LocalBusiness entity.",
+            "fix": "Display phone number visibly and include 'telephone' in LocalBusiness schema.",
+        })
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Main analysis
+# ---------------------------------------------------------------------------
+
+def run_entity_check(url: str, entity_name: str = "", kg_api_key: str = "") -> dict:
+    """Run full entity SEO check."""
+    html = fetch_html(url)
+    if not html:
+        return {"error": f"Failed to fetch {url}", "url": url}
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Extract entities from schema
+    entities = extract_entities_from_schema(soup)
+
+    # Determine entity name
+    if not entity_name and entities:
+        entity_name = entities[0].get("name", "")
+
+    if not entity_name:
+        # Try og:site_name or title
+        og_site = soup.find("meta", property="og:site_name")
+        if og_site:
+            entity_name = og_site.get("content", "")
+        else:
+            title = soup.find("title")
+            if title:
+                entity_name = title.get_text(strip=True).split("|")[0].split("-")[0].strip()
+
+    # Analyze sameAs from all entities
+    all_same_as = []
+    for e in entities:
+        sa = e.get("sameAs", [])
+        if isinstance(sa, str):
+            all_same_as.append(sa)
+        elif isinstance(sa, list):
+            all_same_as.extend(sa)
+
+    sameas_analysis = analyze_sameas(all_same_as)
+
+    # External lookups
+    wikidata = check_wikidata(entity_name)
+    wikipedia = check_wikipedia(entity_name)
+    google_kg = check_google_knowledge_graph(entity_name, kg_api_key)
+    has_notability_signal = bool(wikidata.get("found") or wikipedia.get("found") or google_kg.get("found"))
+
+    # NAP consistency
+    nap_issues = check_nap_consistency(soup, entities)
+
+    # Build issues list
+    issues = []
+
+    if not entities:
+        issues.append({
+            "severity": "Critical",
+            "area": "Schema",
+            "finding": "No Organization/Person entity found in JSON-LD.",
+            "fix": "Add Organization or Person schema with name, url, logo, and sameAs properties.",
+        })
+
+    if entities and not all_same_as:
+        issues.append({
+            "severity": "Critical",
+            "area": "sameAs",
+            "finding": "Entity schema exists but has no sameAs properties.",
+            "fix": "Add sameAs URLs pointing to Wikipedia, LinkedIn, Twitter/X, etc.",
+        })
+
+    if not wikidata["found"]:
+        issues.append({
+            "severity": "Info",
+            "area": "Wikidata",
+            "finding": f"No Wikidata entry found for '{entity_name}'.",
+            "fix": "If the entity meets Wikidata notability guidelines, create or improve an item with accurate third-party references. Do not create one solely for SEO.",
+        })
+
+    if not wikipedia["found"]:
+        issues.append({
+            "severity": "Info",
+            "area": "Wikipedia",
+            "finding": f"No Wikipedia article found for '{entity_name}'.",
+            "fix": "Only pursue Wikipedia if the entity meets independent notability standards. Otherwise, strengthen official schema, sameAs profiles, citations, and About/Contact signals.",
+        })
+
+    if google_kg.get("checked") and not google_kg.get("found"):
+        issues.append({
+            "severity": "Info",
+            "area": "Google Knowledge Graph",
+            "finding": f"No Google Knowledge Graph Search API match found for '{entity_name}'.",
+            "fix": "Improve entity consistency across official site schema, sameAs profiles, authoritative mentions, and organization/person pages.",
+        })
+
+    for name, data in sameas_analysis.get("missing", {}).items():
+        missing_primary_kg_profile = name in ("Wikipedia", "Wikidata")
+        issues.append({
+            "severity": "Warning" if data["priority"] == "Critical" and has_notability_signal else "Info",
+            "area": "sameAs",
+            "finding": f"Missing sameAs link to {name} ({data['kg_signal']} KG signal).",
+            "fix": (
+                f"Add the existing official '{data['domain']}' URL to sameAs; do not create this profile solely for SEO."
+                if missing_primary_kg_profile
+                else f"Add '{data['domain']}' profile URL to sameAs array in your entity schema."
+            ),
+        })
+
+    issues.extend(sameas_analysis.get("issues", []))
+    issues.extend(nap_issues)
+
+    return {
+        "url": url,
+        "entity_name": entity_name,
+        "entities_in_schema": entities,
+        "sameas_analysis": sameas_analysis,
+        "wikidata": wikidata,
+        "wikipedia": wikipedia,
+        "google_kg": google_kg,
+        "nap_issues": nap_issues,
+        "issues": issues,
+        "summary": {
+            "entities_found": len(entities),
+            "sameas_count": len(all_same_as),
+            "sameas_missing_critical": sameas_analysis["total_missing_critical"],
+            "wikidata_found": wikidata["found"],
+            "wikipedia_found": wikipedia["found"],
+            "google_kg_checked": google_kg.get("checked", False),
+            "google_kg_found": google_kg.get("found", False),
+            "total_issues": len(issues),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Entity SEO Checker — Knowledge Graph, Wikidata, sameAs validation"
+    )
+    parser.add_argument("url", help="Page URL to check")
+    parser.add_argument("--entity", default="", help="Entity name to search (auto-detected from schema/title if omitted)")
+    parser.add_argument("--kg-api-key", default="", help="Google Knowledge Graph API key (optional). Falls back to GOOGLE_KG_API_KEY / GOOGLE_API_KEY env vars or .env file.")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    from env_loader import get_env
+    kg_api_key = args.kg_api_key or get_env("GOOGLE_KG_API_KEY", "GOOGLE_API_KEY")
+    report = run_entity_check(args.url, entity_name=args.entity, kg_api_key=kg_api_key)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return
+
+    if report.get("error"):
+        print(f"Error: {report['error']}")
+        sys.exit(1)
+
+    print(f"\nEntity SEO Check — {report['url']}")
+    print("=" * 60)
+    print(f"Entity Name       : {report['entity_name']}")
+    print(f"Entities in Schema: {report['summary']['entities_found']}")
+
+    if report["entities_in_schema"]:
+        for e in report["entities_in_schema"]:
+            print(f"  [{e['type']}] {e['name']}")
+
+    print(f"\nsameAs Properties : {report['summary']['sameas_count']}")
+    sa = report["sameas_analysis"]
+    for name, data in sa["found"].items():
+        print(f"  ✅ {name}: {data['url']} ({data['kg_signal']} signal)")
+    for name, data in sa["missing"].items():
+        icon = "🔴" if data["priority"] == "Critical" else "⚠️"
+        print(f"  {icon} Missing: {name} ({data['kg_signal']} signal)")
+
+    wd = report["wikidata"]
+    print(f"\nWikidata          : {'✅ ' + wd['qid'] + ' — ' + wd.get('description', '') if wd['found'] else '❌ Not found'}")
+
+    wp = report["wikipedia"]
+    print(f"Wikipedia         : {'✅ ' + wp.get('url', '') if wp['found'] else '❌ Not found'}")
+
+    kg = report.get("google_kg", {})
+    if kg.get("checked"):
+        if kg.get("found"):
+            print(f"Google KG         : ✅ {kg.get('name', '')} ({kg.get('kg_id', '')})")
+        else:
+            suffix = f" — {kg.get('error')}" if kg.get("error") else ""
+            print(f"Google KG         : ❌ Not found{suffix}")
+    else:
+        print("Google KG         : Not checked (no API key)")
+
+    if report["issues"]:
+        sev_icon = {"Critical": "🔴", "Warning": "⚠️", "Info": "ℹ️"}
+        print(f"\nIssues ({report['summary']['total_issues']}):")
+        for issue in report["issues"]:
+            icon = sev_icon.get(issue.get("severity", "Info"), "ℹ️")
+            print(f"  {icon} [{issue.get('area', issue.get('severity'))}] {issue['finding']}")
+            print(f"     Fix: {issue['fix']}")
+    else:
+        print("\n✅ No entity SEO issues detected.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/env_loader.py
+++ b/.claude/skills/seo/scripts/env_loader.py
@@ -1,0 +1,132 @@
+"""
+Lightweight .env loader for Agentic-SEO scripts.
+
+Loads KEY=VALUE pairs from `.env` files into ``os.environ`` so scripts can
+read secrets (API keys, credential paths) without forcing the user to paste
+them on the CLI.
+
+Search order (first hit per key wins, real shell env always wins):
+  1. The process environment (already exported by the user).
+  2. ``.env`` in the current working directory (where the user invoked the script).
+  3. ``.env`` in the SKILL_DIR root (the parent of ``scripts/``).
+  4. ``$HOME/.agentic-seo/.env`` (cross-project default).
+
+Usage:
+    from env_loader import get_env, load_env
+    load_env()  # idempotent; safe to call from every script
+    api_key = get_env("PAGESPEED_API_KEY")
+
+No third-party dependencies — uses only the standard library.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_LOADED = False
+_LOADED_FROM: list[str] = []
+
+
+def _candidate_paths() -> list[Path]:
+    paths: list[Path] = []
+    try:
+        paths.append(Path.cwd() / ".env")
+    except OSError:
+        pass
+
+    # SKILL_DIR is the parent of the scripts/ directory containing this file.
+    here = Path(__file__).resolve().parent
+    paths.append(here.parent / ".env")
+
+    home = os.environ.get("HOME") or os.environ.get("USERPROFILE")
+    if home:
+        paths.append(Path(home) / ".agentic-seo" / ".env")
+
+    # Deduplicate while preserving order.
+    seen = set()
+    unique: list[Path] = []
+    for p in paths:
+        key = str(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(p)
+    return unique
+
+
+def _parse_line(line: str) -> tuple[str, str] | None:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    if line.startswith("export "):
+        line = line[len("export "):].lstrip()
+    if "=" not in line:
+        return None
+    key, _, value = line.partition("=")
+    key = key.strip()
+    if not key:
+        return None
+    value = value.strip()
+    if (len(value) >= 2) and (
+        (value[0] == value[-1] == '"') or (value[0] == value[-1] == "'")
+    ):
+        value = value[1:-1]
+    return key, value
+
+
+def _load_file(path: Path) -> int:
+    """Load a single .env file. Does not overwrite existing env vars."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+    count = 0
+    for raw in text.splitlines():
+        parsed = _parse_line(raw)
+        if not parsed:
+            continue
+        key, value = parsed
+        if key in os.environ:
+            continue
+        os.environ[key] = value
+        count += 1
+    return count
+
+
+def load_env(force: bool = False) -> list[str]:
+    """
+    Load .env files into ``os.environ``. Idempotent unless ``force=True``.
+
+    Returns the list of file paths that were actually read.
+    """
+    global _LOADED, _LOADED_FROM
+    if _LOADED and not force:
+        return list(_LOADED_FROM)
+
+    loaded_from: list[str] = []
+    for candidate in _candidate_paths():
+        if candidate.is_file() and _load_file(candidate) > 0:
+            loaded_from.append(str(candidate))
+
+    _LOADED = True
+    _LOADED_FROM = loaded_from
+    return list(loaded_from)
+
+
+def get_env(*names: str, default: str = "") -> str:
+    """
+    Return the first non-empty value among the given env var names.
+
+    Triggers ``load_env()`` on first call so scripts can use this without
+    explicit setup.
+    """
+    load_env()
+    for name in names:
+        value = os.environ.get(name, "")
+        if value and value.strip():
+            return value.strip()
+    return default
+
+
+__all__ = ["load_env", "get_env"]

--- a/.claude/skills/seo/scripts/external_link_quality.py
+++ b/.claude/skills/seo/scripts/external_link_quality.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Audit external links for status, redirects, rel attributes, and trust patterns."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from urllib.parse import urlparse
+
+from seo_common import fetch_url, normalize_url, parse_html, print_json_or_text, same_host
+
+
+LOW_TRUST_HOST_HINTS = (
+    "bit.ly",
+    "goo.gl",
+    "tinyurl.com",
+    "t.co",
+    "ow.ly",
+    "buff.ly",
+    "linktr.ee",
+    "adf.ly",
+    "clickbank.net",
+)
+
+
+def extract_external_links(html: str, page_url: str, site_url: str) -> list[dict]:
+    parsed = parse_html(html, page_url)
+    output = []
+    for link in parsed.get("links", []):
+        href = link.get("href") or ""
+        if not href or same_host(site_url, href):
+            continue
+        rel = [str(v).lower() for v in (link.get("rel") or [])]
+        output.append(
+            {
+                "source": page_url,
+                "url": normalize_url(href, page_url),
+                "anchor": link.get("text") or "",
+                "rel": rel,
+                "nofollow": "nofollow" in rel,
+                "sponsored": "sponsored" in rel,
+                "ugc": "ugc" in rel,
+            }
+        )
+    return output
+
+
+def _check_external_url(url: str, timeout: int) -> dict:
+    head = fetch_url(url, method="HEAD", timeout=timeout, allow_redirects=True, max_bytes=0)
+    if head.get("status") in (405, 403, None) and head.get("error"):
+        return fetch_url(url, method="GET", timeout=timeout, allow_redirects=True, max_bytes=200_000)
+    return head
+
+
+def audit_external_links(urls: list[str], check_status: bool = True, timeout: int = 15, max_links: int = 200) -> dict:
+    pages = []
+    links = []
+    errors = []
+    for source in urls:
+        source_url = normalize_url(source)
+        fetched = fetch_url(source_url, timeout=timeout, max_bytes=2_000_000)
+        pages.append({"url": source_url, "status": fetched.get("status"), "error": fetched.get("error")})
+        if fetched.get("status") != 200 or not fetched.get("text"):
+            errors.append({"url": source_url, "status": fetched.get("status"), "error": fetched.get("error")})
+            continue
+        links.extend(extract_external_links(fetched["text"], fetched.get("url") or source_url, source_url))
+
+    deduped = {}
+    for link in links:
+        deduped.setdefault(link["url"], link)
+
+    checked = []
+    for link in list(deduped.values())[:max_links]:
+        row = dict(link)
+        host = urlparse(link["url"]).netloc.lower()
+        row["host"] = host
+        row["low_trust_pattern"] = any(host == hint or host.endswith(f".{hint}") for hint in LOW_TRUST_HOST_HINTS)
+        if check_status:
+            fetched = _check_external_url(link["url"], timeout=timeout)
+            row["status"] = fetched.get("status")
+            row["final_url"] = fetched.get("url")
+            row["redirect_chain"] = fetched.get("redirect_chain", [])
+            row["error"] = fetched.get("error")
+        checked.append(row)
+
+    broken = [l for l in checked if l.get("status") and l["status"] >= 400]
+    redirects = [l for l in checked if l.get("redirect_chain")]
+    low_trust = [l for l in checked if l.get("low_trust_pattern")]
+    commercial_without_rel = [l for l in checked if not (l.get("nofollow") or l.get("sponsored") or l.get("ugc")) and _looks_commercial(l)]
+    hosts = Counter(l["host"] for l in checked if l.get("host"))
+    issues = []
+    if broken:
+        issues.append({"severity": "error", "type": "broken_external_links", "count": len(broken), "message": "External links return 4xx/5xx"})
+    if redirects:
+        issues.append({"severity": "warning", "type": "redirecting_external_links", "count": len(redirects), "message": "External links redirect"})
+    if low_trust:
+        issues.append({"severity": "warning", "type": "low_trust_patterns", "count": len(low_trust), "message": "External links match shortener or low-trust host patterns"})
+    if commercial_without_rel:
+        issues.append({"severity": "info", "type": "commercial_rel_review", "count": len(commercial_without_rel), "message": "Commercial-looking links may need rel=sponsored/nofollow review"})
+
+    return {
+        "sources": urls,
+        "pages": pages,
+        "summary": {
+            "external_links_found": len(links),
+            "unique_external_links": len(deduped),
+            "checked_links": len(checked),
+            "broken_links": len(broken),
+            "redirecting_links": len(redirects),
+            "low_trust_pattern_links": len(low_trust),
+            "commercial_rel_review": len(commercial_without_rel),
+        },
+        "top_external_hosts": [{"host": host, "count": count} for host, count in hosts.most_common(25)],
+        "links": checked,
+        "issues": issues,
+        "errors": errors,
+    }
+
+
+def _looks_commercial(link: dict) -> bool:
+    text = f"{link.get('anchor', '')} {link.get('url', '')}".lower()
+    return any(token in text for token in ("affiliate", "sponsor", "coupon", "deal", "promo", "ref=", "utm_medium=affiliate"))
+
+
+def _read_url_file(path: str) -> list[str]:
+    with open(path, "r", encoding="utf-8") as fh:
+        return [line.strip() for line in fh if line.strip() and not line.lstrip().startswith("#")]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit external link quality")
+    parser.add_argument("url", nargs="?", help="Page URL to audit")
+    parser.add_argument("--url-file", help="File containing page URLs to audit")
+    parser.add_argument("--no-check-status", action="store_true", help="Skip status/redirect checks")
+    parser.add_argument("--max-links", type=int, default=200, help="Maximum unique external links to check")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    urls = []
+    if args.url:
+        urls.append(args.url)
+    if args.url_file:
+        urls.extend(_read_url_file(args.url_file))
+    if not urls:
+        parser.error("Provide a URL or --url-file")
+
+    result = audit_external_links(urls, check_status=not args.no_check_status, timeout=args.timeout, max_links=args.max_links)
+    lines = [
+        f"External link quality audit for {len(urls)} page(s)",
+        (
+            f"Unique external links: {result['summary']['unique_external_links']}  "
+            f"Broken: {result['summary']['broken_links']}  "
+            f"Redirects: {result['summary']['redirecting_links']}"
+        ),
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}: {issue['count']}" for issue in result["issues"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/faceted_nav_audit.py
+++ b/.claude/skills/seo/scripts/faceted_nav_audit.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Detect faceted navigation crawl traps from URLs and optional page fetches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from urllib.parse import parse_qs, urlparse
+
+from seo_common import fetch_url, parse_html, read_urls
+
+
+FACET_KEYS = {"sort", "filter", "color", "size", "brand", "price", "min_price", "max_price", "rating", "page", "view", "availability", "material"}
+
+
+def audit(urls: list[str], fetch: bool = False, timeout: int = 15) -> dict:
+    rows = []
+    by_path = defaultdict(list)
+    param_counts = Counter()
+    for url in urls:
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query, keep_blank_values=True)
+        facet_params = sorted(k for k in params if k.lower() in FACET_KEYS or k.lower().startswith("filter"))
+        flags = []
+        if len(params) >= 3:
+            flags.append("parameter_combination")
+        if facet_params:
+            flags.append("facet_parameters")
+        if "sort" in params:
+            flags.append("sort_url")
+        if "page" in params and len(params) > 1:
+            flags.append("paginated_filtered_url")
+        row = {"url": url, "path": parsed.path or "/", "params": sorted(params), "facet_params": facet_params, "flags": flags}
+        if fetch:
+            page = fetch_url(url, timeout=timeout, max_bytes=1_500_000)
+            row["status"] = page.get("status")
+            if page.get("text"):
+                html = parse_html(page["text"], page.get("url") or url)
+                row["canonical"] = html.get("canonical")
+                row["meta_robots"] = html.get("meta_robots")
+                if facet_params and not html.get("canonical"):
+                    flags.append("facet_missing_canonical")
+                if facet_params and not (html.get("meta_robots") and "noindex" in html["meta_robots"].lower()):
+                    flags.append("facet_not_noindexed")
+        for key in params:
+            param_counts[key] += 1
+        by_path[row["path"]].append(url)
+        rows.append(row)
+    path_explosions = {path: vals for path, vals in by_path.items() if len(vals) >= 5}
+    issues = []
+    if path_explosions:
+        issues.append({"severity": "warning", "message": "Multiple parameter variants share the same path", "count": len(path_explosions)})
+    frequent_params = {k: v for k, v in param_counts.items() if v >= 3}
+    if frequent_params:
+        issues.append({"severity": "info", "message": "Frequent URL parameters detected", "evidence": frequent_params})
+    return {"count": len(rows), "frequent_params": frequent_params, "path_explosions": path_explosions, "rows": rows, "issues": issues}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit faceted navigation URLs")
+    parser.add_argument("urls", nargs="*")
+    parser.add_argument("--url-file")
+    parser.add_argument("--fetch", action="store_true", help="Fetch pages for canonical/noindex checks")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = audit(read_urls(args.urls, args.url_file), args.fetch, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else "\n".join(f"{','.join(r['flags']) or 'ok'}\t{r['url']}" for r in result["rows"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/fetch_page.py
+++ b/.claude/skills/seo/scripts/fetch_page.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Fetch a web page with proper headers and error handling.
+
+Usage:
+    python fetch_page.py https://example.com
+    python fetch_page.py https://example.com --output page.html
+"""
+
+import argparse
+import sys
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import DEFAULT_HEADERS, normalize_url, safe_get
+except ImportError:
+    from scripts.lib.safe_http import DEFAULT_HEADERS, normalize_url, safe_get
+
+
+def fetch_page(
+    url: str,
+    timeout: int = 30,
+    follow_redirects: bool = True,
+    max_redirects: int = 5,
+) -> dict:
+    """
+    Fetch a web page and return response details.
+
+    Args:
+        url: The URL to fetch
+        timeout: Request timeout in seconds
+        follow_redirects: Whether to follow redirects
+        max_redirects: Maximum number of redirects to follow
+
+    Returns:
+        Dictionary with:
+            - url: Final URL after redirects
+            - status_code: HTTP status code
+            - content: Response body
+            - headers: Response headers
+            - redirect_chain: List of redirect URLs
+            - error: Error message if failed
+    """
+    result = {
+        "url": url,
+        "status_code": None,
+        "content": None,
+        "headers": {},
+        "redirect_chain": [],
+        "error": None,
+    }
+
+    try:
+        url = normalize_url(url)
+
+        response = safe_get(
+            url,
+            headers=DEFAULT_HEADERS,
+            timeout=timeout,
+            allow_redirects=follow_redirects,
+            max_redirects=max_redirects,
+        )
+
+        result["url"] = response.url
+        result["status_code"] = response.status_code
+        result["content"] = response.text
+        result["headers"] = dict(response.headers)
+
+        # Track redirect chain
+        if response.history:
+            result["redirect_chain"] = [r.url for r in response.history]
+
+    except requests.exceptions.Timeout:
+        result["error"] = f"Request timed out after {timeout} seconds"
+    except requests.exceptions.TooManyRedirects:
+        result["error"] = f"Too many redirects (max {max_redirects})"
+    except requests.exceptions.SSLError as e:
+        result["error"] = f"SSL error: {e}"
+    except requests.exceptions.ConnectionError as e:
+        result["error"] = f"Connection error: {e}"
+    except requests.exceptions.RequestException as e:
+        result["error"] = f"Request failed: {e}"
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fetch a web page for SEO analysis")
+    parser.add_argument("url", help="URL to fetch")
+    parser.add_argument("--output", "-o", help="Output file path")
+    parser.add_argument("--timeout", "-t", type=int, default=30, help="Timeout in seconds")
+    parser.add_argument("--no-redirects", action="store_true", help="Don't follow redirects")
+
+    args = parser.parse_args()
+
+    result = fetch_page(
+        args.url,
+        timeout=args.timeout,
+        follow_redirects=not args.no_redirects,
+    )
+
+    if result["error"]:
+        print(f"Error: {result['error']}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(result["content"])
+        print(f"Saved to {args.output}")
+    else:
+        print(result["content"])
+
+    # Print metadata to stderr
+    print(f"\nURL: {result['url']}", file=sys.stderr)
+    print(f"Status: {result['status_code']}", file=sys.stderr)
+    if result["redirect_chain"]:
+        print(f"Redirects: {' -> '.join(result['redirect_chain'])}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/finding_verifier.py
+++ b/.claude/skills/seo/scripts/finding_verifier.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Reusable finding verifier.
+
+Purpose:
+- remove duplicate findings across sources
+- suppress clearly contradicted findings based on provided evidence context
+- return clean, prioritized findings for final reporting
+"""
+
+import argparse
+import json
+import re
+import sys
+
+
+SEVERITY_RANK = {"Critical": 0, "Warning": 1, "Info": 2, "Pass": 3}
+
+
+def _sev_rank(severity: str) -> int:
+    return SEVERITY_RANK.get(severity or "Info", 9)
+
+
+def _normalize_text(text: str) -> str:
+    text = (text or "").lower().strip()
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def canonical_key(finding: dict) -> str:
+    text = _normalize_text(finding.get("finding", ""))
+
+    m = re.search(r"missing required (?:repository )?(?:file|artifact):\s*([^\.\n]+)", text)
+    if m:
+        return f"missing-required:{m.group(1).strip()}"
+
+    m = re.search(r"missing recommended (?:trust|community) artifact:\s*([^\.\n]+)", text)
+    if m:
+        return f"missing-recommended:{m.group(1).strip()}"
+
+    m = re.search(r"missing community profile component:\s*([^\.\n]+)", text)
+    if m:
+        return f"community-profile-missing:{m.group(1).strip()}"
+
+    m = re.search(r"remote community profile marks [`']?([^`'\.\n]+)[`']? as missing", text)
+    if m:
+        return f"community-profile-missing:{m.group(1).strip()}"
+
+    # Generic fallback
+    base = re.sub(r"[^a-z0-9\s:_\-]", "", text)
+    return base[:160]
+
+
+def should_suppress(finding: dict, context: dict) -> tuple:
+    text = _normalize_text(finding.get("finding", ""))
+    metrics = (context or {}).get("readme_metrics", {}) or {}
+
+    if "no code examples detected" in text:
+        if int(metrics.get("code_block_count", 0)) > 0:
+            return True, "Suppressed: README metrics show code blocks present."
+
+    if "readme should contain exactly one h1 heading" in text:
+        if int(metrics.get("h1_count", 0)) == 1:
+            return True, "Suppressed: README metrics show exactly one H1."
+
+    if "installation/quickstart section is missing" in text:
+        if bool(metrics.get("has_install_section")):
+            return True, "Suppressed: README metrics indicate install section exists."
+
+    if "readme sectioning is shallow" in text:
+        if int(metrics.get("heading_count", 0)) >= 4:
+            return True, "Suppressed: README has sufficient heading depth."
+
+    return False, ""
+
+
+def verify_findings(findings: list, context: dict = None) -> dict:
+    """
+    Verify and dedupe findings.
+
+    Returns:
+    {
+      "findings": [...],
+      "dropped": [{"finding":..., "reason": ...}],
+      "raw_count": N,
+      "verified_count": M
+    }
+    """
+    context = context or {}
+    dropped = []
+    grouped = {}
+
+    for item in findings or []:
+        suppress, reason = should_suppress(item, context=context)
+        if suppress:
+            dropped.append({"finding": item.get("finding", ""), "reason": reason})
+            continue
+
+        key = canonical_key(item)
+        existing = grouped.get(key)
+        if not existing:
+            entry = dict(item)
+            entry["sources"] = [item.get("source")] if item.get("source") else []
+            grouped[key] = entry
+            continue
+
+        # Merge duplicates and keep stronger severity.
+        if _sev_rank(item.get("severity")) < _sev_rank(existing.get("severity")):
+            for field in ("severity", "finding", "evidence", "fix", "confidence"):
+                existing[field] = item.get(field, existing.get(field))
+        src = item.get("source")
+        if src and src not in existing.get("sources", []):
+            existing.setdefault("sources", []).append(src)
+
+    deduped = list(grouped.values())
+    deduped.sort(key=lambda x: _sev_rank(x.get("severity")))
+
+    return {
+        "findings": deduped,
+        "dropped": dropped,
+        "raw_count": len(findings or []),
+        "verified_count": len(deduped),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify/dedupe findings from JSON input.")
+    parser.add_argument("--findings-json", help="Path to JSON array of findings.")
+    parser.add_argument("--context-json", help="Path to JSON context object.")
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    args = parser.parse_args()
+
+    if not args.findings_json:
+        print("Error: --findings-json is required", file=sys.stderr)
+        sys.exit(2)
+
+    with open(args.findings_json, "r", encoding="utf-8") as f:
+        findings = json.load(f)
+    context = {}
+    if args.context_json:
+        with open(args.context_json, "r", encoding="utf-8") as f:
+            context = json.load(f)
+
+    result = verify_findings(findings=findings, context=context)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Raw findings: {result['raw_count']}")
+        print(f"Verified findings: {result['verified_count']}")
+        print(f"Dropped: {len(result['dropped'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/font_audit.py
+++ b/.claude/skills/seo/scripts/font_audit.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Audit font loading patterns that affect rendering and Core Web Vitals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+from seo_common import BeautifulSoup, fetch_url, load_html, normalize_url, require_bs4
+
+
+FONT_EXTENSIONS = (".woff2", ".woff", ".ttf", ".otf", ".eot")
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    path = Path(source)
+    if path.is_file():
+        return path.read_text(encoding="utf-8"), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _font_format(url: str) -> str:
+    path = urlparse(url).path.lower()
+    for ext in FONT_EXTENSIONS:
+        if path.endswith(ext):
+            return ext.lstrip(".")
+    return ""
+
+
+def _extract_font_faces(css: str) -> list[dict]:
+    faces = []
+    for block in re.findall(r"@font-face\s*{([^}]+)}", css or "", flags=re.I | re.S):
+        urls = re.findall(r"""url\(["']?([^)"']+)["']?\)""", block, flags=re.I)
+        display_match = re.search(r"font-display\s*:\s*([^;]+)", block, flags=re.I)
+        family_match = re.search(r"font-family\s*:\s*([^;]+)", block, flags=re.I)
+        faces.append({
+            "family": family_match.group(1).strip(" '\"") if family_match else None,
+            "font_display": display_match.group(1).strip() if display_match else None,
+            "urls": urls,
+        })
+    return faces
+
+
+def audit(source: str, fetch_fonts: bool = False, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout=timeout)
+    require_bs4()
+    soup = BeautifulSoup(html or "", "html.parser")
+    issues = []
+
+    preloads = []
+    preconnects = []
+    stylesheets = []
+    font_files = []
+    inline_faces = []
+
+    for link in soup.find_all("link"):
+        rel = " ".join(link.get("rel") or []).lower()
+        href = link.get("href") or ""
+        href = normalize_url(href, url) if href and url else href
+        if "preconnect" in rel:
+            preconnects.append(href)
+        if "stylesheet" in rel:
+            stylesheets.append(href)
+        if "preload" in rel and (link.get("as") == "font" or _font_format(href)):
+            preloads.append({
+                "href": href,
+                "type": link.get("type"),
+                "crossorigin": link.has_attr("crossorigin"),
+            })
+            if not link.has_attr("crossorigin"):
+                issues.append({"severity": "warning", "message": "Preloaded font is missing crossorigin", "url": href})
+        if _font_format(href):
+            font_files.append(href)
+
+    for style in soup.find_all("style"):
+        for face in _extract_font_faces(style.get_text() or ""):
+            inline_faces.append(face)
+            for font_url in face["urls"]:
+                abs_url = normalize_url(font_url, url) if url else font_url
+                font_files.append(abs_url)
+            if not face["font_display"]:
+                issues.append({"severity": "warning", "message": "@font-face missing font-display", "evidence": face.get("family")})
+            elif face["font_display"].lower() not in ("swap", "optional", "fallback"):
+                issues.append({"severity": "info", "message": "font-display may delay text rendering", "evidence": face["font_display"]})
+
+    rows = []
+    for font_url in sorted(set(font_files)):
+        row = {
+            "url": font_url,
+            "format": _font_format(font_url),
+            "preloaded": any(preload["href"] == font_url for preload in preloads),
+            "status": None,
+            "content_length": None,
+            "cache_control": None,
+        }
+        if fetch_fonts and font_url.startswith(("http://", "https://")):
+            head = fetch_url(font_url, method="HEAD", timeout=timeout)
+            row["status"] = head.get("status")
+            headers = head.get("headers", {})
+            length = headers.get("content-length")
+            row["content_length"] = int(length) if length and length.isdigit() else None
+            row["cache_control"] = headers.get("cache-control")
+            if row["content_length"] and row["content_length"] > 100_000:
+                issues.append({"severity": "warning", "message": "Large font file", "url": font_url, "evidence": f"{row['content_length']} bytes"})
+        if row["format"] and row["format"] != "woff2":
+            issues.append({"severity": "info", "message": "Font is not WOFF2", "url": font_url, "evidence": row["format"]})
+        rows.append(row)
+
+    if stylesheets and not preconnects:
+        third_party_css = [href for href in stylesheets if href.startswith(("http://", "https://")) and url and urlparse(href).netloc != urlparse(url).netloc]
+        if third_party_css:
+            issues.append({"severity": "info", "message": "Third-party stylesheet without preconnect", "url": third_party_css[0]})
+
+    return {
+        "url": url or source,
+        "font_file_count": len(rows),
+        "font_face_count": len(inline_faces),
+        "preload_count": len(preloads),
+        "preconnect_count": len(preconnects),
+        "issues": issues,
+        "fonts": rows,
+        "font_faces": inline_faces,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit font loading for FOIT/FOUT and CWV risk")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--fetch-fonts", action="store_true", help="HEAD remote font files for size and cache headers")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    result = audit(args.source, args.fetch_fonts, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Fonts: {result['font_file_count']}; @font-face: {result['font_face_count']}; issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/freshness_checker.py
+++ b/.claude/skills/seo/scripts/freshness_checker.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Check content freshness signals and stale references."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import date, datetime
+
+from seo_common import load_html, parse_html
+
+
+DATE_RE = re.compile(
+    r"\b(?:20\d{2}|19\d{2})[-/](?:0?[1-9]|1[0-2])[-/](?:0?[1-9]|[12]\d|3[01])\b|"
+    r"\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+"
+    r"(?:0?[1-9]|[12]\d|3[01]),?\s+(?:20\d{2}|19\d{2})\b",
+    re.I,
+)
+YEAR_RE = re.compile(r"\b(20\d{2}|19\d{2})\b")
+STAT_RE = re.compile(r"\b(\d+(?:\.\d+)?%|\$[\d,.]+|\d[\d,.]+\s+(?:users|customers|people|studies|respondents|pages))\b", re.I)
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    if os.path.exists(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    value = value.strip()
+    for candidate in (value, value[:10]):
+        try:
+            return datetime.fromisoformat(candidate.replace("Z", "+00:00")).date()
+        except ValueError:
+            pass
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%B %d, %Y", "%b %d, %Y", "%B %d %Y", "%b %d %Y"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _walk_json(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_json(child)
+
+
+def _schema_dates(schema_items: list) -> dict[str, list[str]]:
+    dates = {"datePublished": [], "dateModified": []}
+    for item in schema_items:
+        for node in _walk_json(item):
+            for key in dates:
+                if isinstance(node.get(key), str):
+                    dates[key].append(node[key])
+    return dates
+
+
+def check_freshness(source: str, timeout: int = 15, today: date | None = None) -> dict:
+    today = today or date.today()
+    html, url, fetched = _load_source(source, timeout)
+    parsed = parse_html(html, url)
+    soup = parsed["soup"]
+    body = parsed.get("body_text", "")
+
+    meta_dates = {}
+    for tag in soup.find_all("meta"):
+        key = (tag.get("property") or tag.get("name") or "").lower()
+        if key in {"article:published_time", "article:modified_time", "date", "last-modified", "dc.date"}:
+            meta_dates[key] = tag.get("content")
+    time_dates = [tag.get("datetime") or tag.get_text(" ", strip=True) for tag in soup.find_all("time")]
+    schema_dates = _schema_dates(parsed.get("schema", []))
+
+    parsed_dates = []
+    for source_name, values in {
+        "meta": list(meta_dates.values()),
+        "time": time_dates,
+        "schema_published": schema_dates["datePublished"],
+        "schema_modified": schema_dates["dateModified"],
+        "body": DATE_RE.findall(body),
+    }.items():
+        for raw in values:
+            parsed_date = _parse_date(raw)
+            if parsed_date:
+                parsed_dates.append({"source": source_name, "raw": raw, "date": parsed_date.isoformat()})
+
+    modified_dates = [_parse_date(value) for value in schema_dates["dateModified"] + [meta_dates.get("article:modified_time")]]
+    modified_dates = [value for value in modified_dates if value]
+    published_dates = [_parse_date(value) for value in schema_dates["datePublished"] + [meta_dates.get("article:published_time")]]
+    published_dates = [value for value in published_dates if value]
+    latest = max([_parse_date(item["date"]) for item in parsed_dates if _parse_date(item["date"])] or modified_dates or published_dates or [], default=None)
+
+    old_years = sorted({int(year) for year in YEAR_RE.findall(body) if int(year) <= today.year - 3})
+    stale_stat_count = 0
+    for sentence in re.split(r"(?<=[.!?])\s+", body):
+        if STAT_RE.search(sentence) and any(str(year) in sentence for year in old_years):
+            stale_stat_count += 1
+
+    mismatch = False
+    if modified_dates and published_dates and max(modified_dates) < max(published_dates):
+        mismatch = True
+
+    age_days = (today - latest).days if latest else None
+    score = 100
+    if latest is None:
+        score -= 35
+    elif age_days is not None:
+        score -= min(45, max(0, age_days - 365) // 30)
+    score -= min(25, stale_stat_count * 5)
+    score -= 15 if mismatch else 0
+
+    issues = []
+    if latest is None:
+        issues.append({"severity": "warning", "message": "No parseable published or modified date found."})
+    elif age_days and age_days > 730:
+        issues.append({"severity": "warning", "message": f"Latest visible freshness date is {age_days} days old."})
+    if stale_stat_count:
+        issues.append({"severity": "warning", "message": f"{stale_stat_count} statistic sentence(s) reference old years."})
+    if mismatch:
+        issues.append({"severity": "warning", "message": "dateModified appears older than datePublished."})
+
+    return {
+        "url": url or source,
+        "score": max(0, score),
+        "latest_date": latest.isoformat() if latest else None,
+        "age_days": age_days,
+        "dates": parsed_dates[:50],
+        "old_years": old_years,
+        "stale_stat_sentences": stale_stat_count,
+        "schema_date_mismatch": mismatch,
+        "issues": issues,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check published/modified dates, stale stats, and freshness mismatches.")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--today", help="Override current date as YYYY-MM-DD for deterministic tests")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    today = _parse_date(args.today) if args.today else None
+
+    result = check_freshness(args.source, args.timeout, today)
+    print(json.dumps(result, indent=2) if args.json else f"Score: {result['score']} Latest: {result['latest_date']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/generate_report.py
+++ b/.claude/skills/seo/scripts/generate_report.py
@@ -1,0 +1,1766 @@
+#!/usr/bin/env python3
+"""
+Generate an interactive HTML SEO report.
+
+Runs all analysis scripts and aggregates results into a single,
+self-contained interactive HTML file with a premium dashboard UI.
+
+Usage:
+    python generate_report.py https://example.com
+    python generate_report.py https://example.com --output my-report.html
+"""
+
+import argparse
+import html as html_lib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from urllib.parse import urlparse
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(SCRIPT_DIR)
+SCORING_CONFIG_PATH = os.path.join(ROOT_DIR, "resources", "config", "scoring.json")
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+DEFAULT_SCORING_CONFIG = {
+    "version": 1,
+    "overall": {"method": "weighted_average", "score_floor": 0, "score_ceiling": 100},
+    "categories": {
+        "security": {"weight": 8, "label": "Security Headers"},
+        "social": {"weight": 5, "label": "Social Meta"},
+        "robots": {"weight": 8, "label": "Robots and Crawlers"},
+        "broken_links": {"weight": 10, "label": "Broken Links"},
+        "internal_links": {"weight": 8, "label": "Internal Links"},
+        "redirects": {"weight": 3, "label": "Redirects"},
+        "llms_txt": {"weight": 5, "label": "AI Search"},
+        "pagespeed": {"weight": 13, "label": "Performance and Core Web Vitals"},
+        "onpage": {"weight": 10, "label": "On-Page SEO"},
+        "readability": {"weight": 8, "label": "Readability"},
+        "entity": {"weight": 5, "label": "Entity SEO"},
+        "link_profile": {"weight": 7, "label": "Link Profile"},
+        "hreflang": {"weight": 5, "label": "Hreflang"},
+        "duplicate_content": {"weight": 5, "label": "Content Uniqueness"},
+    },
+}
+
+
+def load_scoring_config(path: str = SCORING_CONFIG_PATH) -> dict:
+    """Load report scoring weights from resources/config/scoring.json."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return DEFAULT_SCORING_CONFIG
+
+    categories = config.get("categories")
+    if not isinstance(categories, dict):
+        return DEFAULT_SCORING_CONFIG
+    for details in categories.values():
+        if not isinstance(details, dict) or not isinstance(details.get("weight"), (int, float)):
+            return DEFAULT_SCORING_CONFIG
+    return config
+
+
+def get_scoring_weights(config: dict | None = None) -> dict:
+    """Return category weights from the scoring config."""
+    config = config or load_scoring_config()
+    return {
+        key: details["weight"]
+        for key, details in config.get("categories", {}).items()
+        if isinstance(details, dict) and isinstance(details.get("weight"), (int, float))
+    }
+
+
+def run_script(script_name: str, args: list, timeout: int = 120) -> dict:
+    """Run an analysis script and capture JSON output."""
+    script_path = os.path.join(SCRIPT_DIR, script_name)
+    if not os.path.exists(script_path):
+        return {"error": f"Script {script_name} not found"}
+
+    cmd = [sys.executable, script_path] + args + ["--json"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+        err_msg = result.stderr.strip() or f"Exit code {result.returncode}"
+        return {"error": f"[{script_name}] {err_msg}"}
+    except subprocess.TimeoutExpired:
+        return {"error": f"Script timed out after {timeout}s"}
+    except json.JSONDecodeError:
+        return {"error": "Invalid JSON output from script"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def fetch_page(url: str) -> str:
+    """Fetch page HTML to a temp file, return path."""
+    try:
+        html = safe_get(url, timeout=15).text
+        tmp = tempfile.NamedTemporaryFile(suffix=".html", delete=False, mode="w", encoding="utf-8")
+        tmp.write(html)
+        tmp.close()
+        return tmp.name
+    except Exception:
+        return ""
+
+
+def detect_environment(html_text: str, url: str) -> dict:
+    """Infer site environment/CMS/framework from source signals."""
+    lower = (html_text or "").lower()
+    domain = urlparse(url).netloc.lower()
+    scores = {}
+    reasons = {}
+
+    def hit(name: str, points: int, reason: str):
+        scores[name] = scores.get(name, 0) + points
+        reasons.setdefault(name, []).append(reason)
+
+    # Managed CMS signals
+    if any(s in lower for s in ("bloggerusercontent.com", "www.blogger.com", "data:blog.", "b:skin")):
+        hit("Blogger", 6, "Blogger template/assets detected")
+    if domain.endswith("blogspot.com"):
+        hit("Blogger", 4, "Blogspot domain detected")
+
+    if any(s in lower for s in ("wp-content/", "wp-includes/", "wp-json")):
+        hit("WordPress", 6, "WordPress core paths detected")
+    if re.search(r'generator[^>]+wordpress', lower):
+        hit("WordPress", 3, "WordPress generator meta detected")
+
+    if any(s in lower for s in ("cdn.shopify.com", "shopify.theme", "shopify-section")):
+        hit("Shopify", 6, "Shopify assets/theme markers detected")
+
+    if any(s in lower for s in ("wixstatic.com", "wix.com", "wixsite")):
+        hit("Wix", 6, "Wix assets detected")
+
+    if any(s in lower for s in ("webflow", "w-webflow")):
+        hit("Webflow", 5, "Webflow markers detected")
+
+    if any(s in lower for s in ("squarespace.com", "static1.squarespace")):
+        hit("Squarespace", 6, "Squarespace assets detected")
+
+    if re.search(r'generator[^>]+ghost', lower) or "ghost/" in lower:
+        hit("Ghost", 5, "Ghost generator/assets detected")
+
+    # Framework signals
+    if any(s in lower for s in ("/_next/", "__next_data__")):
+        hit("Next.js", 6, "Next.js runtime/build markers detected")
+    if any(s in lower for s in ("/_nuxt/", "__nuxt")):
+        hit("Nuxt", 6, "Nuxt runtime/build markers detected")
+
+    if not scores:
+        return {
+            "primary": "Unknown",
+            "runtime": "Unknown",
+            "confidence": "low",
+            "signals": ["No strong CMS/framework markers were found in HTML source."],
+            "alternatives": [],
+        }
+
+    ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    primary, top_score = ranked[0]
+    confidence = "high" if top_score >= 8 else "medium" if top_score >= 5 else "low"
+    runtime_map = {
+        "Blogger": "Managed CMS",
+        "WordPress": "Managed CMS",
+        "Shopify": "Managed CMS / Commerce",
+        "Wix": "Managed CMS",
+        "Webflow": "Managed CMS",
+        "Squarespace": "Managed CMS",
+        "Ghost": "Managed CMS",
+        "Next.js": "JavaScript Framework",
+        "Nuxt": "JavaScript Framework",
+    }
+    return {
+        "primary": primary,
+        "runtime": runtime_map.get(primary, "Unknown"),
+        "confidence": confidence,
+        "signals": reasons.get(primary, [])[:5],
+        "alternatives": [name for name, _ in ranked[1:3]],
+    }
+
+
+def _platform_hint(primary: str, area: str) -> str:
+    """Provide platform-specific implementation guidance."""
+    blogger = {
+        "metadata": "In Blogger, update Theme -> Edit HTML and add tags in the <head> section (title template, meta description, OG/Twitter tags).",
+        "heading": "In Blogger templates, keep exactly one content H1 per page (post title on posts, site headline on homepage).",
+        "headers": "Blogger cannot set most response headers directly. Add Cloudflare in front and configure Response Header Transform Rules.",
+        "llms": "Blogger cannot natively serve arbitrary root files. Serve /llms.txt via Cloudflare Workers/Pages or reverse-proxy route.",
+        "links": "Fix broken internal links in post content and navigation widgets; update outdated post URLs and labels.",
+        "performance": "Optimize Blogger theme widgets/scripts, compress hero/media assets, and defer non-critical third-party scripts.",
+    }
+    wordpress = {
+        "metadata": "Use your SEO plugin (Yoast/RankMath/AIOSEO) or theme templates to set title/meta and OG/Twitter tags.",
+        "heading": "Ensure one H1 in theme templates and avoid duplicate H1 in builders/widgets.",
+        "headers": "Set headers via server config (Nginx/Apache) or CDN edge rules.",
+        "llms": "Create /llms.txt at web root or route it through your web server.",
+        "links": "Fix links in menus, content blocks, and internal link plugin data.",
+        "performance": "Use caching, image optimization, script deferral, and CWV-focused plugin settings.",
+    }
+    nextjs = {
+        "metadata": "Use the Next.js Metadata API (`app/`) or `next/head` (`pages/`) for title/meta/OG/Twitter tags.",
+        "heading": "Set a single semantic H1 in each route component.",
+        "headers": "Set security headers in `next.config.js` `headers()` or at your edge/CDN.",
+        "llms": "Serve `/llms.txt` from `/public/llms.txt`.",
+        "links": "Fix links in route components and content source files; validate with link checks in CI.",
+        "performance": "Use `next/image`, dynamic imports, script strategy controls, and reduce main-thread JS.",
+    }
+    fallback = {
+        "metadata": "Update page templates to set complete title/meta/OG/Twitter tags.",
+        "heading": "Ensure each page has exactly one descriptive H1 aligned to intent.",
+        "headers": "Set missing security headers at web server or CDN layer.",
+        "llms": "Add `/llms.txt` at site root with concise site description and key URLs.",
+        "links": "Repair or remove broken internal links and refresh outdated navigation targets.",
+        "performance": "Compress critical assets, reduce render-blocking scripts, and optimize CWV bottlenecks.",
+    }
+
+    platform_map = {
+        "Blogger": blogger,
+        "WordPress": wordpress,
+        "Shopify": fallback,
+        "Wix": fallback,
+        "Webflow": fallback,
+        "Squarespace": fallback,
+        "Ghost": fallback,
+        "Next.js": nextjs,
+        "Nuxt": nextjs,
+    }
+    return platform_map.get(primary, fallback).get(area, fallback.get(area, ""))
+
+
+def build_environment_fixes(data: dict) -> list:
+    """Build actionable issue fixes tailored to detected environment."""
+    env = data.get("environment", {})
+    platform = env.get("primary", "Unknown")
+    fixes = []
+
+    def add(severity: str, title: str, reason: str, fix: str):
+        fixes.append({
+            "severity": severity,
+            "title": title,
+            "reason": reason,
+            "fix": fix,
+        })
+
+    op = data["sections"].get("onpage", {})
+    sec = data["sections"].get("security", {})
+    soc = data["sections"].get("social", {})
+    llm = data["sections"].get("llms_txt", {})
+    bl = data["sections"].get("broken_links", {})
+    rd = data["sections"].get("readability", {})
+    psi = data["sections"].get("pagespeed", {})
+
+    title = (op.get("title") or "").strip()
+    meta = (op.get("meta_description") or "").strip()
+    h1s = op.get("h1", []) if isinstance(op.get("h1"), list) else []
+
+    if not h1s:
+        add(
+            "critical",
+            "Missing H1 on page",
+            "No primary content heading was detected, which weakens topical clarity.",
+            _platform_hint(platform, "heading"),
+        )
+
+    if not meta or len(meta) < 110 or len(meta) > 170:
+        add(
+            "warning",
+            "Meta description is missing or out of range",
+            "This can reduce SERP CTR and snippet quality.",
+            _platform_hint(platform, "metadata"),
+        )
+
+    if not title or len(title) < 30 or len(title) > 65:
+        add(
+            "warning",
+            "Title tag needs optimization",
+            "Title length/content is likely suboptimal for rankings and click-through.",
+            _platform_hint(platform, "metadata"),
+        )
+
+    missing_headers = sec.get("headers_missing", {})
+    if missing_headers:
+        add(
+            "critical" if len(missing_headers) >= 4 else "warning",
+            f"{len(missing_headers)} security headers missing",
+            "Missing headers reduce trust and can expose the site to browser/security risks.",
+            _platform_hint(platform, "headers"),
+        )
+
+    if not llm.get("exists"):
+        add(
+            "warning",
+            "No llms.txt found",
+            "AI crawlers and assistants have no curated machine-readable guidance for key pages.",
+            _platform_hint(platform, "llms"),
+        )
+
+    broken_count = bl.get("summary", {}).get("broken", 0)
+    if broken_count > 0:
+        add(
+            "critical" if broken_count >= 5 else "warning",
+            f"{broken_count} broken links detected",
+            "Broken internal links hurt crawl flow and user trust.",
+            _platform_hint(platform, "links"),
+        )
+
+    og_missing = soc.get("og_missing", [])
+    tw_missing = soc.get("twitter_missing", [])
+    if og_missing or tw_missing:
+        add(
+            "warning",
+            "Social meta tags are incomplete",
+            "Missing OG/Twitter tags weakens social previews and share quality.",
+            _platform_hint(platform, "metadata"),
+        )
+
+    if psi.get("error"):
+        add(
+            "info",
+            "Performance measurement incomplete",
+            "PageSpeed API returned an error, so CWV recommendations are less reliable.",
+            "Set `PAGESPEED_API_KEY` in your environment or `.env` file (see `.env.example`), then rerun. The CLI also accepts `--api-key`. Prioritize LCP/INP/CLS fixes from that output.",
+        )
+
+    if rd.get("flesch_reading_ease", 100) < 40 or rd.get("avg_sentence_length", 0) > 25:
+        add(
+            "warning",
+            "Content readability is difficult",
+            "Long, complex text can reduce engagement and comprehension.",
+            "Rewrite key sections with shorter sentences (15-20 words), shorter paragraphs (2-4 sentences), and clearer subheadings.",
+        )
+
+    if not fixes:
+        add(
+            "pass",
+            "No major implementation blockers detected",
+            "Core checks look healthy for current scope.",
+            "Continue monitoring with regular crawls and keep metadata/security/performance baselines in CI.",
+        )
+
+    return fixes
+
+
+def render_environment_fixes(fixes: list) -> str:
+    """Render environment-specific fixes for HTML output."""
+    if not fixes:
+        return '<p style="color:var(--green)">✅ No environment-specific fixes needed.</p>'
+
+    severity_order = {"critical": 0, "warning": 1, "info": 2, "pass": 3}
+    html = ""
+    for item in sorted(fixes, key=lambda x: severity_order.get(x.get("severity", "info"), 9)):
+        sev = item.get("severity", "info")
+        badge = sev.upper()
+        title = html_lib.escape(item.get("title", ""), quote=True)
+        reason = html_lib.escape(item.get("reason", ""), quote=True)
+        fix = html_lib.escape(item.get("fix", ""), quote=True)
+        html += (
+            f'<div class="issue-item {sev if sev in ("critical","warning","info") else "info"}">'
+            f'<span class="issue-badge">{badge}</span>'
+            f'<div><strong>{title}</strong><br>'
+            f'<span style="color:var(--text-muted)">{reason}</span><br>'
+            f'<span><strong>Fix:</strong> {fix}</span></div></div>'
+        )
+    return html
+
+
+def collect_data(url: str) -> dict:
+    """Run all analysis scripts and collect results."""
+    print(f"🔍 Analyzing {url}...")
+    data = {
+        "url": url,
+        "domain": urlparse(url).netloc,
+        "timestamp": datetime.now().isoformat(),
+        "sections": {},
+    }
+
+    # Fetch page for parse_html and readability
+    print("  ⏳ Fetching page HTML...")
+    html_path = fetch_page(url)
+    page_html = ""
+    if html_path and os.path.exists(html_path):
+        try:
+            with open(html_path, "r", encoding="utf-8", errors="ignore") as f:
+                page_html = f.read()
+        except OSError:
+            page_html = ""
+    data["environment"] = detect_environment(page_html, url)
+
+    analyses = [
+        ("robots", "robots_checker.py", [url]),
+        ("security", "security_headers.py", [url]),
+        ("social", "social_meta.py", [url]),
+        ("redirects", "redirect_checker.py", [url]),
+        ("llms_txt", "llms_txt_checker.py", [url]),
+        ("broken_links", "broken_links.py", [url, "--workers", "5", "--timeout", "8"]),
+        ("internal_links", "internal_links.py", [url, "--depth", "1", "--max-pages", "15"]),
+        ("pagespeed", "pagespeed.py", [url, "--strategy", "mobile"]),
+        # New analysis scripts (supplementary — failures don't block report)
+        ("entity", "entity_checker.py", [url]),
+        ("link_profile", "link_profile.py", [url, "--max-pages", "20"]),
+        ("hreflang", "hreflang_checker.py", [url]),
+        ("duplicate_content", "duplicate_content.py", [url]),
+    ]
+
+    # Add parse_html and readability if page was fetched
+    if html_path:
+        analyses.append(("onpage", "parse_html.py", [html_path, "--url", url]))
+        analyses.append(("readability", "readability.py", [html_path]))
+        analyses.append(("article", "article_seo.py", [url]))
+
+    for name, script, args in analyses:
+        print(f"  ⏳ Running {script}...")
+        start = time.time()
+        result = run_script(script, args)
+        elapsed = round(time.time() - start, 1)
+        data["sections"][name] = result
+        status = "⚠️ error" if "error" in result and result.get("error") else "✅"
+        print(f"  {status} {script} ({elapsed}s)")
+
+    # Cleanup temp file
+    if html_path and os.path.exists(html_path):
+        os.unlink(html_path)
+
+    data["environment_fixes"] = build_environment_fixes(data)
+
+    return data
+
+
+def calculate_overall_score(data: dict, scoring_config: dict | None = None) -> dict:
+    """Calculate overall SEO score from all analyses."""
+    scores = {}
+    scoring_config = scoring_config or load_scoring_config()
+    weights = get_scoring_weights(scoring_config)
+
+    # Security score
+    sec = data["sections"].get("security", {})
+    scores["security"] = sec.get("score", 0)
+
+    # Social meta score
+    soc = data["sections"].get("social", {})
+    scores["social"] = soc.get("score", 0)
+
+    # Robots score
+    rob = data["sections"].get("robots", {})
+    if rob.get("status") == 200:
+        base = 60
+        if rob.get("sitemaps"):
+            base += 20
+        ai_managed = sum(1 for s in rob.get("ai_crawler_status", {}).values()
+                         if "not managed" not in s)
+        base += min(20, ai_managed * 2)
+        scores["robots"] = min(100, base)
+    elif rob.get("status") == 404:
+        scores["robots"] = 20
+    else:
+        scores["robots"] = 0
+
+    # Article score (informational, not weighted heavily)
+    art = data["sections"].get("article", {})
+    if art and not art.get("error"):
+        art_score = 50
+        if art.get("target_keyword"): art_score += 25
+        if art.get("lsi_keywords"): art_score += 25
+        scores["article"] = min(100, art_score)
+    else:
+        scores["article"] = 0
+
+    # Broken links score
+    bl = data["sections"].get("broken_links", {})
+    summary = bl.get("summary", {})
+    total = summary.get("total", 1) or 1
+    broken = summary.get("broken", 0)
+    scores["broken_links"] = max(0, 100 - int((broken / total) * 300))
+
+    # Internal links score
+    il = data["sections"].get("internal_links", {})
+    il_issues = len(il.get("issues", []))
+    scores["internal_links"] = max(0, 100 - il_issues * 20)
+
+    # Redirects score
+    red = data["sections"].get("redirects", {})
+    red_issues = len(red.get("issues", []))
+    scores["redirects"] = max(0, 100 - red_issues * 25)
+
+    # llms.txt score
+    llm = data["sections"].get("llms_txt", {})
+    if llm.get("exists"):
+        scores["llms_txt"] = llm.get("quality", {}).get("score", 0)
+    else:
+        scores["llms_txt"] = 0
+
+    # PageSpeed score
+    psi = data["sections"].get("pagespeed", {})
+    scores["pagespeed"] = psi.get("performance_score", 0)
+
+    # On-page score
+    op = data["sections"].get("onpage", {})
+    if op and not op.get("error"):
+        op_score = 50
+        if op.get("title"): op_score += 15
+        if op.get("meta_description"): op_score += 15
+        if op.get("h1"): op_score += 10
+        if op.get("canonical"): op_score += 10
+        scores["onpage"] = min(100, op_score)
+    else:
+        scores["onpage"] = 0
+
+    # Readability score
+    rd = data["sections"].get("readability", {})
+    flesch = rd.get("flesch_reading_ease", 0)
+    if flesch >= 60:
+        scores["readability"] = 100
+    elif flesch >= 30:
+        scores["readability"] = 50 + int((flesch - 30) * (50 / 30))
+    else:
+        scores["readability"] = max(0, int(flesch * (50 / 30)))
+
+    # Entity SEO score
+    ent = data["sections"].get("entity", {})
+    if ent and not ent.get("error"):
+        sameas = ent.get("sameas_analysis", {})
+        found = sameas.get("total_found", 0)
+        missing = sameas.get("total_missing_critical", 4)
+        has_wikidata = 1 if ent.get("wikidata", {}).get("found") else 0
+        has_wikipedia = 1 if ent.get("wikipedia", {}).get("found") else 0
+        ent_score = min(100, found * 15 + has_wikidata * 25 + has_wikipedia * 25)
+        issues_count = len(ent.get("issues", []))
+        ent_score = max(0, ent_score - issues_count * 10)
+        scores["entity"] = ent_score
+    else:
+        scores["entity"] = 0
+
+    # Link profile score
+    lp = data["sections"].get("link_profile", {})
+    if lp and not lp.get("error"):
+        avg_links = lp.get("avg_internal_links_per_page", 0)
+        orphans = lp.get("orphan_pages", {}).get("count", 0)
+        dead_ends = lp.get("dead_end_pages", {}).get("count", 0)
+        lp_score = 70
+        if avg_links >= 5: lp_score += 15
+        elif avg_links >= 3: lp_score += 5
+        else: lp_score -= 15
+        lp_score -= min(30, orphans * 5)
+        lp_score -= min(20, dead_ends * 3)
+        scores["link_profile"] = max(0, min(100, lp_score))
+    else:
+        scores["link_profile"] = 0
+
+    # Hreflang score (skip weight if not applicable)
+    hf = data["sections"].get("hreflang", {})
+    if hf and not hf.get("error"):
+        if hf.get("hreflang_tags_found", 0) > 0:
+            summary = hf.get("summary", {})
+            hf_score = 100 - summary.get("critical", 0) * 30 - summary.get("high", 0) * 15 - summary.get("medium", 0) * 5
+            scores["hreflang"] = max(0, min(100, hf_score))
+        else:
+            # No hreflang = single language site, skip from weighting
+            scores["hreflang"] = None
+    else:
+        scores["hreflang"] = None
+
+    # Duplicate content score
+    dc = data["sections"].get("duplicate_content", {})
+    if dc and not dc.get("error"):
+        dupes = len(dc.get("near_duplicates", []))
+        thin = len(dc.get("thin_pages", []))
+        dc_score = 100 - dupes * 20 - thin * 10
+        scores["duplicate_content"] = max(0, min(100, dc_score))
+    else:
+        scores["duplicate_content"] = 0
+
+    # Weighted average (only scored categories)
+    total_weight = 0
+    weighted_sum = 0
+    for k, w in weights.items():
+        if k in scores:
+            val = scores.get(k)
+            if val is not None:
+                total_weight += w
+                weighted_sum += val * w
+    
+    overall = round(weighted_sum / total_weight) if total_weight else 0
+
+    # Coerce any None scores to 0 to prevent UI crashes
+    for k in list(scores.keys()):
+        if scores[k] is None:
+            scores[k] = 0
+
+    return {
+        "overall": overall,
+        "categories": scores,
+        "weights": weights,
+        "scoring_version": scoring_config.get("version"),
+    }
+
+
+def render_recommendations(section_data: dict) -> str:
+    """Render recommendations from a section's JSON data."""
+    recs = section_data.get("recommendations", section_data.get("suggestions", []))
+    if isinstance(recs, dict):
+        items = [f"{k}: {v}" for k, v in recs.items()]
+    elif isinstance(recs, list):
+        items = recs
+    else:
+        items = []
+    # Also check opportunities from pagespeed
+    opps = section_data.get("opportunities", [])
+    if isinstance(opps, list):
+        items.extend(opps)
+
+    # Render structured issues (used by entity_checker, hreflang_checker, etc.)
+    issues = section_data.get("issues", [])
+    issues_html = ""
+    if isinstance(issues, list) and issues:
+        severity_map = {"critical": "critical", "high": "critical", "warning": "warning", "medium": "warning", "info": "info", "low": "info"}
+        for issue in issues[:15]:
+            if isinstance(issue, dict):
+                sev = severity_map.get(issue.get("severity", "info").lower(), "info")
+                badge = html_lib.escape(issue.get("severity", "INFO").upper(), quote=True)
+                finding = html_lib.escape(str(issue.get("finding", "")), quote=True)
+                fix = html_lib.escape(str(issue.get("fix", "")), quote=True)
+                issues_html += (
+                    f'<div class="issue-item {sev}">'
+                    f'<span class="issue-badge">{badge}</span>'
+                    f'<div><strong>{finding}</strong>'
+                    f'{f"<br><span style=&quot;color:var(--text-muted)&quot;>Fix: {fix}</span>" if fix else ""}'
+                    f'</div></div>'
+                )
+            elif isinstance(issue, str):
+                items.append(issue)
+
+    html = ""
+    if issues_html:
+        html += f'<div style="margin-top:16px"><h3 style="font-size:0.95rem;margin-bottom:8px;">🔍 Issues Found</h3>{issues_html}</div>'
+    if items:
+        html += '<div style="margin-top:16px"><h3 style="font-size:0.95rem;margin-bottom:8px;">💡 Recommendations</h3>'
+        for item in items[:15]:
+            item_str = str(item) if not isinstance(item, str) else item
+            html += f'<div class="issue-item info"><span class="issue-badge">FIX</span> {item_str}</div>'
+        html += '</div>'
+    return html
+
+
+def render_readability_rewrites(readability_data: dict) -> str:
+    """Render concrete sentence replacements for readability fixes."""
+    rewrites = readability_data.get("sentence_rewrites", [])
+    if not rewrites:
+        return ""
+
+    html = (
+        '<div style="margin-top:16px">'
+        '<h3 style="font-size:0.95rem;margin-bottom:8px;">✍️ What To Replace (Before/After)</h3>'
+    )
+    for item in rewrites[:5]:
+        current = html_lib.escape(str(item.get("current", "")), quote=True)
+        suggested = html_lib.escape(str(item.get("suggested", "")), quote=True)
+        wc_raw = item.get("current_word_count", "")
+        wc_label = f"{wc_raw}w" if isinstance(wc_raw, (int, float)) else str(wc_raw)
+        wc = html_lib.escape(wc_label, quote=True)
+        html += (
+            '<div class="issue-item warning">'
+            f'<span class="issue-badge">SENTENCE ({wc})</span>'
+            '<div>'
+            f'<div><strong>Current:</strong> {current}</div>'
+            f'<div style="margin-top:6px;"><strong>Replace with:</strong> {suggested}</div>'
+            '</div>'
+            '</div>'
+        )
+    html += "</div>"
+    return html
+
+
+def render_all_recommendations(data: dict) -> str:
+    """Render all recommendations from all sections."""
+    section_names = {
+        "security": "🔒 Security", "social": "📱 Social Meta", "robots": "🤖 Robots",
+        "broken_links": "🔗 Links", "internal_links": "🕸️ Internal Links",
+        "redirects": "↪️ Redirects", "llms_txt": "🧠 AI Search",
+        "pagespeed": "⚡ Performance", "onpage": "📝 On-Page", "readability": "📖 Readability",
+        "article": "📄 Article SEO", "entity": "🏛️ Entity SEO",
+        "link_profile": "🔗 Link Profile", "hreflang": "🌍 Hreflang",
+        "duplicate_content": "📋 Content Uniqueness",
+    }
+    html = ""
+    env_fixes = data.get("environment_fixes", [])
+    if env_fixes:
+        html += '<h3 style="font-size:0.95rem;margin:16px 0 8px;">🛠️ Environment-Specific Fixes</h3>'
+        for item in env_fixes[:8]:
+            title = html_lib.escape(item.get("title", ""), quote=True)
+            fix = html_lib.escape(item.get("fix", ""), quote=True)
+            html += f'<div class="issue-item info"><span class="issue-badge">FIX</span> <strong>{title}</strong>: {fix}</div>'
+
+    for key, label in section_names.items():
+        section = data["sections"].get(key, {})
+        recs = section.get("recommendations", section.get("suggestions", []))
+        if isinstance(recs, dict):
+            items = [f"{k}: {v}" for k, v in recs.items()]
+        elif isinstance(recs, list):
+            items = recs
+        else:
+            items = []
+        opps = section.get("opportunities", [])
+        if isinstance(opps, list):
+            items.extend(opps)
+        if key == "readability":
+            for rw in section.get("sentence_rewrites", [])[:3]:
+                cur = html_lib.escape(str(rw.get("current", ""))[:180], quote=True)
+                sug = html_lib.escape(str(rw.get("suggested", ""))[:180], quote=True)
+                items.append(f"Rewrite: {cur} → {sug}")
+        if items:
+            html += f'<h3 style="font-size:0.95rem;margin:16px 0 8px;">{label}</h3>'
+            for item in items[:10]:
+                html += f'<div class="issue-item info"><span class="issue-badge">FIX</span> {item}</div>'
+    return html if html else '<p style="color:var(--green)">✅ No recommendations — everything looks good!</p>'
+
+
+def _markdown_cell(value) -> str:
+    """Escape a value for use in a compact Markdown table cell."""
+    text = str(value or "").replace("\n", " ").replace("|", "\\|").strip()
+    return re.sub(r"\s+", " ", text)
+
+
+def _severity_rank(severity: str) -> int:
+    return {"critical": 0, "high": 0, "warning": 1, "medium": 1, "info": 2, "low": 2, "pass": 3}.get(
+        (severity or "info").lower(), 2
+    )
+
+
+def _severity_label(severity: str) -> str:
+    normalized = (severity or "info").lower()
+    if normalized in ("critical", "high"):
+        return "Critical"
+    if normalized in ("warning", "medium"):
+        return "Warning"
+    if normalized in ("pass",):
+        return "Pass"
+    return "Info"
+
+
+def collect_report_findings(data: dict) -> list[dict]:
+    """Collect findings from section outputs, script errors, and environment fixes."""
+    findings: list[dict] = []
+
+    for section_name, section_data in data.get("sections", {}).items():
+        if not isinstance(section_data, dict):
+            continue
+
+        if section_data.get("error"):
+            findings.append({
+                "severity": "info",
+                "area": section_name,
+                "finding": f"{section_name} measurement incomplete",
+                "evidence": section_data.get("error"),
+                "fix": "Rerun this check after resolving the environment/API/network limitation.",
+            })
+
+        for issue in section_data.get("issues", []) or []:
+            if isinstance(issue, dict):
+                findings.append({
+                    "severity": _severity_label(issue.get("severity", "info")),
+                    "area": issue.get("area") or section_name,
+                    "finding": issue.get("finding") or issue.get("title") or str(issue),
+                    "evidence": issue.get("evidence") or issue.get("reason") or "",
+                    "fix": issue.get("fix") or issue.get("recommendation") or "",
+                })
+            elif isinstance(issue, str):
+                severity = "critical" if "🔴" in issue else "warning" if "⚠️" in issue else "info"
+                findings.append({
+                    "severity": _severity_label(severity),
+                    "area": section_name,
+                    "finding": issue,
+                    "evidence": "",
+                    "fix": "",
+                })
+
+    for item in data.get("environment_fixes", []) or []:
+        findings.append({
+            "severity": _severity_label(item.get("severity", "info")),
+            "area": "environment",
+            "finding": item.get("title", ""),
+            "evidence": item.get("reason", ""),
+            "fix": item.get("fix", ""),
+        })
+
+    return sorted(findings, key=lambda item: (_severity_rank(item.get("severity", "info")), item.get("area", "")))
+
+
+def render_markdown_report(data: dict, scores: dict, scoring_config: dict | None = None) -> str:
+    """Render the required detailed Markdown audit artifact."""
+    scoring_config = scoring_config or load_scoring_config()
+    labels = {
+        key: details.get("label", key.replace("_", " ").title())
+        for key, details in scoring_config.get("categories", {}).items()
+        if isinstance(details, dict)
+    }
+    findings = collect_report_findings(data)
+    error_count = sum(1 for section in data.get("sections", {}).values() if isinstance(section, dict) and section.get("error"))
+    score_confidence = "Low" if error_count >= 4 else "Medium" if error_count else "High"
+
+    lines = [
+        "# Full Audit Report",
+        "",
+        f"- URL: `{data.get('url', '')}`",
+        f"- Generated: `{data.get('timestamp', '')}`",
+        f"- Overall score: `{scores.get('overall', 0)}/100`",
+        f"- Score confidence: `{score_confidence}`",
+        f"- Scoring version: `{scores.get('scoring_version', scoring_config.get('version', 'unknown'))}`",
+        "",
+        "## Score Card",
+        "",
+        "| Category | Weight | Score |",
+        "| --- | ---: | ---: |",
+    ]
+
+    weights = scores.get("weights", {})
+    for key, weight in weights.items():
+        label = labels.get(key, key.replace("_", " ").title())
+        score = scores.get("categories", {}).get(key, 0)
+        lines.append(f"| {_markdown_cell(label)} | {weight} | {score} |")
+
+    lines.extend(["", "## Findings", ""])
+    if findings:
+        lines.extend(["| Severity | Area | Finding | Evidence | Fix |", "| --- | --- | --- | --- | --- |"])
+        for item in findings[:50]:
+            lines.append(
+                "| {severity} | {area} | {finding} | {evidence} | {fix} |".format(
+                    severity=_markdown_cell(item.get("severity")),
+                    area=_markdown_cell(item.get("area")),
+                    finding=_markdown_cell(item.get("finding")),
+                    evidence=_markdown_cell(item.get("evidence")),
+                    fix=_markdown_cell(item.get("fix")),
+                )
+            )
+    else:
+        lines.append("No confirmed findings were produced by the completed checks.")
+
+    lines.extend(["", "## Measurement Notes", ""])
+    if error_count:
+        lines.append(f"{error_count} checks returned errors or incomplete measurements; treat affected scores as directional.")
+    else:
+        lines.append("All configured checks completed without script-level errors.")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_action_plan(data: dict, scores: dict) -> str:
+    """Render the required prioritized Markdown action-plan artifact."""
+    findings = collect_report_findings(data)
+    actionable = [
+        item for item in findings
+        if item.get("fix") and item.get("severity") in ("Critical", "Warning", "Info")
+    ]
+    pagespeed = data.get("sections", {}).get("pagespeed", {})
+    for opp in pagespeed.get("opportunities", []) if isinstance(pagespeed, dict) else []:
+        actionable.append({
+            "severity": "Warning",
+            "area": "pagespeed",
+            "finding": opp.get("title", "PageSpeed opportunity"),
+            "evidence": f"Estimated savings: {opp.get('savings_ms', 0)}ms",
+            "fix": opp.get("description") or "Apply the PageSpeed recommendation and rerun the audit.",
+        })
+
+    actionable = sorted(actionable, key=lambda item: (_severity_rank(item.get("severity")), item.get("area", "")))
+
+    lines = [
+        "# Action Plan",
+        "",
+        f"- URL: `{data.get('url', '')}`",
+        f"- Overall score: `{scores.get('overall', 0)}/100`",
+        "",
+        "## Priority Fixes",
+        "",
+    ]
+
+    if not actionable:
+        lines.append("No prioritized fixes were produced by the completed checks.")
+        return "\n".join(lines) + "\n"
+
+    for idx, item in enumerate(actionable[:20], start=1):
+        lines.extend([
+            f"{idx}. **{_markdown_cell(item.get('finding'))}**",
+            f"   - Priority: `{_markdown_cell(item.get('severity'))}`",
+            f"   - Area: `{_markdown_cell(item.get('area'))}`",
+            f"   - Evidence: {_markdown_cell(item.get('evidence')) or 'See audit output.'}",
+            f"   - Fix: {_markdown_cell(item.get('fix'))}",
+        ])
+
+    return "\n".join(lines) + "\n"
+
+
+def write_text_output(path: str, content: str) -> str:
+    """Write a text artifact and return its absolute path."""
+    output_dir = os.path.dirname(path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+    return os.path.abspath(path)
+
+
+def generate_html(data: dict, scores: dict) -> str:
+    """Generate the interactive HTML report."""
+    domain = data["domain"]
+    url = data["url"]
+    timestamp = data["timestamp"]
+    overall = scores["overall"]
+
+    # Determine overall grade
+    if overall >= 90:
+        grade, grade_color = "A+", "#22c55e"
+    elif overall >= 80:
+        grade, grade_color = "A", "#22c55e"
+    elif overall >= 70:
+        grade, grade_color = "B", "#eab308"
+    elif overall >= 60:
+        grade, grade_color = "C", "#f97316"
+    elif overall >= 50:
+        grade, grade_color = "D", "#ef4444"
+    else:
+        grade, grade_color = "F", "#dc2626"
+
+    # Collect all issues
+    all_issues = []
+    for section_name, section_data in data["sections"].items():
+        issues = section_data.get("issues", [])
+        for issue in issues:
+            if isinstance(issue, dict):
+                # Structured issue from entity_checker, hreflang_checker, etc.
+                sev_raw = issue.get("severity", "info").lower()
+                severity_map = {"critical": "critical", "high": "critical", "warning": "warning", "medium": "warning", "info": "info", "low": "info"}
+                severity = severity_map.get(sev_raw, "info")
+                text = f"{issue.get('finding', '')} — Fix: {issue.get('fix', '')}" if issue.get('fix') else issue.get('finding', str(issue))
+                all_issues.append({"text": text, "severity": severity, "section": section_name})
+            elif isinstance(issue, str):
+                severity = "critical" if "🔴" in issue else "warning" if "⚠️" in issue else "info"
+                all_issues.append({"text": issue, "severity": severity, "section": section_name})
+
+    critical_count = sum(1 for i in all_issues if i["severity"] == "critical")
+    warning_count = sum(1 for i in all_issues if i["severity"] == "warning")
+    pass_count = sum(1 for i in all_issues if i["severity"] == "info")
+
+    # Section data extraction
+    sec = data["sections"].get("security", {})
+    soc = data["sections"].get("social", {})
+    rob = data["sections"].get("robots", {})
+    bl = data["sections"].get("broken_links", {})
+    il = data["sections"].get("internal_links", {})
+    red = data["sections"].get("redirects", {})
+    llm = data["sections"].get("llms_txt", {})
+    psi = data["sections"].get("pagespeed", {})
+    op = data["sections"].get("onpage", {})
+    rd = data["sections"].get("readability", {})
+    art = data["sections"].get("article", {})
+    ent = data["sections"].get("entity", {})
+    lp = data["sections"].get("link_profile", {})
+    hf = data["sections"].get("hreflang", {})
+    dc = data["sections"].get("duplicate_content", {})
+    env = data.get("environment", {})
+    env_fixes = data.get("environment_fixes", [])
+
+    env_primary = html_lib.escape(env.get("primary", "Unknown"), quote=True)
+    env_runtime = html_lib.escape(env.get("runtime", "Unknown"), quote=True)
+    env_confidence = html_lib.escape(env.get("confidence", "low").upper(), quote=True)
+    env_alts = [html_lib.escape(x, quote=True) for x in env.get("alternatives", [])]
+    env_signals_html = "".join(
+        f'<li class="mono" style="margin:4px 0;">{html_lib.escape(sig, quote=True)}</li>'
+        for sig in env.get("signals", [])
+    ) or '<li style="color:var(--text-muted)">No strong platform markers found.</li>'
+    env_fixes_html = render_environment_fixes(env_fixes)
+
+    # Build issues HTML
+    issues_html = ""
+    for issue in sorted(all_issues, key=lambda x: {"critical": 0, "warning": 1, "info": 2}[x["severity"]]):
+        badge_class = issue["severity"]
+        issues_html += f'<div class="issue-item {badge_class}"><span class="issue-badge">{badge_class.upper()}</span> {issue["text"]}</div>\n'
+
+    # Build category cards
+    category_labels = {
+        "security": ("🔒", "Security Headers"),
+        "social": ("📱", "Social Meta"),
+        "robots": ("🤖", "Robots & Crawlers"),
+        "broken_links": ("🔗", "Broken Links"),
+        "internal_links": ("🕸️", "Internal Links"),
+        "redirects": ("↪️", "Redirects"),
+        "llms_txt": ("🧠", "AI Search (llms.txt)"),
+        "pagespeed": ("⚡", "Performance (CWV)"),
+        "onpage": ("📝", "On-Page SEO"),
+        "readability": ("📖", "Readability"),
+        "article": ("📄", "Article Extractor"),
+        "entity": ("🏛️", "Entity SEO"),
+        "link_profile": ("🔗", "Link Profile"),
+        "hreflang": ("🌍", "Hreflang"),
+        "duplicate_content": ("📋", "Content Uniqueness"),
+    }
+
+    category_cards = ""
+    for key, (icon, label) in category_labels.items():
+        score = scores["categories"].get(key, 0)
+        if score is None:
+            score = 0
+        if score >= 80:
+            ring_color = "#22c55e"
+        elif score >= 50:
+            ring_color = "#eab308"
+        else:
+            ring_color = "#ef4444"
+        dash = round(score * 2.51327, 1)  # circumference = 251.327
+        category_cards += f'''
+        <div class="category-card" onclick="scrollToSection('{key}')">
+            <svg class="ring" viewBox="0 0 90 90">
+                <circle cx="45" cy="45" r="40" fill="none" stroke="var(--card-border)" stroke-width="6"/>
+                <circle cx="45" cy="45" r="40" fill="none" stroke="{ring_color}" stroke-width="6"
+                    stroke-dasharray="{dash} 251.327" stroke-linecap="round"
+                    transform="rotate(-90 45 45)" class="ring-progress"/>
+            </svg>
+            <div class="ring-label">{score}</div>
+            <div class="category-icon">{icon}</div>
+            <div class="category-name">{label}</div>
+        </div>'''
+
+    # Security details
+    security_rows = ""
+    for header, value in sec.get("headers_present", {}).items():
+        security_rows += f'<tr><td>{header}</td><td><span class="badge pass">Present</span></td><td class="mono">{value[:60]}</td></tr>'
+    for header, desc in sec.get("headers_missing", {}).items():
+        security_rows += f'<tr><td>{header}</td><td><span class="badge critical">Missing</span></td><td>{desc}</td></tr>'
+
+    # Social meta details
+    social_rows = ""
+    og = soc.get("og_tags", {})
+    tw = soc.get("twitter_tags", {})
+    for tag in ["og:title", "og:description", "og:image", "og:url", "og:type", "og:site_name"]:
+        val = og.get(tag, "")
+        status = '<span class="badge pass">✅</span>' if val else '<span class="badge critical">Missing</span>'
+        social_rows += f'<tr><td>{tag}</td><td>{status}</td><td>{val[:60] if val else "—"}</td></tr>'
+    for tag in ["twitter:card", "twitter:title", "twitter:description", "twitter:image", "twitter:site"]:
+        val = tw.get(tag, "")
+        status = '<span class="badge pass">✅</span>' if val else '<span class="badge warning">Missing</span>'
+        social_rows += f'<tr><td>{tag}</td><td>{status}</td><td>{val[:60] if val else "—"}</td></tr>'
+
+    # AI Crawlers details
+    ai_rows = ""
+    for crawler, status in rob.get("ai_crawler_status", {}).items():
+        if "blocked" in status:
+            badge = '<span class="badge pass">Blocked</span>'
+        elif "not managed" in status:
+            badge = '<span class="badge warning">Unmanaged</span>'
+        else:
+            badge = '<span class="badge info">Info</span>'
+        ai_rows += f'<tr><td>{crawler}</td><td>{badge}</td><td>{status}</td></tr>'
+
+    # Broken links details
+    broken_rows = ""
+    for link in bl.get("broken", [])[:20]:
+        status = link.get("status") or link.get("error", "?")
+        loc = "Internal" if link.get("is_internal") else "External"
+        broken_rows += f'<tr><td><span class="badge {"critical" if link.get("is_internal") else "warning"}">{loc}</span></td><td class="mono">{status}</td><td class="link-url">{link["url"][:80]}</td><td>{link.get("anchor_text", "")[:40]}</td></tr>'
+
+    bl_summary = bl.get("summary", {})
+    bl_total = bl_summary.get("total", 0)
+    bl_healthy = bl_summary.get("healthy", 0)
+    bl_broken = bl_summary.get("broken", 0)
+
+    # Internal links details
+    orphan_rows = ""
+    for orphan in il.get("orphan_candidates", [])[:15]:
+        orphan_rows += f'<tr><td class="link-url">{orphan["url"][:80]}</td><td>{orphan["incoming_links"]}</td></tr>'
+
+    il_pages = il.get("pages_crawled", 0)
+    il_total = il.get("total_internal_links", 0)
+    il_dist = il.get("link_distribution", {})
+
+    # Redirect details
+    redirect_rows = ""
+    for hop in red.get("chain", []):
+        status = hop.get("status", "?")
+        time_ms = hop.get("time_ms", 0)
+        if hop.get("final"):
+            icon_c = "pass" if 200 <= status < 300 else "critical"
+            redirect_rows += f'<tr><td>{hop["step"]}</td><td><span class="badge {icon_c}">{status}</span></td><td class="link-url">{hop["url"][:80]}</td><td>{time_ms}ms</td><td>FINAL</td></tr>'
+        else:
+            redirect_rows += f'<tr><td>{hop["step"]}</td><td><span class="badge warning">{status}</span></td><td class="link-url">{hop["url"][:80]}</td><td>{time_ms}ms</td><td>{hop.get("redirect_type", "")}</td></tr>'
+
+    # Anchor text chart data
+    anchor_data = il.get("anchor_texts", {})
+    anchor_items = list(anchor_data.items())[:10]
+    anchor_bars = ""
+    if anchor_items:
+        max_val = max(v for _, v in anchor_items) if anchor_items else 1
+        for text, count in anchor_items:
+            pct = round(count / max_val * 100)
+            anchor_bars += f'<div class="bar-row"><span class="bar-label">{text[:25]}</span><div class="bar-track"><div class="bar-fill" style="width:{pct}%"></div></div><span class="bar-value">{count}</span></div>'
+
+    html = f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SEO Report — {domain}</title>
+<style>
+:root {{
+    --bg: #0f172a;
+    --surface: #1e293b;
+    --card: #1e293b;
+    --card-border: #334155;
+    --text: #f1f5f9;
+    --text-muted: #94a3b8;
+    --accent: #6366f1;
+    --accent-glow: rgba(99, 102, 241, 0.3);
+    --green: #22c55e;
+    --yellow: #eab308;
+    --red: #ef4444;
+    --orange: #f97316;
+    --radius: 12px;
+}}
+[data-theme="light"] {{
+    --bg: #f8fafc;
+    --surface: #ffffff;
+    --card: #ffffff;
+    --card-border: #e2e8f0;
+    --text: #1e293b;
+    --text-muted: #64748b;
+    --accent-glow: rgba(99, 102, 241, 0.15);
+}}
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    min-height: 100vh;
+}}
+.container {{ max-width: 1200px; margin: 0 auto; padding: 24px; }}
+
+/* Header */
+.header {{
+    background: linear-gradient(135deg, #1e1b4b 0%, #312e81 50%, #4338ca 100%);
+    padding: 48px 0 60px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+}}
+.header::before {{
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(ellipse at center, rgba(99,102,241,0.15) 0%, transparent 70%);
+    animation: pulse 4s ease-in-out infinite;
+}}
+@keyframes pulse {{ 0%,100% {{ opacity: 0.5; }} 50% {{ opacity: 1; }} }}
+.header h1 {{ font-size: 2rem; font-weight: 700; color: white; position: relative; }}
+.header .domain {{ font-size: 1.1rem; color: #a5b4fc; margin-top: 8px; position: relative; }}
+.header .timestamp {{ font-size: 0.85rem; color: #818cf8; margin-top: 4px; position: relative; }}
+
+/* Theme Toggle */
+.theme-toggle {{
+    position: fixed; top: 16px; right: 16px; z-index: 100;
+    background: var(--surface); border: 1px solid var(--card-border);
+    border-radius: 50%; width: 44px; height: 44px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; font-size: 1.2rem; transition: all 0.3s;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}}
+.theme-toggle:hover {{ transform: scale(1.1); }}
+
+/* Overall Score */
+.score-hero {{
+    display: flex; justify-content: center; align-items: center;
+    gap: 48px; padding: 40px 0; flex-wrap: wrap;
+}}
+.score-gauge {{ position: relative; width: 180px; height: 180px; }}
+.score-gauge svg {{ width: 100%; height: 100%; }}
+.score-gauge .gauge-value {{
+    position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
+    text-align: center;
+}}
+.score-gauge .gauge-number {{ font-size: 3rem; font-weight: 800; color: {grade_color}; }}
+.score-gauge .gauge-grade {{ font-size: 1rem; color: var(--text-muted); }}
+.score-stats {{ display: flex; gap: 24px; }}
+.stat-card {{
+    background: var(--card); border: 1px solid var(--card-border);
+    border-radius: var(--radius); padding: 20px 28px; text-align: center;
+    min-width: 100px;
+}}
+.stat-value {{ font-size: 2rem; font-weight: 700; }}
+.stat-label {{ font-size: 0.8rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 1px; }}
+.stat-critical .stat-value {{ color: var(--red); }}
+.stat-warning .stat-value {{ color: var(--yellow); }}
+.stat-pass .stat-value {{ color: var(--green); }}
+
+/* Category Cards Grid */
+.categories {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 16px; margin: 32px 0; }}
+.category-card {{
+    background: var(--card); border: 1px solid var(--card-border);
+    border-radius: var(--radius); padding: 20px; text-align: center;
+    cursor: pointer; transition: all 0.3s;
+    position: relative;
+}}
+.category-card:hover {{ transform: translateY(-4px); box-shadow: 0 8px 24px var(--accent-glow); border-color: var(--accent); }}
+.category-card .ring {{ width: 70px; height: 70px; margin: 0 auto 8px; }}
+.category-card .ring-label {{
+    position: absolute; top: 52px; left: 50%; transform: translate(-50%, -50%);
+    font-size: 1.1rem; font-weight: 700;
+}}
+.ring-progress {{ transition: stroke-dasharray 1s ease; }}
+.category-icon {{ font-size: 1.3rem; margin: 4px 0; }}
+.category-name {{ font-size: 0.8rem; color: var(--text-muted); font-weight: 500; }}
+
+/* Sections */
+.section {{
+    background: var(--card); border: 1px solid var(--card-border);
+    border-radius: var(--radius); margin: 24px 0; overflow: hidden;
+}}
+.section-header {{
+    padding: 20px 24px; cursor: pointer; display: flex;
+    align-items: center; justify-content: space-between;
+    transition: background 0.2s;
+}}
+.section-header:hover {{ background: rgba(99,102,241,0.05); }}
+.section-header h2 {{ font-size: 1.15rem; font-weight: 600; display: flex; align-items: center; gap: 10px; }}
+.section-header .chevron {{ transition: transform 0.3s; font-size: 1.2rem; color: var(--text-muted); }}
+.section-header .chevron.open {{ transform: rotate(180deg); }}
+.section-body {{ padding: 0 24px 24px; display: none; }}
+.section-body.open {{ display: block; animation: fadeIn 0.3s; }}
+@keyframes fadeIn {{ from {{ opacity: 0; transform: translateY(-8px); }} to {{ opacity: 1; transform: translateY(0); }} }}
+
+/* Tables */
+table {{ width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 0.9rem; }}
+th {{ text-align: left; padding: 10px 12px; border-bottom: 2px solid var(--card-border); color: var(--text-muted); font-weight: 600; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.5px; }}
+td {{ padding: 10px 12px; border-bottom: 1px solid var(--card-border); vertical-align: top; }}
+tr:last-child td {{ border-bottom: none; }}
+tr:hover td {{ background: rgba(99,102,241,0.03); }}
+.mono {{ font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 0.85rem; }}
+.link-url {{ word-break: break-all; max-width: 400px; color: var(--accent); }}
+
+/* Badges */
+.badge {{
+    display: inline-block; padding: 2px 10px; border-radius: 100px;
+    font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
+}}
+.badge.critical {{ background: rgba(239,68,68,0.15); color: var(--red); }}
+.badge.warning {{ background: rgba(234,179,8,0.15); color: var(--yellow); }}
+.badge.pass {{ background: rgba(34,197,94,0.15); color: var(--green); }}
+.badge.info {{ background: rgba(99,102,241,0.15); color: var(--accent); }}
+
+/* Issues */
+.issue-item {{
+    padding: 12px 16px; border-radius: 8px; margin: 6px 0;
+    font-size: 0.9rem; display: flex; align-items: flex-start; gap: 10px;
+}}
+.issue-item.critical {{ background: rgba(239,68,68,0.08); border-left: 3px solid var(--red); }}
+.issue-item.warning {{ background: rgba(234,179,8,0.08); border-left: 3px solid var(--yellow); }}
+.issue-item.info {{ background: rgba(99,102,241,0.08); border-left: 3px solid var(--accent); }}
+.issue-badge {{ flex-shrink: 0; }}
+
+/* Bar Chart */
+.bar-row {{ display: flex; align-items: center; gap: 10px; margin: 6px 0; }}
+.bar-label {{ width: 150px; font-size: 0.85rem; text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-muted); }}
+.bar-track {{ flex: 1; height: 22px; background: var(--card-border); border-radius: 4px; overflow: hidden; }}
+.bar-fill {{ height: 100%; background: linear-gradient(90deg, var(--accent), #818cf8); border-radius: 4px; transition: width 1s ease; }}
+.bar-value {{ width: 30px; font-size: 0.85rem; font-weight: 600; }}
+
+/* Summary cards row */
+.summary-row {{ display: flex; gap: 16px; margin: 16px 0; flex-wrap: wrap; }}
+.summary-item {{
+    flex: 1; min-width: 120px; background: var(--bg); border-radius: 8px;
+    padding: 16px; text-align: center;
+}}
+.summary-item .val {{ font-size: 1.5rem; font-weight: 700; }}
+.summary-item .lbl {{ font-size: 0.75rem; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; }}
+
+/* Footer */
+.footer {{ text-align: center; padding: 32px 0; color: var(--text-muted); font-size: 0.8rem; }}
+
+@media (max-width: 768px) {{
+    .score-hero {{ flex-direction: column; gap: 24px; }}
+    .score-stats {{ flex-wrap: wrap; justify-content: center; }}
+    .categories {{ grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); }}
+    .container {{ padding: 16px; }}
+}}
+</style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+</head>
+<body>
+
+<div class="theme-toggle" onclick="toggleTheme()" title="Toggle theme">🌙</div>
+
+<div class="header">
+    <div class="container">
+        <h1>SEO Analysis Report</h1>
+        <div class="domain">{domain}</div>
+        <div class="timestamp">Generated: {datetime.fromisoformat(timestamp).strftime("%B %d, %Y at %I:%M %p")}</div>
+    </div>
+</div>
+
+<div class="container">
+
+    <!-- Overall Score -->
+    <div class="score-hero">
+        <div class="score-gauge">
+            <svg viewBox="0 0 200 200">
+                <circle cx="100" cy="100" r="85" fill="none" stroke="var(--card-border)" stroke-width="12"/>
+                <circle cx="100" cy="100" r="85" fill="none" stroke="{grade_color}" stroke-width="12"
+                    stroke-dasharray="{round(overall * 5.341, 1)} 534.07" stroke-linecap="round"
+                    transform="rotate(-90 100 100)"/>
+            </svg>
+            <div class="gauge-value">
+                <div class="gauge-number">{overall}</div>
+                <div class="gauge-grade">Grade: {grade}</div>
+            </div>
+        </div>
+        <div class="score-stats">
+            <div class="stat-card stat-critical">
+                <div class="stat-value">{critical_count}</div>
+                <div class="stat-label">Critical</div>
+            </div>
+            <div class="stat-card stat-warning">
+                <div class="stat-value">{warning_count}</div>
+                <div class="stat-label">Warnings</div>
+            </div>
+            <div class="stat-card stat-pass">
+                <div class="stat-value">{pass_count}</div>
+                <div class="stat-label">Info</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Category Cards -->
+    <div class="categories">
+        {category_cards}
+    </div>
+
+    <!-- Environment Detection -->
+    <div class="section" id="section-environment">
+        <div class="section-header" onclick="toggleSection('environment')">
+            <h2>🧭 Environment Detection (LLM-Inferred)</h2>
+            <span class="chevron" id="chevron-environment">▼</span>
+        </div>
+        <div class="section-body" id="body-environment">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{env_primary}</div><div class="lbl">Primary Platform</div></div>
+                <div class="summary-item"><div class="val">{env_runtime}</div><div class="lbl">Runtime Type</div></div>
+                <div class="summary-item"><div class="val">{env_confidence}</div><div class="lbl">Confidence</div></div>
+                <div class="summary-item"><div class="val">{len(env.get("signals", []))}</div><div class="lbl">Matched Signals</div></div>
+            </div>
+            <h3 style="margin: 16px 0 8px; font-size: 0.95rem;">Detection Signals</h3>
+            <ul style="padding-left:20px;">{env_signals_html}</ul>
+            {f'<p style="margin-top:10px;color:var(--text-muted)"><strong>Alternative matches:</strong> {", ".join(env_alts)}</p>' if env_alts else ''}
+        </div>
+    </div>
+
+    <!-- Environment-specific Fix Plan -->
+    <div class="section" id="section-env_fixes">
+        <div class="section-header" onclick="toggleSection('env_fixes')">
+            <h2>🛠️ Environment-Specific Fix Plan</h2>
+            <span class="chevron" id="chevron-env_fixes">▼</span>
+        </div>
+        <div class="section-body" id="body-env_fixes">
+            {env_fixes_html}
+        </div>
+    </div>
+
+    <!-- Issues Summary -->
+    <div class="section" id="section-issues">
+        <div class="section-header" onclick="toggleSection('issues')">
+            <h2>🚨 All Issues ({len(all_issues)})</h2>
+            <span class="chevron" id="chevron-issues">▼</span>
+        </div>
+        <div class="section-body" id="body-issues">
+            {issues_html if issues_html else '<p style="color:var(--text-muted)">No issues found — excellent!</p>'}
+        </div>
+    </div>
+
+    <!-- Security Headers -->
+    <div class="section" id="section-security">
+        <div class="section-header" onclick="toggleSection('security')">
+            <h2>🔒 Security Headers <span class="badge {"pass" if scores["categories"].get("security",0) >= 80 else "warning" if scores["categories"].get("security",0) >= 50 else "critical"}">{scores["categories"].get("security",0)}/100</span></h2>
+            <span class="chevron" id="chevron-security">▼</span>
+        </div>
+        <div class="section-body" id="body-security">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{"✅" if sec.get("https") else "❌"}</div><div class="lbl">HTTPS</div></div>
+                <div class="summary-item"><div class="val">{len(sec.get("headers_present", {}))}</div><div class="lbl">Present</div></div>
+                <div class="summary-item"><div class="val">{len(sec.get("headers_missing", {}))}</div><div class="lbl">Missing</div></div>
+            </div>
+            <table>
+                <thead><tr><th>Header</th><th>Status</th><th>Value / Description</th></tr></thead>
+                <tbody>{security_rows}</tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Social Meta -->
+    <div class="section" id="section-social">
+        <div class="section-header" onclick="toggleSection('social')">
+            <h2>📱 Social Meta Tags <span class="badge {"pass" if scores["categories"].get("social",0) >= 80 else "warning" if scores["categories"].get("social",0) >= 50 else "critical"}">{scores["categories"].get("social",0)}/100</span></h2>
+            <span class="chevron" id="chevron-social">▼</span>
+        </div>
+        <div class="section-body" id="body-social">
+            <table>
+                <thead><tr><th>Tag</th><th>Status</th><th>Value</th></tr></thead>
+                <tbody>{social_rows}</tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- AI Crawlers -->
+    <div class="section" id="section-robots">
+        <div class="section-header" onclick="toggleSection('robots')">
+            <h2>🤖 Robots & AI Crawlers <span class="badge {"pass" if scores["categories"].get("robots",0) >= 80 else "warning" if scores["categories"].get("robots",0) >= 50 else "critical"}">{scores["categories"].get("robots",0)}/100</span></h2>
+            <span class="chevron" id="chevron-robots">▼</span>
+        </div>
+        <div class="section-body" id="body-robots">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{rob.get("status", "?")}</div><div class="lbl">robots.txt</div></div>
+                <div class="summary-item"><div class="val">{len(rob.get("sitemaps", []))}</div><div class="lbl">Sitemaps</div></div>
+                <div class="summary-item"><div class="val">{len(rob.get("user_agents", {}))}</div><div class="lbl">User-Agents</div></div>
+            </div>
+            <h3 style="margin: 16px 0 8px; font-size: 0.95rem;">AI Crawler Management</h3>
+            <table>
+                <thead><tr><th>Crawler</th><th>Status</th><th>Details</th></tr></thead>
+                <tbody>{ai_rows}</tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- Broken Links -->
+    <div class="section" id="section-broken_links">
+        <div class="section-header" onclick="toggleSection('broken_links')">
+            <h2>🔗 Broken Links <span class="badge {"pass" if bl_broken == 0 else "critical"}">{bl_broken} broken / {bl_total} total</span></h2>
+            <span class="chevron" id="chevron-broken_links">▼</span>
+        </div>
+        <div class="section-body" id="body-broken_links">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val" style="color:var(--green)">{bl_healthy}</div><div class="lbl">Healthy</div></div>
+                <div class="summary-item"><div class="val" style="color:var(--red)">{bl_broken}</div><div class="lbl">Broken</div></div>
+                <div class="summary-item"><div class="val" style="color:var(--yellow)">{bl_summary.get("redirected", 0)}</div><div class="lbl">Redirected</div></div>
+                <div class="summary-item"><div class="val" style="color:var(--orange)">{bl_summary.get("timeout", 0)}</div><div class="lbl">Timeout</div></div>
+            </div>
+            {"<table><thead><tr><th>Type</th><th>Status</th><th>URL</th><th>Anchor</th></tr></thead><tbody>" + broken_rows + "</tbody></table>" if broken_rows else '<p style="color:var(--green);margin-top:12px">✅ No broken links found</p>'}
+        </div>
+    </div>
+
+    <!-- Internal Links -->
+    <div class="section" id="section-internal_links">
+        <div class="section-header" onclick="toggleSection('internal_links')">
+            <h2>🕸️ Internal Link Structure <span class="badge {"pass" if scores["categories"].get("internal_links",0) >= 80 else "warning" if scores["categories"].get("internal_links",0) >= 50 else "critical"}">{scores["categories"].get("internal_links",0)}/100</span></h2>
+            <span class="chevron" id="chevron-internal_links">▼</span>
+        </div>
+        <div class="section-body" id="body-internal_links">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{il_pages}</div><div class="lbl">Pages Crawled</div></div>
+                <div class="summary-item"><div class="val">{il_total}</div><div class="lbl">Internal Links</div></div>
+                <div class="summary-item"><div class="val">{il_dist.get("avg", 0)}</div><div class="lbl">Avg Links/Page</div></div>
+                <div class="summary-item"><div class="val">{len(il.get("orphan_candidates", []))}</div><div class="lbl">Orphan Pages</div></div>
+            </div>
+            {f'<h3 style="margin:16px 0 8px;font-size:0.95rem;">Top Anchor Texts</h3>' + anchor_bars if anchor_bars else ''}
+            {f'<h3 style="margin:16px 0 8px;font-size:0.95rem;">Potential Orphan Pages</h3><table><thead><tr><th>URL</th><th>Incoming Links</th></tr></thead><tbody>{orphan_rows}</tbody></table>' if orphan_rows else ''}
+        </div>
+    </div>
+
+    <!-- Redirects -->
+    <div class="section" id="section-redirects">
+        <div class="section-header" onclick="toggleSection('redirects')">
+            <h2>↪️ Redirect Chain <span class="badge {"pass" if red.get("total_hops", 0) <= 1 else "warning"}">{red.get("total_hops", 0)} hops</span></h2>
+            <span class="chevron" id="chevron-redirects">▼</span>
+        </div>
+        <div class="section-body" id="body-redirects">
+            {f'<table><thead><tr><th>#</th><th>Status</th><th>URL</th><th>Time</th><th>Type</th></tr></thead><tbody>{redirect_rows}</tbody></table>' if redirect_rows else '<p style="color:var(--green)">✅ No redirects — direct access</p>'}
+        </div>
+    </div>
+
+    <!-- llms.txt -->
+    <div class="section" id="section-llms_txt">
+        <div class="section-header" onclick="toggleSection('llms_txt')">
+            <h2>🧠 AI Search Readiness (llms.txt) <span class="badge {"pass" if llm.get("exists") else "critical"}">{"Found" if llm.get("exists") else "Not Found"}</span></h2>
+            <span class="chevron" id="chevron-llms_txt">▼</span>
+        </div>
+        <div class="section-body" id="body-llms_txt">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{"✅" if llm.get("exists") else "❌"}</div><div class="lbl">llms.txt</div></div>
+                <div class="summary-item"><div class="val">{"✅" if llm.get("full_exists") else "❌"}</div><div class="lbl">llms-full.txt</div></div>
+                <div class="summary-item"><div class="val">{llm.get("quality", {}).get("score", 0)}</div><div class="lbl">Quality Score</div></div>
+            </div>
+            {"".join(f'<div class="issue-item warning"><span class="issue-badge">TIP</span> {s}</div>' for s in llm.get("quality", {}).get("suggestions", []))}
+        </div>
+    </div>
+
+    <!-- PageSpeed / Core Web Vitals -->
+    <div class="section" id="section-pagespeed">
+        <div class="section-header" onclick="toggleSection('pagespeed')">
+            <h2>⚡ Performance & Core Web Vitals <span class="badge {"pass" if scores["categories"].get("pagespeed",0) >= 80 else "warning" if scores["categories"].get("pagespeed",0) >= 50 else "critical"}">{scores["categories"].get("pagespeed",0)}/100</span></h2>
+            <span class="chevron" id="chevron-pagespeed">▼</span>
+        </div>
+        <div class="section-body" id="body-pagespeed">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{psi.get("performance_score", "?")}</div><div class="lbl">Performance</div></div>
+                <div class="summary-item"><div class="val">{psi.get("field_data", psi.get("lab_data", {})).get("LCP", "?")}</div><div class="lbl">LCP</div></div>
+                <div class="summary-item"><div class="val">{psi.get("field_data", psi.get("lab_data", {})).get("INP", psi.get("field_data", psi.get("lab_data", {})).get("TBT", "?"))}</div><div class="lbl">INP/TBT</div></div>
+                <div class="summary-item"><div class="val">{psi.get("field_data", psi.get("lab_data", {})).get("CLS", "?")}</div><div class="lbl">CLS</div></div>
+            </div>
+            {'<div class="issue-item warning"><span class="issue-badge">NOTE</span> <div><strong>PageSpeed API returned an error or was rate-limited.</strong><br><span style="color:var(--text-muted)">Set <code>PAGESPEED_API_KEY</code> in a <code>.env</code> file (see <code>.env.example</code>) or export it in your shell, then rerun. The CLI also accepts <code>--api-key</code>. The LLM can still analyze Core Web Vitals by reading the page directly.</span></div></div>' if psi.get('error') or psi.get('performance_score', 0) == 0 else ''}
+            {render_recommendations(psi)}
+        </div>
+    </div>
+
+    <!-- On-Page SEO -->
+    <div class="section" id="section-onpage">
+        <div class="section-header" onclick="toggleSection('onpage')">
+            <h2>📝 On-Page SEO <span class="badge {"pass" if scores["categories"].get("onpage",0) >= 80 else "warning" if scores["categories"].get("onpage",0) >= 50 else "critical"}">{scores["categories"].get("onpage",0)}/100</span></h2>
+            <span class="chevron" id="chevron-onpage">▼</span>
+        </div>
+        <div class="section-body" id="body-onpage">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{'✅' if op.get('title') else '❌'}</div><div class="lbl">Title Tag</div></div>
+                <div class="summary-item"><div class="val">{'✅' if op.get('meta_description') else '❌'}</div><div class="lbl">Meta Desc</div></div>
+                <div class="summary-item"><div class="val">{'✅' if op.get('h1') else '❌'}</div><div class="lbl">H1</div></div>
+                <div class="summary-item"><div class="val">{'✅' if op.get('canonical') else '❌'}</div><div class="lbl">Canonical</div></div>
+            </div>
+            <table>
+                <thead><tr><th>Element</th><th>Value</th><th>Length</th></tr></thead>
+                <tbody>
+                    <tr><td>Title</td><td>{(op.get('title','') or '—')[:70]}</td><td>{len(op.get('title','') or '')}</td></tr>
+                    <tr><td>Meta Description</td><td>{(op.get('meta_description','') or '—')[:100]}</td><td>{len(op.get('meta_description','') or '')}</td></tr>
+                    <tr><td>H1</td><td>{(op.get('h1',[''])[0] if isinstance(op.get('h1'), list) and op.get('h1') else op.get('h1','') or '—')[:70]}</td><td>—</td></tr>
+                    <tr><td>Canonical</td><td class="link-url">{op.get('canonical','—')[:80]}</td><td>—</td></tr>
+                </tbody>
+            </table>
+            {render_recommendations(op)}
+        </div>
+    </div>
+
+    <!-- Readability -->
+    <div class="section" id="section-readability">
+        <div class="section-header" onclick="toggleSection('readability')">
+            <h2>📖 Readability <span class="badge {"pass" if scores["categories"].get("readability",0) >= 80 else "warning" if scores["categories"].get("readability",0) >= 50 else "critical"}">{scores["categories"].get("readability",0)}/100</span></h2>
+            <span class="chevron" id="chevron-readability">▼</span>
+        </div>
+        <div class="section-body" id="body-readability">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{rd.get('flesch_reading_ease', '?')}</div><div class="lbl">Flesch Score</div></div>
+                <div class="summary-item"><div class="val">{rd.get('flesch_kincaid_grade', '?')}</div><div class="lbl">Grade Level</div></div>
+                <div class="summary-item"><div class="val">{rd.get('word_count', '?')}</div><div class="lbl">Words</div></div>
+                <div class="summary-item"><div class="val">{rd.get('estimated_reading_time_min', '?')} min</div><div class="lbl">Read Time</div></div>
+            </div>
+            {render_recommendations(rd)}
+            {render_readability_rewrites(rd)}
+        </div>
+    </div>
+
+    <!-- Article SEO Extractor -->
+    <div class="section" id="section-article">
+        <div class="section-header" onclick="toggleSection('article')">
+            <h2>📄 Article Info & Keywords <span class="badge {"pass" if scores["categories"].get("article",0) >= 80 else "warning" if scores["categories"].get("article",0) >= 50 else "critical"}">{scores["categories"].get("article",0)}/100</span></h2>
+            <span class="chevron" id="chevron-article">▼</span>
+        </div>
+        <div class="section-body" id="body-article">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{art.get('word_count', '?')}</div><div class="lbl">Words</div></div>
+                <div class="summary-item"><div class="val">{len(art.get('headings', dict()).get('h2', []))}</div><div class="lbl">H2 Headings</div></div>
+                <div class="summary-item"><div class="val">{len(art.get('images', []))}</div><div class="lbl">Images</div></div>
+            </div>
+            <h3 style="margin: 16px 0 8px; font-size: 0.95rem;">Extracted Keywords</h3>
+            <table>
+                <thead><tr><th>Target Keyword</th><th>LSI / Related Keywords</th></tr></thead>
+                <tbody>
+                    <tr>
+                        <td style="font-weight: 600; color: var(--accent);">{art.get('target_keyword', '—')}</td>
+                        <td>{', '.join(art.get('lsi_keywords', [])) if art.get('lsi_keywords') else '—'}</td>
+                    </tr>
+                </tbody>
+            </table>
+            {render_recommendations(art)}
+        </div>
+    </div>
+
+    <!-- Entity SEO -->
+    <div class="section" id="section-entity">
+        <div class="section-header" onclick="toggleSection('entity')">
+            <h2>🏛️ Entity SEO <span class="badge {"pass" if scores["categories"].get("entity",0) >= 50 else "warning" if scores["categories"].get("entity",0) >= 20 else "critical"}">{scores["categories"].get("entity",0)}/100</span></h2>
+            <span class="chevron" id="chevron-entity">▼</span>
+        </div>
+        <div class="section-body" id="body-entity">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{'✅' if ent.get('wikidata', {}).get('found') else '❌'}</div><div class="lbl">Wikidata</div></div>
+                <div class="summary-item"><div class="val">{'✅' if ent.get('wikipedia', {}).get('found') else '❌'}</div><div class="lbl">Wikipedia</div></div>
+                <div class="summary-item"><div class="val">{ent.get('sameas_analysis', {}).get('total_found', 0)}</div><div class="lbl">sameAs Links</div></div>
+                <div class="summary-item"><div class="val">{len(ent.get('issues', []))}</div><div class="lbl">Issues</div></div>
+            </div>
+            {render_recommendations(ent)}
+        </div>
+    </div>
+
+    <!-- Link Profile -->
+    <div class="section" id="section-link_profile">
+        <div class="section-header" onclick="toggleSection('link_profile')">
+            <h2>🔗 Link Profile <span class="badge {"pass" if scores["categories"].get("link_profile",0) >= 70 else "warning" if scores["categories"].get("link_profile",0) >= 40 else "critical"}">{scores["categories"].get("link_profile",0)}/100</span></h2>
+            <span class="chevron" id="chevron-link_profile">▼</span>
+        </div>
+        <div class="section-body" id="body-link_profile">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{lp.get('pages_crawled', '?')}</div><div class="lbl">Pages Crawled</div></div>
+                <div class="summary-item"><div class="val">{lp.get('avg_internal_links_per_page', '?')}</div><div class="lbl">Avg Links/Page</div></div>
+                <div class="summary-item"><div class="val">{lp.get('orphan_pages', {}).get('count', 0)}</div><div class="lbl">Orphan Pages</div></div>
+                <div class="summary-item"><div class="val">{lp.get('dead_end_pages', {}).get('count', 0)}</div><div class="lbl">Dead Ends</div></div>
+            </div>
+            {render_recommendations(lp)}
+        </div>
+    </div>
+
+    <!-- Hreflang -->
+    <div class="section" id="section-hreflang">
+        <div class="section-header" onclick="toggleSection('hreflang')">
+            <h2>🌍 Hreflang / International SEO <span class="badge {"pass" if hf.get('hreflang_tags_found', 0) > 0 else "info"}">{hf.get('hreflang_tags_found', 0)} tags</span></h2>
+            <span class="chevron" id="chevron-hreflang">▼</span>
+        </div>
+        <div class="section-body" id="body-hreflang">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{hf.get('implementation_method', 'none')}</div><div class="lbl">Method</div></div>
+                <div class="summary-item"><div class="val">{hf.get('hreflang_tags_found', 0)}</div><div class="lbl">Tags Found</div></div>
+            </div>
+            {'<p style="color:var(--text-muted);margin-top:12px">No hreflang tags found — this is expected for single-language sites.</p>' if hf.get('hreflang_tags_found', 0) == 0 else render_recommendations(hf)}
+        </div>
+    </div>
+
+    <!-- Duplicate Content -->
+    <div class="section" id="section-duplicate_content">
+        <div class="section-header" onclick="toggleSection('duplicate_content')">
+            <h2>📋 Content Uniqueness <span class="badge {"pass" if len(dc.get('near_duplicates', [])) == 0 else "warning"}">{len(dc.get('near_duplicates', []))} dupes / {len(dc.get('thin_pages', []))} thin</span></h2>
+            <span class="chevron" id="chevron-duplicate_content">▼</span>
+        </div>
+        <div class="section-body" id="body-duplicate_content">
+            <div class="summary-row">
+                <div class="summary-item"><div class="val">{dc.get('pages_analyzed', '?')}</div><div class="lbl">Pages Analyzed</div></div>
+                <div class="summary-item"><div class="val">{len(dc.get('near_duplicates', []))}</div><div class="lbl">Near Duplicates</div></div>
+                <div class="summary-item"><div class="val">{len(dc.get('thin_pages', []))}</div><div class="lbl">Thin Pages</div></div>
+            </div>
+            {render_recommendations(dc)}
+        </div>
+    </div>
+
+    <!-- Recommendations Summary -->
+    <div class="section" id="section-recs">
+        <div class="section-header" onclick="toggleSection('recs')">
+            <h2>💡 All Recommendations</h2>
+            <span class="chevron" id="chevron-recs">▼</span>
+        </div>
+        <div class="section-body" id="body-recs">
+            {render_all_recommendations(data)}
+        </div>
+    </div>
+
+</div>
+
+<div class="footer">
+    <p>Generated by SEO Skill · {datetime.fromisoformat(timestamp).strftime("%Y-%m-%d %H:%M")}</p>
+</div>
+
+<script>
+function toggleSection(id) {{
+    const body = document.getElementById('body-' + id);
+    const chevron = document.getElementById('chevron-' + id);
+    body.classList.toggle('open');
+    chevron.classList.toggle('open');
+}}
+function scrollToSection(id) {{
+    const el = document.getElementById('section-' + id);
+    if (el) {{
+        el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
+        // Auto-open
+        const body = document.getElementById('body-' + id);
+        const chevron = document.getElementById('chevron-' + id);
+        if (!body.classList.contains('open')) {{
+            body.classList.add('open');
+            chevron.classList.add('open');
+        }}
+    }}
+}}
+function toggleTheme() {{
+    const html = document.documentElement;
+    const btn = document.querySelector('.theme-toggle');
+    if (html.getAttribute('data-theme') === 'light') {{
+        html.removeAttribute('data-theme');
+        btn.textContent = '🌙';
+    }} else {{
+        html.setAttribute('data-theme', 'light');
+        btn.textContent = '☀️';
+    }}
+}}
+// Auto-open issues section
+document.getElementById('body-issues').classList.add('open');
+document.getElementById('chevron-issues').classList.add('open');
+</script>
+
+</body>
+</html>'''
+
+    return html
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate interactive SEO HTML report")
+    parser.add_argument("url", help="Website URL to analyze")
+    parser.add_argument("--output", "-o", help="Output filename (default: seo-report-<domain>.html)")
+    parser.add_argument("--html", dest="html_output", help="HTML output filename (alias for --output)")
+    parser.add_argument("--markdown", default="FULL-AUDIT-REPORT.md",
+                        help="Markdown audit output path (default: FULL-AUDIT-REPORT.md)")
+    parser.add_argument("--action-plan", default="ACTION-PLAN.md",
+                        help="Markdown action-plan output path (default: ACTION-PLAN.md)")
+    parser.add_argument("--no-html", action="store_true", help="Do not write the HTML dashboard")
+    parser.add_argument("--no-markdown", action="store_true", help="Do not write markdown/action-plan artifacts")
+
+    args = parser.parse_args()
+    scoring_config = load_scoring_config()
+
+    # Collect all data
+    data = collect_data(args.url)
+
+    # Calculate scores
+    scores = calculate_overall_score(data, scoring_config=scoring_config)
+
+    written = []
+
+    if not args.no_html:
+        # Generate HTML
+        html = generate_html(data, scores)
+
+        # Determine output path
+        if args.html_output or args.output:
+            output_path = args.html_output or args.output
+        else:
+            domain = urlparse(args.url).netloc.replace(".", "_")
+            output_path = f"seo-report-{domain}.html"
+
+        written.append(("HTML report", write_text_output(output_path, html)))
+
+    if not args.no_markdown:
+        markdown = render_markdown_report(data, scores, scoring_config=scoring_config)
+        action_plan = render_action_plan(data, scores)
+        written.append(("Full audit report", write_text_output(args.markdown, markdown)))
+        written.append(("Action plan", write_text_output(args.action_plan, action_plan)))
+
+    print("\nReport artifacts:")
+    for label, path in written:
+        print(f"   {label}: {path}")
+    print(f"   Overall Score: {scores['overall']}/100")
+    if not args.no_html:
+        print(f"   Open the HTML report in a browser to view the interactive dashboard")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_api.py
+++ b/.claude/skills/seo/scripts/github_api.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""
+Shared GitHub API helpers for repository SEO scripts.
+"""
+
+import json
+import os
+import re
+import subprocess
+import time
+import urllib.parse
+
+try:
+    from lib.safe_http import default_headers, safe_request
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_request
+
+
+API_BASE = "https://api.github.com"
+_GH_AUTH_CACHE = None
+
+
+class GitHubAPIError(RuntimeError):
+    """Raised when GitHub API requests fail."""
+
+    def __init__(self, message: str, status: int = None, details: dict = None):
+        super().__init__(message)
+        self.status = status
+        self.details = details or {}
+
+
+def get_token(cli_token: str = None) -> str:
+    """Resolve token from CLI override, env vars, or .env file."""
+    if cli_token:
+        return cli_token.strip()
+    try:
+        from env_loader import load_env
+        load_env()
+    except Exception:
+        pass
+    for env_key in ("GITHUB_TOKEN", "GH_TOKEN"):
+        value = os.environ.get(env_key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def gh_available() -> bool:
+    """Return True when GitHub CLI is available in PATH."""
+    try:
+        result = subprocess.run(
+            ["gh", "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            text=True,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def gh_auth_details(force_refresh: bool = False) -> dict:
+    """
+    Return GitHub CLI auth status.
+    Notes:
+    - `gh auth status` may exit 0 even with invalid token, so parse output text.
+    """
+    global _GH_AUTH_CACHE
+    if _GH_AUTH_CACHE is not None and not force_refresh:
+        return _GH_AUTH_CACHE
+
+    details = {
+        "available": False,
+        "authenticated": False,
+        "raw": "",
+    }
+    if not gh_available():
+        _GH_AUTH_CACHE = details
+        return details
+
+    details["available"] = True
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status", "-h", "github.com"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=12,
+        )
+        text = (result.stdout or "") + "\n" + (result.stderr or "")
+        lower = text.lower()
+        authenticated = (
+            "logged in to github.com" in lower
+            and "failed to log in" not in lower
+            and "not logged into" not in lower
+            and "token is invalid" not in lower
+        )
+        details["authenticated"] = authenticated
+        details["raw"] = text.strip()
+    except Exception as exc:
+        details["raw"] = str(exc)
+
+    _GH_AUTH_CACHE = details
+    return details
+
+
+def auth_context(token: str = "") -> dict:
+    """Return auth context used by scripts for messaging and fallback decisions."""
+    gh = gh_auth_details()
+    mode = "token" if bool(token) else ("gh" if gh.get("authenticated") else "unauthenticated")
+    return {
+        "token_present": bool(token),
+        "gh_available": gh.get("available", False),
+        "gh_authenticated": gh.get("authenticated", False),
+        "mode": mode,
+    }
+
+
+def normalize_repo_slug(value: str) -> str:
+    """Normalize a repo identifier to owner/repo format."""
+    if not value:
+        return ""
+
+    text = value.strip()
+    text = re.sub(r"\.git$", "", text)
+
+    if text.startswith("git@github.com:"):
+        text = text.split(":", 1)[1]
+    elif text.startswith(("https://github.com/", "http://github.com/")):
+        parsed = urllib.parse.urlparse(text)
+        text = parsed.path.strip("/")
+
+    parts = [p for p in text.split("/") if p]
+    if len(parts) >= 2:
+        return f"{parts[0]}/{parts[1]}"
+    return ""
+
+
+def infer_repo_from_git(cwd: str = None) -> str:
+    """Infer owner/repo from local git origin URL."""
+    try:
+        output = subprocess.check_output(
+            ["git", "remote", "get-url", "origin"],
+            cwd=cwd,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return ""
+    return normalize_repo_slug(output)
+
+
+def resolve_repo(repo: str = None, cwd: str = None) -> str:
+    """Resolve repository slug from explicit value or local git origin."""
+    slug = normalize_repo_slug(repo or "")
+    if slug:
+        return slug
+    inferred = infer_repo_from_git(cwd=cwd)
+    if inferred:
+        return inferred
+    raise GitHubAPIError(
+        "Could not resolve repository slug. Use --repo owner/repo or run inside a git repo with origin configured."
+    )
+
+
+def parse_repo_slug(repo: str) -> tuple:
+    """Return (owner, repo_name)."""
+    slug = normalize_repo_slug(repo)
+    parts = slug.split("/")
+    if len(parts) != 2:
+        raise GitHubAPIError(f"Invalid repository slug: {repo}")
+    return parts[0], parts[1]
+
+
+def _headers(token: str = "", accept: str = "", content_type: str = "application/json") -> dict:
+    headers = default_headers({
+        "Accept": accept or "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    })
+    if content_type:
+        headers["Content-Type"] = content_type
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _build_url(path: str, params: dict = None) -> str:
+    url = path if path.startswith("http") else f"{API_BASE}{path}"
+    if params:
+        query = urllib.parse.urlencode(params, doseq=True)
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}{query}"
+    return url
+
+
+def rest_json(
+    path: str,
+    token: str = "",
+    method: str = "GET",
+    params: dict = None,
+    body: dict = None,
+    accept: str = "",
+    timeout: int = 20,
+    retries: int = 2,
+    max_sleep_seconds: int = 30,
+) -> dict:
+    """
+    Execute a REST request and return parsed JSON plus metadata.
+    Raises GitHubAPIError on terminal failures.
+    """
+    url = _build_url(path, params=params)
+    payload = None
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+
+    attempt = 0
+    while attempt <= retries:
+        try:
+            resp = safe_request(
+                method.upper(),
+                url,
+                data=payload,
+                headers=_headers(token=token, accept=accept),
+                timeout=timeout,
+            )
+            raw = resp.text.strip()
+            if resp.status_code < 400:
+                data = json.loads(raw) if raw else {}
+                return {
+                    "data": data,
+                    "status": resp.status_code,
+                    "rate_limit": {
+                        "limit": resp.headers.get("X-RateLimit-Limit"),
+                        "remaining": resp.headers.get("X-RateLimit-Remaining"),
+                        "reset": resp.headers.get("X-RateLimit-Reset"),
+                    },
+                }
+
+            response_text = raw
+            try:
+                payload_json = json.loads(response_text) if response_text else {}
+            except Exception:
+                payload_json = {"raw": response_text}
+
+            status = resp.status_code
+            remaining = resp.headers.get("X-RateLimit-Remaining")
+            reset = resp.headers.get("X-RateLimit-Reset")
+
+            can_retry = attempt < retries
+            if can_retry and status in (429, 500, 502, 503, 504):
+                sleep_seconds = min(max_sleep_seconds, 2 ** attempt)
+                time.sleep(max(1, sleep_seconds))
+                attempt += 1
+                continue
+
+            if can_retry and status == 403 and remaining == "0" and reset:
+                try:
+                    reset_ts = int(reset)
+                    wait_for = max(1, min(max_sleep_seconds, reset_ts - int(time.time()) + 1))
+                except Exception:
+                    wait_for = 2 ** attempt
+                time.sleep(wait_for)
+                attempt += 1
+                continue
+
+            message = payload_json.get("message", f"GitHub API error: HTTP {status}")
+            raise GitHubAPIError(message=message, status=status, details=payload_json)
+        except Exception as exc:
+            if isinstance(exc, GitHubAPIError):
+                raise
+            if attempt < retries:
+                time.sleep(max(1, 2 ** attempt))
+                attempt += 1
+                continue
+            raise GitHubAPIError(f"Network error while calling GitHub API: {exc}") from exc
+
+    raise GitHubAPIError("GitHub API request retries exhausted.")
+
+
+def graphql_json(query: str, variables: dict = None, token: str = "", timeout: int = 20, retries: int = 2) -> dict:
+    """Execute a GraphQL query and return data."""
+    result = rest_json(
+        "/graphql",
+        token=token,
+        method="POST",
+        body={"query": query, "variables": variables or {}},
+        timeout=timeout,
+        retries=retries,
+    )
+    payload = result.get("data", {})
+    if payload.get("errors"):
+        raise GitHubAPIError("GraphQL query failed", details={"errors": payload.get("errors")})
+    return payload.get("data", {})
+
+
+def gh_api_json(
+    path: str,
+    method: str = "GET",
+    params: dict = None,
+    body: dict = None,
+    timeout: int = 25,
+) -> dict:
+    """
+    Call GitHub API through `gh api`.
+    Returns response payload dictionary.
+    """
+    if not gh_available():
+        raise GitHubAPIError("GitHub CLI (`gh`) is not available.")
+
+    endpoint = path
+    if endpoint.startswith(API_BASE):
+        endpoint = endpoint.replace(API_BASE, "", 1)
+    endpoint = endpoint.lstrip("/")
+
+    if params:
+        query = urllib.parse.urlencode(params, doseq=True)
+        sep = "&" if "?" in endpoint else "?"
+        endpoint = f"{endpoint}{sep}{query}"
+
+    cmd = ["gh", "api", endpoint, "--method", method.upper()]
+    input_data = None
+    if body is not None:
+        cmd += ["--input", "-"]
+        input_data = json.dumps(body)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            input=input_data,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GitHubAPIError(f"gh api timed out after {timeout}s") from exc
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip() or "Unknown gh api failure"
+        raise GitHubAPIError(f"gh api error: {stderr}")
+
+    payload = (result.stdout or "").strip()
+    if not payload:
+        return {}
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise GitHubAPIError("gh api returned non-JSON output.") from exc
+
+
+def fetch_json(
+    path: str,
+    token: str = "",
+    method: str = "GET",
+    params: dict = None,
+    body: dict = None,
+    accept: str = "",
+    timeout: int = 20,
+    retries: int = 2,
+    provider: str = "auto",
+) -> dict:
+    """
+    Unified API accessor.
+
+    provider modes:
+    - api: use direct REST API only.
+    - gh: use gh api only.
+    - auto: try REST API first when token exists, then fallback to gh api.
+    """
+    mode = (provider or "auto").lower()
+    if mode not in ("auto", "api", "gh"):
+        raise GitHubAPIError(f"Invalid provider mode: {provider}")
+
+    if mode == "api":
+        return rest_json(
+            path=path,
+            token=token,
+            method=method,
+            params=params,
+            body=body,
+            accept=accept,
+            timeout=timeout,
+            retries=retries,
+        )
+
+    if mode == "gh":
+        data = gh_api_json(path=path, method=method, params=params, body=body, timeout=timeout)
+        return {"data": data, "status": 200, "rate_limit": {}}
+
+    # auto mode
+    ctx = auth_context(token=token)
+    errors = []
+
+    def try_rest(use_token: str):
+        return rest_json(
+            path=path,
+            token=use_token,
+            method=method,
+            params=params,
+            body=body,
+            accept=accept,
+            timeout=timeout,
+            retries=retries,
+        )
+
+    def try_gh():
+        data = gh_api_json(path=path, method=method, params=params, body=body, timeout=timeout)
+        return {"data": data, "status": 200, "rate_limit": {}}
+
+    attempts = []
+    if ctx["token_present"]:
+        attempts.append(("api(token)", lambda: try_rest(token)))
+        if ctx["gh_available"]:
+            attempts.append(("gh", try_gh))
+        attempts.append(("api(public)", lambda: try_rest("")))
+    else:
+        if ctx["gh_authenticated"]:
+            attempts.append(("gh", try_gh))
+            attempts.append(("api(public)", lambda: try_rest("")))
+        else:
+            attempts.append(("api(public)", lambda: try_rest("")))
+            if ctx["gh_available"]:
+                attempts.append(("gh", try_gh))
+
+    for label, fn in attempts:
+        try:
+            return fn()
+        except GitHubAPIError as exc:
+            errors.append(f"{label}: {exc}")
+            continue
+
+    detail = " | ".join(errors) if errors else "No provider attempts available."
+    raise GitHubAPIError(f"All provider attempts failed. {detail}")

--- a/.claude/skills/seo/scripts/github_community_health.py
+++ b/.claude/skills/seo/scripts/github_community_health.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+GitHub Community Health Checker
+
+Checks contribution/trust artifacts locally and via GitHub community profile API.
+
+Usage:
+  python github_community_health.py --repo owner/repo --json
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from github_api import (
+    GitHubAPIError,
+    auth_context,
+    fetch_json,
+    get_token,
+    infer_repo_from_git,
+    resolve_repo,
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def local_artifacts(cwd: str) -> dict:
+    return {
+        "README.md": os.path.exists(os.path.join(cwd, "README.md")),
+        "LICENSE": os.path.exists(os.path.join(cwd, "LICENSE")),
+        "CONTRIBUTING.md": os.path.exists(os.path.join(cwd, "CONTRIBUTING.md")),
+        "CODE_OF_CONDUCT.md": os.path.exists(os.path.join(cwd, "CODE_OF_CONDUCT.md")),
+        "SECURITY.md": os.path.exists(os.path.join(cwd, "SECURITY.md")),
+        "SUPPORT.md": os.path.exists(os.path.join(cwd, "SUPPORT.md")),
+        "CITATION.cff": os.path.exists(os.path.join(cwd, "CITATION.cff")),
+        ".github/ISSUE_TEMPLATE": os.path.isdir(os.path.join(cwd, ".github", "ISSUE_TEMPLATE")),
+        ".github/PULL_REQUEST_TEMPLATE.md": os.path.exists(
+            os.path.join(cwd, ".github", "PULL_REQUEST_TEMPLATE.md")
+        ),
+    }
+
+
+def add_finding(findings: list, severity: str, finding: str, evidence: str, fix: str, confidence: str = "Confirmed"):
+    findings.append(
+        {
+            "severity": severity,
+            "confidence": confidence,
+            "finding": finding,
+            "evidence": evidence,
+            "fix": fix,
+        }
+    )
+
+
+def evaluate(repo: str, token: str, provider: str, cwd: str) -> dict:
+    ctx = auth_context(token=token)
+    local_repo = infer_repo_from_git(cwd=cwd)
+    local_checks_enabled = bool(local_repo) and (local_repo.lower() == repo.lower())
+    local = local_artifacts(cwd) if local_checks_enabled else {}
+    findings = []
+    limitations = []
+    remote = {}
+    confidence = "Confirmed"
+
+    required = ("README.md", "LICENSE")
+    recommended = (
+        "CONTRIBUTING.md",
+        "CODE_OF_CONDUCT.md",
+        "SECURITY.md",
+        ".github/ISSUE_TEMPLATE",
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        "CITATION.cff",
+    )
+
+    if local_checks_enabled:
+        for file_name in required:
+            if not local.get(file_name):
+                add_finding(
+                    findings,
+                    "Critical",
+                    f"Missing required repository artifact: {file_name}.",
+                    f"Local check indicates `{file_name}` is absent.",
+                    f"Add `{file_name}` to satisfy baseline community trust requirements.",
+                )
+
+        for file_name in recommended:
+            if not local.get(file_name):
+                add_finding(
+                    findings,
+                    "Warning",
+                    f"Missing recommended community artifact: {file_name}.",
+                    f"Local check indicates `{file_name}` is absent.",
+                    f"Add `{file_name}` to improve contribution readiness and trust signals.",
+                )
+    else:
+        limitations.append(
+            "Local filesystem checks skipped because target repo does not match current working repository."
+        )
+
+    if not token:
+        if ctx.get("gh_authenticated"):
+            limitations.append("No GitHub token provided. Using authenticated gh CLI fallback for remote profile checks.")
+        elif ctx.get("gh_available"):
+            limitations.append(
+                "No GitHub token provided and gh CLI is not authenticated. Run `gh auth login -h github.com` or set GITHUB_TOKEN/GH_TOKEN."
+            )
+        else:
+            limitations.append("No GitHub token provided and gh CLI is unavailable. Set GITHUB_TOKEN/GH_TOKEN.")
+
+    try:
+        payload = fetch_json(f"/repos/{repo}/community/profile", token=token, provider=provider)
+        remote = payload.get("data", {})
+    except GitHubAPIError as exc:
+        confidence = "Likely"
+        limitations.append(f"Remote community profile unavailable: {exc} (status: {exc.status or 'unknown'})")
+
+    if remote:
+        health = remote.get("health_percentage")
+        files = remote.get("files", {})
+        if isinstance(health, (int, float)) and health < 85:
+            add_finding(
+                findings,
+                "Warning",
+                "GitHub community profile health is below baseline target.",
+                f"health_percentage={health}",
+                "Add missing governance artifacts until health percentage reaches >=85.",
+                confidence=confidence,
+            )
+        for key in ("code_of_conduct", "contributing", "issue_template", "pull_request_template", "readme", "license"):
+            if not files.get(key):
+                add_finding(
+                    findings,
+                    "Warning",
+                    f"Remote community profile marks `{key}` as missing.",
+                    f"GitHub API `files.{key}` is null/false.",
+                    f"Add `{key}`-related file(s) so GitHub recognizes this component.",
+                    confidence=confidence,
+                )
+
+    total_checks = len(required) + len(recommended)
+    passed_checks = sum(1 for key in required + recommended if local.get(key)) if local_checks_enabled else 0
+    local_completion = round((passed_checks / total_checks) * 100, 2) if local_checks_enabled else None
+
+    critical_count = sum(1 for f in findings if f["severity"] == "Critical")
+    warning_count = sum(1 for f in findings if f["severity"] == "Warning")
+    base = local_completion if isinstance(local_completion, (int, float)) else 100
+    score = max(0, int(base - (critical_count * 20) - (warning_count * 5)))
+
+    if not findings:
+        add_finding(
+            findings,
+            "Pass",
+            "Community health baseline is satisfied.",
+            "Local and remote checks did not detect major gaps.",
+            "Keep artifacts current as repository evolves.",
+        )
+
+    return {
+        "timestamp_utc": utc_now_iso(),
+        "repo": repo,
+        "provider": provider,
+        "auth_context": ctx,
+        "local_repo_context": {"detected_local_repo": local_repo or "", "local_checks_enabled": local_checks_enabled},
+        "token_present": bool(token),
+        "local_completion_percent": local_completion,
+        "score": score,
+        "local_artifacts": local,
+        "remote_profile": {
+            "health_percentage": remote.get("health_percentage"),
+            "description": remote.get("description"),
+            "documentation": remote.get("documentation"),
+            "files": remote.get("files") if isinstance(remote.get("files"), dict) else {},
+        },
+        "limitations": limitations,
+        "findings": findings,
+    }
+
+
+def print_text(report: dict):
+    print(f"\nGitHub Community Health: {report.get('repo')}")
+    print("=" * 60)
+    print(f"Score: {report.get('score', 'NA')}/100")
+    print(f"Local completion: {report.get('local_completion_percent', 0)}%")
+    remote_health = report.get("remote_profile", {}).get("health_percentage")
+    if remote_health is not None:
+        print(f"Remote health: {remote_health}%")
+    if report.get("limitations"):
+        print("\nLimitations:")
+        for item in report["limitations"]:
+            print(f"- {item}")
+    print("\nFindings:")
+    for finding in report.get("findings", [])[:10]:
+        print(f"- [{finding['severity']}] {finding['finding']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check GitHub repository community health and trust artifacts.")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo). If omitted, infer from git origin.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument("--cwd", default=".", help="Working directory for local artifact checks (default: .)")
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "api", "gh"],
+        default="auto",
+        help="GitHub data provider mode (default: auto).",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--output", help="Write JSON report to path.")
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo(args.repo, cwd=args.cwd)
+        token = get_token(args.token)
+        report = evaluate(repo=repo, token=token, provider=args.provider, cwd=args.cwd)
+    except GitHubAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        sys.exit(130)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_text(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_competitor_research.py
+++ b/.claude/skills/seo/scripts/github_competitor_research.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""
+GitHub Competitor Research
+
+Builds a competitor intelligence snapshot from GitHub search queries, then
+extracts metadata and README pattern gaps against the target repository.
+
+Usage:
+  python github_competitor_research.py --repo owner/repo --query "seo skill" --json
+  python github_competitor_research.py --repo owner/repo --query-file queries.txt --top-n 8 --json
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+
+from github_api import GitHubAPIError, auth_context, fetch_json, get_token, normalize_repo_slug, resolve_repo
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _dedupe(values: list) -> list:
+    out = []
+    seen = set()
+    for item in values:
+        key = item.lower().strip()
+        if key and key not in seen:
+            out.append(item.strip())
+            seen.add(key)
+    return out
+
+
+def load_queries(args) -> list:
+    queries = []
+    if args.query:
+        queries.extend([q.strip() for q in args.query if q.strip()])
+    if args.query_file:
+        if not os.path.exists(args.query_file):
+            raise GitHubAPIError(f"Query file not found: {args.query_file}")
+        with open(args.query_file, "r", encoding="utf-8") as f:
+            for line in f:
+                text = line.strip()
+                if text and not text.startswith("#"):
+                    queries.append(text)
+    return _dedupe(queries)
+
+
+def parse_iso8601(value: str):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def days_since(value: str):
+    dt = parse_iso8601(value)
+    if not dt:
+        return None
+    return (datetime.now(timezone.utc) - dt).days
+
+
+def run_query_candidates(
+    repo: str,
+    query: str,
+    token: str,
+    provider: str,
+    per_page: int,
+    max_pages: int,
+) -> dict:
+    out = {"query": query, "sampled_results": 0, "total_count": None, "errors": []}
+    candidates = []
+    rank = 0
+    for page in range(1, max_pages + 1):
+        params = {"q": query, "per_page": per_page, "page": page}
+        try:
+            response = fetch_json(
+                "/search/repositories",
+                token=token,
+                params=params,
+                provider=provider,
+                timeout=35,
+            )
+            data = response.get("data", {})
+        except GitHubAPIError as exc:
+            out["errors"].append(f"Page {page}: {exc} (status: {exc.status or 'unknown'})")
+            break
+
+        if out["total_count"] is None:
+            out["total_count"] = data.get("total_count")
+
+        items = data.get("items", [])
+        if not items:
+            break
+
+        for item in items:
+            rank += 1
+            out["sampled_results"] += 1
+            full_name = item.get("full_name") or ""
+            if full_name.lower() == repo.lower():
+                continue
+            candidates.append(
+                {
+                    "full_name": full_name,
+                    "rank": rank,
+                    "stargazers_count": int(item.get("stargazers_count", 0)),
+                    "description": item.get("description") or "",
+                    "topics": item.get("topics") or [],
+                    "html_url": item.get("html_url"),
+                }
+            )
+    out["candidates"] = candidates
+    return out
+
+
+def aggregate_candidates(query_runs: list) -> dict:
+    aggregate = {}
+    for run in query_runs:
+        query = run["query"]
+        for item in run.get("candidates", []):
+            slug = item["full_name"]
+            entry = aggregate.setdefault(
+                slug,
+                {
+                    "full_name": slug,
+                    "seen_in_queries": 0,
+                    "best_rank": item["rank"],
+                    "query_ranks": {},
+                    "sample_item": item,
+                },
+            )
+            if query not in entry["query_ranks"]:
+                entry["seen_in_queries"] += 1
+            entry["query_ranks"][query] = min(entry["query_ranks"].get(query, 10**9), item["rank"])
+            entry["best_rank"] = min(entry["best_rank"], item["rank"])
+    return aggregate
+
+
+def score_competitor(entry: dict) -> tuple:
+    # Lower rank and wider query coverage should bubble up.
+    return (-entry["seen_in_queries"], entry["best_rank"])
+
+
+def fetch_repo_metadata(repo: str, token: str, provider: str) -> dict:
+    try:
+        response = fetch_json(f"/repos/{repo}", token=token, provider=provider, timeout=30)
+        return response.get("data", {})
+    except GitHubAPIError:
+        return {}
+
+
+def decode_readme_content(payload: dict) -> str:
+    content = payload.get("content") or ""
+    if not content:
+        return ""
+    try:
+        raw = base64.b64decode(content.encode("utf-8"), validate=False)
+        return raw.decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def fetch_readme_metrics(repo: str, token: str, provider: str) -> dict:
+    try:
+        response = fetch_json(f"/repos/{repo}/readme", token=token, provider=provider, timeout=30)
+        payload = response.get("data", {})
+    except GitHubAPIError:
+        return {"available": False}
+
+    text = decode_readme_content(payload)
+    if not text:
+        return {"available": False}
+
+    headings = re.findall(r"^(#{1,6})\s+.+$", text, flags=re.MULTILINE)
+    words = re.findall(r"\b[\w']+\b", re.sub(r"```.*?```", "", text, flags=re.DOTALL))
+    images = re.findall(r"!\[(.*?)\]\((.*?)\)", text)
+    lower = text.lower()
+
+    return {
+        "available": True,
+        "word_count": len(words),
+        "heading_count": len(headings),
+        "h1_count": len([h for h in headings if len(h) == 1]),
+        "image_count": len(images),
+        "images_missing_alt": len([img for img in images if not (img[0] or "").strip()]),
+        "has_install_section": "install" in lower or "getting started" in lower or "quickstart" in lower,
+        "has_contributing_section": "contribut" in lower,
+        "has_examples_section": "example" in lower or "usage" in lower or "demo" in lower,
+    }
+
+
+def summarize_gaps(target_repo_data: dict, competitor_details: list) -> dict:
+    target_topics = set((target_repo_data.get("topics") or []))
+    target_desc = (target_repo_data.get("description") or "").strip()
+    target_desc_words = len(re.findall(r"\b[\w']+\b", target_desc))
+
+    competitor_topics = Counter()
+    competitor_readme_signals = Counter()
+    competitor_desc_words = []
+
+    for item in competitor_details:
+        md = item.get("metadata", {})
+        rm = item.get("readme_metrics", {})
+        topics = md.get("topics") or []
+        competitor_topics.update(topics)
+        desc = (md.get("description") or "").strip()
+        competitor_desc_words.append(len(re.findall(r"\b[\w']+\b", desc)))
+
+        if rm.get("has_install_section"):
+            competitor_readme_signals["install"] += 1
+        if rm.get("has_contributing_section"):
+            competitor_readme_signals["contributing"] += 1
+        if rm.get("has_examples_section"):
+            competitor_readme_signals["examples"] += 1
+
+    topic_gaps = []
+    for topic, freq in competitor_topics.most_common(40):
+        if topic not in target_topics:
+            topic_gaps.append({"topic": topic, "covered_by_competitors": freq})
+    topic_gaps = topic_gaps[:12]
+
+    avg_desc_words = round(sum(competitor_desc_words) / len(competitor_desc_words), 2) if competitor_desc_words else None
+
+    opportunities = []
+    if topic_gaps:
+        top = ", ".join([t["topic"] for t in topic_gaps[:5]])
+        opportunities.append(
+            {
+                "severity": "Warning",
+                "area": "Topics",
+                "finding": "High-frequency competitor topics are missing from target repo.",
+                "evidence": f"Missing topic examples: {top}",
+                "fix": "Add relevant missing topics (without exceeding 20 total) based on actual repository scope.",
+            }
+        )
+
+    if avg_desc_words is not None and target_desc_words and target_desc_words < avg_desc_words:
+        opportunities.append(
+            {
+                "severity": "Info",
+                "area": "Description",
+                "finding": "Target repository description is shorter than competitor baseline.",
+                "evidence": f"Target words: {target_desc_words}, competitor average: {avg_desc_words}",
+                "fix": "Expand description with intent terms, scope, and supported environments.",
+            }
+        )
+
+    for signal_key, label in (("install", "install"), ("examples", "usage/examples"), ("contributing", "contributing")):
+        if competitor_readme_signals.get(signal_key, 0) >= 2:
+            opportunities.append(
+                {
+                    "severity": "Info",
+                    "area": "README",
+                    "finding": f"Competitors frequently include `{label}` sections.",
+                    "evidence": f"{competitor_readme_signals.get(signal_key, 0)} competitor repos include this pattern.",
+                    "fix": f"Ensure README has a clear `{label}` section near the top-level navigation flow.",
+                }
+            )
+
+    return {
+        "target_topics_count": len(target_topics),
+        "topic_gaps": topic_gaps,
+        "description_word_count_target": target_desc_words,
+        "description_word_count_competitor_avg": avg_desc_words,
+        "readme_pattern_frequency": dict(competitor_readme_signals),
+        "opportunities": opportunities,
+    }
+
+
+def build_report(
+    repo: str,
+    token: str,
+    provider: str,
+    queries: list,
+    competitors: list,
+    per_page: int,
+    max_pages: int,
+    top_n: int,
+) -> dict:
+    ctx = auth_context(token=token)
+    report = {
+        "timestamp_utc": utc_now_iso(),
+        "repo": repo,
+        "provider": provider,
+        "auth_context": ctx,
+        "token_present": bool(token),
+        "queries": queries,
+        "query_runs": [],
+        "competitors": [],
+        "gaps": {},
+        "limitations": [],
+    }
+
+    if not token:
+        if ctx.get("gh_authenticated"):
+            report["limitations"].append(
+                "No GitHub token found. Using authenticated gh CLI fallback for competitor research."
+            )
+        elif ctx.get("gh_available"):
+            report["limitations"].append(
+                "No GitHub token found and gh CLI is not authenticated. Run `gh auth login -h github.com` or set GITHUB_TOKEN/GH_TOKEN."
+            )
+        else:
+            report["limitations"].append(
+                "No GitHub token found and gh CLI is unavailable. Competitor research may be rate-limited; set GITHUB_TOKEN/GH_TOKEN."
+            )
+
+    ranked = []
+    if competitors:
+        for slug in competitors:
+            if slug.lower() == repo.lower():
+                continue
+            ranked.append(
+                {
+                    "full_name": slug,
+                    "seen_in_queries": 0,
+                    "best_rank": None,
+                    "query_ranks": {},
+                    "sample_item": {"description": "", "topics": [], "stargazers_count": 0, "html_url": f"https://github.com/{slug}"},
+                }
+            )
+        ranked = ranked[:top_n]
+    elif queries:
+        query_run_full = []
+        for query in queries:
+            run = run_query_candidates(
+                repo=repo,
+                query=query,
+                token=token,
+                provider=provider,
+                per_page=per_page,
+                max_pages=max_pages,
+            )
+            query_run_full.append(run)
+            report["query_runs"].append({
+                "query": run["query"],
+                "sampled_results": run["sampled_results"],
+                "total_count": run["total_count"],
+                "errors": run["errors"],
+            })
+            for err in run.get("errors", []):
+                report["limitations"].append(f"{query}: {err}")
+        aggregate = aggregate_candidates(query_run_full)
+        ranked = sorted(aggregate.values(), key=score_competitor)[:top_n]
+    else:
+        report["limitations"].append(
+            "No competitor inputs provided. Supply `--query/--query-file` from LLM/web search or pass explicit `--competitor` repo slugs."
+        )
+
+    target_repo_data = fetch_repo_metadata(repo=repo, token=token, provider=provider)
+    competitor_details = []
+    for entry in ranked:
+        slug = entry["full_name"]
+        md = fetch_repo_metadata(repo=slug, token=token, provider=provider)
+        rm = fetch_readme_metrics(repo=slug, token=token, provider=provider)
+        competitor_details.append(
+            {
+                "full_name": slug,
+                "seen_in_queries": entry["seen_in_queries"],
+                "best_rank": entry["best_rank"],
+                "query_ranks": entry["query_ranks"],
+                "metadata": {
+                    "description": md.get("description") or entry["sample_item"].get("description", ""),
+                    "topics": md.get("topics") or entry["sample_item"].get("topics", []),
+                    "stargazers_count": int(md.get("stargazers_count", entry["sample_item"].get("stargazers_count", 0))),
+                    "forks_count": int(md.get("forks_count", 0)),
+                    "homepage": md.get("homepage") or "",
+                    "pushed_at": md.get("pushed_at"),
+                    "pushed_days_ago": days_since(md.get("pushed_at")),
+                    "html_url": md.get("html_url") or entry["sample_item"].get("html_url"),
+                },
+                "readme_metrics": rm,
+            }
+        )
+
+    report["competitors"] = competitor_details
+    report["gaps"] = summarize_gaps(target_repo_data=target_repo_data, competitor_details=competitor_details)
+    report["target_metadata"] = {
+        "description": target_repo_data.get("description") or "",
+        "topics": target_repo_data.get("topics") or [],
+        "stargazers_count": int(target_repo_data.get("stargazers_count", 0)),
+        "forks_count": int(target_repo_data.get("forks_count", 0)),
+        "html_url": target_repo_data.get("html_url") or f"https://github.com/{repo}",
+    }
+    report["summary"] = {
+        "competitors_analyzed": len(competitor_details),
+        "queries_used": len(queries),
+        "top_topic_gaps": report["gaps"].get("topic_gaps", [])[:5],
+    }
+    return report
+
+
+def print_text(report: dict):
+    print(f"\nGitHub Competitor Research: {report.get('repo')}")
+    print("=" * 60)
+    summary = report.get("summary", {})
+    print(
+        f"Competitors analyzed: {summary.get('competitors_analyzed', 0)} | "
+        f"Queries: {summary.get('queries_used', 0)}"
+    )
+    top_gaps = summary.get("top_topic_gaps", [])
+    if top_gaps:
+        print("Top topic gaps:")
+        for gap in top_gaps:
+            print(f"- {gap['topic']} ({gap['covered_by_competitors']} competitors)")
+    if report.get("limitations"):
+        print("\nLimitations:")
+        for item in report["limitations"][:10]:
+            print(f"- {item}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run GitHub competitor research against query-defined peers.")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo). If omitted, infer from git origin.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument("--query", action="append", help="Search query (repeatable).")
+    parser.add_argument("--query-file", help="Path to newline-delimited query file.")
+    parser.add_argument("--competitor", action="append", help="Explicit competitor repo slug/URL (repeatable).")
+    parser.add_argument("--per-page", type=int, default=30, help="Results per page (default: 30, max: 100).")
+    parser.add_argument("--max-pages", type=int, default=2, help="Max search pages per query (default: 2).")
+    parser.add_argument("--top-n", type=int, default=6, help="Number of competitor repos to analyze deeply (default: 6).")
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "api", "gh"],
+        default="auto",
+        help="GitHub data provider mode (default: auto).",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--output", help="Write JSON report to path.")
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo(args.repo)
+        token = get_token(args.token)
+        queries = load_queries(args)
+    except GitHubAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    competitors = []
+    if args.competitor:
+        for raw in args.competitor:
+            slug = normalize_repo_slug(raw)
+            if slug:
+                competitors.append(slug)
+    competitors = _dedupe(competitors)
+
+    report = build_report(
+        repo=repo,
+        token=token,
+        provider=args.provider,
+        queries=queries,
+        competitors=competitors,
+        per_page=max(1, min(100, args.per_page)),
+        max_pages=max(1, args.max_pages),
+        top_n=max(1, min(25, args.top_n)),
+    )
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_text(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_readme_lint.py
+++ b/.claude/skills/seo/scripts/github_readme_lint.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+GitHub README SEO Lint
+
+Scores README quality for GitHub discoverability and conversion readiness.
+
+Usage:
+  python github_readme_lint.py README.md --json
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+from github_api import GitHubAPIError, fetch_json, get_token, resolve_repo
+
+
+DEFAULT_INTENTS = [
+    "seo",
+    "audit",
+    "technical seo",
+    "schema",
+    "core web vitals",
+]
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def looks_like_placeholder(text: str) -> bool:
+    value = (text or "").strip().lower()
+    if value in {"404", "404: not found", "not found"}:
+        return True
+    if value.startswith("404:"):
+        return True
+    if value.startswith("<html") and "not found" in value:
+        return True
+    return False
+
+
+def fetch_readme_from_repo(repo: str, token: str, provider: str) -> str:
+    response = fetch_json(f"/repos/{repo}/readme", token=token, provider=provider, timeout=30)
+    payload = response.get("data", {})
+    content = payload.get("content") or ""
+    if not content:
+        return ""
+    raw = base64.b64decode(content.encode("utf-8"), validate=False)
+    return raw.decode("utf-8", errors="replace")
+
+
+def strip_code_fences(text: str) -> str:
+    text = re.sub(r"(?ms)^```[\s\S]*?^```[ \t]*$", "", text)
+    text = re.sub(r"(?ms)^~~~[\s\S]*?^~~~[ \t]*$", "", text)
+    return text
+
+
+def extract_headings(markdown: str) -> list:
+    headings = []
+    lines = markdown.splitlines()
+    for i, line in enumerate(lines, start=1):
+        m = re.match(r"^(#{1,6})\s+(.+?)\s*$", line.strip())
+        if m:
+            headings.append({"line": i, "level": len(m.group(1)), "text": m.group(2).strip()})
+            continue
+
+        # Setext headings:
+        # Title
+        # =====
+        if i < len(lines):
+            next_line = lines[i].strip()
+            if line.strip() and re.match(r"^(=+|-+)\s*$", next_line):
+                level = 1 if next_line.startswith("=") else 2
+                headings.append({"line": i, "level": level, "text": line.strip()})
+    return headings
+
+
+def count_code_blocks(markdown: str) -> int:
+    fenced_backticks = len(re.findall(r"(?ms)^```[\s\S]*?^```[ \t]*$", markdown))
+    fenced_tildes = len(re.findall(r"(?ms)^~~~[\s\S]*?^~~~[ \t]*$", markdown))
+    fenced_total = fenced_backticks + fenced_tildes
+
+    # Count indented code blocks (>=2 consecutive indented non-empty lines)
+    indented_total = 0
+    run = 0
+    for line in markdown.splitlines():
+        if re.match(r"^(    |\t)\S", line):
+            run += 1
+        else:
+            if run >= 2:
+                indented_total += 1
+            run = 0
+    if run >= 2:
+        indented_total += 1
+
+    return fenced_total + indented_total
+
+
+def extract_images(markdown: str) -> list:
+    images = []
+    for m in re.finditer(r"!\[(.*?)\]\((.*?)\)", markdown):
+        images.append({"alt": (m.group(1) or "").strip(), "url": (m.group(2) or "").strip()})
+    return images
+
+
+def plain_word_count(markdown: str) -> int:
+    text = strip_code_fences(markdown)
+    text = re.sub(r"!\[.*?\]\(.*?\)", " ", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"[#>*`_~\-]", " ", text)
+    words = re.findall(r"\b[\w']+\b", text.lower())
+    return len(words)
+
+
+def add_finding(findings: list, category: str, severity: str, finding: str, evidence: str, fix: str):
+    findings.append(
+        {
+            "category": category,
+            "severity": severity,
+            "confidence": "Confirmed",
+            "finding": finding,
+            "evidence": evidence,
+            "fix": fix,
+        }
+    )
+
+
+def normalize_heading_text(headings: list) -> list:
+    return [h["text"].strip().lower() for h in headings]
+
+
+def detect_heading_jumps(headings: list) -> list:
+    jumps = []
+    prev = None
+    for h in headings:
+        if prev is not None and h["level"] > prev + 1:
+            jumps.append({"line": h["line"], "from": prev, "to": h["level"], "text": h["text"]})
+        prev = h["level"]
+    return jumps
+
+
+def score_report(markdown: str, intents: list) -> dict:
+    headings = extract_headings(markdown)
+    heading_text = normalize_heading_text(headings)
+    images = extract_images(markdown)
+    words = plain_word_count(markdown)
+    findings = []
+
+    # Opening clarity (20)
+    opening_score = 20
+    opening_chunk = strip_code_fences(markdown).strip().splitlines()[:20]
+    opening_text = " ".join(opening_chunk).lower()
+    matched_intents = [term for term in intents if term.lower() in opening_text]
+    if not matched_intents:
+        opening_score -= 12
+        add_finding(
+            findings,
+            "Opening Clarity",
+            "Warning",
+            "Opening section lacks target intent terms.",
+            "None of the configured intent terms appear in the opening section.",
+            "Include primary use-case language in first 2-3 paragraphs.",
+        )
+    if words < 250:
+        opening_score -= 4
+        add_finding(
+            findings,
+            "Opening Clarity",
+            "Info",
+            "README is short for a discoverability-oriented project page.",
+            f"Word count is {words}.",
+            "Expand with concise sections for install, proof, and contribution paths.",
+        )
+    opening_score = max(0, opening_score)
+
+    # Information architecture (20)
+    ia_score = 20
+    h1_count = sum(1 for h in headings if h["level"] == 1)
+    heading_jumps = detect_heading_jumps(headings)
+    if h1_count != 1:
+        ia_score -= 12
+        severity = "Critical" if h1_count == 0 else "Warning"
+        add_finding(
+            findings,
+            "Information Architecture",
+            severity,
+            "README should contain exactly one H1 heading.",
+            f"Detected H1 count: {h1_count}.",
+            "Keep a single H1 title and move other top-level sections to H2.",
+        )
+    if heading_jumps:
+        ia_score -= 5
+        add_finding(
+            findings,
+            "Information Architecture",
+            "Warning",
+            "Heading hierarchy has level jumps.",
+            f"Detected {len(heading_jumps)} jump(s) where heading level skips intermediary levels.",
+            "Normalize heading flow (H1 -> H2 -> H3) without skipping levels.",
+        )
+    ia_score = max(0, ia_score)
+
+    # Install + quickstart (20)
+    install_score = 20
+    install_markers = ("install", "quick start", "quickstart", "getting started", "setup")
+    has_install_section = any(any(marker in t for marker in install_markers) for t in heading_text)
+    if not has_install_section:
+        install_score -= 14
+        add_finding(
+            findings,
+            "Install + Quickstart",
+            "Critical",
+            "Installation/quickstart section is missing.",
+            "No install or getting-started heading detected.",
+            "Add a dedicated install section with copy-paste commands and prerequisites.",
+        )
+    code_block_count = count_code_blocks(markdown)
+    if code_block_count == 0:
+        install_score -= 4
+        add_finding(
+            findings,
+            "Install + Quickstart",
+            "Warning",
+            "No code examples detected.",
+            "README contains zero detectable code blocks (fenced or indented).",
+            "Add runnable command examples for setup and core usage.",
+        )
+    install_score = max(0, install_score)
+
+    # Proof + credibility (15)
+    proof_score = 15
+    proof_markers = ("example", "output", "report", "screenshot", "demo", "result")
+    has_examples_section = any(any(marker in t for marker in proof_markers) for t in heading_text)
+    if not has_examples_section:
+        proof_score -= 8
+        add_finding(
+            findings,
+            "Proof + Credibility",
+            "Warning",
+            "README lacks explicit proof/results section.",
+            "No heading found for examples, reports, screenshots, or outputs.",
+            "Add evidence sections with sample outputs or screenshots.",
+        )
+    if "license" not in " ".join(heading_text) and "license" not in markdown.lower():
+        proof_score -= 4
+        add_finding(
+            findings,
+            "Proof + Credibility",
+            "Warning",
+            "License reference is missing or unclear in README.",
+            "No explicit license mention detected.",
+            "Add a short license section linking to LICENSE file.",
+        )
+    proof_score = max(0, proof_score)
+
+    # CTA + community (15)
+    cta_score = 15
+    cta_markers = ("contribut", "issue", "pull request", "support", "discussion", "star")
+    cta_hits = sum(1 for marker in cta_markers if marker in markdown.lower())
+    has_contributing_section = "contribut" in markdown.lower()
+    if cta_hits < 2:
+        cta_score -= 9
+        add_finding(
+            findings,
+            "CTA + Community",
+            "Warning",
+            "README has weak contribution/support call-to-action coverage.",
+            f"Detected {cta_hits} CTA marker(s) from contribution/support keyword set.",
+            "Add clear paths for contributing, opening issues, and support requests.",
+        )
+    cta_score = max(0, cta_score)
+
+    # Readability + accessibility (10)
+    read_score = 10
+    missing_alt = [img for img in images if not img["alt"]]
+    if missing_alt:
+        read_score -= 6
+        add_finding(
+            findings,
+            "Readability + Accessibility",
+            "Warning",
+            "Some README images are missing alt text.",
+            f"{len(missing_alt)} image(s) detected with empty alt text.",
+            "Add descriptive alt text for each non-decorative image.",
+        )
+    if len(headings) < 4:
+        read_score -= 2
+        add_finding(
+            findings,
+            "Readability + Accessibility",
+            "Info",
+            "README sectioning is shallow.",
+            f"Detected only {len(headings)} heading(s).",
+            "Use additional headings to improve scannability and structure.",
+        )
+    read_score = max(0, read_score)
+
+    category_scores = {
+        "opening_clarity": opening_score,
+        "information_architecture": ia_score,
+        "install_quickstart": install_score,
+        "proof_credibility": proof_score,
+        "cta_community": cta_score,
+        "readability_accessibility": read_score,
+    }
+    total_score = sum(category_scores.values())
+
+    if total_score >= 90:
+        rating = "Excellent"
+    elif total_score >= 70:
+        rating = "Good"
+    elif total_score >= 50:
+        rating = "Needs Improvement"
+    elif total_score >= 30:
+        rating = "Poor"
+    else:
+        rating = "Critical"
+
+    if not findings:
+        add_finding(
+            findings,
+            "Overall",
+            "Pass",
+            "README meets baseline GitHub SEO and conversion quality checks.",
+            "No major structural, install, or accessibility deficiencies detected.",
+            "Maintain quality with periodic linting and updates.",
+        )
+
+    return {
+        "summary": {"score": total_score, "rating": rating},
+        "metrics": {
+            "word_count": words,
+            "heading_count": len(headings),
+            "h1_count": h1_count,
+            "code_block_count": code_block_count,
+            "image_count": len(images),
+            "images_missing_alt": len(missing_alt),
+            "matched_intents_in_opening": matched_intents,
+            "has_install_section": has_install_section,
+            "has_examples_section": has_examples_section,
+            "has_contributing_section": has_contributing_section,
+        },
+        "category_scores": category_scores,
+        "findings": findings,
+    }
+
+
+def print_text(report: dict):
+    summary = report.get("summary", {})
+    print("\nREADME SEO Lint")
+    print("=" * 60)
+    print(f"Score: {summary.get('score', 'NA')}/100 ({summary.get('rating', 'Unknown')})")
+    metrics = report.get("metrics", {})
+    print(
+        f"Words: {metrics.get('word_count', 0)} | Headings: {metrics.get('heading_count', 0)} | "
+        f"Images missing alt: {metrics.get('images_missing_alt', 0)}"
+    )
+    print("\nTop findings:")
+    for f in report.get("findings", [])[:10]:
+        print(f"- [{f['severity']}] {f['finding']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="README SEO and conversion linting for GitHub repositories.")
+    parser.add_argument("readme_path", nargs="?", default="README.md", help="Path to README file (default: README.md)")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo) for remote README fallback.")
+    parser.add_argument("--provider", choices=["auto", "api", "gh"], default="auto", help="GitHub data provider mode for README fallback.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument("--intent", action="append", help="Target intent phrase (repeatable).")
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--output", help="Write JSON report to file path.")
+    args = parser.parse_args()
+
+    intents = args.intent if args.intent else DEFAULT_INTENTS
+    limitations = []
+    content_source = "local_file"
+    markdown = ""
+
+    if os.path.exists(args.readme_path):
+        markdown = read_text(args.readme_path)
+    else:
+        limitations.append(f"Local README file not found: {args.readme_path}")
+
+    needs_remote = (not markdown.strip()) or looks_like_placeholder(markdown)
+    if needs_remote and args.repo:
+        try:
+            token = get_token(args.token)
+            repo = resolve_repo(args.repo)
+            remote_md = fetch_readme_from_repo(repo=repo, token=token, provider=args.provider)
+            if remote_md.strip():
+                markdown = remote_md
+                content_source = "github_api"
+                limitations.append("Used remote README fallback due missing/placeholder local README.")
+        except GitHubAPIError as exc:
+            limitations.append(f"Remote README fallback failed: {exc}")
+
+    if looks_like_placeholder(markdown):
+        print(
+            "Error: README content appears to be placeholder/404. Provide valid README path or repo access for remote fallback.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    if not markdown.strip():
+        print("Error: README content unavailable from local file and remote fallback.", file=sys.stderr)
+        sys.exit(2)
+
+    scored = score_report(markdown=markdown, intents=intents)
+    report = {
+        "timestamp_utc": utc_now_iso(),
+        "readme_path": args.readme_path,
+        "content_source": content_source,
+        "limitations": limitations,
+        "intents": intents,
+        **scored,
+    }
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_text(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_repo_audit.py
+++ b/.claude/skills/seo/scripts/github_repo_audit.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""
+GitHub Repository SEO Audit
+
+Audits repository metadata, trust signals, and community health with GitHub API
+data (when token is available) plus local file fallback checks.
+
+Usage:
+  python github_repo_audit.py --repo owner/repo --json
+  python github_repo_audit.py --repo owner/repo --token $GITHUB_TOKEN
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+
+from github_api import (
+    GitHubAPIError,
+    auth_context,
+    fetch_json,
+    get_token,
+    infer_repo_from_git,
+    resolve_repo,
+)
+
+STOP_WORDS = {
+    "the", "and", "for", "with", "from", "into", "this", "that", "your",
+    "are", "was", "were", "been", "being", "have", "has", "had", "will",
+    "would", "could", "should", "about", "over", "under", "between", "while",
+    "where", "when", "which", "what", "into", "than", "then", "them", "they",
+    "you", "our", "their", "its", "it's", "via", "all", "any", "not", "can",
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def parse_iso8601(value: str):
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def days_since(value: str):
+    dt = parse_iso8601(value)
+    if not dt:
+        return None
+    return (datetime.now(timezone.utc) - dt).days
+
+
+def local_file_signals(cwd: str) -> dict:
+    """Check local governance/community files."""
+    checks = {
+        "README.md": os.path.exists(os.path.join(cwd, "README.md")),
+        "LICENSE": os.path.exists(os.path.join(cwd, "LICENSE")),
+        "CONTRIBUTING.md": os.path.exists(os.path.join(cwd, "CONTRIBUTING.md")),
+        "CODE_OF_CONDUCT.md": os.path.exists(os.path.join(cwd, "CODE_OF_CONDUCT.md")),
+        "SECURITY.md": os.path.exists(os.path.join(cwd, "SECURITY.md")),
+        "SUPPORT.md": os.path.exists(os.path.join(cwd, "SUPPORT.md")),
+        "CITATION.cff": os.path.exists(os.path.join(cwd, "CITATION.cff")),
+        ".github/ISSUE_TEMPLATE": os.path.isdir(os.path.join(cwd, ".github", "ISSUE_TEMPLATE")),
+        ".github/PULL_REQUEST_TEMPLATE.md": os.path.exists(
+            os.path.join(cwd, ".github", "PULL_REQUEST_TEMPLATE.md")
+        ),
+    }
+    return checks
+
+
+def add_finding(
+    findings: list,
+    area: str,
+    severity: str,
+    confidence: str,
+    finding: str,
+    evidence: str,
+    fix: str,
+):
+    findings.append(
+        {
+            "area": area,
+            "severity": severity,
+            "confidence": confidence,
+            "finding": finding,
+            "evidence": evidence,
+            "fix": fix,
+        }
+    )
+
+
+def score_findings(findings: list) -> dict:
+    """Compute a directional score from severity counts."""
+    critical = sum(1 for f in findings if f["severity"] == "Critical")
+    warning = sum(1 for f in findings if f["severity"] == "Warning")
+    score = max(0, 100 - (critical * 20) - (warning * 8))
+    if score >= 90:
+        rating = "Excellent"
+    elif score >= 70:
+        rating = "Good"
+    elif score >= 50:
+        rating = "Needs Improvement"
+    elif score >= 30:
+        rating = "Poor"
+    else:
+        rating = "Critical"
+    return {"score": score, "rating": rating, "critical": critical, "warning": warning}
+
+
+def _tokenize(text: str) -> list:
+    words = re.findall(r"[a-z0-9]+", (text or "").lower())
+    return [w for w in words if len(w) > 1 and w not in STOP_WORDS]
+
+
+def _dedupe_keep_order(items: list) -> list:
+    out = []
+    seen = set()
+    for item in items:
+        if item not in seen:
+            out.append(item)
+            seen.add(item)
+    return out
+
+
+def _format_title_token(token: str) -> str:
+    mapping = {"seo": "SEO", "llm": "LLM", "ai": "AI", "api": "API", "github": "GitHub", "aeo": "AEO", "geo": "GEO"}
+    return mapping.get(token.lower(), token.capitalize())
+
+
+def analyze_title_strategy(repo_slug: str, metadata: dict) -> dict:
+    """Generate intent-based title and slug recommendations."""
+    repo_name = (metadata.get("name") or "").strip()
+    if not repo_name and repo_slug:
+        repo_name = repo_slug.split("/", 1)[-1]
+
+    description = (metadata.get("description") or "").strip()
+    topics = metadata.get("topics") or []
+
+    name_tokens = _tokenize(repo_name.replace("_", " ").replace("-", " "))
+    topic_tokens = []
+    for topic in topics:
+        topic_tokens.extend(_tokenize(topic.replace("-", " ").replace("_", " ")))
+
+    desc_tokens = _tokenize(description)
+    desc_freq = Counter(desc_tokens)
+    desc_priority = [word for word, _ in desc_freq.most_common(15)]
+
+    priority_seed = name_tokens + topic_tokens + desc_priority
+    keywords = _dedupe_keep_order(priority_seed)
+
+    if not keywords:
+        keywords = _tokenize(repo_slug.replace("/", " "))
+
+    slug_tokens = keywords[:5] if keywords else []
+    if "seo" in keywords and "seo" not in slug_tokens:
+        slug_tokens = ["seo"] + slug_tokens[:4]
+    slug_tokens = _dedupe_keep_order(slug_tokens)
+    recommended_slug = "-".join(slug_tokens) if slug_tokens else repo_name.replace("_", "-").lower()
+
+    title_tokens = []
+    for token in slug_tokens:
+        if token in ("for", "and", "the"):
+            continue
+        title_tokens.append(token)
+    title_tokens = _dedupe_keep_order(title_tokens)
+    display_title = " ".join(_format_title_token(t) for t in title_tokens[:7]).strip()
+
+    alt_titles = []
+    if display_title:
+        alt_titles.append(display_title)
+    alt_titles = _dedupe_keep_order([t for t in alt_titles if t])
+
+    return {
+        "current_name": repo_name,
+        "current_has_underscore": "_" in repo_name,
+        "current_has_hyphen": "-" in repo_name,
+        "search_intent_keywords": keywords[:12],
+        "recommended_repo_slug": recommended_slug,
+        "recommended_display_title": display_title or repo_name,
+        "alternative_titles": alt_titles[:3],
+        "notes": [
+            "Keyword suggestions are intent-based heuristics.",
+            "Search volume should be validated separately with keyword tools.",
+            "Use hyphen-separated words for slug readability and token separation.",
+        ],
+    }
+
+
+def build_audit(repo: str, token: str, cwd: str, provider: str) -> dict:
+    ctx = auth_context(token=token)
+    local_repo = infer_repo_from_git(cwd=cwd)
+    local_checks_enabled = bool(local_repo) and (local_repo.lower() == repo.lower())
+    report = {
+        "timestamp_utc": utc_now_iso(),
+        "repo": repo,
+        "auth_context": ctx,
+        "local_repo_context": {"detected_local_repo": local_repo or "", "local_checks_enabled": local_checks_enabled},
+        "api_access": {"token_present": bool(token), "repo_endpoint_ok": False, "community_endpoint_ok": False},
+        "limitations": [],
+        "metadata": {},
+        "title_analysis": {},
+        "community_profile": {},
+        "local_signals": local_file_signals(cwd) if local_checks_enabled else {},
+        "findings": [],
+    }
+
+    repo_data = {}
+    community_data = {}
+    confidence = "Confirmed"
+
+    if not token:
+        if ctx.get("gh_authenticated"):
+            report["limitations"].append(
+                "No GitHub token found. Using authenticated gh CLI session as fallback."
+            )
+        elif ctx.get("gh_available"):
+            report["limitations"].append(
+                "No GitHub token found and gh CLI is not authenticated. Run `gh auth login -h github.com` or set GITHUB_TOKEN/GH_TOKEN."
+            )
+        else:
+            report["limitations"].append(
+                "No GitHub token found and gh CLI is unavailable. Set GITHUB_TOKEN/GH_TOKEN for reliable API access."
+            )
+    if not local_checks_enabled:
+        report["limitations"].append(
+            "Local filesystem checks skipped because target repo does not match current working repository."
+        )
+
+    try:
+        repo_resp = fetch_json(f"/repos/{repo}", token=token, provider=provider)
+        repo_data = repo_resp.get("data", {})
+        report["api_access"]["repo_endpoint_ok"] = True
+        report["api_access"]["rate_limit"] = repo_resp.get("rate_limit", {})
+    except GitHubAPIError as exc:
+        confidence = "Likely"
+        report["limitations"].append(
+            f"Repository API unavailable: {exc} (status: {exc.status or 'unknown'})"
+        )
+
+    try:
+        comm_resp = fetch_json(f"/repos/{repo}/community/profile", token=token, provider=provider)
+        community_data = comm_resp.get("data", {})
+        report["api_access"]["community_endpoint_ok"] = True
+    except GitHubAPIError as exc:
+        confidence = "Likely"
+        report["limitations"].append(
+            f"Community profile API unavailable: {exc} (status: {exc.status or 'unknown'})"
+        )
+
+    if repo_data:
+        report["metadata"] = {
+            "name": repo_data.get("name"),
+            "full_name": repo_data.get("full_name"),
+            "description": repo_data.get("description") or "",
+            "homepage": repo_data.get("homepage") or "",
+            "topics": repo_data.get("topics") or [],
+            "open_graph_image_url": repo_data.get("open_graph_image_url") or "",
+            "archived": bool(repo_data.get("archived")),
+            "fork": bool(repo_data.get("fork")),
+            "stargazers_count": int(repo_data.get("stargazers_count", 0)),
+            "forks_count": int(repo_data.get("forks_count", 0)),
+            "watchers_count": int(repo_data.get("watchers_count", 0)),
+            "open_issues_count": int(repo_data.get("open_issues_count", 0)),
+            "pushed_at": repo_data.get("pushed_at"),
+            "updated_at": repo_data.get("updated_at"),
+            "license": (repo_data.get("license") or {}).get("spdx_id"),
+        }
+
+    if community_data:
+        report["community_profile"] = {
+            "health_percentage": community_data.get("health_percentage"),
+            "description": community_data.get("description") or "",
+            "documentation": community_data.get("documentation") or "",
+            "files": community_data.get("files") or {},
+        }
+
+    findings = report["findings"]
+    report["title_analysis"] = analyze_title_strategy(repo_slug=repo, metadata=report["metadata"] or {})
+
+    # Metadata checks
+    if report["metadata"]:
+        md = report["metadata"]
+        title_analysis = report["title_analysis"]
+        description = (md.get("description") or "").strip()
+        topics = md.get("topics") or []
+        pushed_days = days_since(md.get("pushed_at"))
+
+        if not description:
+            add_finding(
+                findings,
+                "Metadata",
+                "Warning",
+                confidence,
+                "Repository description is missing.",
+                "GitHub metadata `description` is empty.",
+                "Add a concise, intent-matched description that explains scope and audience.",
+            )
+        elif len(description) < 60:
+            add_finding(
+                findings,
+                "Metadata",
+                "Info",
+                confidence,
+                "Repository description is short.",
+                f"Description length is {len(description)} characters.",
+                "Expand description to include primary use case and distinctive value.",
+            )
+
+        if not topics:
+            add_finding(
+                findings,
+                "Metadata",
+                "Warning",
+                confidence,
+                "No repository topics configured.",
+                "GitHub topics list is empty.",
+                "Add relevant discovery topics (up to 20) for intent coverage.",
+            )
+        elif len(topics) > 20:
+            add_finding(
+                findings,
+                "Metadata",
+                "Critical",
+                confidence,
+                "Topic count exceeds GitHub topic cap.",
+                f"Detected {len(topics)} topics.",
+                "Reduce to 20 or fewer high-signal, non-overlapping topics.",
+            )
+        elif len(topics) < 5:
+            add_finding(
+                findings,
+                "Metadata",
+                "Info",
+                confidence,
+                "Topic coverage may be thin.",
+                f"Detected {len(topics)} topics.",
+                "Add additional relevant topics to cover primary user intents.",
+            )
+
+        if not md.get("homepage"):
+            add_finding(
+                findings,
+                "Metadata",
+                "Info",
+                confidence,
+                "Homepage URL is not set.",
+                "GitHub metadata `homepage` is empty.",
+                "Set homepage to documentation or project landing page if available.",
+            )
+
+        if md.get("archived"):
+            add_finding(
+                findings,
+                "Maintenance",
+                "Critical",
+                confidence,
+                "Repository is archived.",
+                "GitHub metadata shows `archived=true`.",
+                "Unarchive if active development/discovery is still a goal.",
+            )
+
+        if pushed_days is not None and pushed_days > 180:
+            add_finding(
+                findings,
+                "Maintenance",
+                "Warning",
+                confidence,
+                "Repository appears stale.",
+                f"Last push was {pushed_days} days ago.",
+                "Publish a maintenance release or documentation refresh to signal activity.",
+            )
+
+        if title_analysis.get("current_has_underscore"):
+            add_finding(
+                findings,
+                "Metadata",
+                "Warning",
+                confidence,
+                "Repository title/slug uses underscore separators.",
+                f"Current repository name: `{title_analysis.get('current_name')}`",
+                "Prefer hyphen-separated words in repository slug for clearer token separation in search indexing.",
+            )
+
+        suggested_slug = title_analysis.get("recommended_repo_slug", "")
+        current_name = (title_analysis.get("current_name") or "").lower()
+        if suggested_slug and current_name and suggested_slug != current_name:
+            add_finding(
+                findings,
+                "Metadata",
+                "Info",
+                confidence,
+                "Repository title can be better aligned to search intent keywords.",
+                f"Suggested slug: `{suggested_slug}` | Suggested title: `{title_analysis.get('recommended_display_title')}`",
+                "Consider renaming repository slug and updating description/topics to reflect the suggested intent keywords.",
+            )
+    else:
+        title_analysis = report["title_analysis"]
+        if title_analysis.get("current_has_underscore"):
+            add_finding(
+                findings,
+                "Metadata",
+                "Warning",
+                "Likely",
+                "Repository slug uses underscore separators.",
+                f"Current repository name: `{title_analysis.get('current_name')}` (derived from slug)",
+                "Prefer hyphen-separated words in repository slug for clearer token separation in search indexing.",
+            )
+
+        suggested_slug = title_analysis.get("recommended_repo_slug", "")
+        current_name = (title_analysis.get("current_name") or "").lower()
+        if suggested_slug and current_name and suggested_slug != current_name:
+            add_finding(
+                findings,
+                "Metadata",
+                "Info",
+                "Likely",
+                "Repository title can be better aligned to intent terms.",
+                f"Suggested slug: `{suggested_slug}` | Suggested title: `{title_analysis.get('recommended_display_title')}`",
+                "Review slug/title recommendations and align repository naming with high-intent keywords.",
+            )
+
+    # Community profile checks from API
+    if report["community_profile"]:
+        cp = report["community_profile"]
+        health = cp.get("health_percentage")
+        files = cp.get("files", {})
+        if isinstance(health, (int, float)) and health < 85:
+            add_finding(
+                findings,
+                "Community",
+                "Warning",
+                confidence,
+                "Community health score is below recommended baseline.",
+                f"GitHub community health is {health}%.",
+                "Complete missing governance files and contribution docs to raise score.",
+            )
+
+        for key in ("code_of_conduct", "contributing", "issue_template", "pull_request_template", "readme", "license"):
+            if not files.get(key):
+                add_finding(
+                    findings,
+                    "Community",
+                    "Warning",
+                    confidence,
+                    f"Missing community profile component: {key}.",
+                    f"GitHub community profile `files.{key}` is missing.",
+                    f"Add the missing `{key}` file/template in repository root or `.github/`.",
+                )
+
+    # Local fallback checks
+    if local_checks_enabled:
+        local = report["local_signals"]
+        for required in ("README.md", "LICENSE"):
+            if not local.get(required):
+                add_finding(
+                    findings,
+                    "Community",
+                    "Critical",
+                    "Confirmed",
+                    f"Missing required repository file: {required}.",
+                    f"Local file check indicates `{required}` is absent.",
+                    f"Add `{required}` to restore baseline project trust and discoverability.",
+                )
+
+        for recommended in ("CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "SECURITY.md", ".github/ISSUE_TEMPLATE", ".github/PULL_REQUEST_TEMPLATE.md", "CITATION.cff"):
+            if not local.get(recommended):
+                add_finding(
+                    findings,
+                    "Community",
+                    "Warning",
+                    "Confirmed",
+                    f"Missing recommended trust artifact: {recommended}.",
+                    f"Local file check indicates `{recommended}` is absent.",
+                    f"Add `{recommended}` to improve contribution readiness and credibility signals.",
+                )
+
+    if not findings:
+        add_finding(
+            findings,
+            "Overall",
+            "Pass",
+            "Confirmed",
+            "No major GitHub SEO issues detected in current scope.",
+            "Metadata, community, and local trust checks met baseline.",
+            "Continue weekly monitoring and query benchmark tracking.",
+        )
+
+    report["summary"] = score_findings(findings)
+    return report
+
+
+def print_text(report: dict):
+    summary = report.get("summary", {})
+    print(f"\nGitHub Repo Audit: {report.get('repo')}")
+    print("=" * 60)
+    print(f"Score: {summary.get('score', 'NA')}/100 ({summary.get('rating', 'Unknown')})")
+    print(f"Critical: {summary.get('critical', 0)} | Warning: {summary.get('warning', 0)}")
+
+    if report.get("limitations"):
+        print("\nEnvironment limitations:")
+        for item in report["limitations"]:
+            print(f"- {item}")
+
+    title_analysis = report.get("title_analysis", {})
+    if title_analysis:
+        print("\nTitle recommendations:")
+        print(f"- Suggested slug: {title_analysis.get('recommended_repo_slug')}")
+        print(f"- Suggested title: {title_analysis.get('recommended_display_title')}")
+        if title_analysis.get("search_intent_keywords"):
+            print(
+                f"- Intent keywords: {', '.join(title_analysis['search_intent_keywords'][:8])}"
+            )
+
+    print("\nTop findings:")
+    for finding in report.get("findings", [])[:10]:
+        print(
+            f"- [{finding['severity']}] {finding['finding']} "
+            f"(confidence: {finding['confidence']})"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GitHub repository SEO metadata and trust audit.")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo). If omitted, infer from git origin.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument("--cwd", default=".", help="Working directory for local file checks (default: .)")
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "api", "gh"],
+        default="auto",
+        help="GitHub data provider mode (default: auto).",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--output", help="Write JSON report to path.")
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo(args.repo, cwd=args.cwd)
+        token = get_token(args.token)
+        report = build_audit(repo=repo, token=token, cwd=args.cwd, provider=args.provider)
+    except GitHubAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        sys.exit(130)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_text(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_search_benchmark.py
+++ b/.claude/skills/seo/scripts/github_search_benchmark.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+GitHub Search Benchmark
+
+Benchmarks repository visibility for a deterministic set of search queries.
+
+Usage:
+  python github_search_benchmark.py --repo owner/repo --query "seo skill" --json
+  python github_search_benchmark.py --repo owner/repo --query-file queries.txt --max-pages 2
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from github_api import (
+    GitHubAPIError,
+    auth_context,
+    fetch_json,
+    get_token,
+    resolve_repo,
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _dedupe(values: list) -> list:
+    out = []
+    seen = set()
+    for item in values:
+        key = item.lower().strip()
+        if key and key not in seen:
+            out.append(item.strip())
+            seen.add(key)
+    return out
+
+
+def load_queries(args) -> list:
+    queries = []
+    if args.query:
+        queries.extend([q.strip() for q in args.query if q.strip()])
+    if args.query_file:
+        if not os.path.exists(args.query_file):
+            raise GitHubAPIError(f"Query file not found: {args.query_file}")
+        with open(args.query_file, "r", encoding="utf-8") as f:
+            for line in f:
+                text = line.strip()
+                if text and not text.startswith("#"):
+                    queries.append(text)
+    return _dedupe(queries)
+
+
+def run_query(repo: str, query: str, token: str, per_page: int, max_pages: int, provider: str) -> dict:
+    target_rank = None
+    competitors = []
+    sampled = 0
+    total_count = None
+    errors = []
+
+    for page in range(1, max_pages + 1):
+        params = {"q": query, "per_page": per_page, "page": page}
+        try:
+            response = fetch_json(
+                "/search/repositories",
+                token=token,
+                params=params,
+                provider=provider,
+                timeout=35,
+            )
+            data = response.get("data", {})
+        except GitHubAPIError as exc:
+            errors.append(f"Page {page}: {exc} (status: {exc.status or 'unknown'})")
+            break
+
+        if total_count is None:
+            total_count = data.get("total_count", 0)
+
+        items = data.get("items", [])
+        if not items:
+            break
+
+        for item in items:
+            sampled += 1
+            full_name = (item.get("full_name") or "").lower()
+            if target_rank is None and full_name == repo.lower():
+                target_rank = sampled
+            if len(competitors) < 10 and full_name != repo.lower():
+                competitors.append(
+                    {
+                        "full_name": item.get("full_name"),
+                        "stargazers_count": item.get("stargazers_count", 0),
+                        "description": item.get("description") or "",
+                        "topics": item.get("topics") or [],
+                        "html_url": item.get("html_url"),
+                    }
+                )
+
+        if target_rank is not None and len(competitors) >= 5:
+            break
+
+    return {
+        "query": query,
+        "total_count": total_count,
+        "sampled_results": sampled,
+        "target_rank": target_rank,
+        "target_found": target_rank is not None,
+        "top_competitors": competitors[:5],
+        "errors": errors,
+    }
+
+
+def summarize(results: list) -> dict:
+    found = [r for r in results if r.get("target_found")]
+    not_found = [r["query"] for r in results if not r.get("target_found")]
+    avg_rank = None
+    if found:
+        avg_rank = round(sum(r["target_rank"] for r in found) / len(found), 2)
+    return {
+        "queries_total": len(results),
+        "queries_found": len(found),
+        "queries_not_found": len(not_found),
+        "not_found_queries": not_found,
+        "average_rank_when_found": avg_rank,
+    }
+
+
+def print_text(report: dict):
+    print(f"\nGitHub Search Benchmark: {report.get('repo')}")
+    print("=" * 60)
+    summary = report.get("summary", {})
+    print(
+        f"Found in {summary.get('queries_found', 0)}/{summary.get('queries_total', 0)} queries | "
+        f"Average rank when found: {summary.get('average_rank_when_found', 'NA')}"
+    )
+    if report.get("limitations"):
+        print("\nLimitations:")
+        for item in report["limitations"]:
+            print(f"- {item}")
+    print("\nQueries:")
+    for item in report.get("results", []):
+        rank = item["target_rank"] if item["target_rank"] is not None else "Not found"
+        print(f"- {item['query']}: rank={rank}, sampled={item['sampled_results']}, total={item['total_count']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark repository visibility across GitHub search queries.")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo). If omitted, infer from git origin.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument("--query", action="append", help="Search query (repeatable).")
+    parser.add_argument("--query-file", help="Path to newline-delimited query file.")
+    parser.add_argument("--per-page", type=int, default=50, help="Results per page (default: 50, max: 100).")
+    parser.add_argument("--max-pages", type=int, default=2, help="Max pages per query (default: 2).")
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "api", "gh"],
+        default="auto",
+        help="GitHub data provider mode (default: auto).",
+    )
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--output", help="Write JSON report to file path.")
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo(args.repo)
+        token = get_token(args.token)
+        queries = load_queries(args)
+    except GitHubAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    per_page = max(1, min(100, args.per_page))
+    max_pages = max(1, args.max_pages)
+
+    report = {
+        "timestamp_utc": utc_now_iso(),
+        "repo": repo,
+        "auth_context": auth_context(token=token),
+        "token_present": bool(token),
+        "queries": queries,
+        "results": [],
+        "limitations": [],
+    }
+
+    if not token:
+        ctx = report["auth_context"]
+        if ctx.get("gh_authenticated"):
+            report["limitations"].append(
+                "No GitHub token found. Using authenticated gh CLI fallback for search."
+            )
+        elif ctx.get("gh_available"):
+            report["limitations"].append(
+                "No GitHub token found and gh CLI is not authenticated. Run `gh auth login -h github.com` or set GITHUB_TOKEN/GH_TOKEN."
+            )
+        else:
+            report["limitations"].append(
+                "No GitHub token found and gh CLI is unavailable. Search may be rate-limited; set GITHUB_TOKEN/GH_TOKEN."
+            )
+
+    if not queries:
+        report["limitations"].append(
+            "No queries provided. Supply `--query` or `--query-file` using LLM/web-search-derived intent keywords."
+        )
+    else:
+        for query in queries:
+            result = run_query(
+                repo=repo,
+                query=query,
+                token=token,
+                per_page=per_page,
+                max_pages=max_pages,
+                provider=args.provider,
+            )
+            if result.get("errors"):
+                report["limitations"].extend([f"{query}: {err}" for err in result["errors"]])
+            report["results"].append(result)
+
+    report["summary"] = summarize(report["results"])
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_text(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_seo_report.py
+++ b/.claude/skills/seo/scripts/github_seo_report.py
@@ -1,0 +1,833 @@
+#!/usr/bin/env python3
+"""
+GitHub SEO Report Generator
+
+Runs GitHub SEO scripts and combines their outputs into a single markdown report.
+
+Usage:
+  python github_seo_report.py --repo owner/repo --markdown GITHUB-SEO-REPORT.md
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+from finding_verifier import verify_findings
+from github_api import get_token, resolve_repo
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+QUERY_STOP_WORDS = {
+    "a",
+    "an",
+    "and",
+    "for",
+    "from",
+    "in",
+    "into",
+    "of",
+    "on",
+    "or",
+    "the",
+    "to",
+    "with",
+}
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def run_json_script(script_name: str, extra_args: list) -> dict:
+    script_path = os.path.join(SCRIPT_DIR, script_name)
+    cmd = [sys.executable, script_path] + extra_args + ["--json"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "error": (result.stderr or result.stdout or f"Exit {result.returncode}").strip(),
+            "returncode": result.returncode,
+        }
+    try:
+        payload = json.loads((result.stdout or "").strip() or "{}")
+        return {"ok": True, "data": payload}
+    except json.JSONDecodeError as exc:
+        return {"ok": False, "error": f"Invalid JSON from {script_name}: {exc}", "returncode": 1}
+
+
+def _normalize_query_phrase(text: str) -> str:
+    tokens = re.findall(r"[a-z0-9]+", (text or "").lower())
+    filtered = [t for t in tokens if len(t) > 1 and t not in QUERY_STOP_WORDS]
+    if not filtered:
+        filtered = [t for t in tokens if len(t) > 1]
+    return " ".join(filtered[:6]).strip()
+
+
+def _dedupe_queries(values: list) -> list:
+    out = []
+    seen = set()
+    for item in values:
+        cleaned = " ".join((item or "").split()).strip()
+        if not cleaned:
+            continue
+        key = cleaned.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(cleaned)
+    return out
+
+
+def load_explicit_queries(args) -> tuple[list, list]:
+    queries = []
+    warnings = []
+    if args.query:
+        queries.extend([q.strip() for q in args.query if q and q.strip()])
+    if args.query_file:
+        if not os.path.exists(args.query_file):
+            warnings.append(f"Query file not found: {args.query_file}")
+        else:
+            try:
+                with open(args.query_file, "r", encoding="utf-8") as f:
+                    for line in f:
+                        text = line.strip()
+                        if text and not text.startswith("#"):
+                            queries.append(text)
+            except Exception as exc:
+                warnings.append(f"Could not read query file `{args.query_file}`: {exc}")
+    return _dedupe_queries(queries), warnings
+
+
+def derive_auto_queries(repo: str, repo_audit_data: dict, max_queries: int = 6) -> list:
+    metadata = (repo_audit_data or {}).get("metadata", {}) or {}
+    title_analysis = (repo_audit_data or {}).get("title_analysis", {}) or {}
+    owner, _, repo_name = repo.partition("/")
+
+    candidates = []
+    for seed in (
+        repo_name,
+        metadata.get("name"),
+        title_analysis.get("recommended_repo_slug"),
+        title_analysis.get("recommended_display_title"),
+    ):
+        phrase = _normalize_query_phrase(seed or "")
+        if phrase:
+            candidates.append(phrase)
+
+    topics = metadata.get("topics") or []
+    for topic in topics[:10]:
+        phrase = _normalize_query_phrase(topic)
+        if phrase:
+            candidates.append(phrase)
+
+    keywords = []
+    for raw in (title_analysis.get("search_intent_keywords") or [])[:14]:
+        token = _normalize_query_phrase(raw)
+        if token:
+            keywords.append(token.split()[0])
+    keywords = _dedupe_queries(keywords)
+
+    if len(keywords) >= 2:
+        candidates.append(" ".join(keywords[:2]))
+    if len(keywords) >= 3:
+        candidates.append(" ".join(keywords[:3]))
+    for i in range(0, max(0, len(keywords) - 1)):
+        candidates.append(" ".join(keywords[i:i + 2]))
+
+    core_tokens = _normalize_query_phrase(repo_name).split()
+    for kw in keywords[:6]:
+        if kw in core_tokens:
+            continue
+        blend = _dedupe_queries(core_tokens[:2] + [kw])
+        if len(blend) >= 2:
+            candidates.append(" ".join(blend))
+
+    owner_phrase = _normalize_query_phrase(owner)
+    if owner_phrase and core_tokens:
+        candidates.append(f"{owner_phrase} {' '.join(core_tokens[:2])}".strip())
+
+    final = _dedupe_queries(candidates)
+    if not final:
+        slug_fallback = _normalize_query_phrase(repo_name)
+        if slug_fallback:
+            final = [slug_fallback]
+    return final[: max(1, max_queries)]
+
+
+def collect_inputs(args, repo: str, token: str, queries: list) -> dict:
+    common = ["--repo", repo, "--provider", args.provider]
+    if token:
+        common += ["--token", token]
+
+    traffic_args = common + ["--archive-dir", args.archive_dir]
+    if args.no_archive_write:
+        traffic_args += ["--no-write"]
+
+    readme_args = [args.readme_path, "--repo", repo, "--provider", args.provider]
+    if token:
+        readme_args += ["--token", token]
+
+    tasks = {
+        "repo_audit": ["github_repo_audit.py", common],
+        "readme_lint": ["github_readme_lint.py", readme_args],
+        "community_health": ["github_community_health.py", common],
+        "traffic_archiver": ["github_traffic_archiver.py", traffic_args],
+    }
+
+    benchmark_args = common[:]
+    query_supplied = False
+    for query in queries:
+        benchmark_args += ["--query", query]
+        query_supplied = True
+    benchmark_args += ["--max-pages", str(args.max_pages), "--per-page", str(args.per_page)]
+
+    competitor_args = benchmark_args[:] + ["--top-n", str(args.competitor_top_n)]
+    competitor_supplied = False
+    if args.competitor:
+        for comp in args.competitor:
+            competitor_args += ["--competitor", comp]
+            competitor_supplied = True
+
+    if query_supplied:
+        tasks["search_benchmark"] = ["github_search_benchmark.py", benchmark_args]
+
+    if query_supplied or competitor_supplied:
+        tasks["competitor_research"] = ["github_competitor_research.py", competitor_args]
+
+    return tasks
+
+
+def apply_result(result_key: str, result: dict, limitations: list):
+    if not result.get("ok"):
+        limitations.append(f"{result_key} failed: {result.get('error', 'unknown')}")
+        return
+    for item in result["data"].get("limitations", []):
+        limitations.append(f"{result_key}: {item}")
+    if result_key == "traffic_archiver":
+        snapshot = result["data"].get("snapshot", {})
+        for item in snapshot.get("limitations", []):
+            limitations.append(f"{result_key}: {item}")
+
+
+def extract_score(outputs: dict) -> dict:
+    score_map = {}
+    if outputs.get("repo_audit", {}).get("ok"):
+        score_map["repo_audit"] = outputs["repo_audit"]["data"].get("summary", {}).get("score")
+    if outputs.get("readme_lint", {}).get("ok"):
+        score_map["readme_lint"] = outputs["readme_lint"]["data"].get("summary", {}).get("score")
+    if outputs.get("community_health", {}).get("ok"):
+        score_map["community_health"] = outputs["community_health"]["data"].get("score")
+    valid = [v for v in score_map.values() if isinstance(v, (int, float))]
+    overall = round(sum(valid) / len(valid), 2) if valid else None
+    return {"components": score_map, "overall": overall}
+
+
+def collect_findings(outputs: dict) -> list:
+    findings = []
+    for key in ("repo_audit", "readme_lint", "community_health"):
+        item = outputs.get(key, {})
+        if not item.get("ok"):
+            continue
+        for finding in item["data"].get("findings", []):
+            findings.append(
+                {
+                    "source": key,
+                    "severity": finding.get("severity", "Info"),
+                    "finding": finding.get("finding", ""),
+                    "evidence": finding.get("evidence", ""),
+                    "fix": finding.get("fix", ""),
+                    "confidence": finding.get("confidence", "Likely"),
+                }
+            )
+    competitor = outputs.get("competitor_research", {})
+    if competitor.get("ok"):
+        for opp in competitor.get("data", {}).get("gaps", {}).get("opportunities", []):
+            findings.append(
+                {
+                    "source": "competitor_research",
+                    "severity": opp.get("severity", "Info"),
+                    "finding": opp.get("finding", ""),
+                    "evidence": opp.get("evidence", ""),
+                    "fix": opp.get("fix", ""),
+                    "confidence": "Likely",
+                }
+            )
+    severity_order = {"Critical": 0, "Warning": 1, "Pass": 2, "Info": 3}
+    findings.sort(key=lambda x: severity_order.get(x["severity"], 9))
+    return findings
+
+
+def build_backlink_plan(outputs: dict) -> dict:
+    """Create a practical backlink and promotion plan for the repository."""
+    repo_audit = outputs.get("repo_audit", {})
+    metadata = {}
+    title_analysis = {}
+    if repo_audit.get("ok"):
+        metadata = repo_audit.get("data", {}).get("metadata", {}) or {}
+        title_analysis = repo_audit.get("data", {}).get("title_analysis", {}) or {}
+
+    keywords = title_analysis.get("search_intent_keywords", [])[:6]
+    base_title = title_analysis.get("recommended_display_title") or metadata.get("name") or "Repository"
+    repo_url = metadata.get("html_url")
+    if not repo_url:
+        repo_slug = metadata.get("full_name")
+        if repo_slug:
+            repo_url = f"https://github.com/{repo_slug}"
+
+    title_ideas = [
+        f"How I Built {base_title} for SEO Automation",
+        f"GitHub SEO Playbook: Improving Discoverability for {base_title}",
+        f"{base_title}: From Idea to Open-Source SEO Workflow",
+    ]
+    if keywords:
+        kw_phrase = ", ".join(keywords[:3])
+        title_ideas.append(f"Open-Source Guide: {kw_phrase} with {base_title}")
+
+    channels = [
+        {
+            "channel": "Medium",
+            "type": "Technical case study",
+            "cadence": "1 post per major release",
+            "cta": "Link to repo + install quickstart + release notes",
+        },
+        {
+            "channel": "Dev.to",
+            "type": "Tutorial / launch post",
+            "cadence": "1 launch post + update posts quarterly",
+            "cta": "Link to GitHub repo and usage examples",
+        },
+        {
+            "channel": "Hashnode",
+            "type": "Deep-dive engineering write-up",
+            "cadence": "Bi-monthly",
+            "cta": "Link to architecture docs and scripts",
+        },
+        {
+            "channel": "Personal/Company Blog",
+            "type": "Canonical long-form article",
+            "cadence": "Monthly",
+            "cta": "Link to repo, docs, and comparison pages",
+        },
+        {
+            "channel": "LinkedIn Article",
+            "type": "Problem/solution summary for practitioners",
+            "cadence": "Per release",
+            "cta": "Link to repo and demo outputs",
+        },
+        {
+            "channel": "Reddit (relevant subreddits)",
+            "type": "Show-and-tell with value-first context",
+            "cadence": "Selective (major feature drops)",
+            "cta": "Share repo only after explaining workflow and results",
+        },
+    ]
+
+    anchor_guidance = {
+        "exact_match_max_percent": 10,
+        "recommended_mix": [
+            "Brand anchors (repo/owner name)",
+            "Partial-match anchors (e.g., 'agentic SEO skill')",
+            "Generic anchors ('GitHub repo', 'source code')",
+            "Naked URL anchors",
+        ],
+    }
+
+    return {
+        "repo_url": repo_url,
+        "title_ideas": title_ideas[:4],
+        "channels": channels,
+        "anchor_text_guidance": anchor_guidance,
+    }
+
+
+def dedupe_preserve(items: list) -> list:
+    out = []
+    seen = set()
+    for item in items:
+        key = item.strip()
+        if key and key not in seen:
+            out.append(item)
+            seen.add(key)
+    return out
+
+
+def build_markdown(report: dict) -> str:
+    lines = []
+    lines.append("# GitHub SEO Report")
+    lines.append("")
+    lines.append(f"- Repository: `{report['repo']}`")
+    lines.append(f"- Generated (UTC): `{report['timestamp_utc']}`")
+    lines.append(f"- Provider mode: `{report['provider']}`")
+    lines.append(f"- Overall score: `{report['scores']['overall']}`")
+    verification = report.get("verification", {})
+    if verification:
+        lines.append(
+            f"- Verified findings: `{verification.get('verified_count', 0)}` "
+            f"(raw: `{verification.get('raw_count', 0)}`, dropped: `{verification.get('dropped_count', 0)}`)"
+        )
+    lines.append("")
+
+    lines.append("## Score Components")
+    lines.append("")
+    lines.append("| Component | Score |")
+    lines.append("|-----------|-------|")
+    for key, value in report["scores"]["components"].items():
+        lines.append(f"| {key} | {value} |")
+    lines.append("")
+
+    lines.append("## Script Status")
+    lines.append("")
+    lines.append("| Script | Status |")
+    lines.append("|--------|--------|")
+    for key, payload in report["outputs"].items():
+        status = "ok" if payload.get("ok") else f"failed: {payload.get('error', 'unknown')}"
+        lines.append(f"| {key} | {status} |")
+    lines.append("")
+
+    query_inputs = report.get("query_inputs", {}) or {}
+    if query_inputs:
+        lines.append("## Query Discovery")
+        lines.append("")
+        lines.append(f"- Mode: `{query_inputs.get('mode', 'unknown')}`")
+        source = query_inputs.get("source")
+        if source:
+            lines.append(f"- Source: `{source}`")
+        queries = query_inputs.get("queries", []) or []
+        if queries:
+            lines.append(f"- Queries: `{'; '.join(queries)}`")
+        else:
+            lines.append("- Queries: `none`")
+        lines.append("")
+
+    if report["limitations"]:
+        lines.append("## Limitations")
+        lines.append("")
+        for item in report["limitations"]:
+            lines.append(f"- {item}")
+        lines.append("")
+
+    if verification and verification.get("dropped"):
+        lines.append("## Verifier Notes")
+        lines.append("")
+        lines.append("Suppressed findings due to contradiction/duplication checks:")
+        for item in verification.get("dropped", [])[:10]:
+            lines.append(f"- {item.get('finding')} ({item.get('reason')})")
+        lines.append("")
+
+    lines.append("## Prioritized Findings")
+    lines.append("")
+    lines.append("| Severity | Source | Finding | Evidence | Fix |")
+    lines.append("|----------|--------|---------|----------|-----|")
+    for finding in report["findings"][:40]:
+        source = finding.get("source")
+        if finding.get("sources"):
+            source = ", ".join(finding.get("sources", []))
+        lines.append(
+            "| {severity} | {source} | {finding} | {evidence} | {fix} |".format(
+                severity=finding["severity"],
+                source=source,
+                finding=finding["finding"].replace("|", "/"),
+                evidence=finding["evidence"].replace("|", "/"),
+                fix=finding["fix"].replace("|", "/"),
+            )
+        )
+    if not report["findings"]:
+        lines.append("| Pass | system | No major findings captured. | n/a | Continue monitoring. |")
+    lines.append("")
+
+    benchmark = report["outputs"].get("search_benchmark", {})
+    if benchmark.get("ok"):
+        data = benchmark["data"]
+        lines.append("## Query Benchmark")
+        lines.append("")
+        lines.append("| Query | Rank | Sampled | Total Results |")
+        lines.append("|-------|------|---------|---------------|")
+        for item in data.get("results", []):
+            rank = item["target_rank"] if item["target_rank"] is not None else "Not found"
+            lines.append(
+                f"| {item['query']} | {rank} | {item.get('sampled_results')} | {item.get('total_count')} |"
+            )
+        lines.append("")
+
+    competitor = report["outputs"].get("competitor_research", {})
+    if competitor.get("ok"):
+        comp_data = competitor["data"]
+        lines.append("## Competitor Research")
+        lines.append("")
+        summary = comp_data.get("summary", {})
+        lines.append(
+            f"- Competitors analyzed: `{summary.get('competitors_analyzed', 0)}` "
+            f"across `{summary.get('queries_used', 0)}` queries"
+        )
+        lines.append("")
+        lines.append("| Competitor | Seen Queries | Best Rank | Stars | Topics |")
+        lines.append("|------------|--------------|-----------|-------|--------|")
+        for item in comp_data.get("competitors", [])[:10]:
+            md = item.get("metadata", {})
+            lines.append(
+                f"| {item.get('full_name')} | {item.get('seen_in_queries')} | {item.get('best_rank')} | "
+                f"{md.get('stargazers_count')} | {len(md.get('topics') or [])} |"
+            )
+        if not comp_data.get("competitors"):
+            lines.append("| n/a | 0 | n/a | n/a | n/a |")
+        lines.append("")
+        gap_data = comp_data.get("gaps", {})
+        lines.append("### Topic Gaps")
+        lines.append("")
+        topic_gaps = gap_data.get("topic_gaps", [])[:10]
+        if topic_gaps:
+            for gap in topic_gaps:
+                lines.append(
+                    f"- `{gap.get('topic')}` (covered by {gap.get('covered_by_competitors')} competitors)"
+                )
+        else:
+            lines.append("- No high-confidence topic gaps detected from current sample.")
+        lines.append("")
+        lines.append("### Competitor Opportunities")
+        lines.append("")
+        opportunities = gap_data.get("opportunities", [])
+        if opportunities:
+            for opp in opportunities:
+                lines.append(f"- [{opp.get('severity', 'Info')}] {opp.get('finding')}")
+                lines.append(f"  Evidence: {opp.get('evidence')}")
+                lines.append(f"  Fix: {opp.get('fix')}")
+        else:
+            lines.append("- No additional competitor-derived opportunities captured.")
+        lines.append("")
+
+    traffic = report["outputs"].get("traffic_archiver", {})
+    if traffic.get("ok"):
+        snap = traffic["data"].get("snapshot", {})
+        totals = snap.get("totals", {})
+        lines.append("## Traffic Snapshot")
+        lines.append("")
+        lines.append(
+            f"- Views: `{totals.get('views_count')}` (unique: `{totals.get('views_uniques')}`)"
+        )
+        lines.append(
+            f"- Clones: `{totals.get('clones_count')}` (unique: `{totals.get('clones_uniques')}`)"
+        )
+        archive_paths = traffic["data"].get("archive_paths", {})
+        if archive_paths:
+            lines.append(f"- Archive history: `{archive_paths.get('traffic_history')}`")
+            lines.append(f"- Latest snapshot: `{archive_paths.get('latest_snapshot')}`")
+        lines.append("")
+
+    title_analysis = report.get("title_analysis", {})
+    if title_analysis:
+        lines.append("## Title Optimization")
+        lines.append("")
+        lines.append(f"- Current name: `{title_analysis.get('current_name')}`")
+        lines.append(f"- Recommended slug: `{title_analysis.get('recommended_repo_slug')}`")
+        lines.append(f"- Recommended title: `{title_analysis.get('recommended_display_title')}`")
+        keywords = title_analysis.get("search_intent_keywords", [])
+        if keywords:
+            lines.append(f"- Intent keywords: `{', '.join(keywords)}`")
+        lines.append("")
+
+    backlink_plan = report.get("backlink_plan", {})
+    if backlink_plan:
+        lines.append("## Backlink Distribution Plan")
+        lines.append("")
+        if backlink_plan.get("repo_url"):
+            lines.append(f"- Target repo URL: `{backlink_plan.get('repo_url')}`")
+        lines.append("")
+        lines.append("### Suggested Post Titles")
+        lines.append("")
+        for title in backlink_plan.get("title_ideas", []):
+            lines.append(f"- {title}")
+        lines.append("")
+        lines.append("### Channels")
+        lines.append("")
+        lines.append("| Channel | Content Type | Cadence | CTA |")
+        lines.append("|---------|--------------|---------|-----|")
+        for item in backlink_plan.get("channels", []):
+            lines.append(
+                f"| {item['channel']} | {item['type']} | {item['cadence']} | {item['cta']} |"
+            )
+        lines.append("")
+        anchor = backlink_plan.get("anchor_text_guidance", {})
+        lines.append("### Anchor Guidance")
+        lines.append("")
+        lines.append(
+            f"- Exact-match anchor cap: `{anchor.get('exact_match_max_percent', 10)}%`"
+        )
+        for mix in anchor.get("recommended_mix", []):
+            lines.append(f"- {mix}")
+        lines.append("")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def _priority_for_severity(severity: str) -> str:
+    if severity == "Critical":
+        return "P0"
+    if severity == "Warning":
+        return "P1"
+    if severity == "Info":
+        return "P2"
+    return "P3"
+
+
+def build_action_plan_markdown(report: dict) -> str:
+    lines = []
+    lines.append("# GitHub Action Plan")
+    lines.append("")
+    lines.append(f"- Repository: `{report.get('repo')}`")
+    lines.append(f"- Generated (UTC): `{report.get('timestamp_utc')}`")
+    lines.append(f"- Source report: `{report.get('markdown_path', 'GITHUB-SEO-REPORT.md')}`")
+    lines.append(f"- Overall score: `{report.get('scores', {}).get('overall')}`")
+    verification = report.get("verification", {}) or {}
+    lines.append(f"- Verified findings: `{verification.get('verified_count', len(report.get('findings', [])))}`")
+    lines.append("")
+
+    actionable = []
+    for finding in report.get("findings", []):
+        sev = finding.get("severity", "Info")
+        if sev in ("Pass",):
+            continue
+        fix = (finding.get("fix") or "").strip()
+        if not fix:
+            continue
+        actionable.append(
+            {
+                "priority": _priority_for_severity(sev),
+                "severity": sev,
+                "source": finding.get("source") or ", ".join(finding.get("sources") or []),
+                "finding": finding.get("finding", ""),
+                "evidence": finding.get("evidence", ""),
+                "fix": fix,
+            }
+        )
+
+    severity_order = {"Critical": 0, "Warning": 1, "Info": 2, "Pass": 3}
+    actionable.sort(key=lambda x: (severity_order.get(x["severity"], 9), x["finding"]))
+
+    now_items = [x for x in actionable if x["severity"] in ("Critical", "Warning")]
+    next_items = [x for x in actionable if x["severity"] == "Info"]
+
+    lines.append("## Now (0-7 Days)")
+    lines.append("")
+    lines.append("| Priority | Task | Evidence | Owner |")
+    lines.append("|----------|------|----------|-------|")
+    if now_items:
+        for item in now_items[:20]:
+            task = item["fix"].replace("|", "/")
+            evidence = item["evidence"].replace("|", "/")
+            lines.append(f"| {item['priority']} | {task} | {evidence} | Repo maintainer |")
+    else:
+        lines.append("| P2 | Maintain current baseline and monitor weekly. | No critical/warning issues in current run. | Repo maintainer |")
+    lines.append("")
+
+    lines.append("## Next (1-4 Weeks)")
+    lines.append("")
+    lines.append("| Priority | Improvement | Source |")
+    lines.append("|----------|-------------|--------|")
+    if next_items:
+        for item in next_items[:15]:
+            improvement = item["fix"].replace("|", "/")
+            source = (item["source"] or "analysis").replace("|", "/")
+            lines.append(f"| {item['priority']} | {improvement} | {source} |")
+    else:
+        lines.append("| P3 | Continue incremental README/topic optimization and monitor competitor changes. | analysis |")
+    lines.append("")
+
+    competitor = report.get("outputs", {}).get("competitor_research", {})
+    if competitor.get("ok"):
+        comp_data = competitor.get("data", {}) or {}
+        gaps = (comp_data.get("gaps", {}) or {}).get("topic_gaps", [])[:8]
+        lines.append("## Competitor Moves")
+        lines.append("")
+        if gaps:
+            lines.append("Top topic opportunities to validate and adopt when relevant:")
+            for gap in gaps:
+                lines.append(
+                    f"- Evaluate topic `{gap.get('topic')}` (observed across {gap.get('covered_by_competitors')} competitors)."
+                )
+        else:
+            lines.append("- No high-confidence topic gaps detected in this sample.")
+        lines.append("")
+
+    backlink = report.get("backlink_plan", {}) or {}
+    channels = backlink.get("channels", [])[:5]
+    if channels:
+        lines.append("## Backlink Distribution")
+        lines.append("")
+        lines.append("| Channel | Cadence | Next Action |")
+        lines.append("|---------|---------|-------------|")
+        for ch in channels:
+            action = f"Publish/update a post and link to `{backlink.get('repo_url') or report.get('repo')}`"
+            lines.append(f"| {ch.get('channel')} | {ch.get('cadence')} | {action} |")
+        lines.append("")
+
+    lines.append("## Measurement Cadence")
+    lines.append("")
+    lines.append("1. Run `github_seo_report.py` weekly and track score/findings deltas.")
+    lines.append("2. Archive traffic snapshots at least every 7 days to avoid 14-day GitHub retention loss.")
+    lines.append("3. Re-run competitor benchmarking monthly or after major releases.")
+    lines.append("")
+
+    lines.append("## Completion Criteria")
+    lines.append("")
+    lines.append("- All `Critical` and `Warning` tasks in `Now` are resolved or explicitly deferred.")
+    lines.append("- Repository metadata and README reflect target intent terms and trust signals.")
+    lines.append("- Traffic history remains continuously archived.")
+    lines.append("")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate consolidated GitHub SEO report from local script outputs.")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo). If omitted, infer from git origin.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "api", "gh"],
+        default="auto",
+        help="GitHub data provider mode (default: auto).",
+    )
+    parser.add_argument("--readme-path", default="README.md", help="README path for linting (default: README.md)")
+    parser.add_argument("--query", action="append", help="Search query for benchmark (repeatable).")
+    parser.add_argument("--query-file", help="Path to query list file.")
+    parser.add_argument("--competitor", action="append", help="Explicit competitor repo slug/URL (repeatable).")
+    parser.add_argument("--max-pages", type=int, default=2, help="Search pages per query (default: 2).")
+    parser.add_argument("--per-page", type=int, default=50, help="Search results per page (default: 50).")
+    parser.add_argument("--competitor-top-n", type=int, default=6, help="Competitors to analyze in depth (default: 6).")
+    parser.add_argument(
+        "--auto-query-max",
+        type=int,
+        default=6,
+        help="Maximum auto-derived benchmark queries when explicit queries are not provided (default: 6).",
+    )
+    parser.add_argument("--archive-dir", default=".github-seo-data", help="Traffic archive directory.")
+    parser.add_argument("--no-archive-write", action="store_true", help="Do not write traffic archive files.")
+    parser.add_argument("--markdown", default="GITHUB-SEO-REPORT.md", help="Output markdown path.")
+    parser.add_argument(
+        "--action-plan",
+        default="GITHUB-ACTION-PLAN.md",
+        help="Output markdown path for prioritized action plan (default: GITHUB-ACTION-PLAN.md).",
+    )
+    parser.add_argument("--json", action="store_true", help="Output merged JSON.")
+    parser.add_argument("--output", help="Write merged JSON to file path.")
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo(args.repo)
+        token = get_token(args.token)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    outputs = {}
+    limitations = []
+    explicit_queries, query_warnings = load_explicit_queries(args)
+    limitations.extend(query_warnings)
+
+    repo_audit_args = ["--repo", repo, "--provider", args.provider]
+    if token:
+        repo_audit_args += ["--token", token]
+    outputs["repo_audit"] = run_json_script("github_repo_audit.py", repo_audit_args)
+    apply_result("repo_audit", outputs["repo_audit"], limitations)
+
+    query_mode = "explicit" if explicit_queries else "none"
+    query_source = "cli: --query/--query-file" if explicit_queries else ""
+    benchmark_queries = explicit_queries[:]
+
+    if not benchmark_queries:
+        repo_audit_data = outputs.get("repo_audit", {}).get("data", {}) if outputs.get("repo_audit", {}).get("ok") else {}
+        benchmark_queries = derive_auto_queries(
+            repo=repo,
+            repo_audit_data=repo_audit_data,
+            max_queries=max(1, args.auto_query_max),
+        )
+        if benchmark_queries:
+            query_mode = "auto-derived"
+            query_source = "repo slug + metadata + title analysis"
+            limitations.append(
+                "search_benchmark: no explicit query supplied; using auto-derived repo-specific benchmark queries."
+            )
+        else:
+            limitations.append(
+                "search_benchmark skipped: could not derive benchmark queries from repository slug/metadata. Provide `--query`/`--query-file`."
+            )
+
+    plan = collect_inputs(args=args, repo=repo, token=token, queries=benchmark_queries)
+
+    for key, (script_name, extra_args) in plan.items():
+        if key in outputs:
+            continue
+        result = run_json_script(script_name, extra_args)
+        outputs[key] = result
+        apply_result(key, result, limitations)
+
+    if "search_benchmark" not in plan:
+        limitations.append(
+            "search_benchmark skipped: provide `--query`/`--query-file` (or ensure repo metadata supports auto query derivation)."
+        )
+    if "competitor_research" not in plan:
+        limitations.append(
+            "competitor_research skipped: provide `--competitor` repo list or benchmark queries."
+        )
+
+    report = {
+        "timestamp_utc": utc_now_iso(),
+        "repo": repo,
+        "provider": args.provider,
+        "outputs": outputs,
+        "limitations": limitations,
+    }
+    report["limitations"] = dedupe_preserve(report["limitations"])
+    report["scores"] = extract_score(outputs)
+    raw_findings = collect_findings(outputs)
+    verification_result = verify_findings(
+        findings=raw_findings,
+        context={
+            "readme_metrics": outputs.get("readme_lint", {}).get("data", {}).get("metrics", {}) or {}
+        },
+    )
+    report["findings"] = verification_result.get("findings", [])
+    report["verification"] = {
+        "raw_count": verification_result.get("raw_count", len(raw_findings)),
+        "verified_count": verification_result.get("verified_count", len(report["findings"])),
+        "dropped_count": len(verification_result.get("dropped", [])),
+        "dropped": verification_result.get("dropped", []),
+    }
+    report["query_inputs"] = {
+        "mode": query_mode,
+        "source": query_source,
+        "queries": benchmark_queries,
+    }
+    report["title_analysis"] = outputs.get("repo_audit", {}).get("data", {}).get("title_analysis", {})
+    report["backlink_plan"] = build_backlink_plan(outputs)
+    report["markdown_path"] = args.markdown
+    report["action_plan_path"] = args.action_plan
+
+    markdown = build_markdown(report)
+    with open(args.markdown, "w", encoding="utf-8") as f:
+        f.write(markdown)
+    action_plan_markdown = build_action_plan_markdown(report)
+    with open(args.action_plan, "w", encoding="utf-8") as f:
+        f.write(action_plan_markdown)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"Generated markdown report: {args.markdown}")
+        print(f"Generated action plan: {args.action_plan}")
+        if limitations:
+            print("Limitations:")
+            for item in limitations[:10]:
+                print(f"- {item}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_traffic_archiver.py
+++ b/.claude/skills/seo/scripts/github_traffic_archiver.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+GitHub Traffic Archiver
+
+Fetches GitHub traffic endpoints and appends timestamped snapshots to local
+storage so data survives GitHub's 14-day traffic window.
+
+Usage:
+  python github_traffic_archiver.py --repo owner/repo --json
+  python github_traffic_archiver.py --repo owner/repo --archive-dir .github-seo-data
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from github_api import (
+    GitHubAPIError,
+    auth_context,
+    fetch_json,
+    get_token,
+    resolve_repo,
+)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def ensure_dir(path: str):
+    os.makedirs(path, exist_ok=True)
+
+
+def append_jsonl(path: str, payload: dict):
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, separators=(",", ":")) + "\n")
+
+
+def write_json(path: str, payload: dict):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+
+def fetch_endpoint(path: str, token: str, provider: str) -> dict:
+    try:
+        response = fetch_json(path, token=token, provider=provider, timeout=30)
+        return {"ok": True, "data": response.get("data", {}), "rate_limit": response.get("rate_limit", {})}
+    except GitHubAPIError as exc:
+        return {"ok": False, "error": str(exc), "status": exc.status, "details": exc.details}
+
+
+def collect_traffic(repo: str, token: str, provider: str) -> dict:
+    base = f"/repos/{repo}/traffic"
+    result = {
+        "views": fetch_endpoint(f"{base}/views", token, provider),
+        "clones": fetch_endpoint(f"{base}/clones", token, provider),
+        "referrers": fetch_endpoint(f"{base}/popular/referrers", token, provider),
+        "paths": fetch_endpoint(f"{base}/popular/paths", token, provider),
+    }
+    return result
+
+
+def build_snapshot(repo: str, token: str, provider: str) -> dict:
+    ctx = auth_context(token=token)
+    snapshot = {
+        "timestamp_utc": utc_now_iso(),
+        "repo": repo,
+        "auth_context": ctx,
+        "token_present": bool(token),
+        "endpoints": {},
+        "limitations": [],
+    }
+    if not token:
+        if ctx.get("gh_authenticated"):
+            snapshot["limitations"].append(
+                "No GitHub token found. Using authenticated gh CLI fallback for traffic endpoints."
+            )
+        elif ctx.get("gh_available"):
+            snapshot["limitations"].append(
+                "No GitHub token found and gh CLI is not authenticated. Traffic endpoints require auth. Run `gh auth login -h github.com` or set GITHUB_TOKEN/GH_TOKEN."
+            )
+        else:
+            snapshot["limitations"].append(
+                "No GitHub token found and gh CLI is unavailable. Traffic endpoints require auth; set GITHUB_TOKEN/GH_TOKEN."
+            )
+
+    endpoint_data = collect_traffic(repo, token, provider)
+    endpoint_summary = {}
+
+    for key, payload in endpoint_data.items():
+        if payload.get("ok"):
+            endpoint_summary[key] = payload.get("data")
+        else:
+            endpoint_summary[key] = {"error": payload.get("error"), "status": payload.get("status")}
+            snapshot["limitations"].append(
+                f"{key} endpoint failed: {payload.get('error')} (status: {payload.get('status', 'unknown')})"
+            )
+
+    snapshot["endpoints"] = endpoint_summary
+
+    views = endpoint_summary.get("views", {})
+    clones = endpoint_summary.get("clones", {})
+    snapshot["totals"] = {
+        "views_count": views.get("count"),
+        "views_uniques": views.get("uniques"),
+        "clones_count": clones.get("count"),
+        "clones_uniques": clones.get("uniques"),
+    }
+    return snapshot
+
+
+def print_text(snapshot: dict, archive_paths: dict):
+    print(f"\nGitHub Traffic Snapshot: {snapshot.get('repo')}")
+    print("=" * 60)
+    print(f"Timestamp (UTC): {snapshot.get('timestamp_utc')}")
+    totals = snapshot.get("totals", {})
+    print(
+        f"Views: {totals.get('views_count', 'NA')} (unique: {totals.get('views_uniques', 'NA')}) | "
+        f"Clones: {totals.get('clones_count', 'NA')} (unique: {totals.get('clones_uniques', 'NA')})"
+    )
+    if snapshot.get("limitations"):
+        print("\nLimitations:")
+        for item in snapshot["limitations"]:
+            print(f"- {item}")
+    if archive_paths:
+        print("\nArchive files:")
+        for key, value in archive_paths.items():
+            print(f"- {key}: {value}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Archive GitHub traffic metrics to local history files.")
+    parser.add_argument("--repo", help="Repository slug or URL (owner/repo). If omitted, infer from git origin.")
+    parser.add_argument("--token", help="GitHub token override. Prefer env vars GITHUB_TOKEN or GH_TOKEN.")
+    parser.add_argument("--archive-dir", default=".github-seo-data", help="Archive directory (default: .github-seo-data)")
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "api", "gh"],
+        default="auto",
+        help="GitHub data provider mode (default: auto).",
+    )
+    parser.add_argument("--no-write", action="store_true", help="Do not write archive files.")
+    parser.add_argument("--json", action="store_true", help="Output JSON.")
+    parser.add_argument("--output", help="Write current snapshot JSON to file path.")
+    args = parser.parse_args()
+
+    try:
+        repo = resolve_repo(args.repo)
+        token = get_token(args.token)
+        snapshot = build_snapshot(repo, token, provider=args.provider)
+    except GitHubAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except KeyboardInterrupt:
+        print("Interrupted.", file=sys.stderr)
+        sys.exit(130)
+
+    archive_paths = {}
+    if not args.no_write:
+        ensure_dir(args.archive_dir)
+        history_path = os.path.join(args.archive_dir, "traffic_history.jsonl")
+        latest_path = os.path.join(args.archive_dir, "latest_traffic_snapshot.json")
+        append_jsonl(history_path, snapshot)
+        write_json(latest_path, snapshot)
+        archive_paths["traffic_history"] = history_path
+        archive_paths["latest_snapshot"] = latest_path
+
+    if args.output:
+        write_json(args.output, snapshot)
+
+    if args.json:
+        out = {"snapshot": snapshot, "archive_paths": archive_paths}
+        print(json.dumps(out, indent=2))
+    else:
+        print_text(snapshot, archive_paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/github_weekly_scorecard.py
+++ b/.claude/skills/seo/scripts/github_weekly_scorecard.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Build a weekly GitHub SEO scorecard from local and API-backed checks."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+
+from github_api import get_token, resolve_repo
+from repo_docs_site_checker import check_docs_site
+from repo_file_inventory import inventory_repository
+from repo_release_seo import audit_release_seo
+from repo_social_preview_checker import check_social_preview
+from repo_topic_suggester import suggest_topics
+from seo_common import print_json_or_text
+
+
+def _score_from_inventory(result: dict) -> int:
+    return int(result.get("summary", {}).get("score", 0))
+
+
+def _score_from_release(result: dict) -> int:
+    return int(result.get("summary", {}).get("score", 0))
+
+
+def build_scorecard(repo: str | None = None, path: str = ".", token: str = "", provider: str = "auto", offline: bool = False) -> dict:
+    limitations = []
+    resolved_repo = ""
+    try:
+        resolved_repo = resolve_repo(repo, cwd=path)
+    except Exception as exc:
+        limitations.append(str(exc))
+
+    effective_provider = "api" if offline else provider
+    effective_token = "" if offline else token
+    inventory = inventory_repository(path)
+    release = audit_release_seo(resolved_repo or repo, path=path, token=effective_token, provider=effective_provider)
+    docs = check_docs_site(resolved_repo or repo, path=path, token=effective_token, provider=effective_provider)
+    social = check_social_preview(resolved_repo or repo, path=path, token=effective_token, provider=effective_provider)
+    topics = suggest_topics(resolved_repo or repo, path=path, token=effective_token, provider=effective_provider)
+
+    if offline:
+        limitations.append("Offline mode requested; GitHub/API checks use local fallbacks where available.")
+
+    category_scores = {
+        "file_inventory": _score_from_inventory(inventory),
+        "release_seo": _score_from_release(release),
+        "docs_site": int(docs.get("summary", {}).get("score", 0)),
+        "social_preview": int(social.get("summary", {}).get("score", 0)),
+        "topics": max(0, 100 - max(0, 3 - topics.get("summary", {}).get("current_topic_count", 0)) * 20),
+    }
+    overall = round(sum(category_scores.values()) / len(category_scores))
+    all_issues = []
+    for category, result in (
+        ("file_inventory", inventory),
+        ("release_seo", release),
+        ("docs_site", docs),
+        ("social_preview", social),
+        ("topics", topics),
+    ):
+        for issue in result.get("issues", []):
+            row = dict(issue)
+            row["category"] = category
+            all_issues.append(row)
+        limitations.extend(result.get("limitations", []))
+
+    return {
+        "timestamp_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "repo": resolved_repo or repo or "",
+        "summary": {"overall_score": overall, "issue_count": len(all_issues)},
+        "category_scores": category_scores,
+        "checks": {
+            "file_inventory": inventory,
+            "release_seo": release,
+            "docs_site": docs,
+            "social_preview": social,
+            "topics": topics,
+        },
+        "top_issues": all_issues[:25],
+        "limitations": sorted(set(limitations)),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a weekly GitHub SEO scorecard")
+    parser.add_argument("--repo", help="Repository slug or URL (defaults to local git origin)")
+    parser.add_argument("--path", default=".", help="Local repository path")
+    parser.add_argument("--token", help="GitHub token override")
+    parser.add_argument("--provider", choices=["auto", "api", "gh"], default="auto")
+    parser.add_argument("--offline", action="store_true", help="Avoid authenticated GitHub checks and use local fallbacks")
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = build_scorecard(args.repo, path=args.path, token=get_token(args.token), provider=args.provider, offline=args.offline)
+    lines = [
+        f"GitHub weekly SEO scorecard for {result['repo'] or args.path}",
+        f"Overall score: {result['summary']['overall_score']}  Issues: {result['summary']['issue_count']}",
+    ]
+    lines.extend(f"{name}: {score}" for name, score in result["category_scores"].items())
+    lines.extend(f"Limitation: {item}" for item in result["limitations"][:10])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/gsc_checker.py
+++ b/.claude/skills/seo/scripts/gsc_checker.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+Google Search Console Data Checker
+
+Connects to the Google Search Console API (v3) to pull performance data,
+crawl errors, and sitemaps for a verified property. Outputs JSON for LLM
+analysis in the SEO audit pipeline.
+
+Requirements:
+    pip install google-api-python-client google-auth-oauthlib
+    A service account or OAuth2 credentials JSON file.
+
+Usage:
+    python gsc_checker.py https://example.com --credentials creds.json --json
+    python gsc_checker.py https://example.com --credentials creds.json --days 28
+    python gsc_checker.py https://example.com --credentials creds.json --query "red team"
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+
+try:
+    from google.oauth2 import service_account
+    from googleapiclient.discovery import build
+    HAS_GSC_DEPS = True
+except ImportError:
+    HAS_GSC_DEPS = False
+
+
+SCOPES = ["https://www.googleapis.com/auth/webmasters.readonly"]
+
+
+# ---------------------------------------------------------------------------
+# GSC client
+# ---------------------------------------------------------------------------
+
+def build_service(credentials_path: str):
+    """Build the Search Console API service."""
+    if not HAS_GSC_DEPS:
+        print("Error: google-api-python-client and google-auth-oauthlib required.", file=sys.stderr)
+        print("Install with: pip install google-api-python-client google-auth-oauthlib", file=sys.stderr)
+        sys.exit(1)
+
+    creds = service_account.Credentials.from_service_account_file(
+        credentials_path, scopes=SCOPES
+    )
+    return build("searchconsole", "v1", credentials=creds)
+
+
+# ---------------------------------------------------------------------------
+# Data retrieval
+# ---------------------------------------------------------------------------
+
+def get_performance_data(
+    service,
+    site_url: str,
+    days: int = 28,
+    query_filter: str = "",
+    row_limit: int = 25,
+) -> dict:
+    """
+    Pull search performance data: impressions, clicks, CTR, position.
+    Groups by query and page.
+    """
+    end_date = datetime.now().strftime("%Y-%m-%d")
+    start_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+
+    body = {
+        "startDate": start_date,
+        "endDate": end_date,
+        "dimensions": ["query", "page"],
+        "rowLimit": row_limit,
+        "startRow": 0,
+    }
+
+    if query_filter:
+        body["dimensionFilterGroups"] = [{
+            "filters": [{
+                "dimension": "query",
+                "operator": "contains",
+                "expression": query_filter,
+            }]
+        }]
+
+    try:
+        resp = service.searchanalytics().query(siteUrl=site_url, body=body).execute()
+        rows = resp.get("rows", [])
+        return {
+            "period": f"{start_date} to {end_date}",
+            "total_rows": len(rows),
+            "data": [
+                {
+                    "query": r["keys"][0],
+                    "page": r["keys"][1],
+                    "clicks": r.get("clicks", 0),
+                    "impressions": r.get("impressions", 0),
+                    "ctr": round(r.get("ctr", 0) * 100, 2),
+                    "position": round(r.get("position", 0), 1),
+                }
+                for r in rows
+            ],
+        }
+    except Exception as exc:
+        return {"error": str(exc), "period": f"{start_date} to {end_date}"}
+
+
+def get_sitemaps(service, site_url: str) -> list:
+    """List submitted sitemaps and their status."""
+    try:
+        resp = service.sitemaps().list(siteUrl=site_url).execute()
+        return [
+            {
+                "path": s.get("path"),
+                "type": s.get("type"),
+                "last_submitted": s.get("lastSubmitted"),
+                "last_downloaded": s.get("lastDownloaded"),
+                "is_pending": s.get("isPending", False),
+                "errors": s.get("errors", 0),
+                "warnings": s.get("warnings", 0),
+                "contents": s.get("contents", []),
+            }
+            for s in resp.get("sitemap", [])
+        ]
+    except Exception as exc:
+        return [{"error": str(exc)}]
+
+
+def get_url_inspection(service, site_url: str, inspect_url: str) -> dict:
+    """Inspect a single URL for indexing status."""
+    try:
+        resp = service.urlInspection().index().inspect(
+            body={"inspectionUrl": inspect_url, "siteUrl": site_url}
+        ).execute()
+        result = resp.get("inspectionResult", {})
+        index_status = result.get("indexStatusResult", {})
+        mobile = result.get("mobileUsabilityResult", {})
+        rich = result.get("richResultsResult", {})
+
+        return {
+            "url": inspect_url,
+            "verdict": index_status.get("verdict"),
+            "coverage_state": index_status.get("coverageState"),
+            "crawled_as": index_status.get("crawledAs"),
+            "last_crawl_time": index_status.get("lastCrawlTime"),
+            "page_fetch_state": index_status.get("pageFetchState"),
+            "robots_txt_state": index_status.get("robotsTxtState"),
+            "indexing_state": index_status.get("indexingState"),
+            "mobile_usability": mobile.get("verdict"),
+            "rich_results": rich.get("verdict"),
+        }
+    except Exception as exc:
+        return {"url": inspect_url, "error": str(exc)}
+
+
+def get_top_pages(service, site_url: str, days: int = 28, limit: int = 20) -> list:
+    """Get top pages by clicks."""
+    end_date = datetime.now().strftime("%Y-%m-%d")
+    start_date = (datetime.now() - timedelta(days=days)).strftime("%Y-%m-%d")
+
+    body = {
+        "startDate": start_date,
+        "endDate": end_date,
+        "dimensions": ["page"],
+        "rowLimit": limit,
+    }
+
+    try:
+        resp = service.searchanalytics().query(siteUrl=site_url, body=body).execute()
+        return [
+            {
+                "page": r["keys"][0],
+                "clicks": r.get("clicks", 0),
+                "impressions": r.get("impressions", 0),
+                "ctr": round(r.get("ctr", 0) * 100, 2),
+                "position": round(r.get("position", 0), 1),
+            }
+            for r in resp.get("rows", [])
+        ]
+    except Exception as exc:
+        return [{"error": str(exc)}]
+
+
+# ---------------------------------------------------------------------------
+# Analysis helpers
+# ---------------------------------------------------------------------------
+
+def detect_opportunities(performance_data: list) -> list:
+    """
+    Identify SEO opportunities from GSC performance data.
+    - High impressions, low CTR → title/meta optimization needed
+    - Position 4-20 → "striking distance" keywords
+    - Position 1-3 with low CTR → Featured Snippet opportunity
+    """
+    opportunities = []
+
+    for row in performance_data:
+        pos = row.get("position", 0)
+        ctr = row.get("ctr", 0)
+        imps = row.get("impressions", 0)
+
+        if 4 <= pos <= 20 and imps >= 50:
+            opportunities.append({
+                "type": "striking_distance",
+                "severity": "High",
+                "query": row["query"],
+                "page": row["page"],
+                "position": pos,
+                "impressions": imps,
+                "finding": f"Position {pos} with {imps} impressions — within striking distance.",
+                "fix": "Optimize content for this query. Add keyword to H1/H2, expand content depth, build internal links.",
+            })
+        elif pos <= 3 and ctr < 5 and imps >= 100:
+            opportunities.append({
+                "type": "low_ctr_top_position",
+                "severity": "Medium",
+                "query": row["query"],
+                "page": row["page"],
+                "position": pos,
+                "ctr": ctr,
+                "impressions": imps,
+                "finding": f"Position {pos} but only {ctr}% CTR — a Featured Snippet may be stealing clicks.",
+                "fix": "Optimize for Featured Snippet (40-55 word answer after H2). Improve title tag and meta description.",
+            })
+        elif imps >= 200 and ctr < 2:
+            opportunities.append({
+                "type": "high_impressions_low_ctr",
+                "severity": "Medium",
+                "query": row["query"],
+                "page": row["page"],
+                "ctr": ctr,
+                "impressions": imps,
+                "finding": f"{imps} impressions but {ctr}% CTR — title/meta not compelling.",
+                "fix": "Rewrite title tag with keyword + benefit. Add numbers, power words, or year to title.",
+            })
+
+    return opportunities
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Google Search Console Data Checker — pulls GSC data for LLM analysis"
+    )
+    parser.add_argument("site_url", help="GSC property URL (e.g., https://example.com)")
+    parser.add_argument("--credentials", default="", help="Path to service account JSON credentials file. Falls back to GSC_CREDENTIALS_PATH env var or .env file.")
+    parser.add_argument("--days", type=int, default=28, help="Performance data lookback period (default: 28)")
+    parser.add_argument("--query", default="", help="Filter by query keyword")
+    parser.add_argument("--inspect", default="", help="URL to inspect for indexing status")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    from env_loader import get_env
+    credentials_path = args.credentials or get_env("GSC_CREDENTIALS_PATH")
+    if not credentials_path:
+        parser.error("GSC credentials required. Pass --credentials <path> or set GSC_CREDENTIALS_PATH in your environment / .env file.")
+    service = build_service(credentials_path)
+
+    report = {
+        "site_url": args.site_url,
+        "days": args.days,
+    }
+
+    # Performance data
+    perf = get_performance_data(service, args.site_url, days=args.days, query_filter=args.query)
+    report["performance"] = perf
+
+    # Opportunities
+    if "data" in perf:
+        report["opportunities"] = detect_opportunities(perf["data"])
+
+    # Top pages
+    report["top_pages"] = get_top_pages(service, args.site_url, days=args.days)
+
+    # Sitemaps
+    report["sitemaps"] = get_sitemaps(service, args.site_url)
+
+    # URL inspection (if requested)
+    if args.inspect:
+        report["url_inspection"] = get_url_inspection(service, args.site_url, args.inspect)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return
+
+    print(f"\nGoogle Search Console Report — {args.site_url}")
+    print("=" * 60)
+    print(f"Period: {perf.get('period', 'N/A')}")
+
+    if "data" in perf:
+        print(f"\nTop Queries ({len(perf['data'])} results):")
+        for row in perf["data"][:10]:
+            print(f"  [{row['position']:>5.1f}] {row['query'][:40]:<40} "
+                  f"clicks={row['clicks']:<5} imps={row['impressions']:<6} CTR={row['ctr']}%")
+
+    if report.get("opportunities"):
+        print(f"\nOpportunities ({len(report['opportunities'])}):")
+        for opp in report["opportunities"][:10]:
+            print(f"  ⚡ [{opp['type']}] {opp['query'][:40]} — {opp['finding']}")
+
+    if report.get("sitemaps"):
+        print(f"\nSitemaps ({len(report['sitemaps'])}):")
+        for sm in report["sitemaps"]:
+            if "error" in sm:
+                print(f"  ❌ Error: {sm['error']}")
+            else:
+                print(f"  📄 {sm['path']} — errors: {sm['errors']}, warnings: {sm['warnings']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/hreflang_checker.py
+++ b/.claude/skills/seo/scripts/hreflang_checker.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""
+Hreflang Validator
+
+Validates hreflang implementations against all 8 checks defined in
+resources/skills/seo-hreflang.md:
+
+  1. Self-referencing tags
+  2. Bidirectional return tags
+  3. x-default presence
+  4. ISO 639-1 language code format
+  5. ISO 3166-1 Alpha-2 region code format
+  6. Canonical URL alignment
+  7. HTTP/HTTPS protocol consistency
+  8. Cross-domain / sitemap-based hreflang detection
+
+Usage:
+    python hreflang_checker.py https://example.com/page
+    python hreflang_checker.py https://example.com/page --json
+    python hreflang_checker.py https://example.com/page --verify-returns
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+from urllib.parse import urlparse, urljoin
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get, safe_head
+except ImportError:
+    from scripts.lib.safe_http import safe_get, safe_head
+
+
+# ---------------------------------------------------------------------------
+# Reference data (ISO 639-1 + ISO 3166-1 Alpha-2)
+# ---------------------------------------------------------------------------
+
+# Valid ISO 639-1 two-letter language codes (subset — common + frequently misused)
+VALID_LANG_CODES = {
+    "af", "sq", "am", "ar", "hy", "as", "az", "eu", "be", "bn", "bs", "bg",
+    "ca", "ceb", "zh", "co", "hr", "cs", "da", "nl", "en", "eo", "et", "fi",
+    "fr", "fy", "gl", "ka", "de", "el", "gu", "ht", "ha", "haw", "he", "hi",
+    "hu", "is", "ig", "id", "ga", "it", "ja", "jv", "kn", "kk", "km", "rw",
+    "ko", "ku", "ky", "lo", "la", "lv", "lt", "lb", "mk", "mg", "ms", "ml",
+    "mt", "mi", "mr", "mn", "my", "ne", "no", "ny", "or", "ps", "fa", "pl",
+    "pt", "pa", "ro", "ru", "sm", "gd", "sr", "st", "sn", "sd", "si", "sk",
+    "sl", "so", "es", "su", "sw", "sv", "tl", "tg", "ta", "tt", "te", "th",
+    "tr", "tk", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi", "yo", "zu",
+}
+
+# Common wrong codes and their corrections
+COMMON_LANG_MISTAKES = {
+    "eng": "en",   # ISO 639-2 (3-letter), not valid for hreflang
+    "jp": "ja",    # Wrong code for Japanese
+    "zh-cn": "zh-Hans",  # Simplified Chinese region variant gone wrong
+    "zh-tw": "zh-Hant",  # Traditional Chinese
+    "iw": "he",    # Old code for Hebrew
+    "in": "id",    # Old code for Indonesian
+}
+
+# Valid ISO 3166-1 Alpha-2 region codes (common ones)
+VALID_REGION_CODES = {
+    "AF", "AL", "DZ", "AD", "AO", "AG", "AR", "AM", "AU", "AT", "AZ",
+    "BS", "BH", "BD", "BB", "BY", "BE", "BZ", "BJ", "BT", "BO", "BA",
+    "BW", "BR", "BN", "BG", "BF", "BI", "CV", "KH", "CM", "CA", "CF",
+    "TD", "CL", "CN", "CO", "KM", "CG", "CD", "CR", "CI", "HR", "CU",
+    "CY", "CZ", "DK", "DJ", "DM", "DO", "EC", "EG", "SV", "GQ", "ER",
+    "EE", "SZ", "ET", "FJ", "FI", "FR", "GA", "GM", "GE", "DE", "GH",
+    "GR", "GD", "GT", "GN", "GW", "GY", "HT", "HN", "HU", "IS", "IN",
+    "ID", "IR", "IQ", "IE", "IL", "IT", "JM", "JP", "JO", "KZ", "KE",
+    "KI", "KP", "KR", "KW", "KG", "LA", "LV", "LB", "LS", "LR", "LY",
+    "LI", "LT", "LU", "MG", "MW", "MY", "MV", "ML", "MT", "MH", "MR",
+    "MU", "MX", "FM", "MD", "MC", "MN", "ME", "MA", "MZ", "MM", "NA",
+    "NR", "NP", "NL", "NZ", "NI", "NE", "NG", "NO", "OM", "PK", "PW",
+    "PA", "PG", "PY", "PE", "PH", "PL", "PT", "QA", "RO", "RU", "RW",
+    "KN", "LC", "VC", "WS", "SM", "ST", "SA", "SN", "RS", "SC", "SL",
+    "SG", "SK", "SI", "SB", "SO", "ZA", "SS", "ES", "LK", "SD", "SR",
+    "SE", "CH", "SY", "TW", "TJ", "TZ", "TH", "TL", "TG", "TO", "TT",
+    "TN", "TR", "TM", "TV", "UG", "UA", "AE", "GB", "US", "UY", "UZ",
+    "VU", "VE", "VN", "YE", "ZM", "ZW",
+    # Common non-sovereign but valid in context
+    "HK", "MO", "PR", "GU", "VI", "AS",
+}
+
+# Common region mistakes
+COMMON_REGION_MISTAKES = {
+    "UK": "GB",   # UK is not a valid ISO 3166-1 code; use GB
+    "LA": None,   # Latin America is not a country
+    "EU": None,   # European Union is not a country
+}
+
+# ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+def fetch_html(url: str, timeout: int = 10) -> tuple[str, str]:
+    """Return (html, final_url) after fetching. Returns ('', url) on error."""
+    try:
+        resp = safe_get(url, timeout=timeout)
+        return resp.text, resp.url
+    except Exception as exc:
+        return "", url
+
+
+def fetch_robots_txt(base_url: str) -> str:
+    parsed = urlparse(base_url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    html, _ = fetch_html(robots_url, timeout=6)
+    return html
+
+
+# ---------------------------------------------------------------------------
+# Hreflang tag extraction
+# ---------------------------------------------------------------------------
+
+def extract_hreflang_from_html(soup: BeautifulSoup, page_url: str) -> list[dict]:
+    """
+    Extract hreflang tags from <link rel="alternate" hreflang="..."> in <head>.
+    Returns list of {lang, url, raw_lang, raw_url}.
+    """
+    tags = []
+    for link in soup.find_all("link", rel="alternate"):
+        lang = link.get("hreflang", "").strip()
+        href = link.get("href", "").strip()
+        if not lang or not href:
+            continue
+        # Resolve relative URLs
+        absolute = urljoin(page_url, href)
+        tags.append({
+            "lang": lang.lower() if lang != "x-default" else "x-default",
+            "raw_lang": lang,
+            "url": absolute,
+            "raw_url": href,
+        })
+    return tags
+
+
+def extract_hreflang_from_http_headers(url: str) -> list[dict]:
+    """Check HTTP Link headers for hreflang (used for non-HTML files)."""
+    tags = []
+    try:
+        resp = safe_head(url, timeout=8)
+        link_header = resp.headers.get("Link", "")
+        if not link_header:
+            return []
+        # Parse: <url>; rel="alternate"; hreflang="lang"
+        for part in link_header.split(","):
+            part = part.strip()
+            url_match = re.search(r'<([^>]+)>', part)
+            hreflang_match = re.search(r'hreflang="([^"]+)"', part)
+            rel_match = re.search(r'rel="([^"]+)"', part)
+            if url_match and hreflang_match and rel_match and "alternate" in rel_match.group(1):
+                tags.append({
+                    "lang": hreflang_match.group(1).lower(),
+                    "raw_lang": hreflang_match.group(1),
+                    "url": url_match.group(1),
+                    "raw_url": url_match.group(1),
+                    "source": "http_header",
+                })
+    except Exception:
+        pass
+    return tags
+
+
+def check_sitemap_hreflang(base_url: str) -> dict:
+    """Check /sitemap.xml for xhtml:link hreflang attributes."""
+    parsed = urlparse(base_url)
+    sitemap_url = f"{parsed.scheme}://{parsed.netloc}/sitemap.xml"
+    html, _ = fetch_html(sitemap_url, timeout=8)
+    if not html:
+        return {"found": False, "url": sitemap_url}
+
+    # Check for xhtml:link in sitemap (hreflang sitemap pattern)
+    has_xhtml_link = "xhtml:link" in html or 'rel="alternate"' in html
+    lang_matches = re.findall(r'hreflang="([^"]+)"', html)
+
+    return {
+        "found": bool(lang_matches),
+        "url": sitemap_url,
+        "has_xhtml_namespace": "xmlns:xhtml" in html,
+        "language_variants_found": list(set(lang_matches)) if lang_matches else [],
+        "note": "Sitemap-based hreflang detected." if lang_matches else "No hreflang found in sitemap.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Validation logic (maps 1:1 to seo-hreflang.md checks)
+# ---------------------------------------------------------------------------
+
+def validate_lang_code(lang_tag: str) -> dict:
+    """
+    Validate a single hreflang value with a pragmatic BCP 47 parser.
+
+    Supported shape:
+      language[-script][-region][-variant...]
+
+    Examples: en, en-US, zh-Hans, zh-Hant-TW, sr-Cyrl-RS.
+    Returns {valid, lang, script, region, variants, issues}.
+    """
+    raw_tag = (lang_tag or "").strip()
+    if raw_tag.lower() == "x-default":
+        return {
+            "valid": True,
+            "lang": "x-default",
+            "script": None,
+            "region": None,
+            "variants": [],
+            "issues": [],
+        }
+
+    issues = []
+    if "_" in raw_tag:
+        issues.append("Use hyphens, not underscores, in hreflang values.")
+
+    mistake = COMMON_LANG_MISTAKES.get(raw_tag.lower())
+    if mistake:
+        issues.append(f"'{raw_tag}' is a common invalid hreflang value. Use '{mistake}' instead.")
+
+    parts = raw_tag.replace("_", "-").split("-")
+    lang = parts[0].lower() if parts and parts[0] else ""
+    script = None
+    region = None
+    variants = []
+    index = 1
+
+    if not re.fullmatch(r"[A-Za-z]{2,3}", lang or ""):
+        issues.append(
+            f"Invalid primary language subtag '{parts[0] if parts else ''}'. "
+            "Use a 2-3 letter BCP 47 language subtag."
+        )
+    elif len(lang) == 2 and lang not in VALID_LANG_CODES:
+        correction = COMMON_LANG_MISTAKES.get(lang)
+        issue = f"Unknown language code '{lang}'."
+        if correction:
+            issue += f" Did you mean '{correction}'?"
+        issues.append(issue)
+
+    if index < len(parts) and re.fullmatch(r"[A-Za-z]{4}", parts[index]):
+        script = parts[index].title()
+        index += 1
+
+    if index < len(parts) and (
+        re.fullmatch(r"[A-Za-z]{2}", parts[index])
+        or re.fullmatch(r"\d{3}", parts[index])
+    ):
+        region = parts[index].upper()
+        index += 1
+
+    while index < len(parts):
+        part = parts[index]
+        if re.fullmatch(r"[A-Za-z0-9]{5,8}", part) or re.fullmatch(r"\d[A-Za-z0-9]{3}", part):
+            variants.append(part)
+            index += 1
+            continue
+        if re.fullmatch(r"[A-WY-Za-wy-z0-9]", part):
+            issues.append("Extension subtags are valid BCP 47 but are not supported for hreflang targeting.")
+            break
+        issues.append(f"Invalid or out-of-order BCP 47 subtag '{part}'.")
+        index += 1
+
+    if lang == "zh" and not script and region not in {"CN", "SG", "TW", "HK", "MO"}:
+        issues.append("'zh' is ambiguous — use 'zh-Hans' or 'zh-Hant' when no clear region is present.")
+
+    if region:
+        if region in COMMON_REGION_MISTAKES:
+            fix = COMMON_REGION_MISTAKES[region]
+            if fix:
+                issues.append(f"Region '{region}' is not a valid ISO 3166-1 code. Use '{fix}'.")
+            else:
+                issues.append(f"'{region}' is not a valid ISO 3166-1 country code for hreflang.")
+        elif re.fullmatch(r"[A-Z]{2}", region) and region not in VALID_REGION_CODES:
+            issues.append(f"Unknown region code '{region}' — verify against ISO 3166-1 Alpha-2.")
+
+    return {
+        "valid": len(issues) == 0,
+        "lang": lang,
+        "script": script,
+        "region": region,
+        "variants": variants,
+        "issues": issues,
+    }
+
+
+def check_self_reference(tags: list[dict], page_url: str) -> dict:
+    """Check 1: Self-referencing tag must be present and URL must match canonical."""
+    normalized_page = page_url.rstrip("/")
+    for tag in tags:
+        tag_url = tag["url"].rstrip("/")
+        if tag_url == normalized_page:
+            return {"passed": True, "detail": "Self-referencing hreflang tag found."}
+
+    return {
+        "passed": False,
+        "severity": "Critical",
+        "finding": "No self-referencing hreflang tag found.",
+        "fix": "Add <link rel=\"alternate\" hreflang=\"{lang}\" href=\"{page_url}\"> pointing to this page's own canonical URL.",
+    }
+
+
+def check_x_default(tags: list[dict]) -> dict:
+    """Check 3: x-default tag presence."""
+    x_defaults = [t for t in tags if t["lang"] == "x-default"]
+    if not x_defaults:
+        return {
+            "passed": False,
+            "severity": "High",
+            "finding": "No x-default hreflang tag found.",
+            "fix": "Add <link rel=\"alternate\" hreflang=\"x-default\" href=\"{fallback_url}\"> pointing to your language selector or primary language version.",
+        }
+    if len(x_defaults) > 1:
+        return {
+            "passed": False,
+            "severity": "High",
+            "finding": f"Multiple x-default tags found ({len(x_defaults)}). Only one is allowed.",
+            "fix": "Remove duplicate x-default tags. Keep only one pointing to the language selector or primary version.",
+        }
+    return {"passed": True, "detail": f"x-default present → {x_defaults[0]['url']}"}
+
+
+def check_protocol_consistency(tags: list[dict]) -> dict:
+    """Check 7: All URLs in the hreflang set must use the same protocol."""
+    protocols = {urlparse(t["url"]).scheme for t in tags if t["url"]}
+    if len(protocols) > 1:
+        return {
+            "passed": False,
+            "severity": "Medium",
+            "finding": f"Mixed protocols in hreflang set: {', '.join(sorted(protocols))}.",
+            "fix": "Standardize all hreflang URLs to HTTPS. Update any remaining HTTP URLs.",
+        }
+    return {"passed": True, "detail": f"All hreflang URLs use: {list(protocols)[0] if protocols else 'unknown'}"}
+
+
+def check_lang_codes(tags: list[dict]) -> list[dict]:
+    """Checks 4 & 5: Validate each language/region code."""
+    issues = []
+    for tag in tags:
+        if tag["lang"] == "x-default":
+            continue
+        validation = validate_lang_code(tag["raw_lang"])
+        if not validation["valid"]:
+            for issue_text in validation["issues"]:
+                issues.append({
+                    "passed": False,
+                    "severity": "High",
+                    "lang_tag": tag["raw_lang"],
+                    "url": tag["url"],
+                    "finding": issue_text,
+                    "fix": "Fix the language/region code to use ISO 639-1 + ISO 3166-1 Alpha-2 format.",
+                })
+    return issues
+
+
+def check_return_tags(
+    tags: list[dict],
+    page_url: str,
+    verify_remote: bool = False,
+    timeout: int = 8,
+) -> list[dict]:
+    """
+    Check 2: Bidirectional return tags.
+    If verify_remote=True, fetches each alternate URL and checks for a reciprocal tag.
+    Without remote fetch, returns Hypothesis-confidence findings.
+    """
+    issues = []
+    non_self = [t for t in tags if t["url"].rstrip("/") != page_url.rstrip("/")
+                and t["lang"] != "x-default"]
+
+    if not non_self:
+        return []
+
+    if not verify_remote:
+        issues.append({
+            "passed": None,  # Cannot confirm without fetching
+            "severity": "Info",
+            "confidence": "Hypothesis",
+            "finding": f"Found {len(non_self)} alternate URL(s). Return tag verification requires --verify-returns flag.",
+            "fix": "Run with --verify-returns to fetch each alternate and confirm bidirectional hreflang.",
+            "alternates": [t["url"] for t in non_self],
+        })
+        return issues
+
+    # Remote verification
+    for alt_tag in non_self:
+        alt_url = alt_tag["url"]
+        time.sleep(0.5)  # polite crawl delay
+        alt_html, _ = fetch_html(alt_url, timeout=timeout)
+        if not alt_html:
+            issues.append({
+                "passed": None,
+                "confidence": "Hypothesis",
+                "severity": "Info",
+                "finding": f"Could not fetch alternate URL to verify return tag: {alt_url}",
+                "fix": "Manually verify that this page links back to the source page with hreflang.",
+            })
+            continue
+
+        alt_soup = BeautifulSoup(alt_html, "html.parser")
+        alt_tags = extract_hreflang_from_html(alt_soup, alt_url)
+        returns_to_source = any(
+            t["url"].rstrip("/") == page_url.rstrip("/") for t in alt_tags
+        )
+
+        if not returns_to_source:
+            issues.append({
+                "passed": False,
+                "confidence": "Confirmed",
+                "severity": "Critical",
+                "lang_tag": alt_tag["lang"],
+                "finding": f"Missing return tag on {alt_url} — no hreflang pointing back to {page_url}.",
+                "fix": f"Add hreflang tag on {alt_url} that references {page_url}.",
+            })
+        else:
+            issues.append({
+                "passed": True,
+                "confidence": "Confirmed",
+                "lang_tag": alt_tag["lang"],
+                "finding": f"Return tag confirmed on {alt_url}",
+            })
+
+    return issues
+
+
+def check_canonical_alignment(soup: BeautifulSoup, tags: list[dict], page_url: str) -> dict:
+    """
+    Check 6: Hreflang tags should only appear on canonical URLs.
+    Warns if a canonical tag points elsewhere, invalidating the hreflang set.
+    """
+    canonical_tag = soup.find("link", rel="canonical")
+    if not canonical_tag:
+        return {"passed": None, "confidence": "Hypothesis",
+                "finding": "No canonical tag found — cannot verify hreflang/canonical alignment.",
+                "fix": "Add a self-referencing canonical tag to confirm this is the canonical URL."}
+
+    canonical_url = canonical_tag.get("href", "").strip()
+    if canonical_url and canonical_url.rstrip("/") != page_url.rstrip("/"):
+        return {
+            "passed": False,
+            "severity": "High",
+            "confidence": "Confirmed",
+            "finding": f"Canonical tag points to a different URL ({canonical_url}). Hreflang on non-canonical pages is ignored by Google.",
+            "fix": "Remove hreflang tags from this page OR move them to the canonical URL.",
+        }
+
+    return {"passed": True, "detail": f"Canonical URL matches page URL: {canonical_url}"}
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+def run_hreflang_check(url: str, verify_returns: bool = False) -> dict:
+    """Run all 8 hreflang checks and return a structured report."""
+    html, final_url = fetch_html(url)
+    if not html:
+        return {"error": f"Failed to fetch URL: {url}", "url": url}
+
+    soup = BeautifulSoup(html, "html.parser")
+    tags = extract_hreflang_from_html(soup, final_url)
+
+    # Also check HTTP headers (Check 8 — alternative implementation method)
+    http_header_tags = extract_hreflang_from_http_headers(final_url)
+    implementation_method = "none"
+    if tags:
+        implementation_method = "html_link_tags"
+    elif http_header_tags:
+        tags = http_header_tags
+        implementation_method = "http_headers"
+
+    # Check sitemap hreflang (Check 8)
+    sitemap_info = check_sitemap_hreflang(final_url)
+    if sitemap_info["found"] and implementation_method == "none":
+        implementation_method = "xml_sitemap"
+
+    results = {
+        "url": final_url,
+        "implementation_method": implementation_method,
+        "hreflang_tags_found": len(tags),
+        "tags": tags,
+        "sitemap": sitemap_info,
+        "checks": {},
+        "language_code_issues": [],
+        "return_tag_checks": [],
+        "summary": {"critical": 0, "high": 0, "medium": 0, "low": 0, "passed": 0},
+    }
+
+    if not tags:
+        results["checks"]["hreflang_present"] = {
+            "passed": False,
+            "severity": "Info",
+            "finding": "No hreflang tags found (HTML, HTTP headers, or sitemap).",
+            "fix": "If this is a single-language site, hreflang is not needed. For multi-language sites, implement hreflang via HTML link tags or sitemap.",
+        }
+        return results
+
+    # Check 1 — Self-reference
+    results["checks"]["self_reference"] = check_self_reference(tags, final_url)
+
+    # Check 3 — x-default
+    results["checks"]["x_default"] = check_x_default(tags)
+
+    # Check 7 — Protocol consistency
+    results["checks"]["protocol_consistency"] = check_protocol_consistency(tags)
+
+    # Check 6 — Canonical alignment
+    results["checks"]["canonical_alignment"] = check_canonical_alignment(soup, tags, final_url)
+
+    # Checks 4 & 5 — Language/region code validation
+    results["language_code_issues"] = check_lang_codes(tags)
+
+    # Check 2 — Return tags (bidirectional)
+    results["return_tag_checks"] = check_return_tags(tags, final_url, verify_remote=verify_returns)
+
+    # Tally summary
+    sev_map = {"Critical": "critical", "High": "high", "Medium": "medium", "Low": "low"}
+    for check in results["checks"].values():
+        if check.get("passed") is True:
+            results["summary"]["passed"] += 1
+        elif check.get("passed") is False:
+            sev = check.get("severity", "low")
+            results["summary"][sev_map.get(sev, "low")] += 1
+
+    for issue in results["language_code_issues"] + results["return_tag_checks"]:
+        if issue.get("passed") is False:
+            sev = issue.get("severity", "low")
+            results["summary"][sev_map.get(sev, "low")] += 1
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Hreflang Validator — checks all 8 rules from seo-hreflang.md"
+    )
+    parser.add_argument("url", help="Page URL to validate")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument(
+        "--verify-returns",
+        action="store_true",
+        help="Fetch each alternate URL to verify bidirectional return tags (slower, makes HTTP requests)",
+    )
+    args = parser.parse_args()
+
+    report = run_hreflang_check(args.url, verify_returns=args.verify_returns)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+
+    if report.get("error"):
+        print(f"Error: {report['error']}")
+        sys.exit(1)
+
+    print(f"\nHreflang Validation — {report['url']}")
+    print("=" * 60)
+    print(f"Implementation Method : {report['implementation_method']}")
+    print(f"Tags Found            : {report['hreflang_tags_found']}")
+
+    if report["tags"]:
+        print("\nDetected Alternates:")
+        for tag in report["tags"]:
+            validation = validate_lang_code(tag["raw_lang"])
+            status = "✅" if validation["valid"] or tag["lang"] == "x-default" else "❌"
+            print(f"  {status} [{tag['raw_lang']:12}] {tag['url']}")
+
+    print(f"\nSitemap Hreflang : {'Found' if report['sitemap']['found'] else 'Not found'}")
+    if report["sitemap"]["found"]:
+        print(f"  Variants: {', '.join(report['sitemap']['language_variants_found'])}")
+
+    print("\nValidation Results:")
+    sev_icon = {"Critical": "🔴", "High": "🟠", "Medium": "⚠️", "Low": "ℹ️", "Info": "ℹ️"}
+
+    for name, check in report["checks"].items():
+        if check.get("passed") is True:
+            print(f"  ✅ {name.replace('_', ' ').title()}: {check.get('detail', 'Pass')}")
+        elif check.get("passed") is False:
+            icon = sev_icon.get(check.get("severity", "Low"), "⚠️")
+            print(f"  {icon} {name.replace('_', ' ').title()}: {check.get('finding', '')}")
+            print(f"       Fix: {check.get('fix', '')}")
+        else:
+            print(f"  ℹ️  {name.replace('_', ' ').title()}: {check.get('finding', '')} (Confidence: {check.get('confidence', 'Hypothesis')})")
+
+    if report["language_code_issues"]:
+        print("\nLanguage/Region Code Issues:")
+        for issue in report["language_code_issues"]:
+            icon = sev_icon.get(issue.get("severity", "High"), "🟠")
+            print(f"  {icon} [{issue['lang_tag']}] {issue['finding']}")
+
+    if report["return_tag_checks"]:
+        print("\nReturn Tag Checks:")
+        for check in report["return_tag_checks"]:
+            if check.get("passed") is True:
+                print(f"  ✅ [{check.get('lang_tag', '')}] {check['finding']}")
+            elif check.get("passed") is False:
+                icon = sev_icon.get(check.get("severity", "Critical"), "🔴")
+                print(f"  {icon} [{check.get('lang_tag', '')}] {check['finding']}")
+            else:
+                print(f"  ℹ️  {check['finding']}")
+
+    s = report["summary"]
+    total_issues = s["critical"] + s["high"] + s["medium"] + s["low"]
+    print(f"\nSummary: {s['passed']} passed, {total_issues} issues")
+    print(f"  🔴 Critical: {s['critical']}  🟠 High: {s['high']}  ⚠️ Medium: {s['medium']}  ℹ️ Low: {s['low']}")
+
+    if not args.verify_returns and report["hreflang_tags_found"] > 1:
+        print("\nTip: Run with --verify-returns to fetch each alternate URL and confirm bidirectional return tags.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/hreflang_sitemap_validator.py
+++ b/.claude/skills/seo/scripts/hreflang_sitemap_validator.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate hreflang annotations across sitemap indexes and sitemap URL sets."""
+
+from __future__ import annotations
+
+import argparse
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+
+from hreflang_checker import validate_lang_code
+from seo_common import discover_sitemap_urls, fetch_url, issue, normalize_url, print_json_or_text
+
+
+def local_name(tag: str) -> str:
+    return tag.split("}", 1)[-1]
+
+
+def parse_hreflang_sitemap(xml_text: str, sitemap_url: str = "") -> dict:
+    try:
+        root = ET.fromstring((xml_text or "").encode("utf-8"))
+    except ET.ParseError as exc:
+        return {"type": "invalid", "sitemaps": [], "urls": [], "error": str(exc)}
+    if local_name(root.tag) == "sitemapindex":
+        sitemaps = []
+        for node in root:
+            if local_name(node.tag) != "sitemap":
+                continue
+            loc = next((child.text for child in node if local_name(child.tag) == "loc"), None)
+            if loc:
+                sitemaps.append(normalize_url(loc, sitemap_url))
+        return {"type": "sitemapindex", "sitemaps": sitemaps, "urls": [], "error": None}
+    urls = []
+    for node in root:
+        if local_name(node.tag) != "url":
+            continue
+        loc = next((child.text for child in node if local_name(child.tag) == "loc"), None)
+        alternates = []
+        for child in node:
+            if local_name(child.tag) != "link":
+                continue
+            attrs = child.attrib
+            rel = attrs.get("rel") or attrs.get("{http://www.w3.org/1999/xhtml}rel")
+            hreflang = attrs.get("hreflang") or attrs.get("{http://www.w3.org/1999/xhtml}hreflang")
+            href = attrs.get("href") or attrs.get("{http://www.w3.org/1999/xhtml}href")
+            if rel == "alternate" and hreflang and href:
+                alternates.append({"lang": hreflang.lower() if hreflang != "x-default" else "x-default", "raw_lang": hreflang, "url": normalize_url(href, sitemap_url)})
+        if loc:
+            urls.append({"loc": normalize_url(loc, sitemap_url), "alternates": alternates})
+    return {"type": "urlset", "sitemaps": [], "urls": urls, "error": None}
+
+
+def validate_hreflang_sitemaps(site: str, sitemap_urls: list[str] | None = None, timeout: int = 15, max_sitemaps: int = 50) -> dict:
+    queue = list(dict.fromkeys(sitemap_urls or discover_sitemap_urls(site, timeout=timeout)))
+    seen = set()
+    rows = []
+    issues = []
+    alternate_map = defaultdict(dict)
+    while queue and len(seen) < max_sitemaps:
+        sitemap_url = normalize_url(queue.pop(0), site)
+        if sitemap_url in seen:
+            continue
+        seen.add(sitemap_url)
+        fetched = fetch_url(sitemap_url, timeout=timeout, max_bytes=8_000_000)
+        entry = {"url": sitemap_url, "status": fetched.get("status"), "type": None, "urls": 0, "alternates": 0, "error": fetched.get("error")}
+        if fetched.get("status") != 200:
+            issues.append(issue("error", f"Sitemap returned HTTP {fetched.get('status')}", sitemap_url, fetched.get("error")))
+            rows.append(entry)
+            continue
+        parsed = parse_hreflang_sitemap(fetched.get("text") or "", sitemap_url)
+        entry["type"] = parsed["type"]
+        entry["error"] = parsed["error"]
+        if parsed["error"]:
+            issues.append(issue("error", f"Invalid sitemap XML: {parsed['error']}", sitemap_url))
+        if parsed["type"] == "sitemapindex":
+            queue.extend(parsed["sitemaps"])
+        for url_row in parsed["urls"]:
+            entry["urls"] += 1
+            entry["alternates"] += len(url_row["alternates"])
+            if not url_row["alternates"]:
+                continue
+            has_self = any(alt["url"].rstrip("/") == url_row["loc"].rstrip("/") for alt in url_row["alternates"])
+            if not has_self:
+                issues.append(issue("error", "Sitemap hreflang set is missing self reference", url_row["loc"]))
+            has_x_default = any(alt["lang"] == "x-default" for alt in url_row["alternates"])
+            if not has_x_default:
+                issues.append(issue("warning", "Sitemap hreflang set is missing x-default", url_row["loc"]))
+            seen_langs = set()
+            for alt in url_row["alternates"]:
+                if alt["lang"] in seen_langs:
+                    issues.append(issue("warning", f"Duplicate hreflang '{alt['lang']}' in sitemap set", url_row["loc"]))
+                seen_langs.add(alt["lang"])
+                validation = validate_lang_code(alt["raw_lang"])
+                if not validation["valid"]:
+                    issues.extend(issue("error", text, url_row["loc"], alt["raw_lang"]) for text in validation["issues"])
+                alternate_map[url_row["loc"]][alt["lang"]] = alt["url"]
+        rows.append(entry)
+    for source_url, alternates in alternate_map.items():
+        for lang, alternate_url in alternates.items():
+            if lang == "x-default" or alternate_url not in alternate_map:
+                continue
+            reverse = alternate_map[alternate_url]
+            if not any(url.rstrip("/") == source_url.rstrip("/") for url in reverse.values()):
+                issues.append(issue("error", "Missing reciprocal sitemap hreflang return tag", source_url, f"{lang} -> {alternate_url}"))
+    return {
+        "site": normalize_url(site),
+        "sitemaps_checked": len(rows),
+        "rows": rows,
+        "hreflang_url_sets": len(alternate_map),
+        "issues": issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate hreflang annotations in sitemap indexes and urlsets")
+    parser.add_argument("site", help="Site URL")
+    parser.add_argument("--sitemap", action="append", help="Explicit sitemap URL; can be repeated")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--max-sitemaps", type=int, default=50)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    result = validate_hreflang_sitemaps(args.site, args.sitemap, args.timeout, args.max_sitemaps)
+    lines = [
+        f"Hreflang sitemap validation for {args.site}",
+        f"Sitemaps: {result['sitemaps_checked']}  URL sets: {result['hreflang_url_sets']}  Issues: {len(result['issues'])}",
+    ] + [f"[{item['severity']}] {item['message']} {item.get('url') or ''} {item.get('evidence') or ''}" for item in result["issues"][:30]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/image_inventory.py
+++ b/.claude/skills/seo/scripts/image_inventory.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Inventory images for SEO, accessibility, and performance signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from urllib.parse import urlparse
+
+from seo_common import fetch_url, load_html, parse_html
+
+
+def inventory(source: str, fetch_images: bool = False, timeout: int = 15) -> dict:
+    html, url, fetched = load_html(source, timeout=timeout)
+    parsed = parse_html(html, url)
+    rows = []
+    issues = []
+    for idx, img in enumerate(parsed["images"]):
+        src = img.get("src") or ""
+        ext = os.path.splitext(urlparse(src).path)[1].lower().lstrip(".")
+        row = {
+            "src": src,
+            "alt": img.get("alt"),
+            "has_alt": img.get("alt") is not None and img.get("alt") != "",
+            "width": img.get("width"),
+            "height": img.get("height"),
+            "is_responsive_fill": bool(img.get("is_responsive_fill")),
+            "loading": img.get("loading"),
+            "srcset": bool(img.get("srcset")),
+            "sizes": bool(img.get("sizes")),
+            "format": ext,
+            "likely_lcp_candidate": idx == 0 or img.get("fetchpriority") == "high" or img.get("loading") == "eager",
+        }
+        if not row["has_alt"]:
+            issues.append({"severity": "warning", "message": "Image missing alt text", "url": src})
+        if not row["is_responsive_fill"] and (not row["width"] or not row["height"]):
+            issues.append({"severity": "info", "message": "Image missing explicit dimensions", "url": src})
+        if row["likely_lcp_candidate"] and row["loading"] == "lazy":
+            issues.append({"severity": "warning", "message": "Likely LCP image is lazy-loaded", "url": src})
+        if fetch_images and src.startswith("http"):
+            head = fetch_url(src, method="HEAD", timeout=timeout)
+            row["status"] = head.get("status")
+            row["content_length"] = head.get("headers", {}).get("content-length")
+            row["content_type"] = head.get("headers", {}).get("content-type")
+        rows.append(row)
+    return {"url": url or source, "count": len(rows), "missing_alt": sum(1 for r in rows if not r["has_alt"]), "issues": issues, "images": rows, "fetch_error": fetched.get("error")}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inventory images on a page")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--fetch-images", action="store_true")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = inventory(args.source, args.fetch_images, args.timeout)
+    print(json.dumps(result, indent=2) if args.json else "\n".join(f"{'missing-alt' if not r['has_alt'] else 'ok'}\t{r['src']}" for r in result["images"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/image_weight_audit.py
+++ b/.claude/skills/seo/scripts/image_weight_audit.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Audit image weight, responsive image usage, and likely LCP image risk."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+from seo_common import fetch_url, load_html, parse_html
+
+
+MODERN_FORMATS = {"avif", "webp"}
+RASTER_FORMATS = {"jpg", "jpeg", "png", "gif"}
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    path = Path(source)
+    if path.is_file():
+        return path.read_text(encoding="utf-8"), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _extension(src: str) -> str:
+    return os.path.splitext(urlparse(src).path)[1].lower().lstrip(".")
+
+
+def _local_size(src: str, html_source: str) -> int | None:
+    if src.startswith(("http://", "https://", "data:")):
+        return None
+    base = Path(html_source).resolve().parent if Path(html_source).exists() else Path.cwd()
+    candidate = (base / src.lstrip("/")).resolve()
+    try:
+        if candidate.is_file():
+            return candidate.stat().st_size
+    except OSError:
+        return None
+    return None
+
+
+def audit(source: str, fetch_images: bool = False, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout=timeout)
+    parsed = parse_html(html, url)
+    images = []
+    issues = []
+
+    for index, img in enumerate(parsed["images"]):
+        src = img.get("src") or ""
+        ext = _extension(src)
+        likely_lcp = index == 0 or img.get("fetchpriority") == "high" or img.get("loading") == "eager"
+        row = {
+            "src": src,
+            "format": ext,
+            "width": img.get("width"),
+            "height": img.get("height"),
+            "loading": img.get("loading"),
+            "fetchpriority": img.get("fetchpriority"),
+            "srcset": bool(img.get("srcset")),
+            "sizes": bool(img.get("sizes")),
+            "likely_lcp_candidate": likely_lcp,
+            "status": None,
+            "content_length": _local_size(src, source),
+            "content_type": None,
+        }
+        if fetch_images and src.startswith(("http://", "https://")):
+            head = fetch_url(src, method="HEAD", timeout=timeout)
+            row["status"] = head.get("status")
+            headers = head.get("headers", {})
+            length = headers.get("content-length")
+            row["content_length"] = int(length) if length and length.isdigit() else None
+            row["content_type"] = headers.get("content-type")
+
+        if likely_lcp and row["loading"] == "lazy":
+            issues.append({"severity": "warning", "message": "Likely LCP image is lazy-loaded", "url": src})
+        if likely_lcp and row["fetchpriority"] != "high":
+            issues.append({"severity": "info", "message": "Likely LCP image lacks fetchpriority=high", "url": src})
+        if ext in RASTER_FORMATS:
+            issues.append({"severity": "info", "message": "Consider AVIF/WebP for raster image", "url": src, "evidence": ext})
+        if not row["srcset"]:
+            issues.append({"severity": "info", "message": "Image has no srcset", "url": src})
+        if row["srcset"] and not row["sizes"]:
+            issues.append({"severity": "info", "message": "Responsive image has srcset but no sizes", "url": src})
+        if row["content_length"] and row["content_length"] > 250_000:
+            issues.append({"severity": "warning", "message": "Large image transfer size", "url": src, "evidence": f"{row['content_length']} bytes"})
+        images.append(row)
+
+    known_bytes = sum(row["content_length"] or 0 for row in images)
+    return {
+        "url": url or source,
+        "image_count": len(images),
+        "known_image_bytes": known_bytes if fetch_images or any(row["content_length"] for row in images) else None,
+        "modern_format_count": sum(1 for row in images if row["format"] in MODERN_FORMATS),
+        "responsive_count": sum(1 for row in images if row["srcset"]),
+        "issues": issues,
+        "images": images,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit image weight and responsive-image performance")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--fetch-images", action="store_true", help="HEAD remote images for status and byte size")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    result = audit(args.source, args.fetch_images, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Images: {result['image_count']}; responsive: {result['responsive_count']}; issues: {len(result['issues'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/indexability_matrix.py
+++ b/.claude/skills/seo/scripts/indexability_matrix.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Build per-URL indexability verdicts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from seo_common import (
+    discover_sitemap_urls,
+    fetch_robots,
+    fetch_url,
+    parse_html,
+    parse_sitemap_xml,
+    read_urls,
+    robots_allowed,
+    normalize_url,
+)
+
+
+def urls_from_sitemaps(site: str, timeout: int) -> set[str]:
+    urls = set()
+    for sm in discover_sitemap_urls(site, timeout=timeout)[:10]:
+        fetched = fetch_url(sm, timeout=timeout, max_bytes=8_000_000)
+        parsed = parse_sitemap_xml(fetched.get("text") or "", sm)
+        urls.update(row["loc"] for row in parsed["urls"])
+    return urls
+
+
+def evaluate(urls: list[str], site: str | None = None, timeout: int = 15) -> dict:
+    base = site or (urls[0] if urls else "")
+    robots = fetch_robots(base, timeout=timeout) if base else {"parsed": None}
+    sitemap_urls = urls_from_sitemaps(base, timeout) if base else set()
+    rows = []
+    for url in urls:
+        url = normalize_url(url)
+        allowed, robots_rule = robots_allowed(robots.get("parsed"), url, "Googlebot")
+        fetched = fetch_url(url, timeout=timeout, max_bytes=1_500_000)
+        headers = fetched.get("headers", {})
+        xrobots = headers.get("x-robots-tag") or headers.get("X-Robots-Tag")
+        html = {}
+        ctype = headers.get("content-type", "")
+        if fetched.get("text") and "html" in ctype:
+            html = parse_html(fetched["text"], fetched.get("url") or url)
+        blockers = []
+        if not allowed:
+            blockers.append("robots.txt disallow")
+        if fetched.get("status") != 200:
+            blockers.append(f"HTTP {fetched.get('status')}")
+        if html.get("meta_robots") and "noindex" in html["meta_robots"].lower():
+            blockers.append("meta robots noindex")
+        if xrobots and "noindex" in xrobots.lower():
+            blockers.append("x-robots-tag noindex")
+        if html.get("canonical") and normalize_url(html["canonical"]) != normalize_url(fetched.get("url") or url):
+            blockers.append("canonicalized to different URL")
+        rows.append({
+            "url": url,
+            "final_url": fetched.get("url"),
+            "status": fetched.get("status"),
+            "robots_allowed": allowed,
+            "robots_rule": robots_rule,
+            "meta_robots": html.get("meta_robots"),
+            "x_robots_tag": xrobots,
+            "canonical": html.get("canonical"),
+            "in_sitemap": url in sitemap_urls,
+            "redirects": fetched.get("redirect_chain", []),
+            "verdict": "indexable" if not blockers else "not_indexable",
+            "blockers": blockers,
+            "error": fetched.get("error"),
+        })
+    return {"site": normalize_url(base) if base else None, "count": len(rows), "rows": rows}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate an indexability matrix")
+    parser.add_argument("urls", nargs="*")
+    parser.add_argument("--url-file")
+    parser.add_argument("--site", help="Site URL for robots/sitemap context")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    urls = read_urls(args.urls, args.url_file)
+    result = evaluate(urls, args.site, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        for row in result["rows"]:
+            print(f"{row['verdict']}\t{row['status']}\t{row['url']}\t{', '.join(row['blockers'])}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/indexnow_checker.py
+++ b/.claude/skills/seo/scripts/indexnow_checker.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+IndexNow Checker & Pinger
+
+Validates IndexNow implementation on a site and optionally pings the
+IndexNow API to notify search engines of URL updates.
+
+Checks:
+  1. IndexNow key file hosted at /{key}.txt
+  2. Key referenced in <meta> or robots.txt
+  3. Previously submitted URLs (via local log)
+  4. Ping mode: submit URLs to IndexNow API
+
+Supported engines: Bing, Yandex, Seznam, Naver
+
+Usage:
+    python indexnow_checker.py https://example.com --key YOUR_KEY --json
+    python indexnow_checker.py https://example.com --key YOUR_KEY --ping https://example.com/updated-page
+    python indexnow_checker.py https://example.com --key YOUR_KEY --ping-sitemap
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from urllib.parse import urlparse
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    BeautifulSoup = None
+
+try:
+    from lib.safe_http import safe_get, safe_post
+except ImportError:
+    from scripts.lib.safe_http import safe_get, safe_post
+
+INDEXNOW_ENDPOINTS = {
+    "bing": "https://www.bing.com/indexnow",
+    "yandex": "https://yandex.com/indexnow",
+    "seznam": "https://search.seznam.cz/indexnow",
+    "naver": "https://searchadvisor.naver.com/indexnow",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+def fetch_url(url: str, timeout: int = 8) -> tuple:
+    """Return (status_code, body) or (None, error_msg)."""
+    try:
+        resp = safe_get(url, timeout=timeout)
+        return resp.status_code, resp.text
+    except Exception as exc:
+        return None, str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Validation checks
+# ---------------------------------------------------------------------------
+
+def check_key_file(site_url: str, key: str) -> dict:
+    """Check 1: Verify key file is hosted at /{key}.txt"""
+    parsed = urlparse(site_url)
+    key_url = f"{parsed.scheme}://{parsed.netloc}/{key}.txt"
+
+    status, body = fetch_url(key_url)
+    if status == 200 and key in body:
+        return {
+            "passed": True,
+            "detail": f"Key file found at {key_url}",
+            "url": key_url,
+        }
+    elif status == 200:
+        return {
+            "passed": False,
+            "severity": "Critical",
+            "finding": f"Key file exists at {key_url} but does not contain the expected key.",
+            "fix": f"Update {key_url} to contain only the key value: {key}",
+        }
+    else:
+        return {
+            "passed": False,
+            "severity": "Critical",
+            "finding": f"Key file not found at {key_url} (HTTP {status}).",
+            "fix": f"Create a text file at {key_url} containing only: {key}",
+        }
+
+
+def check_key_in_meta(html: str, key: str) -> dict:
+    """Check 2: Verify key is referenced in <meta> tag (optional but recommended)."""
+    if not BeautifulSoup:
+        return {"passed": None, "finding": "beautifulsoup4 not available for meta tag check."}
+
+    soup = BeautifulSoup(html, "html.parser")
+    meta = soup.find("meta", attrs={"name": "indexnow"})
+    if meta and meta.get("content") == key:
+        return {"passed": True, "detail": "IndexNow key found in <meta name='indexnow'> tag."}
+
+    return {
+        "passed": False,
+        "severity": "Info",
+        "finding": "No <meta name='indexnow'> tag found (optional but improves validation speed).",
+        "fix": f'Add <meta name="indexnow" content="{key}"> to the <head> section.',
+    }
+
+
+def check_robots_txt(site_url: str, key: str) -> dict:
+    """Check 3: See if robots.txt references IndexNow."""
+    parsed = urlparse(site_url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+
+    status, body = fetch_url(robots_url)
+    if status != 200:
+        return {"passed": None, "finding": f"Could not fetch robots.txt (HTTP {status})."}
+
+    if "indexnow" in body.lower() or key in body:
+        return {"passed": True, "detail": "IndexNow reference found in robots.txt."}
+
+    return {
+        "passed": None,
+        "severity": "Info",
+        "finding": "No IndexNow reference in robots.txt (not required, just informational).",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ping API
+# ---------------------------------------------------------------------------
+
+def ping_indexnow(site_url: str, key: str, urls: list, engine: str = "bing") -> dict:
+    """Submit URLs to IndexNow API."""
+    endpoint = INDEXNOW_ENDPOINTS.get(engine, INDEXNOW_ENDPOINTS["bing"])
+    parsed = urlparse(site_url)
+    host = parsed.netloc
+
+    payload = json.dumps({
+        "host": host,
+        "key": key,
+        "keyLocation": f"{parsed.scheme}://{host}/{key}.txt",
+        "urlList": urls,
+    }).encode("utf-8")
+
+    try:
+        resp = safe_post(
+            endpoint,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+            },
+            timeout=10,
+        )
+        return {
+            "success": resp.status_code in (200, 202),
+            "status_code": resp.status_code,
+            "engine": engine,
+            "urls_submitted": len(urls),
+            "endpoint": endpoint,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "engine": engine,
+            "error": str(exc),
+        }
+
+
+def extract_sitemap_urls(site_url: str, limit: int = 50) -> list:
+    """Extract URLs from sitemap.xml for bulk ping."""
+    parsed = urlparse(site_url)
+    sitemap_url = f"{parsed.scheme}://{parsed.netloc}/sitemap.xml"
+
+    status, body = fetch_url(sitemap_url)
+    if status != 200:
+        return []
+
+    import re
+    urls = re.findall(r"<loc>([^<]+)</loc>", body)
+    return urls[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def run_indexnow_check(site_url: str, key: str) -> dict:
+    """Run all IndexNow validation checks."""
+    # Fetch homepage for meta tag check
+    status, html = fetch_url(site_url)
+    if status is None:
+        return {"error": f"Failed to fetch {site_url}", "url": site_url}
+
+    results = {
+        "url": site_url,
+        "key": key[:4] + "..." + key[-4:] if len(key) > 8 else "***",
+        "checks": {},
+        "issues": [],
+        "summary": {"passed": 0, "failed": 0, "info": 0},
+    }
+
+    # Run checks
+    results["checks"]["key_file"] = check_key_file(site_url, key)
+    results["checks"]["meta_tag"] = check_key_in_meta(html, key)
+    results["checks"]["robots_txt"] = check_robots_txt(site_url, key)
+
+    # Tally
+    for check in results["checks"].values():
+        if check.get("passed") is True:
+            results["summary"]["passed"] += 1
+        elif check.get("passed") is False:
+            results["summary"]["failed"] += 1
+            results["issues"].append(check)
+        else:
+            results["summary"]["info"] += 1
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="IndexNow Checker & Pinger — validate and submit URLs to search engines"
+    )
+    parser.add_argument("url", help="Site URL")
+    parser.add_argument("--key", required=True, help="IndexNow API key")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--ping", nargs="*", help="URL(s) to submit via IndexNow API")
+    parser.add_argument("--ping-sitemap", action="store_true", help="Submit all sitemap URLs")
+    parser.add_argument("--engine", default="bing", choices=INDEXNOW_ENDPOINTS.keys(),
+                        help="Search engine to ping (default: bing)")
+    args = parser.parse_args()
+
+    report = run_indexnow_check(args.url, args.key)
+
+    # Handle ping mode
+    if args.ping:
+        report["ping_result"] = ping_indexnow(args.url, args.key, args.ping, engine=args.engine)
+
+    if args.ping_sitemap:
+        sitemap_urls = extract_sitemap_urls(args.url)
+        if sitemap_urls:
+            report["ping_result"] = ping_indexnow(args.url, args.key, sitemap_urls, engine=args.engine)
+            report["ping_result"]["sitemap_urls_found"] = len(sitemap_urls)
+        else:
+            report["ping_result"] = {"error": "No sitemap URLs found."}
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return
+
+    if report.get("error"):
+        print(f"Error: {report['error']}")
+        sys.exit(1)
+
+    print(f"\nIndexNow Validation — {report['url']}")
+    print("=" * 60)
+    print(f"Key: {report['key']}")
+
+    for name, check in report["checks"].items():
+        if check.get("passed") is True:
+            print(f"  ✅ {name.replace('_', ' ').title()}: {check.get('detail', 'Pass')}")
+        elif check.get("passed") is False:
+            print(f"  🔴 {name.replace('_', ' ').title()}: {check.get('finding', '')}")
+            print(f"     Fix: {check.get('fix', '')}")
+        else:
+            print(f"  ℹ️  {name.replace('_', ' ').title()}: {check.get('finding', '')}")
+
+    s = report["summary"]
+    print(f"\nSummary: {s['passed']} passed, {s['failed']} failed, {s['info']} info")
+
+    if report.get("ping_result"):
+        pr = report["ping_result"]
+        if pr.get("success"):
+            print(f"\n✅ Ping Success: {pr['urls_submitted']} URLs submitted to {pr['engine']} (HTTP {pr['status_code']})")
+        else:
+            print(f"\n❌ Ping Failed: {pr.get('error', 'Unknown error')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/internal_links.py
+++ b/.claude/skills/seo/scripts/internal_links.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Analyze internal link structure of a website.
+
+Checks link count, anchor text distribution, orphan page detection,
+and link depth from homepage.
+
+Usage:
+    python internal_links.py https://example.com
+    python internal_links.py https://example.com --depth 2 --json
+"""
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urljoin, urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_get
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_get
+
+
+HEADERS = default_headers()
+
+
+def extract_internal_links(html: str, page_url: str, domain: str) -> list:
+    """Extract internal links from HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    links = []
+    seen = set()
+
+    for tag in soup.find_all("a", href=True):
+        href = tag["href"].strip()
+        if href.startswith(("#", "javascript:", "mailto:", "tel:", "data:")):
+            continue
+
+        absolute = urljoin(page_url, href)
+        parsed = urlparse(absolute)
+
+        # Only internal links
+        if parsed.netloc != domain:
+            continue
+
+        # Normalize: remove fragments, trailing slashes
+        normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        if normalized.endswith("/") and len(parsed.path) > 1:
+            normalized = normalized.rstrip("/")
+
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+
+        anchor_text = tag.get_text(strip=True)[:80] or "[no text]"
+        nofollow = "nofollow" in (tag.get("rel", []) or [])
+        links.append({
+            "url": normalized,
+            "anchor_text": anchor_text,
+            "nofollow": nofollow,
+            "source": page_url,
+        })
+
+    return links
+
+
+def crawl_site(start_url: str, max_depth: int = 2, max_pages: int = 50,
+               max_workers: int = 5, timeout: int = 10) -> dict:
+    """
+    Crawl internal links up to max_depth.
+
+    Args:
+        start_url: Starting URL (usually homepage)
+        max_depth: Maximum crawl depth
+        max_pages: Maximum pages to crawl
+        max_workers: Concurrent request threads
+        timeout: Per-page timeout
+
+    Returns:
+        Dictionary with link structure analysis
+    """
+    parsed = urlparse(start_url)
+    domain = parsed.netloc
+
+    result = {
+        "start_url": start_url,
+        "domain": domain,
+        "pages_crawled": 0,
+        "total_internal_links": 0,
+        "unique_pages_found": 0,
+        "max_depth_reached": 0,
+        "pages": {},
+        "anchor_texts": {},
+        "link_distribution": {},
+        "orphan_candidates": [],
+        "nofollow_links": [],
+        "issues": [],
+        "recommendations": [],
+        "error": None,
+    }
+
+    # BFS crawl
+    visited = set()
+    queue = [(start_url, 0)]  # (url, depth)
+    all_links = []
+    page_link_counts = {}
+    pages_linking_to = defaultdict(set)  # url -> set of pages linking to it
+    pages_found_at_depth = defaultdict(list)
+
+    def fetch_page(url):
+        try:
+            resp = safe_get(url, timeout=timeout, headers=HEADERS, allow_redirects=True)
+            if resp.status_code == 200 and "text/html" in resp.headers.get("content-type", ""):
+                return resp.text, resp.url
+        except requests.exceptions.RequestException:
+            pass
+        return None, url
+
+    while queue and len(visited) < max_pages:
+        # Process current batch
+        batch = []
+        while queue and len(batch) < max_workers:
+            url, depth = queue.pop(0)
+            if url in visited or depth > max_depth:
+                continue
+            visited.add(url)
+            batch.append((url, depth))
+
+        if not batch:
+            break
+
+        # Fetch pages concurrently
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(fetch_page, url): (url, depth) for url, depth in batch}
+            for future in as_completed(futures):
+                url, depth = futures[future]
+                html, final_url = future.result()
+
+                if html is None:
+                    continue
+
+                links = extract_internal_links(html, final_url, domain)
+                page_link_counts[url] = len(links)
+                pages_found_at_depth[depth].append(url)
+                result["max_depth_reached"] = max(result["max_depth_reached"], depth)
+
+                for link in links:
+                    all_links.append(link)
+                    pages_linking_to[link["url"]].add(url)
+
+                    if link["nofollow"]:
+                        result["nofollow_links"].append(link)
+
+                    # Add to crawl queue
+                    if link["url"] not in visited and depth + 1 <= max_depth:
+                        queue.append((link["url"], depth + 1))
+
+    result["pages_crawled"] = len(visited)
+    result["total_internal_links"] = len(all_links)
+    result["unique_pages_found"] = len(pages_linking_to)
+
+    # Anchor text distribution
+    anchor_counter = Counter(link["anchor_text"] for link in all_links if link["anchor_text"] != "[no text]")
+    result["anchor_texts"] = dict(anchor_counter.most_common(20))
+
+    # Link distribution (outgoing links per page)
+    result["link_distribution"] = {
+        "min": min(page_link_counts.values()) if page_link_counts else 0,
+        "max": max(page_link_counts.values()) if page_link_counts else 0,
+        "avg": round(sum(page_link_counts.values()) / max(1, len(page_link_counts)), 1),
+    }
+
+    # Pages info
+    for url in visited:
+        outgoing = page_link_counts.get(url, 0)
+        incoming = len(pages_linking_to.get(url, set()))
+        result["pages"][url] = {
+            "outgoing_links": outgoing,
+            "incoming_links": incoming,
+        }
+
+    # Orphan candidates (pages with 0 or 1 incoming links, excluding start)
+    for url, sources in pages_linking_to.items():
+        if url != start_url and len(sources) <= 1:
+            result["orphan_candidates"].append({
+                "url": url,
+                "incoming_links": len(sources),
+            })
+
+    # Issues
+    if result["orphan_candidates"]:
+        result["issues"].append(
+            f"⚠️ {len(result['orphan_candidates'])} potential orphan page(s) "
+            f"(≤1 internal link pointing to them)"
+        )
+
+    # Check for pages with too few outgoing links
+    low_link_pages = [url for url, count in page_link_counts.items() if count < 3]
+    if low_link_pages:
+        result["issues"].append(
+            f"⚠️ {len(low_link_pages)} page(s) have fewer than 3 internal links"
+        )
+
+    # Check for pages with excessive links
+    high_link_pages = [url for url, count in page_link_counts.items() if count > 100]
+    if high_link_pages:
+        result["issues"].append(
+            f"⚠️ {len(high_link_pages)} page(s) have >100 internal links — may dilute link equity"
+        )
+
+    # Check nofollow on internal links
+    if result["nofollow_links"]:
+        result["issues"].append(
+            f"⚠️ {len(result['nofollow_links'])} internal link(s) have nofollow — "
+            f"this wastes link equity"
+        )
+
+    # Check anchor text issues
+    no_text_links = sum(1 for l in all_links if l["anchor_text"] == "[no text]")
+    if no_text_links:
+        result["issues"].append(
+            f"⚠️ {no_text_links} link(s) have no anchor text"
+        )
+
+    # Recommendations
+    if result["orphan_candidates"]:
+        result["recommendations"].append(
+            "Add internal links pointing to orphan pages from related content"
+        )
+    if result["link_distribution"]["avg"] < 5:
+        result["recommendations"].append(
+            "Increase internal linking — aim for 3-5 relevant links per 1000 words"
+        )
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze internal link structure")
+    parser.add_argument("url", help="Website URL (usually homepage)")
+    parser.add_argument("--depth", "-d", type=int, default=2,
+                        help="Max crawl depth (default: 2)")
+    parser.add_argument("--max-pages", "-m", type=int, default=50,
+                        help="Max pages to crawl (default: 50)")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+    result = crawl_site(args.url, max_depth=args.depth, max_pages=args.max_pages)
+
+    if args.json:
+        # Trim for readability
+        output = {k: v for k, v in result.items()}
+        # Convert sets to lists for JSON
+        for url, info in output.get("pages", {}).items():
+            if isinstance(info, set):
+                output["pages"][url] = list(info)
+        print(json.dumps(output, indent=2, default=str))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    print(f"Internal Link Analysis — {result['domain']}")
+    print("=" * 50)
+    print(f"Pages crawled: {result['pages_crawled']}")
+    print(f"Unique pages found: {result['unique_pages_found']}")
+    print(f"Total internal links: {result['total_internal_links']}")
+    print(f"Max depth reached: {result['max_depth_reached']}")
+
+    dist = result["link_distribution"]
+    print(f"\nLinks per page: min={dist['min']}, max={dist['max']}, avg={dist['avg']}")
+
+    if result["orphan_candidates"]:
+        print(f"\n⚠️ Potential Orphan Pages ({len(result['orphan_candidates'])}):")
+        for orphan in result["orphan_candidates"][:10]:
+            print(f"  • {orphan['url']} ({orphan['incoming_links']} incoming)")
+
+    if result["anchor_texts"]:
+        print(f"\nTop Anchor Texts:")
+        for text, count in list(result["anchor_texts"].items())[:10]:
+            print(f"  [{count}x] \"{text}\"")
+
+    if result["nofollow_links"]:
+        print(f"\n⚠️ Nofollow Internal Links ({len(result['nofollow_links'])}):")
+        for link in result["nofollow_links"][:5]:
+            print(f"  • {link['url']} (from {link['source']})")
+
+    if result["issues"]:
+        print(f"\nIssues:")
+        for issue in result["issues"]:
+            print(f"  {issue}")
+
+    if result["recommendations"]:
+        print(f"\nRecommendations:")
+        for rec in result["recommendations"]:
+            print(f"  💡 {rec}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/javascript_render_audit.py
+++ b/.claude/skills/seo/scripts/javascript_render_audit.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Compare raw HTML against rendered DOM SEO elements when Playwright is available."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from seo_common import fetch_url, load_html, parse_html
+
+
+def summarize(html: str, url: str) -> dict:
+    parsed = parse_html(html, url)
+    return {
+        "title": parsed["title"],
+        "meta_description": parsed["meta_description"],
+        "canonical": parsed["canonical"],
+        "h1_count": len(parsed["headings"]["h1"]),
+        "internal_link_count": len([l for l in parsed["links"] if url and l["href"].startswith(url.split("/", 3)[0] + "//" + url.split("/")[2])]) if url.startswith("http") else len(parsed["links"]),
+        "schema_count": len(parsed["schema"]),
+        "word_count": parsed["word_count"],
+    }
+
+
+def render_with_playwright(url: str, timeout_ms: int) -> tuple[str | None, str | None]:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return None, "playwright not installed"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+            html = page.content()
+            browser.close()
+            return html, None
+    except Exception as exc:  # noqa: BLE001 - CLI should report environment/browser errors
+        return None, str(exc)
+
+
+def audit(source: str, timeout: int = 15, render_timeout: int = 30000) -> dict:
+    raw_html, final_url, fetched = load_html(source, timeout=timeout)
+    raw = summarize(raw_html, final_url or source)
+    rendered_html = None
+    render_error = None
+    if final_url.startswith("http"):
+        rendered_html, render_error = render_with_playwright(final_url, render_timeout)
+    else:
+        render_error = "rendering requires an http(s) URL"
+    rendered = summarize(rendered_html, final_url) if rendered_html else None
+    diffs = []
+    if rendered:
+        for key in raw:
+            if raw.get(key) != rendered.get(key):
+                diffs.append({"field": key, "raw": raw.get(key), "rendered": rendered.get(key)})
+    return {"url": final_url or source, "raw": raw, "rendered": rendered, "diffs": diffs, "render_error": render_error, "fetch_error": fetched.get("error")}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare raw HTML and rendered DOM SEO signals")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--render-timeout", type=int, default=30000)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = audit(args.source, args.timeout, args.render_timeout)
+    print(json.dumps(result, indent=2) if args.json else f"Diffs: {len(result['diffs'])}; render_error={result['render_error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/lcp_subparts.py
+++ b/.claude/skills/seo/scripts/lcp_subparts.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Estimate LCP subparts from Lighthouse JSON or lightweight page evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+try:
+    from lib.safe_http import safe_request
+except ImportError:
+    from scripts.lib.safe_http import safe_request
+
+from seo_common import load_html, normalize_url, parse_html
+
+
+def _is_url(value: str) -> bool:
+    if Path(value).is_file():
+        return False
+    return urlparse(value).scheme in ("http", "https") or ("." in value and "/" not in value)
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    path = Path(source)
+    if path.is_file():
+        return path.read_text(encoding="utf-8"), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _load_lighthouse(path: str) -> dict:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return payload.get("lighthouseResult", payload)
+
+
+def _lcp_element_url(lhr: dict) -> str | None:
+    details = lhr.get("audits", {}).get("largest-contentful-paint-element", {}).get("details", {})
+    for item in details.get("items", []):
+        for key in ("url", "source"):
+            if item.get(key):
+                return item[key]
+        node = item.get("node", {})
+        snippet = node.get("snippet", "")
+        match = re.search(r"""(?:src|href)=["']([^"']+)""", snippet)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _network_item_for_url(lhr: dict, url: str | None) -> dict | None:
+    if not url:
+        return None
+    items = lhr.get("audits", {}).get("network-requests", {}).get("details", {}).get("items", [])
+    for item in items:
+        item_url = item.get("url", "")
+        if item_url == url or item_url.split("?", 1)[0] == url.split("?", 1)[0]:
+            return item
+    return None
+
+
+def subparts_from_lighthouse(path: str) -> dict:
+    lhr = _load_lighthouse(path)
+    audits = lhr.get("audits", {})
+    lcp_ms = audits.get("largest-contentful-paint", {}).get("numericValue")
+    ttfb_ms = audits.get("server-response-time", {}).get("numericValue")
+    lcp_url = _lcp_element_url(lhr)
+    resource = _network_item_for_url(lhr, lcp_url)
+
+    resource_start = resource.get("networkRequestTime") if resource else None
+    resource_end = resource.get("networkEndTime") if resource else None
+    if isinstance(resource_start, (int, float)) and resource_start < 100:
+        resource_start *= 1000
+    if isinstance(resource_end, (int, float)) and resource_end < 100:
+        resource_end *= 1000
+
+    resource_duration = None
+    if isinstance(resource_start, (int, float)) and isinstance(resource_end, (int, float)):
+        resource_duration = max(0, resource_end - resource_start)
+
+    resource_delay = None
+    if isinstance(resource_start, (int, float)) and isinstance(ttfb_ms, (int, float)):
+        resource_delay = max(0, resource_start - ttfb_ms)
+
+    render_delay = None
+    if isinstance(lcp_ms, (int, float)):
+        known = sum(v for v in (ttfb_ms, resource_delay, resource_duration) if isinstance(v, (int, float)))
+        render_delay = max(0, lcp_ms - known)
+
+    return {
+        "source": path,
+        "mode": "lighthouse-json",
+        "lcp_ms": round(lcp_ms) if isinstance(lcp_ms, (int, float)) else None,
+        "lcp_element_url": lcp_url,
+        "subparts": {
+            "ttfb_ms": round(ttfb_ms) if isinstance(ttfb_ms, (int, float)) else None,
+            "resource_load_delay_ms": round(resource_delay) if isinstance(resource_delay, (int, float)) else None,
+            "resource_load_duration_ms": round(resource_duration) if isinstance(resource_duration, (int, float)) else None,
+            "element_render_delay_ms": round(render_delay) if isinstance(render_delay, (int, float)) else None,
+        },
+        "confidence": "medium" if lcp_ms else "low",
+        "notes": ["Computed from Lighthouse audits and network timing where present."],
+        "error": None,
+    }
+
+
+def _candidate_lcp_image(parsed: dict) -> dict | None:
+    images = parsed.get("images", [])
+    prioritized = [
+        img for img in images
+        if img.get("fetchpriority") == "high" or img.get("loading") in (None, "", "eager")
+    ]
+    return (prioritized or images or [None])[0]
+
+
+def _fetch_ttfb(url: str, timeout: int) -> tuple[int | None, dict, str | None]:
+    started = time.perf_counter()
+    try:
+        response = safe_request("GET", normalize_url(url), timeout=timeout, max_response_bytes=2_000_000)
+    except Exception as exc:  # noqa: BLE001 - CLI degrades gracefully for network policy/timeouts
+        return None, {}, str(exc)
+    elapsed_ms = round(response.elapsed.total_seconds() * 1000) if response.elapsed else round((time.perf_counter() - started) * 1000)
+    headers = {str(k).lower(): v for k, v in response.headers.items()}
+    return elapsed_ms, headers, None
+
+
+def analyze_source(source: str, timeout: int = 15) -> dict:
+    html, final_url, fetched = _load_source(source, timeout=timeout)
+    parsed = parse_html(html, final_url or source)
+    image = _candidate_lcp_image(parsed)
+    ttfb_ms = None
+    headers = {}
+    error = fetched.get("error")
+    if _is_url(source) and final_url:
+        ttfb_ms, headers, timing_error = _fetch_ttfb(final_url, timeout)
+        error = error or timing_error
+
+    notes = [
+        "Static mode cannot observe the browser's real LCP render timestamp.",
+        "Use --lighthouse-json with a saved Lighthouse report for stronger subpart estimates.",
+    ]
+    if image and image.get("loading") == "lazy":
+        notes.append("Likely LCP candidate is lazy-loaded, which can increase resource load delay.")
+    if image and image.get("fetchpriority") != "high":
+        notes.append("Likely LCP candidate does not use fetchpriority=high.")
+
+    return {
+        "source": source,
+        "final_url": final_url or source,
+        "mode": "static-html",
+        "lcp_ms": None,
+        "lcp_element_url": image.get("src") if image else None,
+        "subparts": {
+            "ttfb_ms": ttfb_ms,
+            "resource_load_delay_ms": None,
+            "resource_load_duration_ms": None,
+            "element_render_delay_ms": None,
+        },
+        "response_headers": headers,
+        "confidence": "low",
+        "notes": notes,
+        "error": error,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Estimate Largest Contentful Paint subparts")
+    parser.add_argument("source", nargs="?", help="URL or local HTML file")
+    parser.add_argument("--lighthouse-json", help="Path to a Lighthouse JSON report")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    if not args.source and not args.lighthouse_json:
+        parser.error("provide a source or --lighthouse-json")
+    result = subparts_from_lighthouse(args.lighthouse_json) if args.lighthouse_json else analyze_source(args.source, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        parts = result["subparts"]
+        print(
+            "LCP subparts: "
+            f"TTFB={parts['ttfb_ms']}ms, "
+            f"delay={parts['resource_load_delay_ms']}ms, "
+            f"duration={parts['resource_load_duration_ms']}ms, "
+            f"render={parts['element_render_delay_ms']}ms"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/lib/__init__.py
+++ b/.claude/skills/seo/scripts/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers for Agentic SEO scripts."""

--- a/.claude/skills/seo/scripts/lib/safe_http.py
+++ b/.claude/skills/seo/scripts/lib/safe_http.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Safe HTTP helpers shared by network-facing SEO scripts."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse, urlunparse
+
+try:
+    import requests
+except ImportError as exc:  # pragma: no cover - import-time environment guard
+    raise SystemExit("Error: requests library required. Install with: pip install requests") from exc
+
+
+AGENTIC_SEO_USER_AGENT = (
+    "Mozilla/5.0 (compatible; AgenticSEOSkill/1.0; "
+    "+https://github.com/Bhanunamikaze/Agentic-SEO-Skill)"
+)
+DEFAULT_TIMEOUT = 15
+DEFAULT_MAX_REDIRECTS = 5
+DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+
+DEFAULT_HEADERS = {
+    "User-Agent": AGENTIC_SEO_USER_AGENT,
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate",
+    "Connection": "keep-alive",
+}
+
+
+class SafeHTTPError(requests.exceptions.RequestException):
+    """Raised when a request is blocked by safe HTTP policy."""
+
+
+def default_headers(extra: dict | None = None) -> dict:
+    """Return request headers with the shared Agentic SEO User-Agent."""
+    headers = dict(DEFAULT_HEADERS)
+    if extra:
+        headers.update(extra)
+    headers["User-Agent"] = AGENTIC_SEO_USER_AGENT
+    return headers
+
+
+def normalize_url(url: str, default_scheme: str = "https") -> str:
+    """Normalize a user-supplied URL, adding https:// when no scheme exists."""
+    if not url:
+        raise SafeHTTPError("URL is required")
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"{default_scheme}://{url}"
+        parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise SafeHTTPError(f"Invalid URL scheme: {parsed.scheme}")
+    if not parsed.hostname:
+        raise SafeHTTPError("URL must include a hostname")
+    return urlunparse(parsed)
+
+
+def _port_for(parsed) -> int:
+    if parsed.port:
+        return parsed.port
+    return 443 if parsed.scheme == "https" else 80
+
+
+def _is_blocked_ip(ip_text: str) -> bool:
+    ip = ipaddress.ip_address(ip_text)
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_reserved
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def assert_safe_url(url: str) -> str:
+    """Validate URL scheme and reject hosts resolving to private/internal IPs."""
+    normalized = normalize_url(url)
+    parsed = urlparse(normalized)
+    hostname = parsed.hostname
+
+    try:
+        if _is_blocked_ip(hostname):
+            raise SafeHTTPError(f"Blocked: URL resolves to private/internal IP ({hostname})")
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(hostname, _port_for(parsed), type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return normalized
+
+    resolved_ips = sorted({info[4][0] for info in infos})
+    for ip_text in resolved_ips:
+        try:
+            if _is_blocked_ip(ip_text):
+                raise SafeHTTPError(f"Blocked: URL resolves to private/internal IP ({ip_text})")
+        except ValueError as exc:
+            raise SafeHTTPError(f"Blocked: could not validate resolved IP ({ip_text})") from exc
+
+    return normalized
+
+
+def _consume_capped(response, max_response_bytes: int | None):
+    if max_response_bytes is None:
+        response._content = response.content
+        return response
+
+    chunks = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=65536):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_response_bytes:
+            response.close()
+            raise SafeHTTPError(f"Response exceeded {max_response_bytes} byte safety limit")
+        chunks.append(chunk)
+    response._content = b"".join(chunks)
+    response._content_consumed = True
+    return response
+
+
+def safe_request(
+    method: str,
+    url: str,
+    *,
+    headers: dict | None = None,
+    timeout: int | float = DEFAULT_TIMEOUT,
+    allow_redirects: bool = True,
+    max_redirects: int = DEFAULT_MAX_REDIRECTS,
+    max_response_bytes: int | None = DEFAULT_MAX_RESPONSE_BYTES,
+    stream: bool = False,
+    session=None,
+    **kwargs,
+):
+    """
+    Execute an HTTP request with SSRF guards, redirect checks, TLS verification,
+    timeouts, and a response-size cap.
+    """
+    current = assert_safe_url(url)
+    request_headers = default_headers(headers)
+    requester = session or requests.Session()
+    history = []
+    method = method.upper()
+    kwargs["verify"] = True
+
+    for _ in range(max_redirects + 1):
+        response = requester.request(
+            method,
+            current,
+            headers=request_headers,
+            timeout=timeout,
+            allow_redirects=False,
+            stream=True,
+            **kwargs,
+        )
+
+        if not (allow_redirects and response.is_redirect):
+            response.history = history
+            if method == "HEAD":
+                response.close()
+                return response
+            if stream:
+                return response
+            return _consume_capped(response, max_response_bytes)
+
+        location = response.headers.get("Location")
+        if not location:
+            response.history = history
+            if method == "HEAD":
+                response.close()
+                return response
+            if stream:
+                return response
+            return _consume_capped(response, max_response_bytes)
+
+        response.close()
+        history.append(response)
+        if len(history) > max_redirects:
+            raise requests.exceptions.TooManyRedirects(f"Too many redirects (max {max_redirects})")
+
+        next_url = assert_safe_url(urljoin(current, location))
+        if response.status_code == 303 and method not in ("GET", "HEAD"):
+            method = "GET"
+            kwargs.pop("data", None)
+            kwargs.pop("json", None)
+        current = next_url
+
+    raise requests.exceptions.TooManyRedirects(f"Too many redirects (max {max_redirects})")
+
+
+def safe_get(url: str, **kwargs):
+    return safe_request("GET", url, **kwargs)
+
+
+def safe_head(url: str, **kwargs):
+    return safe_request("HEAD", url, **kwargs)
+
+
+def safe_post(url: str, **kwargs):
+    return safe_request("POST", url, **kwargs)

--- a/.claude/skills/seo/scripts/lighthouse_runner.py
+++ b/.claude/skills/seo/scripts/lighthouse_runner.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Run local Lighthouse when available and normalize key audit output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+DEFAULT_CATEGORIES = ("performance", "seo", "accessibility", "best-practices")
+
+
+def _is_url(value: str) -> bool:
+    return urlparse(value).scheme in ("http", "https")
+
+
+def _find_lighthouse_command() -> tuple[list[str] | None, str | None]:
+    lighthouse = shutil.which("lighthouse")
+    if lighthouse:
+        return [lighthouse], None
+    npx = shutil.which("npx")
+    if npx:
+        return [npx, "--no-install", "lighthouse"], None
+    return None, "Lighthouse is not installed. Install it with npm install -g lighthouse, or add it to the project."
+
+
+def _category_scores(lhr: dict) -> dict:
+    scores = {}
+    for key, category in lhr.get("categories", {}).items():
+        raw_score = category.get("score")
+        scores[key] = {
+            "title": category.get("title", key),
+            "score": round(raw_score * 100) if isinstance(raw_score, (int, float)) else None,
+        }
+    return scores
+
+
+def _audit_summary(lhr: dict) -> dict:
+    audit_ids = [
+        "largest-contentful-paint",
+        "total-blocking-time",
+        "cumulative-layout-shift",
+        "speed-index",
+        "interactive",
+        "server-response-time",
+        "render-blocking-resources",
+        "unused-javascript",
+        "unused-css-rules",
+        "uses-optimized-images",
+        "uses-webp-images",
+        "font-display",
+        "third-party-summary",
+    ]
+    audits = {}
+    for audit_id in audit_ids:
+        audit = lhr.get("audits", {}).get(audit_id)
+        if audit:
+            audits[audit_id] = {
+                "title": audit.get("title", audit_id),
+                "score": audit.get("score"),
+                "numeric_value": audit.get("numericValue"),
+                "display": audit.get("displayValue"),
+            }
+    return audits
+
+
+def parse_lighthouse_result(payload: dict, source: str, strategy: str) -> dict:
+    lhr = payload.get("lighthouseResult", payload)
+    return {
+        "source": source,
+        "final_url": lhr.get("finalDisplayedUrl") or lhr.get("finalUrl") or source,
+        "strategy": strategy,
+        "fetch_time": lhr.get("fetchTime"),
+        "lighthouse_version": lhr.get("lighthouseVersion"),
+        "environment": lhr.get("environment", {}),
+        "categories": _category_scores(lhr),
+        "audits": _audit_summary(lhr),
+        "error": None,
+    }
+
+
+def run_lighthouse(
+    source: str,
+    strategy: str = "mobile",
+    categories: tuple[str, ...] = DEFAULT_CATEGORIES,
+    timeout: int = 120,
+) -> dict:
+    if not _is_url(source):
+        path = Path(source)
+        return {
+            "source": source,
+            "final_url": str(path),
+            "strategy": strategy,
+            "categories": {},
+            "audits": {},
+            "error": "Lighthouse requires an http(s) URL; local HTML can be checked with the static performance scripts.",
+        }
+
+    command, error = _find_lighthouse_command()
+    if error:
+        return {
+            "source": source,
+            "final_url": source,
+            "strategy": strategy,
+            "categories": {},
+            "audits": {},
+            "error": error,
+        }
+
+    form_factor = "desktop" if strategy == "desktop" else "mobile"
+    args = [
+        *command,
+        source,
+        "--quiet",
+        "--output=json",
+        "--output-path=stdout",
+        f"--only-categories={','.join(categories)}",
+        f"--emulated-form-factor={form_factor}",
+        "--chrome-flags=--headless",
+    ]
+    try:
+        completed = subprocess.run(args, check=False, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return {
+            "source": source,
+            "final_url": source,
+            "strategy": strategy,
+            "categories": {},
+            "audits": {},
+            "error": f"Lighthouse timed out after {timeout}s",
+        }
+    except OSError as exc:
+        return {
+            "source": source,
+            "final_url": source,
+            "strategy": strategy,
+            "categories": {},
+            "audits": {},
+            "error": str(exc),
+        }
+
+    if completed.returncode != 0:
+        return {
+            "source": source,
+            "final_url": source,
+            "strategy": strategy,
+            "categories": {},
+            "audits": {},
+            "error": (completed.stderr or completed.stdout or "Lighthouse failed").strip()[:1000],
+        }
+
+    try:
+        return parse_lighthouse_result(json.loads(completed.stdout), source, strategy)
+    except json.JSONDecodeError as exc:
+        return {
+            "source": source,
+            "final_url": source,
+            "strategy": strategy,
+            "categories": {},
+            "audits": {},
+            "error": f"Could not parse Lighthouse JSON: {exc}",
+        }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Lighthouse locally when the optional CLI is available")
+    parser.add_argument("source", help="HTTP(S) URL to audit")
+    parser.add_argument("--strategy", choices=("mobile", "desktop"), default="mobile")
+    parser.add_argument("--category", action="append", choices=DEFAULT_CATEGORIES, help="Lighthouse category to include")
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    categories = tuple(args.category) if args.category else DEFAULT_CATEGORIES
+    result = run_lighthouse(args.source, args.strategy, categories, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    elif result["error"]:
+        print(f"Lighthouse unavailable: {result['error']}")
+    else:
+        scores = ", ".join(f"{key}={value['score']}" for key, value in result["categories"].items())
+        print(f"Lighthouse {args.strategy}: {scores}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/link_profile.py
+++ b/.claude/skills/seo/scripts/link_profile.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Link Profile Analyzer
+
+Crawls a site to build an internal/external link graph, identifies orphan
+pages, calculates internal link equity distribution, and analyzes anchor
+text patterns.
+
+For backlink data from external sources, integrates with GSC API
+(if credentials available) or outputs instructions for manual enrichment.
+
+Usage:
+    python link_profile.py https://example.com --json
+    python link_profile.py https://example.com --max-pages 100 --json
+    python link_profile.py https://example.com --gsc-credentials creds.json
+"""
+
+import argparse
+import json
+import re
+import sys
+import time
+from collections import Counter, defaultdict
+from urllib.parse import urlparse, urljoin
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4",
+          file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+
+# ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+def fetch_page(url: str, timeout: int = 10) -> tuple:
+    """Return (final_url, html) or (url, '')."""
+    try:
+        resp = safe_get(url, timeout=timeout)
+        return resp.url, resp.text
+    except Exception:
+        return url, ""
+
+
+def get_sitemap_urls(site_url: str, limit: int = 200) -> list:
+    """Extract URLs from sitemap.xml."""
+    parsed = urlparse(site_url)
+    sitemap_url = f"{parsed.scheme}://{parsed.netloc}/sitemap.xml"
+    _, body = fetch_page(sitemap_url)
+    if not body:
+        return []
+    urls = re.findall(r"<loc>([^<]+)</loc>", body)
+    # Expand sitemap index
+    if any("sitemap" in u.lower() and u.endswith(".xml") for u in urls[:5]):
+        expanded = []
+        for sub in urls[:10]:
+            time.sleep(0.3)
+            _, sub_body = fetch_page(sub)
+            if sub_body:
+                expanded.extend(re.findall(r"<loc>([^<]+)</loc>", sub_body))
+        urls = expanded
+    return urls[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Link extraction
+# ---------------------------------------------------------------------------
+
+def extract_links(html: str, page_url: str, base_domain: str) -> dict:
+    """Extract internal and external links from a page."""
+    soup = BeautifulSoup(html, "html.parser")
+    internal = []
+    external = []
+
+    for a in soup.find_all("a", href=True):
+        href = a["href"].strip()
+        if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
+            continue
+
+        full_url = urljoin(page_url, href)
+        parsed = urlparse(full_url)
+        anchor_text = a.get_text(strip=True)[:100]
+        nofollow = "nofollow" in (a.get("rel") or [])
+
+        link_data = {
+            "url": f"{parsed.scheme}://{parsed.netloc}{parsed.path}",
+            "anchor": anchor_text,
+            "nofollow": nofollow,
+        }
+
+        if parsed.netloc == base_domain or parsed.netloc.endswith(f".{base_domain}"):
+            internal.append(link_data)
+        else:
+            external.append(link_data)
+
+    return {"internal": internal, "external": external}
+
+
+# ---------------------------------------------------------------------------
+# Crawl & build graph
+# ---------------------------------------------------------------------------
+
+def crawl_site(site_url: str, max_pages: int = 50) -> dict:
+    """Crawl site and build link graph."""
+    parsed = urlparse(site_url)
+    base_domain = parsed.netloc
+
+    # Seed URLs from sitemap + homepage
+    seed_urls = get_sitemap_urls(site_url, limit=max_pages)
+    if site_url not in seed_urls:
+        seed_urls.insert(0, site_url)
+    seed_urls = seed_urls[:max_pages]
+
+    # Link graph
+    graph = {
+        "pages": {},          # url -> {internal_links, external_links, inbound_count}
+        "all_internal_targets": Counter(),  # url -> inbound link count
+        "all_external_targets": Counter(),
+        "anchor_texts": defaultdict(list),   # url -> [anchor_texts pointing to it]
+    }
+
+    crawled = set()
+    for url in seed_urls:
+        if url in crawled:
+            continue
+        crawled.add(url)
+
+        time.sleep(0.3)
+        final_url, html = fetch_page(url)
+        if not html:
+            continue
+
+        links = extract_links(html, final_url, base_domain)
+
+        graph["pages"][url] = {
+            "internal_out": len(links["internal"]),
+            "external_out": len(links["external"]),
+            "internal_links": [l["url"] for l in links["internal"][:20]],
+        }
+
+        for link in links["internal"]:
+            graph["all_internal_targets"][link["url"]] += 1
+            if link["anchor"]:
+                graph["anchor_texts"][link["url"]].append(link["anchor"])
+
+        for link in links["external"]:
+            graph["all_external_targets"][link["url"]] += 1
+
+    return graph, crawled, base_domain
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def analyze_link_profile(graph: dict, crawled: set, base_domain: str) -> dict:
+    """Produce analysis from the crawled link graph."""
+    pages = graph["pages"]
+    internal_targets = graph["all_internal_targets"]
+
+    # Orphan pages (in sitemap/crawled but zero inbound internal links)
+    orphan_pages = []
+    for url in crawled:
+        if internal_targets.get(url, 0) == 0 and url != min(crawled):
+            orphan_pages.append(url)
+
+    # Top linked pages (highest inbound internal links)
+    top_linked = internal_targets.most_common(20)
+
+    # Pages with no outbound internal links (dead ends)
+    dead_ends = [url for url, data in pages.items() if data["internal_out"] == 0]
+
+    # External link distribution
+    external_domains = Counter()
+    for url in graph["all_external_targets"]:
+        domain = urlparse(url).netloc
+        external_domains[domain] += 1
+
+    # Anchor text analysis
+    anchor_diversity = {}
+    for url, anchors in graph["anchor_texts"].items():
+        unique = len(set(a.lower() for a in anchors))
+        total = len(anchors)
+        anchor_diversity[url] = {
+            "total_anchors": total,
+            "unique_anchors": unique,
+            "diversity_ratio": round(unique / max(total, 1), 2),
+        }
+
+    # Internal link equity (simplified PageRank-like distribution)
+    total_pages = len(pages)
+    avg_internal_links = (
+        sum(d["internal_out"] for d in pages.values()) / max(total_pages, 1)
+    )
+
+    # Issues
+    issues = []
+    if orphan_pages:
+        issues.append({
+            "type": "orphan_pages",
+            "severity": "High",
+            "count": len(orphan_pages),
+            "finding": f"{len(orphan_pages)} orphan page(s) with zero inbound internal links.",
+            "pages": orphan_pages[:10],
+            "fix": "Add internal links from relevant content pages to these orphan pages.",
+        })
+
+    if dead_ends:
+        issues.append({
+            "type": "dead_end_pages",
+            "severity": "Medium",
+            "count": len(dead_ends),
+            "finding": f"{len(dead_ends)} page(s) with no outbound internal links (dead ends).",
+            "pages": dead_ends[:10],
+            "fix": "Add contextual internal links to related content from these pages.",
+        })
+
+    if avg_internal_links < 3:
+        issues.append({
+            "type": "low_internal_linking",
+            "severity": "High",
+            "finding": f"Average internal links per page is only {avg_internal_links:.1f} (target: 5-10).",
+            "fix": "Increase internal linking by adding contextual links within content.",
+        })
+
+    return {
+        "pages_crawled": total_pages,
+        "total_internal_links": sum(d["internal_out"] for d in pages.values()),
+        "total_external_links": sum(d["external_out"] for d in pages.values()),
+        "unique_internal_targets": len(internal_targets),
+        "unique_external_domains": len(external_domains),
+        "avg_internal_links_per_page": round(avg_internal_links, 1),
+        "orphan_pages": {
+            "count": len(orphan_pages),
+            "urls": orphan_pages[:15],
+        },
+        "dead_end_pages": {
+            "count": len(dead_ends),
+            "urls": dead_ends[:15],
+        },
+        "top_linked_pages": [
+            {"url": url, "inbound_links": count}
+            for url, count in top_linked
+        ],
+        "top_external_domains": [
+            {"domain": domain, "links": count}
+            for domain, count in external_domains.most_common(15)
+        ],
+        "issues": issues,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GSC backlink integration (optional)
+# ---------------------------------------------------------------------------
+
+def get_gsc_backlinks(credentials_path: str, site_url: str) -> dict:
+    """Pull external links from Google Search Console (if available)."""
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+
+        scopes = ["https://www.googleapis.com/auth/webmasters.readonly"]
+        creds = service_account.Credentials.from_service_account_file(
+            credentials_path, scopes=scopes
+        )
+        service = build("searchconsole", "v1", credentials=creds)
+
+        resp = service.links().list(siteUrl=site_url).execute()
+        return {
+            "available": True,
+            "external_links": resp.get("externalLinks", [])[:20],
+            "internal_links_sample": resp.get("internalLinks", [])[:10],
+        }
+    except ImportError:
+        return {"available": False, "reason": "google-api-python-client not installed."}
+    except Exception as exc:
+        return {"available": False, "reason": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Link Profile Analyzer — crawls site, builds link graph, identifies issues"
+    )
+    parser.add_argument("url", help="Site URL to analyze")
+    parser.add_argument("--max-pages", type=int, default=50,
+                        help="Max pages to crawl (default: 50)")
+    parser.add_argument("--gsc-credentials", default="",
+                        help="Path to GSC service account credentials (optional). Falls back to GSC_CREDENTIALS_PATH env var or .env file.")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    from env_loader import get_env
+    gsc_credentials = args.gsc_credentials or get_env("GSC_CREDENTIALS_PATH")
+
+    print(f"Crawling {args.url}...", file=sys.stderr)
+    graph, crawled, base_domain = crawl_site(args.url, max_pages=args.max_pages)
+
+    print("Analyzing link profile...", file=sys.stderr)
+    report = analyze_link_profile(graph, crawled, base_domain)
+    report["site_url"] = args.url
+
+    # Optional GSC backlinks
+    if gsc_credentials:
+        print("Fetching GSC backlinks...", file=sys.stderr)
+        report["gsc_backlinks"] = get_gsc_backlinks(gsc_credentials, args.url)
+
+    if args.json:
+        print(json.dumps(report, indent=2, default=str))
+        return
+
+    print(f"\nLink Profile Analysis — {args.url}")
+    print("=" * 60)
+    print(f"Pages crawled            : {report['pages_crawled']}")
+    print(f"Total internal links     : {report['total_internal_links']}")
+    print(f"Total external links     : {report['total_external_links']}")
+    print(f"Unique internal targets  : {report['unique_internal_targets']}")
+    print(f"Unique external domains  : {report['unique_external_domains']}")
+    print(f"Avg internal links/page  : {report['avg_internal_links_per_page']}")
+
+    orph = report["orphan_pages"]
+    if orph["count"]:
+        print(f"\n🔴 Orphan Pages ({orph['count']}):")
+        for u in orph["urls"][:5]:
+            print(f"  - {u}")
+
+    dead = report["dead_end_pages"]
+    if dead["count"]:
+        print(f"\n⚠️  Dead-End Pages ({dead['count']}):")
+        for u in dead["urls"][:5]:
+            print(f"  - {u}")
+
+    if report["top_linked_pages"]:
+        print(f"\nTop Linked Pages:")
+        for p in report["top_linked_pages"][:10]:
+            print(f"  [{p['inbound_links']:>3}] {p['url']}")
+
+    if report["issues"]:
+        print(f"\nIssues ({len(report['issues'])}):")
+        for issue in report["issues"]:
+            icon = "🔴" if issue["severity"] == "High" else "⚠️"
+            print(f"  {icon} [{issue['type']}] {issue['finding']}")
+            print(f"     Fix: {issue['fix']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/llms_txt_checker.py
+++ b/.claude/skills/seo/scripts/llms_txt_checker.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Check for llms.txt file and validate its format.
+
+llms.txt is a proposed standard for providing LLM-friendly site information.
+See: https://llmstxt.org/
+
+Usage:
+    python llms_txt_checker.py https://example.com
+    python llms_txt_checker.py https://example.com --json
+"""
+
+import argparse
+import json
+import re
+import sys
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_get
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_get
+
+
+def check_llms_txt(url: str, timeout: int = 15) -> dict:
+    """
+    Fetch and validate llms.txt from a domain.
+
+    Args:
+        url: Website URL or domain
+        timeout: Request timeout in seconds
+
+    Returns:
+        Dictionary with validation results
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"https://{url}"
+        parsed = urlparse(url)
+
+    base = f"{parsed.scheme}://{parsed.netloc}"
+
+    result = {
+        "url": f"{base}/llms.txt",
+        "full_url": f"{base}/llms-full.txt",
+        "exists": False,
+        "full_exists": False,
+        "status": None,
+        "full_status": None,
+        "content": None,
+        "parsed": {
+            "title": None,
+            "description": None,
+            "sections": [],
+            "links": [],
+        },
+        "quality": {
+            "score": 0,
+            "issues": [],
+            "suggestions": [],
+        },
+        "error": None,
+    }
+
+    headers = default_headers()
+
+    # Check llms.txt
+    try:
+        resp = safe_get(f"{base}/llms.txt", timeout=timeout, headers=headers)
+        result["status"] = resp.status_code
+
+        if resp.status_code == 200:
+            result["exists"] = True
+            result["content"] = resp.text
+            _parse_llms_txt(resp.text, result)
+            _score_quality(result)
+        elif resp.status_code == 404:
+            result["quality"]["issues"].append("🔴 No llms.txt found")
+            result["quality"]["suggestions"].append(
+                "Create /llms.txt with site name, description, and key page links"
+            )
+    except requests.exceptions.RequestException as e:
+        result["error"] = str(e)
+
+    # Check llms-full.txt (optional extended version)
+    try:
+        resp = safe_get(f"{base}/llms-full.txt", timeout=timeout, headers=headers)
+        result["full_status"] = resp.status_code
+        result["full_exists"] = resp.status_code == 200
+    except requests.exceptions.RequestException:
+        pass
+
+    return result
+
+
+def _parse_llms_txt(content: str, result: dict):
+    """Parse llms.txt content into structured data."""
+    lines = content.strip().splitlines()
+
+    if not lines:
+        result["quality"]["issues"].append("⚠️ llms.txt is empty")
+        return
+
+    # First line should be the title (# Title)
+    first_line = lines[0].strip()
+    if first_line.startswith("# "):
+        result["parsed"]["title"] = first_line[2:].strip()
+    else:
+        result["quality"]["issues"].append("⚠️ First line should be a title (# Site Name)")
+
+    # Look for description (> blockquote)
+    current_section = None
+
+    for line in lines[1:]:
+        line = line.strip()
+
+        if not line:
+            continue
+
+        if line.startswith("> "):
+            desc = line[2:].strip()
+            if not result["parsed"]["description"]:
+                result["parsed"]["description"] = desc
+            else:
+                result["parsed"]["description"] += " " + desc
+
+        elif line.startswith("## "):
+            current_section = line[3:].strip()
+            result["parsed"]["sections"].append({
+                "name": current_section,
+                "links": [],
+            })
+
+        elif line.startswith("- ["):
+            # Parse markdown links: - [Title](URL): Description
+            match = re.match(r'-\s*\[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?', line)
+            if match:
+                link = {
+                    "title": match.group(1),
+                    "url": match.group(2),
+                    "description": match.group(3) or "",
+                }
+                result["parsed"]["links"].append(link)
+                if result["parsed"]["sections"]:
+                    result["parsed"]["sections"][-1]["links"].append(link)
+
+
+def _score_quality(result: dict):
+    """Score the quality of llms.txt content."""
+    score = 0
+    parsed = result["parsed"]
+    quality = result["quality"]
+
+    # Title present (+20)
+    if parsed["title"]:
+        score += 20
+    else:
+        quality["issues"].append("⚠️ Missing title")
+
+    # Description present (+20)
+    if parsed["description"]:
+        score += 20
+        if len(parsed["description"]) < 20:
+            quality["issues"].append("⚠️ Description too short")
+        elif len(parsed["description"]) > 50:
+            score += 5  # Bonus for good description
+    else:
+        quality["issues"].append("⚠️ Missing description (> blockquote)")
+        quality["suggestions"].append("Add a description: > Brief site description")
+
+    # Sections present (+15)
+    if parsed["sections"]:
+        score += 15
+        if len(parsed["sections"]) >= 3:
+            score += 5  # Bonus for good organization
+    else:
+        quality["suggestions"].append("Add sections (## Section Name) to organize content")
+
+    # Links present (+20)
+    if parsed["links"]:
+        score += 20
+        if len(parsed["links"]) >= 5:
+            score += 5  # Bonus for comprehensive links
+        if len(parsed["links"]) >= 10:
+            score += 5
+    else:
+        quality["issues"].append("⚠️ No links found")
+        quality["suggestions"].append("Add key page links: - [Page Title](URL): Description")
+
+    # Content length (+5)
+    content_len = len(result["content"] or "")
+    if content_len > 200:
+        score += 5
+
+    quality["score"] = min(score, 100)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check llms.txt for AI search optimization")
+    parser.add_argument("url", help="Website URL or domain")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+    result = check_llms_txt(args.url)
+
+    if args.json:
+        output = {k: v for k, v in result.items() if k != "content"}
+        print(json.dumps(output, indent=2))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    print(f"llms.txt Check — {result['url']}")
+    print("=" * 50)
+
+    if result["exists"]:
+        print(f"Status: ✅ Found (HTTP {result['status']})")
+        print(f"Title: {result['parsed']['title'] or 'None'}")
+        print(f"Description: {result['parsed']['description'] or 'None'}")
+        print(f"Sections: {len(result['parsed']['sections'])}")
+        print(f"Links: {len(result['parsed']['links'])}")
+        print(f"Quality Score: {result['quality']['score']}/100")
+    else:
+        print(f"Status: 🔴 Not found (HTTP {result['status']})")
+
+    if result["full_exists"]:
+        print(f"\nllms-full.txt: ✅ Found")
+    else:
+        print(f"\nllms-full.txt: ❌ Not found")
+
+    if result["quality"]["issues"]:
+        print(f"\nIssues:")
+        for issue in result["quality"]["issues"]:
+            print(f"  {issue}")
+
+    if result["quality"]["suggestions"]:
+        print(f"\nSuggestions:")
+        for sug in result["quality"]["suggestions"]:
+            print(f"  💡 {sug}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/llms_txt_generator.py
+++ b/.claude/skills/seo/scripts/llms_txt_generator.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Generate an llms.txt draft from site metadata and priority URLs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from urllib.parse import urlparse
+
+from seo_common import fetch_url, normalize_url, parse_html, read_urls
+
+
+def page_title(url: str, timeout: int) -> tuple[str, str]:
+    fetched = fetch_url(url, timeout=timeout, max_bytes=1_000_000)
+    if fetched.get("text") and "html" in fetched.get("headers", {}).get("content-type", ""):
+        html = parse_html(fetched["text"], fetched.get("url") or url)
+        return html.get("title") or urlparse(url).path.strip("/") or url, html.get("meta_description") or ""
+    return urlparse(url).path.strip("/") or url, ""
+
+
+def generate(site: str, urls: list[str], title: str | None = None, description: str | None = None, timeout: int = 15, fetch_titles: bool = False) -> dict:
+    site = normalize_url(site)
+    if not title or not description:
+        fetched = fetch_url(site, timeout=timeout, max_bytes=1_000_000)
+        if fetched.get("text"):
+            html = parse_html(fetched["text"], fetched.get("url") or site)
+            title = title or html.get("title") or urlparse(site).netloc
+            description = description or html.get("meta_description") or f"Official information and priority pages for {urlparse(site).netloc}."
+    title = title or urlparse(site).netloc
+    description = description or f"Official information and priority pages for {urlparse(site).netloc}."
+
+    links = []
+    for url in urls:
+        label, desc = page_title(url, timeout) if fetch_titles else (urlparse(url).path.strip("/") or "Home", "")
+        links.append({"title": label, "url": normalize_url(url, site), "description": desc})
+
+    lines = [f"# {title}", "", f"> {description}", "", "## Priority pages"]
+    for link in links:
+        suffix = f": {link['description']}" if link["description"] else ""
+        lines.append(f"- [{link['title']}]({link['url']}){suffix}")
+    lines.extend(["", "## Notes", "- Use these URLs as the preferred starting points for understanding this site."])
+    text = "\n".join(lines) + "\n"
+    return {"site": site, "count": len(links), "llms_txt": text, "links": links}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a draft llms.txt")
+    parser.add_argument("site")
+    parser.add_argument("urls", nargs="*")
+    parser.add_argument("--url-file")
+    parser.add_argument("--title")
+    parser.add_argument("--description")
+    parser.add_argument("--fetch-titles", action="store_true")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    urls = read_urls(args.urls, args.url_file) or [args.site]
+    result = generate(args.site, urls, args.title, args.description, args.timeout, args.fetch_titles)
+    print(json.dumps(result, indent=2) if args.json else result["llms_txt"])
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/local_seo_checker.py
+++ b/.claude/skills/seo/scripts/local_seo_checker.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Check local SEO signals: NAP, LocalBusiness schema, GBP links, reviews, and maps."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from typing import Any
+
+from schema_required_props import extract_schema_documents, find_schema_nodes, load_source_html
+from seo_common import parse_html, print_json_or_text, issue
+
+
+PHONE_RE = re.compile(r"(\+?\d[\d\s().-]{7,}\d)")
+MAP_PATTERNS = ("google.com/maps", "maps.google.", "bing.com/maps", "openstreetmap.org")
+GBP_PATTERNS = ("g.page/", "business.google.com", "search.google.com/local/writereview")
+
+
+def check_local_seo(source: str, timeout: int = 15) -> dict[str, Any]:
+    html, final_url, fetch = load_source_html(source, timeout=timeout)
+    parsed = parse_html(html, final_url or source) if html else {}
+    documents, _ = extract_schema_documents(source, timeout=timeout)
+    local_nodes = find_schema_nodes(documents, "LocalBusiness")
+    body_text = parsed.get("body_text", "")
+    links = parsed.get("links", [])
+    phones = sorted(set(match.group(1).strip() for match in PHONE_RE.finditer(body_text)))
+    issues = []
+    if not local_nodes:
+        issues.append(issue("warning", "No LocalBusiness JSON-LD found", final_url or source))
+    for row in local_nodes:
+        node = row["node"]
+        for prop in ("name", "address", "telephone"):
+            if not node.get(prop):
+                issues.append(issue("error", f"LocalBusiness is missing {prop}", evidence=row["path"]))
+        if not node.get("areaServed") and not node.get("serviceArea"):
+            issues.append(issue("info", "LocalBusiness is missing service area signal", evidence=row["path"]))
+        if node.get("telephone") and phones and str(node["telephone"]).replace(" ", "") not in "".join(phones).replace(" ", ""):
+            issues.append(issue("warning", "Schema telephone does not visibly match page phone text", evidence=row["path"]))
+    map_embeds = html.count("google.com/maps") + html.count("maps.google.") + html.count("openstreetmap.org") if html else 0
+    if not map_embeds and not any(any(pattern in link["href"] for pattern in MAP_PATTERNS) for link in links):
+        issues.append(issue("info", "No map embed or map link found", final_url or source))
+    if not any(any(pattern in link["href"] for pattern in GBP_PATTERNS) for link in links):
+        issues.append(issue("info", "No Google Business Profile/review link found", final_url or source))
+    if "review" not in body_text.lower() and not any(row["node"].get("aggregateRating") for row in local_nodes):
+        issues.append(issue("info", "No visible reviews or aggregateRating signal found", final_url or source))
+    return {
+        "source": source,
+        "final_url": final_url or source,
+        "status": fetch.get("status"),
+        "local_business_nodes": len(local_nodes),
+        "phones_detected": phones,
+        "map_embeds": map_embeds,
+        "issues": issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check local SEO signals")
+    parser.add_argument("source", help="URL or HTML file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    result = check_local_seo(args.source, timeout=args.timeout)
+    lines = [
+        f"Local SEO check for {args.source}",
+        f"LocalBusiness nodes: {result['local_business_nodes']}  Phones: {len(result['phones_detected'])}  Issues: {len(result['issues'])}",
+    ] + [f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/log_file_analyzer.py
+++ b/.claude/skills/seo/scripts/log_file_analyzer.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Analyze server logs for crawl budget and bot status-code patterns."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+from collections import Counter, defaultdict
+from datetime import datetime
+
+from seo_common import print_json_or_text
+
+
+LOG_RE = re.compile(
+    r'(?P<ip>\S+) \S+ \S+ \[(?P<time>[^\]]+)\] "(?P<method>[A-Z]+) (?P<path>\S+) (?P<protocol>[^"]+)" '
+    r"(?P<status>\d{3}) (?P<bytes>\S+)(?: \"(?P<referrer>[^\"]*)\" \"(?P<ua>[^\"]*)\")?"
+)
+
+BOT_PATTERNS = {
+    "Googlebot": re.compile(r"googlebot|adsbot-google|google-inspectiontool", re.I),
+    "Bingbot": re.compile(r"bingbot", re.I),
+    "GPTBot": re.compile(r"gptbot|chatgpt-user|oai-searchbot", re.I),
+    "ClaudeBot": re.compile(r"claudebot|claude-user", re.I),
+    "PerplexityBot": re.compile(r"perplexitybot", re.I),
+    "Applebot": re.compile(r"applebot", re.I),
+    "OtherBot": re.compile(r"bot|crawler|spider|slurp", re.I),
+}
+
+
+def _open_log(path: str):
+    if path.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "r", encoding="utf-8", errors="replace")
+
+
+def parse_log_line(line: str) -> dict | None:
+    match = LOG_RE.search(line)
+    if not match:
+        return None
+    data = match.groupdict()
+    data["status"] = int(data["status"])
+    try:
+        data["bytes"] = int(data["bytes"]) if data["bytes"] != "-" else 0
+    except ValueError:
+        data["bytes"] = 0
+    data["bot"] = classify_bot(data.get("ua") or "")
+    data["date"] = parse_log_date(data.get("time") or "")
+    return data
+
+
+def parse_log_date(value: str) -> str:
+    try:
+        return datetime.strptime(value.split()[0], "%d/%b/%Y:%H:%M:%S").date().isoformat()
+    except Exception:
+        return ""
+
+
+def classify_bot(user_agent: str) -> str:
+    for name, pattern in BOT_PATTERNS.items():
+        if pattern.search(user_agent or ""):
+            return name
+    return "Human/Unknown"
+
+
+def analyze_logs(paths: list[str], max_lines: int | None = None) -> dict:
+    total = 0
+    parsed_count = 0
+    status_counter = Counter()
+    bot_counter = Counter()
+    bot_status = defaultdict(Counter)
+    wasted = []
+    top_paths = Counter()
+    google_paths = Counter()
+    daily_googlebot = Counter()
+    parse_errors = 0
+
+    for path in paths:
+        with _open_log(path) as fh:
+            for line in fh:
+                total += 1
+                if max_lines and total > max_lines:
+                    break
+                row = parse_log_line(line)
+                if not row:
+                    parse_errors += 1
+                    continue
+                parsed_count += 1
+                status = row["status"]
+                bot = row["bot"]
+                path_only = row["path"].split("?", 1)[0]
+                status_counter[str(status)] += 1
+                bot_counter[bot] += 1
+                bot_status[bot][str(status)] += 1
+                top_paths[path_only] += 1
+                if bot == "Googlebot":
+                    google_paths[path_only] += 1
+                    if row["date"]:
+                        daily_googlebot[row["date"]] += 1
+                if bot != "Human/Unknown" and (status >= 400 or "?" in row["path"]):
+                    wasted.append(
+                        {
+                            "bot": bot,
+                            "status": status,
+                            "path": row["path"],
+                            "user_agent": row.get("ua") or "",
+                        }
+                    )
+            if max_lines and total > max_lines:
+                break
+
+    issues = []
+    bot_hits = parsed_count - bot_counter.get("Human/Unknown", 0)
+    bot_errors = sum(1 for item in wasted if item["status"] >= 400)
+    if bot_errors:
+        issues.append({"severity": "warning", "type": "bot_errors", "count": bot_errors, "message": "Bots are hitting 4xx/5xx URLs"})
+    parameter_hits = sum(1 for item in wasted if "?" in item["path"])
+    if parameter_hits:
+        issues.append({"severity": "info", "type": "parameter_crawl", "count": parameter_hits, "message": "Bots are crawling parameterized URLs"})
+
+    return {
+        "summary": {
+            "lines_read": min(total, max_lines or total),
+            "parsed_lines": parsed_count,
+            "parse_errors": parse_errors,
+            "bot_hits": bot_hits,
+            "googlebot_hits": bot_counter.get("Googlebot", 0),
+            "bot_error_hits": bot_errors,
+            "parameterized_bot_hits": parameter_hits,
+        },
+        "status_codes": dict(status_counter.most_common()),
+        "bot_hits": dict(bot_counter.most_common()),
+        "bot_status_codes": {bot: dict(counter.most_common()) for bot, counter in bot_status.items()},
+        "top_paths": [{"path": path, "hits": hits} for path, hits in top_paths.most_common(50)],
+        "top_googlebot_paths": [{"path": path, "hits": hits} for path, hits in google_paths.most_common(50)],
+        "daily_googlebot_hits": dict(sorted(daily_googlebot.items())),
+        "wasted_crawl_examples": wasted[:100],
+        "issues": issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze server logs for crawl budget patterns")
+    parser.add_argument("log_files", nargs="+", help="Common/combined access logs, optionally .gz")
+    parser.add_argument("--max-lines", type=int, help="Maximum log lines to read")
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = analyze_logs(args.log_files, max_lines=args.max_lines)
+    lines = [
+        "Log file crawl analysis",
+        (
+            f"Parsed: {result['summary']['parsed_lines']}  "
+            f"Bot hits: {result['summary']['bot_hits']}  "
+            f"Googlebot hits: {result['summary']['googlebot_hits']}  "
+            f"Bot errors: {result['summary']['bot_error_hits']}"
+        ),
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}: {issue['count']}" for issue in result["issues"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/mobile_render_checker.py
+++ b/.claude/skills/seo/scripts/mobile_render_checker.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Check mobile rendering risks with static HTML plus optional Playwright signals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+try:
+    from seo_common import load_html, parse_html
+except ImportError:
+    from scripts.seo_common import load_html, parse_html
+
+try:
+    from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+except ImportError:  # pragma: no cover - optional dependency
+    sync_playwright = None
+    PlaywrightTimeout = TimeoutError
+
+
+def _static_checks(source: str, timeout: int = 15) -> dict:
+    html, final_url, fetched = load_html(source, timeout=timeout)
+    parsed = parse_html(html, final_url)
+    viewport = (parsed.get("meta") or {}).get("viewport", "")
+    text = re.sub(r"\s+", " ", html or "")
+
+    issues = []
+    if "width=device-width" not in viewport.lower():
+        issues.append({
+            "severity": "critical",
+            "finding": "Missing or incomplete viewport meta tag.",
+            "fix": "Add `<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">`.",
+        })
+
+    fixed_width_hits = re.findall(r"(?:width|min-width)\s*:\s*(\d{3,})px", text, flags=re.I)
+    wide_values = [int(value) for value in fixed_width_hits if int(value) > 390]
+    if wide_values:
+        issues.append({
+            "severity": "warning",
+            "finding": f"Found {len(wide_values)} fixed-width CSS declarations wider than common mobile viewports.",
+            "fix": "Replace fixed widths with responsive max-width, min(), clamp(), grid, or flex constraints.",
+        })
+
+    sticky_hits = len(re.findall(r"position\s*:\s*(fixed|sticky)", text, flags=re.I))
+    if sticky_hits:
+        issues.append({
+            "severity": "info",
+            "finding": f"Found {sticky_hits} fixed/sticky positioning declaration(s).",
+            "fix": "Verify sticky headers, banners, and chat widgets do not cover mobile content or CTAs.",
+        })
+
+    return {
+        "source": source,
+        "url": final_url or source,
+        "fetch": fetched,
+        "viewport_meta": viewport,
+        "fixed_width_values": wide_values[:25],
+        "sticky_position_count": sticky_hits,
+        "rendered": None,
+        "issues": issues,
+    }
+
+
+def _rendered_checks(url: str, timeout_ms: int) -> dict:
+    if sync_playwright is None:
+        return {"available": False, "error": "playwright is not installed"}
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page(viewport={"width": 390, "height": 844}, device_scale_factor=2)
+            page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+            metrics = page.evaluate(
+                """() => {
+                    const doc = document.documentElement;
+                    const body = document.body;
+                    const links = [...document.querySelectorAll('a,button,input,select,textarea')];
+                    const smallTargets = links.map((el) => {
+                        const r = el.getBoundingClientRect();
+                        return {text: (el.innerText || el.value || el.ariaLabel || '').trim().slice(0, 80), width: r.width, height: r.height};
+                    }).filter((r) => r.width > 0 && r.height > 0 && (r.width < 44 || r.height < 44)).slice(0, 20);
+                    const clippedText = [...document.querySelectorAll('h1,h2,h3,p,a,button,li')]
+                        .filter((el) => el.scrollWidth > el.clientWidth + 1 || el.scrollHeight > el.clientHeight + 1)
+                        .map((el) => ({tag: el.tagName.toLowerCase(), text: el.innerText.trim().slice(0, 120)}))
+                        .slice(0, 20);
+                    return {
+                        viewportWidth: window.innerWidth,
+                        scrollWidth: doc.scrollWidth,
+                        horizontalScroll: doc.scrollWidth > window.innerWidth + 1,
+                        bodyHeight: body ? body.scrollHeight : 0,
+                        smallTargets,
+                        clippedText
+                    };
+                }"""
+            )
+            browser.close()
+            return {"available": True, **metrics}
+    except PlaywrightTimeout:
+        return {"available": True, "error": f"render timed out after {timeout_ms}ms"}
+    except Exception as exc:  # pragma: no cover - browser/runtime dependent
+        return {"available": True, "error": str(exc)}
+
+
+def check_mobile_render(source: str, render: bool = False, timeout: int = 15) -> dict:
+    report = _static_checks(source, timeout=timeout)
+    is_url = bool(re.match(r"^https?://", source, re.I))
+    if render and is_url:
+        rendered = _rendered_checks(source, timeout * 1000)
+        report["rendered"] = rendered
+        if rendered.get("horizontalScroll"):
+            report["issues"].append({
+                "severity": "critical",
+                "finding": "Rendered mobile page has horizontal scroll.",
+                "fix": "Identify overflowing containers at 390px width and constrain media, tables, nav, and code blocks.",
+            })
+        if rendered.get("smallTargets"):
+            report["issues"].append({
+                "severity": "warning",
+                "finding": f"{len(rendered['smallTargets'])} tap target(s) are smaller than 44px.",
+                "fix": "Increase touch target size and spacing for mobile navigation and controls.",
+            })
+        if rendered.get("clippedText"):
+            report["issues"].append({
+                "severity": "warning",
+                "finding": f"{len(rendered['clippedText'])} text element(s) appear clipped or overflowing.",
+                "fix": "Allow wrapping, adjust line-height, or reduce container constraints on mobile.",
+            })
+    elif render and not is_url:
+        report["rendered"] = {"available": False, "error": "render mode requires a URL"}
+
+    report["summary"] = {
+        "issues": len(report["issues"]),
+        "critical": sum(1 for issue in report["issues"] if issue["severity"] == "critical"),
+        "warning": sum(1 for issue in report["issues"] if issue["severity"] == "warning"),
+    }
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check mobile rendering risks")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--render", action="store_true", help="Use Playwright for rendered mobile checks when source is a URL")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    report = check_mobile_render(args.source, render=args.render, timeout=args.timeout)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"Mobile render issues: {report['summary']['issues']}")
+        for issue in report["issues"]:
+            print(f"- [{issue['severity']}] {issue['finding']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/seo/scripts/orphan_pages_from_sitemap.py
+++ b/.claude/skills/seo/scripts/orphan_pages_from_sitemap.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Find sitemap URLs that are not reachable from an internal crawl."""
+
+from __future__ import annotations
+
+import argparse
+from collections import deque
+from urllib.parse import urlparse
+
+from seo_common import (
+    discover_sitemap_urls,
+    fetch_url,
+    normalize_url,
+    parse_html,
+    parse_sitemap_xml,
+    print_json_or_text,
+    same_host,
+)
+
+
+def _page_key(url: str) -> str:
+    parsed = urlparse(normalize_url(url))
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def load_sitemap_urls(site_url: str, sitemap_urls: list[str] | None = None, timeout: int = 15, max_sitemaps: int = 25) -> dict:
+    queue = list(dict.fromkeys(sitemap_urls or discover_sitemap_urls(site_url, timeout=timeout)))
+    seen_sitemaps = set()
+    urls = []
+    errors = []
+
+    while queue and len(seen_sitemaps) < max_sitemaps:
+        sitemap_url = normalize_url(queue.pop(0), site_url)
+        if sitemap_url in seen_sitemaps:
+            continue
+        seen_sitemaps.add(sitemap_url)
+        fetched = fetch_url(sitemap_url, timeout=timeout, max_bytes=8_000_000)
+        if fetched.get("status") != 200 or not fetched.get("text"):
+            errors.append({"url": sitemap_url, "status": fetched.get("status"), "error": fetched.get("error")})
+            continue
+        parsed = parse_sitemap_xml(fetched["text"], sitemap_url)
+        if parsed.get("error"):
+            errors.append({"url": sitemap_url, "error": parsed["error"]})
+            continue
+        queue.extend(item["loc"] for item in parsed.get("sitemaps", []))
+        urls.extend(item["loc"] for item in parsed.get("urls", []))
+
+    deduped = []
+    seen = set()
+    for url in urls:
+        key = _page_key(url)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(key)
+    return {"sitemaps_checked": sorted(seen_sitemaps), "urls": deduped, "errors": errors}
+
+
+def crawl_reachable_pages(start_url: str, depth: int = 2, max_pages: int = 100, timeout: int = 15) -> dict:
+    start_url = normalize_url(start_url)
+    queue = deque([(start_url, 0)])
+    reachable = {}
+    errors = []
+
+    while queue and len(reachable) < max_pages:
+        url, current_depth = queue.popleft()
+        key = _page_key(url)
+        if key in reachable or current_depth > depth:
+            continue
+        fetched = fetch_url(url, timeout=timeout, max_bytes=2_000_000)
+        reachable[key] = {
+            "url": key,
+            "status": fetched.get("status"),
+            "final_url": fetched.get("url"),
+            "depth": current_depth,
+            "in_sitemap": False,
+        }
+        if fetched.get("status") != 200 or not fetched.get("text"):
+            errors.append({"url": url, "status": fetched.get("status"), "error": fetched.get("error")})
+            continue
+        if current_depth >= depth:
+            continue
+        html = parse_html(fetched["text"], fetched.get("url") or url)
+        for link in html.get("links", []):
+            href = link.get("href") or ""
+            if href and same_host(start_url, href):
+                target = _page_key(href)
+                if target not in reachable and len(reachable) + len(queue) < max_pages:
+                    queue.append((target, current_depth + 1))
+
+    return {"pages": reachable, "errors": errors}
+
+
+def find_orphan_pages(site_url: str, sitemap_urls: list[str] | None = None, depth: int = 2, max_pages: int = 100, timeout: int = 15) -> dict:
+    site_url = normalize_url(site_url)
+    sitemap = load_sitemap_urls(site_url, sitemap_urls=sitemap_urls, timeout=timeout)
+    crawl = crawl_reachable_pages(site_url, depth=depth, max_pages=max_pages, timeout=timeout)
+    sitemap_set = set(sitemap["urls"])
+    reachable_set = set(crawl["pages"])
+    for page in crawl["pages"].values():
+        page["in_sitemap"] = page["url"] in sitemap_set
+
+    orphan_urls = sorted(sitemap_set - reachable_set)
+    discovered_not_in_sitemap = sorted(reachable_set - sitemap_set)
+    issues = []
+    if orphan_urls:
+        issues.append({"severity": "warning", "type": "sitemap_orphans", "count": len(orphan_urls), "message": "Sitemap URLs were not reached by crawl"})
+    if discovered_not_in_sitemap:
+        issues.append({"severity": "info", "type": "crawl_only_pages", "count": len(discovered_not_in_sitemap), "message": "Crawled URLs are not present in sitemap"})
+
+    return {
+        "site": site_url,
+        "summary": {
+            "sitemaps_checked": len(sitemap["sitemaps_checked"]),
+            "sitemap_urls": len(sitemap_set),
+            "reachable_pages": len(reachable_set),
+            "orphan_pages": len(orphan_urls),
+            "discovered_not_in_sitemap": len(discovered_not_in_sitemap),
+        },
+        "sitemaps_checked": sitemap["sitemaps_checked"],
+        "orphan_pages": orphan_urls,
+        "discovered_not_in_sitemap": discovered_not_in_sitemap,
+        "reachable_pages": list(crawl["pages"].values()),
+        "issues": issues,
+        "errors": {"sitemap": sitemap["errors"], "crawl": crawl["errors"]},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Find sitemap URLs not reachable from an internal crawl")
+    parser.add_argument("site", help="Website URL")
+    parser.add_argument("--sitemap", action="append", help="Explicit sitemap URL; can be repeated")
+    parser.add_argument("--depth", type=int, default=2, help="Internal crawl depth (default: 2)")
+    parser.add_argument("--max-pages", type=int, default=100, help="Maximum crawl pages (default: 100)")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = find_orphan_pages(args.site, sitemap_urls=args.sitemap, depth=args.depth, max_pages=args.max_pages, timeout=args.timeout)
+    lines = [
+        f"Orphan page check for {result['site']}",
+        (
+            f"Sitemap URLs: {result['summary']['sitemap_urls']}  "
+            f"Reachable pages: {result['summary']['reachable_pages']}  "
+            f"Orphans: {result['summary']['orphan_pages']}"
+        ),
+    ]
+    lines.extend(f"Orphan: {url}" for url in result["orphan_pages"][:25])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/pagespeed.py
+++ b/.claude/skills/seo/scripts/pagespeed.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Fetch Core Web Vitals and performance data from Google PageSpeed Insights API.
+
+Uses the free PSI API v5. An API key is optional but recommended — without one
+Google rate-limits the endpoint aggressively. To avoid pasting the key on the
+CLI, the script reads it (in priority order) from:
+
+    1. ``--api-key <value>`` flag
+    2. ``PAGESPEED_API_KEY`` environment variable
+    3. ``GOOGLE_API_KEY`` environment variable
+    4. A ``.env`` file in the current directory, the skill root, or
+       ``$HOME/.agentic-seo/.env`` (see ``env_loader.py``)
+
+Usage:
+    python pagespeed.py https://example.com
+    python pagespeed.py https://example.com --strategy mobile
+    python pagespeed.py https://example.com --json
+    PAGESPEED_API_KEY=AIza... python pagespeed.py https://example.com
+"""
+
+import argparse
+import json
+import sys
+import time
+from typing import Any
+
+from env_loader import get_env
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+
+PSI_API = "https://www.googleapis.com/pagespeedonline/v5/runPagespeed"
+VALID_STRATEGIES = ("mobile", "desktop")
+
+# Current CWV thresholds (as of 2026)
+CWV_THRESHOLDS = {
+    "LCP": {"good": 2500, "poor": 4000, "unit": "ms", "label": "Largest Contentful Paint"},
+    "INP": {"good": 200, "poor": 500, "unit": "ms", "label": "Interaction to Next Paint"},
+    "CLS": {"good": 0.1, "poor": 0.25, "unit": "", "label": "Cumulative Layout Shift"},
+    "FCP": {"good": 1800, "poor": 3000, "unit": "ms", "label": "First Contentful Paint"},
+    "TTFB": {"good": 800, "poor": 1800, "unit": "ms", "label": "Time to First Byte"},
+}
+
+# Mapping from PSI API field names to our labels
+PSI_METRIC_MAP = {
+    "LARGEST_CONTENTFUL_PAINT_MS": "LCP",
+    "INTERACTION_TO_NEXT_PAINT": "INP",
+    "CUMULATIVE_LAYOUT_SHIFT_SCORE": "CLS",
+    "FIRST_CONTENTFUL_PAINT_MS": "FCP",
+    "EXPERIMENTAL_TIME_TO_FIRST_BYTE": "TTFB",
+}
+
+
+def _empty_result(url: str, strategy: str) -> dict:
+    return {
+        "url": url,
+        "strategy": strategy,
+        "performance_score": None,
+        "metrics": {},
+        "opportunities": [],
+        "diagnostics": [],
+        "field_data_available": False,
+        "error": None,
+    }
+
+
+def parse_pagespeed_response(data: dict[str, Any], url: str, strategy: str = "mobile") -> dict:
+    """Normalize a PageSpeed Insights API response into the script output contract."""
+    result = _empty_result(url, strategy)
+
+    # Extract performance score
+    lighthouse = data.get("lighthouseResult", {})
+    categories = lighthouse.get("categories", {})
+    perf = categories.get("performance", {})
+    result["performance_score"] = round((perf.get("score", 0) or 0) * 100)
+
+    # Extract CrUX field data (real user metrics)
+    loading = data.get("loadingExperience", {})
+    crux_metrics = loading.get("metrics", {})
+
+    if crux_metrics:
+        result["field_data_available"] = True
+        for api_name, label in PSI_METRIC_MAP.items():
+            metric_data = crux_metrics.get(api_name)
+            if metric_data:
+                percentile = metric_data.get("percentile")
+                category = metric_data.get("category", "").lower()
+
+                thresholds = CWV_THRESHOLDS.get(label, {})
+                result["metrics"][label] = {
+                    "value": percentile,
+                    "unit": thresholds.get("unit", ""),
+                    "label": thresholds.get("label", label),
+                    "rating": category,  # FAST, AVERAGE, SLOW
+                }
+
+    # Fall back to Lighthouse lab data if no field data
+    if not result["field_data_available"]:
+        audits = lighthouse.get("audits", {})
+        lab_map = {
+            "largest-contentful-paint": "LCP",
+            "interaction-to-next-paint": "INP",
+            "cumulative-layout-shift": "CLS",
+            "first-contentful-paint": "FCP",
+            "server-response-time": "TTFB",
+        }
+        for audit_id, label in lab_map.items():
+            audit = audits.get(audit_id, {})
+            if audit and audit.get("numericValue") is not None:
+                value = audit["numericValue"]
+                thresholds = CWV_THRESHOLDS.get(label, {})
+
+                # Determine rating
+                good = thresholds.get("good", float("inf"))
+                poor = thresholds.get("poor", float("inf"))
+                if value <= good:
+                    rating = "good"
+                elif value <= poor:
+                    rating = "needs-improvement"
+                else:
+                    rating = "poor"
+
+                # CLS is reported as a score, not ms
+                if label == "CLS":
+                    value = round(value, 3)
+                else:
+                    value = round(value)
+
+                result["metrics"][label] = {
+                    "value": value,
+                    "unit": thresholds.get("unit", ""),
+                    "label": thresholds.get("label", label),
+                    "rating": rating,
+                }
+
+    # Extract opportunities
+    audits = lighthouse.get("audits", {})
+    for audit_id, audit in audits.items():
+        if audit.get("details", {}).get("type") == "opportunity":
+            savings = audit.get("details", {}).get("overallSavingsMs")
+            if savings and savings > 100:
+                result["opportunities"].append({
+                    "title": audit.get("title", audit_id),
+                    "savings_ms": round(savings),
+                    "description": audit.get("description", "")[:200],
+                })
+
+    # Sort opportunities by savings
+    result["opportunities"].sort(key=lambda x: x["savings_ms"], reverse=True)
+
+    # Extract key diagnostics
+    diagnostic_ids = [
+        "dom-size", "total-byte-weight", "render-blocking-resources",
+        "uses-responsive-images", "uses-webp-images", "font-display",
+    ]
+    for diag_id in diagnostic_ids:
+        diag = audits.get(diag_id, {})
+        if diag and diag.get("score") is not None and diag["score"] < 1:
+            result["diagnostics"].append({
+                "title": diag.get("title", diag_id),
+                "score": round(diag["score"] * 100),
+                "display": diag.get("displayValue", ""),
+            })
+
+    return result
+
+
+def get_pagespeed(url: str, strategy: str = "mobile", api_key: str = None) -> dict:
+    """
+    Fetch PageSpeed Insights data for a URL.
+
+    Args:
+        url: URL to analyze
+        strategy: 'mobile' or 'desktop'
+        api_key: Optional Google API key for higher rate limits
+
+    Returns:
+        Dictionary with CWV metrics, performance score, and opportunities
+    """
+    if strategy not in VALID_STRATEGIES:
+        result = _empty_result(url, strategy)
+        result["error"] = f"Unsupported strategy: {strategy}"
+        return result
+    result = _empty_result(url, strategy)
+
+    params = {
+        "url": url,
+        "strategy": strategy,
+        "category": "performance",
+    }
+    if api_key:
+        params["key"] = api_key
+
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            resp = safe_get(PSI_API, params=params, timeout=60)
+
+            if resp.status_code == 429:
+                if attempt < max_retries - 1:
+                    wait_time = (attempt + 1) * 3  # Simple backoff: 3s, 6s
+                    print(f"  [pagespeed] Rate limited by API. Retrying in {wait_time}s...", file=sys.stderr)
+                    time.sleep(wait_time)
+                    continue
+                else:
+                    result["error"] = "Rate limited by Google API. Wait a few minutes or add an API key."
+                    return result
+
+            if resp.status_code != 200:
+                result["error"] = f"API error: HTTP {resp.status_code}"
+                return result
+
+            data = resp.json()
+            return parse_pagespeed_response(data, url=url, strategy=strategy)
+
+        except requests.exceptions.Timeout:
+            if attempt < max_retries - 1:
+                print(f"  [pagespeed] Timeout. Retrying...", file=sys.stderr)
+                time.sleep(2)
+                continue
+            result["error"] = "API request timed out (60s) — try again later"
+            return result
+        except requests.exceptions.RequestException as e:
+            result["error"] = f"Request failed: {e}"
+            return result
+        except (KeyError, ValueError, json.JSONDecodeError) as e:
+            result["error"] = f"Failed to parse API response: {e}"
+            return result
+
+    return result
+
+
+def get_pagespeed_for_strategies(url: str, strategies: list[str], api_key: str = None) -> dict:
+    """Fetch PageSpeed data for multiple strategies and preserve per-strategy errors."""
+    results = {strategy: get_pagespeed(url, strategy=strategy, api_key=api_key) for strategy in strategies}
+    errors = {strategy: data.get("error") for strategy, data in results.items() if data.get("error")}
+    return {
+        "url": url,
+        "strategies": results,
+        "error": "; ".join(f"{strategy}: {error}" for strategy, error in errors.items()) if errors else None,
+    }
+
+
+def print_result(result: dict):
+    """Print one normalized PageSpeed result in the existing human-readable format."""
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        return
+
+    print(f"PageSpeed Insights — {result['url']}")
+    print(f"Strategy: {result['strategy'].upper()}")
+    print("=" * 50)
+
+    score = result["performance_score"]
+    if score >= 90:
+        icon = "🟢"
+    elif score >= 50:
+        icon = "🟡"
+    else:
+        icon = "🔴"
+    print(f"\nPerformance Score: {icon} {score}/100")
+
+    data_source = "Field Data (CrUX)" if result["field_data_available"] else "Lab Data (Lighthouse)"
+    print(f"Data Source: {data_source}")
+
+    if result["metrics"]:
+        print(f"\nCore Web Vitals:")
+        for name, metric in result["metrics"].items():
+            rating = metric["rating"]
+            if "good" in rating.lower() or "fast" in rating.lower():
+                icon = "✅"
+            elif "poor" in rating.lower() or "slow" in rating.lower():
+                icon = "🔴"
+            else:
+                icon = "⚠️"
+
+            unit = metric["unit"]
+            value = metric["value"]
+            if unit == "ms" and value >= 1000:
+                display = f"{value/1000:.1f}s"
+            elif unit == "ms":
+                display = f"{value}ms"
+            else:
+                display = str(value)
+
+            # Show threshold comparison
+            thresholds = CWV_THRESHOLDS.get(name, {})
+            good = thresholds.get("good", "?")
+            threshold_unit = thresholds.get("unit", "")
+            threshold_str = f"(target: <{good}{threshold_unit})" if good != "?" else ""
+
+            print(f"  {icon} {metric['label']}: {display} {threshold_str}")
+
+    if result["opportunities"]:
+        print(f"\nTop Opportunities:")
+        for opp in result["opportunities"][:5]:
+            savings = opp["savings_ms"]
+            if savings >= 1000:
+                display = f"{savings/1000:.1f}s"
+            else:
+                display = f"{savings}ms"
+            print(f"  💡 {opp['title']} (save ~{display})")
+
+    if result["diagnostics"]:
+        print(f"\nDiagnostics:")
+        for diag in result["diagnostics"]:
+            print(f"  ⚠️ {diag['title']}: {diag['display']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get Core Web Vitals from PageSpeed Insights")
+    parser.add_argument("url", help="URL to analyze")
+    parser.add_argument("--strategy", "-s", default="mobile",
+                        choices=["mobile", "desktop", "both"], help="Analysis strategy")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+    parser.add_argument("--api-key", help="Google API key for higher rate limits")
+
+    args = parser.parse_args()
+    api_key = args.api_key or get_env("PAGESPEED_API_KEY", "GOOGLE_API_KEY")
+
+    if args.strategy == "both":
+        result = get_pagespeed_for_strategies(args.url, list(VALID_STRATEGIES), api_key=api_key)
+        if args.json:
+            print(json.dumps(result, indent=2))
+            return
+        for idx, strategy in enumerate(VALID_STRATEGIES):
+            if idx:
+                print("\n")
+            print_result(result["strategies"][strategy])
+        if result["error"]:
+            sys.exit(1)
+        return
+
+    result = get_pagespeed(args.url, strategy=args.strategy, api_key=api_key)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+    print_result(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/parse_html.py
+++ b/.claude/skills/seo/scripts/parse_html.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+Parse HTML and extract SEO-relevant elements.
+
+Usage:
+    python parse_html.py page.html
+    python parse_html.py page.html --url https://example.com
+    python parse_html.py --fetch https://example.com --json
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Optional
+from urllib.parse import urljoin, urlparse
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+
+def _fetch_url(url: str, timeout: int = 20) -> dict[str, Any]:
+    """Fetch HTML for direct parsing."""
+    response = safe_get(
+        url,
+        timeout=timeout,
+        headers={"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+    )
+    return {
+        "url": response.url,
+        "content": response.text,
+        "headers": dict(response.headers),
+        "status_code": response.status_code,
+    }
+
+
+def _schema_items(schema_data: Any) -> list[dict[str, Any]]:
+    """Flatten top-level JSON-LD objects and @graph nodes for validation."""
+    if isinstance(schema_data, list):
+        items: list[dict[str, Any]] = []
+        for item in schema_data:
+            items.extend(_schema_items(item))
+        return items
+    if not isinstance(schema_data, dict):
+        return []
+    items = [schema_data]
+    graph = schema_data.get("@graph")
+    if isinstance(graph, list):
+        items.extend([node for node in graph if isinstance(node, dict)])
+    return items
+
+
+def _rel_contains(value: Any, token: str) -> bool:
+    if not value:
+        return False
+    if isinstance(value, str):
+        values = value.lower().split()
+    else:
+        values = [str(item).lower() for item in value]
+    return token in values
+
+
+def _is_responsive_fill_image(img) -> bool:
+    if img.get("data-nimg") == "fill":
+        return True
+    style = re.sub(r"\s+", "", (img.get("style") or "").lower())
+    return "position:absolute" in style and "width:100%" in style and "height:100%" in style
+
+
+def parse_html(
+    html: str,
+    base_url: Optional[str] = None,
+    headers: Optional[dict[str, Any]] = None,
+) -> dict:
+    """
+    Parse HTML and extract SEO-relevant elements.
+
+    Args:
+        html: HTML content to parse
+        base_url: Base URL for resolving relative links
+
+    Returns:
+        Dictionary with extracted SEO data
+    """
+    soup = BeautifulSoup(html, "lxml" if "lxml" in sys.modules else "html.parser")
+    headers = headers or {}
+    header_lookup = {str(k).lower(): v for k, v in headers.items()}
+
+    result = {
+        "title": None,
+        "meta_description": None,
+        "meta_robots": None,
+        "x_robots_tag": header_lookup.get("x-robots-tag"),
+        "canonical": None,
+        "lang": None,
+        "charset": None,
+        "viewport": None,
+        "favicon": None,
+        "h1": [],
+        "h2": [],
+        "h3": [],
+        "h4": [],
+        "h5": [],
+        "h6": [],
+        "images": [],
+        "links": {
+            "internal": [],
+            "external": [],
+        },
+        "pagination": {
+            "prev": None,
+            "next": None,
+        },
+        "resource_hints": {
+            "preload": [],
+            "preconnect": [],
+            "dns-prefetch": [],
+            "prefetch": [],
+            "prerender": [],
+        },
+        "schema": [],
+        "open_graph": {},
+        "twitter_card": {},
+        "word_count": 0,
+        "hreflang": [],
+    }
+
+    html_tag = soup.find("html")
+    if html_tag:
+        result["lang"] = html_tag.get("lang")
+
+    # Title
+    title_tag = soup.find("title")
+    if title_tag:
+        result["title"] = title_tag.get_text(strip=True)
+
+    # Meta tags
+    for meta in soup.find_all("meta"):
+        name = meta.get("name", "").lower()
+        property_attr = meta.get("property", "").lower()
+        content = meta.get("content", "")
+
+        if name == "description":
+            result["meta_description"] = content
+        elif name == "robots":
+            result["meta_robots"] = content
+        elif name == "viewport":
+            result["viewport"] = content
+
+        if meta.get("charset"):
+            result["charset"] = meta.get("charset")
+        elif meta.get("http-equiv", "").lower() == "content-type":
+            charset_match = re.search(r"charset=([^;\s]+)", content, re.I)
+            if charset_match:
+                result["charset"] = charset_match.group(1)
+
+        # Open Graph
+        if property_attr.startswith("og:"):
+            result["open_graph"][property_attr] = content
+
+        # Twitter Card
+        if name.startswith("twitter:"):
+            result["twitter_card"][name] = content
+
+    # Canonical
+    canonical = soup.find("link", rel="canonical")
+    if canonical:
+        href = canonical.get("href")
+        result["canonical"] = urljoin(base_url, href) if base_url and href else href
+
+    for icon in soup.find_all("link"):
+        rel = icon.get("rel")
+        if icon.get("href") and (
+            _rel_contains(rel, "icon")
+            or _rel_contains(rel, "shortcut")
+            or _rel_contains(rel, "apple-touch-icon")
+        ):
+            result["favicon"] = urljoin(base_url, icon.get("href")) if base_url else icon.get("href")
+            break
+
+    # Hreflang
+    for link in soup.find_all("link", rel="alternate"):
+        hreflang = link.get("hreflang")
+        if hreflang:
+            result["hreflang"].append({
+                "lang": hreflang,
+                "href": urljoin(base_url, link.get("href", "")) if base_url else link.get("href"),
+            })
+
+    for rel_name in ("prev", "next"):
+        page_link = soup.find("link", rel=rel_name)
+        if page_link and page_link.get("href"):
+            href = page_link.get("href")
+            result["pagination"][rel_name] = urljoin(base_url, href) if base_url else href
+
+    for rel_name in result["resource_hints"]:
+        for link in soup.find_all("link", rel=rel_name):
+            href = link.get("href")
+            if href:
+                result["resource_hints"][rel_name].append({
+                    "href": urljoin(base_url, href) if base_url else href,
+                    "as": link.get("as"),
+                    "type": link.get("type"),
+                    "crossorigin": link.get("crossorigin"),
+                })
+
+    # Headings
+    for tag in ["h1", "h2", "h3", "h4", "h5", "h6"]:
+        for heading in soup.find_all(tag):
+            text = heading.get_text(strip=True)
+            if text:
+                result[tag].append(text)
+
+    # Images
+    for img in soup.find_all("img"):
+        src = img.get("src", "")
+        if base_url and src:
+            src = urljoin(base_url, src)
+        is_responsive_fill = _is_responsive_fill_image(img)
+
+        result["images"].append({
+            "src": src,
+            "alt": img.get("alt"),
+            "width": img.get("width"),
+            "height": img.get("height"),
+            "is_responsive_fill": is_responsive_fill,
+            "loading": img.get("loading"),
+        })
+
+    # Links
+    if base_url:
+        base_domain = urlparse(base_url).netloc
+
+        for a in soup.find_all("a", href=True):
+            href = a.get("href", "")
+            if not href or href.startswith("#") or href.startswith("javascript:"):
+                continue
+
+            full_url = urljoin(base_url, href)
+            parsed = urlparse(full_url)
+
+            link_data = {
+                "href": full_url,
+                "text": a.get_text(strip=True)[:100],
+                "rel": a.get("rel", []),
+            }
+
+            if parsed.netloc == base_domain:
+                result["links"]["internal"].append(link_data)
+            else:
+                result["links"]["external"].append(link_data)
+
+    # Schema (JSON-LD) — enhanced with type validation
+    DEPRECATED_SCHEMA = {
+        "HowTo", "SpecialAnnouncement", "CourseInfo", "EstimatedSalary",
+        "LearningVideo", "ClaimReview", "VehicleListing", "PracticeProblems",
+    }
+    RESTRICTED_SCHEMA = {"FAQPage"}  # government/healthcare only
+
+    for script in soup.find_all("script", type="application/ld+json"):
+        try:
+            schema_data = json.loads(script.string)
+        except (json.JSONDecodeError, TypeError):
+            result["schema"].append({
+                "error": "invalid_json",
+                "raw_snippet": (script.string or "")[:120],
+            })
+            continue
+
+        items = _schema_items(schema_data)
+        for item in items or [{}]:
+            schema_type = item.get("@type", "Unknown")
+            if isinstance(schema_type, list):
+                schema_types = schema_type
+                primary_type = next((t for t in schema_type if isinstance(t, str)), "Unknown")
+            else:
+                schema_types = [schema_type]
+                primary_type = schema_type
+
+            status = "active"
+            note = ""
+
+            if primary_type in DEPRECATED_SCHEMA:
+                status = "deprecated"
+                note = f"{primary_type} was deprecated/removed from rich results. Remove or replace."
+            elif primary_type in RESTRICTED_SCHEMA:
+                status = "restricted"
+                note = f"{primary_type} is restricted to government/healthcare authority sites only."
+
+            result["schema"].append({
+                "@type": primary_type,
+                "@types": schema_types,
+                "@id": item.get("@id"),
+                "@context": item.get("@context", schema_data.get("@context", "") if isinstance(schema_data, dict) else ""),
+                "status": status,
+                "note": note,
+                "has_context": bool(item.get("@context") or (isinstance(schema_data, dict) and schema_data.get("@context"))),
+                "has_type": bool(item.get("@type")),
+                "from_graph": item is not schema_data,
+                "raw": item,
+            })
+
+    # Word count (visible text only)
+    for element in soup(["script", "style", "nav", "footer", "header"]):
+        element.decompose()
+
+    text = soup.get_text(separator=" ", strip=True)
+    words = re.findall(r"\b\w+\b", text)
+    result["word_count"] = len(words)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse HTML for SEO analysis")
+    parser.add_argument("file", nargs="?", help="HTML file to parse")
+    parser.add_argument("--url", "-u", help="Base URL for resolving links")
+    parser.add_argument("--fetch", help="Fetch and parse a URL directly")
+    parser.add_argument("--timeout", "-t", type=int, default=20, help="Fetch timeout in seconds")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    headers = {}
+    final_url = args.url
+
+    if args.fetch:
+        try:
+            fetched = _fetch_url(args.fetch, timeout=args.timeout)
+        except Exception as exc:
+            print(f"Error fetching {args.fetch}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if fetched.get("error"):
+            print(f"Error fetching {args.fetch}: {fetched['error']}", file=sys.stderr)
+            sys.exit(1)
+        html = fetched.get("content") or ""
+        headers = fetched.get("headers") or {}
+        final_url = args.url or fetched.get("url") or args.fetch
+    elif args.file:
+        real_path = os.path.realpath(args.file)
+        if not os.path.isfile(real_path):
+            print(f"Error: File not found: {args.file}", file=sys.stderr)
+            sys.exit(1)
+        with open(real_path, "r", encoding="utf-8") as f:
+            html = f.read()
+    else:
+        html = sys.stdin.read()
+
+    result = parse_html(html, final_url, headers=headers)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"Title: {result['title']}")
+        print(f"Meta Description: {result['meta_description']}")
+        print(f"Canonical: {result['canonical']}")
+        print(f"H1 Tags: {len(result['h1'])}")
+        print(f"H2 Tags: {len(result['h2'])}")
+        print(f"Images: {len(result['images'])}")
+        print(f"Internal Links: {len(result['links']['internal'])}")
+        print(f"External Links: {len(result['links']['external'])}")
+        print(f"Schema Blocks: {len(result['schema'])}")
+        print(f"Word Count: {result['word_count']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/pre_commit_seo_check.sh
+++ b/.claude/skills/seo/scripts/pre_commit_seo_check.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-commit SEO validation helper.
+#
+# Example .git/hooks/pre-commit:
+#   #!/usr/bin/env bash
+#   bash path/to/pre_commit_seo_check.sh
+
+ERRORS=0
+WARNINGS=0
+
+# Check if there are staged changes — exit early if not
+if ! git diff --cached --quiet 2>/dev/null; then
+    : # There are staged changes, proceed with checks
+else
+    exit 0  # No staged changes, nothing to check
+fi
+
+echo "🔍 Running pre-commit SEO checks..."
+
+# Check staged HTML-like files
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep -E '\.(html|htm|php|jsx|tsx|vue|svelte)$' || true)
+
+if [ -z "${STAGED_FILES}" ]; then
+    echo "✓ No HTML files staged — skipping SEO checks"
+    exit 0
+fi
+
+for file in ${STAGED_FILES}; do
+    if [ ! -f "${file}" ]; then
+        continue
+    fi
+
+    # Check for placeholder text in schema
+    if grep -qiE '\[(Business Name|City|State|Phone|Address|Your|INSERT|REPLACE)\]' "${file}" 2>/dev/null; then
+        echo "🛑 ${file}: Contains placeholder text in schema markup"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Check title tag length
+    TITLE=$(grep -oP '(?<=<title>).*?(?=</title>)' "${file}" 2>/dev/null | head -1 || true)
+    if [ -n "${TITLE}" ]; then
+        TITLE_LEN=${#TITLE}
+        if [ "${TITLE_LEN}" -lt 30 ] || [ "${TITLE_LEN}" -gt 70 ]; then
+            echo "⚠️  ${file}: Title tag length ${TITLE_LEN} chars (recommend 30-60)"
+            WARNINGS=$((WARNINGS + 1))
+        fi
+    fi
+
+    # Check for images without alt text
+    if grep -qP '<img(?![^>]*alt=)' "${file}" 2>/dev/null; then
+        echo "⚠️  ${file}: Images found without alt text"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    # Check for deprecated schema types
+    if grep -qE '"@type"\s*:\s*"(HowTo|SpecialAnnouncement)"' "${file}" 2>/dev/null; then
+        echo "🛑 ${file}: Contains deprecated schema type"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    # Check for FID references (should be INP)
+    if grep -qi 'First Input Delay\|"FID"' "${file}" 2>/dev/null; then
+        echo "⚠️  ${file}: References FID — should use INP (Interaction to Next Paint)"
+        WARNINGS=$((WARNINGS + 1))
+    fi
+
+    # Check meta description length
+    META_DESC=$(grep -oP '(?<=<meta name="description" content=").*?(?=")' "${file}" 2>/dev/null | head -1 || true)
+    if [ -n "${META_DESC}" ]; then
+        META_LEN=${#META_DESC}
+        if [ "${META_LEN}" -lt 120 ] || [ "${META_LEN}" -gt 160 ]; then
+            echo "⚠️  ${file}: Meta description length ${META_LEN} chars (recommend 120-160)"
+            WARNINGS=$((WARNINGS + 1))
+        fi
+    fi
+done
+
+echo ""
+if [ "${ERRORS}" -gt 0 ]; then
+    echo "🛑 ${ERRORS} critical error(s) found — commit blocked"
+    echo "Fix the errors above and try again."
+    exit 2
+elif [ "${WARNINGS}" -gt 0 ]; then
+    echo "⚠️  ${WARNINGS} warning(s) found — commit allowed"
+    exit 0
+else
+    echo "✓ All SEO checks passed"
+    exit 0
+fi

--- a/.claude/skills/seo/scripts/product_schema_checker.py
+++ b/.claude/skills/seo/scripts/product_schema_checker.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Check Product and ProductGroup JSON-LD for ecommerce rich-result readiness."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from schema_required_props import extract_schema_documents, find_schema_nodes
+from seo_common import issue, print_json_or_text
+
+
+VALID_AVAILABILITY = {
+    "https://schema.org/InStock",
+    "https://schema.org/OutOfStock",
+    "https://schema.org/PreOrder",
+    "https://schema.org/BackOrder",
+    "https://schema.org/LimitedAvailability",
+    "InStock",
+    "OutOfStock",
+    "PreOrder",
+    "BackOrder",
+}
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def check_offer(offer: dict[str, Any], path: str) -> list[dict[str, Any]]:
+    issues = []
+    if not offer.get("price") and not offer.get("lowPrice"):
+        issues.append(issue("error", "Offer is missing price or lowPrice", evidence=path))
+    if not offer.get("priceCurrency"):
+        issues.append(issue("error", "Offer is missing priceCurrency", evidence=path))
+    availability = offer.get("availability")
+    if not availability:
+        issues.append(issue("warning", "Offer is missing availability", evidence=path))
+    elif availability not in VALID_AVAILABILITY:
+        issues.append(issue("warning", "Offer availability should use a Schema.org ItemAvailability URL", evidence=path))
+    if not offer.get("url"):
+        issues.append(issue("info", "Offer is missing url", evidence=path))
+    if not offer.get("shippingDetails"):
+        issues.append(issue("info", "Offer is missing shippingDetails", evidence=path))
+    if not offer.get("hasMerchantReturnPolicy"):
+        issues.append(issue("info", "Offer is missing hasMerchantReturnPolicy", evidence=path))
+    return issues
+
+
+def check_product_schema(documents: list[Any]) -> dict[str, Any]:
+    rows = []
+    issues = []
+    product_rows = find_schema_nodes(documents, "Product") + find_schema_nodes(documents, "ProductGroup")
+    for row in product_rows:
+        node = row["node"]
+        row_issues = []
+        for prop in ("name", "image", "description"):
+            if not node.get(prop):
+                severity = "error" if prop == "name" else "warning"
+                row_issues.append(issue(severity, f"Product is missing {prop}", evidence=row["path"]))
+        if "Product" in row["types"] and not node.get("offers"):
+            row_issues.append(issue("error", "Product is missing offers", evidence=row["path"]))
+        if "ProductGroup" in row["types"]:
+            for prop in ("productGroupID", "variesBy", "hasVariant"):
+                if not node.get(prop):
+                    row_issues.append(issue("error", f"ProductGroup is missing {prop}", evidence=row["path"]))
+        if not node.get("sku") and not node.get("gtin") and not node.get("mpn"):
+            row_issues.append(issue("warning", "Product is missing sku/gtin/mpn identifier", evidence=row["path"]))
+        if not node.get("brand"):
+            row_issues.append(issue("info", "Product is missing brand", evidence=row["path"]))
+        for index, offer in enumerate(as_list(node.get("offers"))):
+            if isinstance(offer, dict):
+                row_issues.extend(check_offer(offer, f"{row['path']}.offers[{index}]"))
+        for index, variant in enumerate(as_list(node.get("hasVariant"))):
+            if isinstance(variant, dict):
+                if not variant.get("offers"):
+                    row_issues.append(issue("error", "Product variant is missing offers", evidence=f"{row['path']}.hasVariant[{index}]"))
+                for offer_index, offer in enumerate(as_list(variant.get("offers"))):
+                    if isinstance(offer, dict):
+                        row_issues.extend(check_offer(offer, f"{row['path']}.hasVariant[{index}].offers[{offer_index}]"))
+        rows.append({"path": row["path"], "types": row["types"], "issues": row_issues})
+        issues.extend(row_issues)
+    return {"products": len(product_rows), "rows": rows, "issues": issues}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check Product/ProductGroup JSON-LD")
+    parser.add_argument("source", help="URL, HTML file, or JSON-LD file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    documents, meta = extract_schema_documents(args.source, timeout=args.timeout)
+    result = check_product_schema(documents)
+    result.update({"source": args.source, "final_url": meta["final_url"]})
+    lines = [f"Product schema check for {args.source}", f"Products: {result['products']}  Issues: {len(result['issues'])}"]
+    lines.extend(f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/readability.py
+++ b/.claude/skills/seo/scripts/readability.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Content readability analysis — pure Python, no external NLP dependencies.
+
+Computes Flesch-Kincaid Reading Ease, grade level, sentence/paragraph stats.
+Accepts HTML file, plain text file, or stdin.
+
+Usage:
+    python readability.py page.html --json
+    python readability.py --url https://example.com --json
+    python readability.py --text "Your text here"
+    cat page.html | python readability.py --json
+"""
+
+import argparse
+import json
+import re
+import sys
+
+try:
+    from bs4 import BeautifulSoup
+    HAS_BS4 = True
+except ImportError:
+    HAS_BS4 = False
+
+try:
+    from lib.safe_http import safe_get
+except ImportError:
+    from scripts.lib.safe_http import safe_get
+
+
+PARAGRAPH_BLOCK_TAGS = ("p", "li", "blockquote")
+
+
+def count_syllables(word: str) -> int:
+    """Count syllables in a word using heuristic rules."""
+    word = word.lower().strip()
+    if not word:
+        return 0
+    if len(word) <= 2:
+        return 1
+
+    # Remove trailing silent e
+    if word.endswith("e"):
+        word = word[:-1]
+
+    # Count vowel groups
+    vowels = "aeiouy"
+    count = 0
+    prev_vowel = False
+    for char in word:
+        is_vowel = char in vowels
+        if is_vowel and not prev_vowel:
+            count += 1
+        prev_vowel = is_vowel
+
+    return max(1, count)
+
+
+def extract_text(html: str) -> str:
+    """Extract readable text from HTML, stripping scripts/styles."""
+    if HAS_BS4:
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["script", "style", "nav", "header", "footer", "aside"]):
+            tag.decompose()
+        paragraph_blocks = []
+        for tag in soup.find_all(PARAGRAPH_BLOCK_TAGS):
+            if tag.find_parent(PARAGRAPH_BLOCK_TAGS):
+                continue
+            block_text = tag.get_text(separator=" ", strip=True)
+            if block_text:
+                paragraph_blocks.append(block_text)
+        if paragraph_blocks:
+            return "\n\n".join(paragraph_blocks)
+        text = soup.get_text(separator="\n", strip=True)
+        text = re.sub(r"\n[ \t]*\n(?:[ \t]*\n)+", "\n\n", text)
+        text = re.sub(r"[ \t]+\n", "\n", text)
+        text = re.sub(r"\n[ \t]+", "\n", text)
+        return text.strip()
+    else:
+        # Basic fallback: strip tags
+        text = re.sub(r'<(script|style)[^>]*>.*?</\1>', '', html, flags=re.DOTALL | re.IGNORECASE)
+        text = re.sub(r'<[^>]+>', '', text)
+        return text.strip()
+
+
+def split_sentences(text: str) -> list:
+    """Split text into sentences while preserving punctuation."""
+    chunks = re.split(r'(?<=[.!?])\s+', text.strip())
+    return [c.strip() for c in chunks if c.strip()]
+
+
+def suggest_sentence_rewrite(sentence: str) -> str:
+    """Generate a simple, shorter rewrite by splitting long sentences."""
+    tokens = sentence.strip().split()
+    if len(tokens) <= 22:
+        return sentence.strip()
+
+    conjunctions = {"and", "but", "because", "which", "that", "while", "although", "however", "so"}
+    split_points = []
+    for i, tok in enumerate(tokens):
+        clean = tok.strip(",;:").lower()
+        if tok.endswith((",", ";", ":")) or clean in conjunctions:
+            split_points.append(i)
+
+    mid = len(tokens) // 2
+    if split_points:
+        split_idx = min(split_points, key=lambda i: abs(i - mid))
+        if split_idx < 8 or split_idx > len(tokens) - 8:
+            split_idx = mid
+    else:
+        split_idx = mid
+
+    first_tokens = tokens[:split_idx]
+    second_tokens = tokens[split_idx:]
+    if second_tokens and second_tokens[0].strip(",;:").lower() in conjunctions:
+        second_tokens = second_tokens[1:]
+
+    first = " ".join(first_tokens).rstrip(",;:.")
+    second = " ".join(second_tokens).lstrip(",;: ")
+    if not second:
+        first = " ".join(tokens[:mid]).rstrip(",;:.")
+        second = " ".join(tokens[mid:]).lstrip(",;: ")
+
+    first = first[0].upper() + first[1:] if first else ""
+    second = second[0].upper() + second[1:] if second else ""
+    if first and second:
+        return f"{first}. {second}."
+    return sentence.strip()
+
+
+def is_navigation_noise(sentence: str) -> bool:
+    """Heuristic filter for nav/widget/template text that should not be rewritten."""
+    s = sentence.strip()
+    low = s.lower()
+    if not s:
+        return True
+
+    # Common homepage widget/navigation phrases
+    nav_phrases = [
+        "read more", "recent posts", "older posts", "subscribe to",
+        "comments (atom)", "labels", "search for a post", "widget",
+        "your browser does not support javascript",
+    ]
+    if any(p in low for p in nav_phrases):
+        return True
+
+    # Menu/list-like chunks with many line breaks are low-signal prose
+    if s.count("\n") >= 2:
+        return True
+
+    tokens = re.findall(r"\b[a-zA-Z]+\b", s)
+    if not tokens:
+        return True
+
+    # Excessively keyword-list style content
+    unique_ratio = len(set(t.lower() for t in tokens)) / max(1, len(tokens))
+    if len(tokens) >= 25 and unique_ratio > 0.85:
+        return True
+
+    return False
+
+
+def analyze_readability(text: str) -> dict:
+    """
+    Analyze text readability.
+
+    Returns:
+        Dictionary with readability metrics and assessment
+    """
+    result = {
+        "word_count": 0,
+        "sentence_count": 0,
+        "paragraph_count": 0,
+        "syllable_count": 0,
+        "avg_sentence_length": 0,
+        "avg_paragraph_length": 0,
+        "avg_syllables_per_word": 0,
+        "flesch_reading_ease": 0,
+        "flesch_kincaid_grade": 0,
+        "reading_level": "",
+        "estimated_reading_time_min": 0,
+        "complex_words": 0,
+        "complex_word_pct": 0,
+        "issues": [],
+        "recommendations": [],
+        "sentence_rewrites": [],
+    }
+
+    if not text or not text.strip():
+        result["issues"].append("🔴 No readable text content found")
+        return result
+
+    # Split into paragraphs
+    paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()]
+    result["paragraph_count"] = len(paragraphs)
+
+    # Split into sentences
+    raw_sentences = split_sentences(text)
+    sentences = [
+        s.strip() for s in raw_sentences
+        if s.strip() and len(re.findall(r"\b[a-zA-Z]+\b", s)) >= 4
+    ]
+    result["sentence_count"] = max(1, len(sentences))
+
+    # Count words
+    words = re.findall(r'\b[a-zA-Z]+\b', text)
+    result["word_count"] = len(words)
+
+    if not words:
+        result["issues"].append("🔴 No words found in content")
+        return result
+
+    # Count syllables
+    syllables = sum(count_syllables(w) for w in words)
+    result["syllable_count"] = syllables
+
+    # Complex words (3+ syllables)
+    complex_words = [w for w in words if count_syllables(w) >= 3]
+    result["complex_words"] = len(complex_words)
+    result["complex_word_pct"] = round(len(complex_words) / len(words) * 100, 1)
+
+    # Averages
+    result["avg_sentence_length"] = round(len(words) / result["sentence_count"], 1)
+    result["avg_paragraph_length"] = round(result["sentence_count"] / max(1, result["paragraph_count"]), 1)
+    result["avg_syllables_per_word"] = round(syllables / len(words), 2)
+
+    # Flesch Reading Ease: 206.835 - 1.015*(words/sentences) - 84.6*(syllables/words)
+    wps = len(words) / result["sentence_count"]
+    spw = syllables / len(words)
+    fre = 206.835 - (1.015 * wps) - (84.6 * spw)
+    result["flesch_reading_ease"] = round(max(0, min(100, fre)), 1)
+
+    # Flesch-Kincaid Grade Level: 0.39*(words/sentences) + 11.8*(syllables/words) - 15.59
+    fkgl = (0.39 * wps) + (11.8 * spw) - 15.59
+    result["flesch_kincaid_grade"] = round(max(0, fkgl), 1)
+
+    # Reading level label
+    fre_val = result["flesch_reading_ease"]
+    if fre_val >= 80:
+        result["reading_level"] = "Easy (6th grade)"
+    elif fre_val >= 60:
+        result["reading_level"] = "Standard (7th-8th grade)"
+    elif fre_val >= 40:
+        result["reading_level"] = "Difficult (9th-12th grade)"
+    elif fre_val >= 20:
+        result["reading_level"] = "Very Difficult (college)"
+    else:
+        result["reading_level"] = "Extremely Difficult (post-graduate)"
+
+    # Reading time (avg 200 WPM)
+    result["estimated_reading_time_min"] = round(len(words) / 200, 1)
+
+    # Issues & recommendations
+    if result["avg_sentence_length"] > 25:
+        result["issues"].append(
+            f"⚠️ Average sentence length ({result['avg_sentence_length']} words) is too long — target 15-20"
+        )
+        result["recommendations"].append("Break long sentences into shorter ones for better readability")
+
+    if fre_val < 40:
+        result["issues"].append(
+            f"⚠️ Content is difficult to read (Flesch: {fre_val}) — may reduce engagement"
+        )
+        result["recommendations"].append("Simplify vocabulary and shorten sentences")
+    elif fre_val < 60:
+        result["issues"].append(
+            f"ℹ️ Content readability is moderate (Flesch: {fre_val}) — suitable for educated audience"
+        )
+
+    if result["complex_word_pct"] > 20:
+        result["issues"].append(
+            f"⚠️ {result['complex_word_pct']}% complex words (3+ syllables) — consider simplifying"
+        )
+
+    if result["paragraph_count"] > 0 and result["avg_paragraph_length"] > 5:
+        result["issues"].append(
+            f"⚠️ Average paragraph length ({result['avg_paragraph_length']} sentences) — aim for 2-4"
+        )
+        result["recommendations"].append("Break long paragraphs into smaller ones")
+
+    if result["word_count"] < 300:
+        result["issues"].append(f"⚠️ Thin content ({result['word_count']} words) — may rank poorly")
+
+    # Build concrete rewrite candidates for long sentences
+    long_sentences = []
+    for s in sentences:
+        wc = len(re.findall(r"\b[a-zA-Z]+\b", s))
+        if wc > 25:
+            long_sentences.append((wc, s))
+
+    long_sentences.sort(key=lambda x: x[0], reverse=True)
+    for wc, s in long_sentences[:5]:
+        if is_navigation_noise(s):
+            continue
+        result["sentence_rewrites"].append({
+            "current": s[:600],
+            "suggested": suggest_sentence_rewrite(s)[:600],
+            "current_word_count": wc,
+            "target_word_count": "15-20",
+        })
+        if len(result["sentence_rewrites"]) >= 3:
+            break
+
+    # If the page appears to be homepage/navigation-heavy and we cannot extract
+    # clean prose sentences, provide actionable homepage replacement targets.
+    if not result["sentence_rewrites"] and (result["avg_sentence_length"] > 25 or fre_val < 40):
+        result["sentence_rewrites"].extend([
+            {
+                "current": "Homepage hero intro block is broad and hard to scan.",
+                "suggested": (
+                    "Use a 2-3 sentence hero: who you help, what users can do here, and "
+                    "where to start. Example: \"Learn practical ethical hacking with "
+                    "step-by-step guides. Start with Wi-Fi security, Active Directory, or "
+                    "malware analysis using the tracks below.\""
+                ),
+                "current_word_count": "template",
+                "target_word_count": "40-60 total (split into 2-3 sentences)",
+            },
+            {
+                "current": "Section descriptions mix too many topics in one long paragraph.",
+                "suggested": (
+                    "Replace with short blurbs per section (1 sentence each) and add a clear "
+                    "CTA link: \"Start Wi-Fi Security\", \"Explore AD Attack Paths\", "
+                    "\"View Red-Team Cheat Sheets\"."
+                ),
+                "current_word_count": "template",
+                "target_word_count": "12-20 words per blurb",
+            },
+        ])
+
+    if result["sentence_rewrites"]:
+        result["recommendations"].append(
+            "Rewrite the flagged long sentences below using the suggested replacements."
+        )
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze content readability")
+    parser.add_argument("file", nargs="?", help="HTML or text file to analyze")
+    parser.add_argument("--url", "-u", help="Analyze content fetched from URL")
+    parser.add_argument("--text", "-t", help="Analyze text directly")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    if args.text:
+        text = args.text
+    elif args.url:
+        try:
+            content = safe_get(args.url, timeout=20).text
+            if "<html" in content.lower() or "<body" in content.lower():
+                text = extract_text(content)
+            else:
+                text = content
+        except Exception as exc:
+            parser.error(f"Failed to fetch URL: {exc}")
+            return
+    elif args.file:
+        with open(args.file, "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+        if "<html" in content.lower() or "<body" in content.lower():
+            text = extract_text(content)
+        else:
+            text = content
+    elif not sys.stdin.isatty():
+        content = sys.stdin.read()
+        if "<html" in content.lower() or "<body" in content.lower():
+            text = extract_text(content)
+        else:
+            text = content
+    else:
+        parser.error("Provide a file, --text, or pipe content via stdin")
+        return
+
+    result = analyze_readability(text)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    print("Readability Analysis")
+    print("=" * 50)
+    print(f"Words: {result['word_count']} | Sentences: {result['sentence_count']} | "
+          f"Paragraphs: {result['paragraph_count']}")
+    print(f"Reading Time: ~{result['estimated_reading_time_min']} min")
+    print()
+    print(f"Flesch Reading Ease: {result['flesch_reading_ease']}/100 — {result['reading_level']}")
+    print(f"Flesch-Kincaid Grade: {result['flesch_kincaid_grade']}")
+    print(f"Avg Sentence Length: {result['avg_sentence_length']} words (target: 15-20)")
+    print(f"Avg Paragraph Length: {result['avg_paragraph_length']} sentences (target: 2-4)")
+    print(f"Complex Words (3+ syllables): {result['complex_words']} ({result['complex_word_pct']}%)")
+
+    if result["issues"]:
+        print(f"\nIssues:")
+        for issue in result["issues"]:
+            print(f"  {issue}")
+
+    if result["recommendations"]:
+        print(f"\nRecommendations:")
+        for rec in result["recommendations"]:
+            print(f"  💡 {rec}")
+
+    if result["sentence_rewrites"]:
+        print("\nSuggested sentence rewrites:")
+        for i, item in enumerate(result["sentence_rewrites"], 1):
+            print(f"  {i}. Current ({item['current_word_count']} words): {item['current']}")
+            print(f"     Suggested: {item['suggested']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/redirect_backlink_reclaim.py
+++ b/.claude/skills/seo/scripts/redirect_backlink_reclaim.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Find backlink reclaim opportunities from a backlink export."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from collections import Counter
+
+from seo_common import fetch_url, normalize_url, print_json_or_text
+
+
+def _first_existing(row: dict, names: list[str]) -> str:
+    lowered = {str(k).lower().strip(): v for k, v in row.items()}
+    for name in names:
+        if name.lower() in lowered and lowered[name.lower()]:
+            return str(lowered[name.lower()]).strip()
+    return ""
+
+
+def read_backlink_export(path: str, source_column: str | None = None, target_column: str | None = None) -> list[dict]:
+    stream = sys.stdin if path == "-" else open(path, "r", encoding="utf-8-sig", newline="")
+    with stream:
+        sample = stream.read(4096)
+        stream.seek(0)
+        dialect = csv.Sniffer().sniff(sample) if sample else csv.excel
+        reader = csv.DictReader(stream, dialect=dialect)
+        rows = []
+        for row in reader:
+            source = row.get(source_column) if source_column else _first_existing(row, ["source_url", "source", "referring_page", "referrer", "backlink"])
+            target = row.get(target_column) if target_column else _first_existing(row, ["target_url", "target", "linked_url", "destination", "url"])
+            if not target:
+                continue
+            rows.append({"source_url": (source or "").strip(), "target_url": normalize_url(target.strip()), "raw": dict(row)})
+        return rows
+
+
+def analyze_backlinks(rows: list[dict], timeout: int = 15, max_rows: int = 500, long_chain_threshold: int = 2) -> dict:
+    checked = []
+    opportunities = []
+    target_counter = Counter(row["target_url"] for row in rows)
+    unique_targets = list(target_counter)[:max_rows]
+
+    target_status = {}
+    for target in unique_targets:
+        fetched = fetch_url(target, method="HEAD", timeout=timeout, allow_redirects=True, max_bytes=0)
+        if fetched.get("status") in (405, 403, None) and fetched.get("error"):
+            fetched = fetch_url(target, method="GET", timeout=timeout, allow_redirects=True, max_bytes=200_000)
+        row = {
+            "target_url": target,
+            "backlink_count": target_counter[target],
+            "status": fetched.get("status"),
+            "final_url": fetched.get("url"),
+            "redirect_chain": fetched.get("redirect_chain", []),
+            "error": fetched.get("error"),
+        }
+        target_status[target] = row
+        checked.append(row)
+
+    for row in rows:
+        status = target_status.get(row["target_url"], {})
+        code = status.get("status")
+        chain = status.get("redirect_chain") or []
+        if code and code >= 400:
+            opportunities.append(
+                {
+                    "type": "broken_backlink_target",
+                    "severity": "high",
+                    "source_url": row.get("source_url"),
+                    "target_url": row["target_url"],
+                    "status": code,
+                    "fix": "Restore the URL or 301 redirect it to the closest relevant live page.",
+                }
+            )
+        elif len(chain) > long_chain_threshold:
+            opportunities.append(
+                {
+                    "type": "long_redirect_chain",
+                    "severity": "medium",
+                    "source_url": row.get("source_url"),
+                    "target_url": row["target_url"],
+                    "final_url": status.get("final_url"),
+                    "redirect_hops": len(chain),
+                    "fix": "Update redirects so the backlink target resolves in one hop.",
+                }
+            )
+
+    return {
+        "summary": {
+            "backlink_rows": len(rows),
+            "unique_targets": len(target_counter),
+            "targets_checked": len(checked),
+            "opportunities": len(opportunities),
+            "broken_targets": sum(1 for item in checked if item.get("status") and item["status"] >= 400),
+            "long_redirect_chains": sum(1 for item in checked if len(item.get("redirect_chain") or []) > long_chain_threshold),
+        },
+        "targets": checked,
+        "opportunities": opportunities,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Find backlink reclaim opportunities from a CSV export")
+    parser.add_argument("csv_file", help="Backlink CSV/TSV export path, or '-' for stdin")
+    parser.add_argument("--source-column", help="Column containing the referring/source page URL")
+    parser.add_argument("--target-column", help="Column containing the linked target URL")
+    parser.add_argument("--max-rows", type=int, default=500, help="Maximum unique target URLs to check")
+    parser.add_argument("--long-chain-threshold", type=int, default=2, help="Redirect hops above this count are flagged")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    rows = read_backlink_export(args.csv_file, source_column=args.source_column, target_column=args.target_column)
+    result = analyze_backlinks(rows, timeout=args.timeout, max_rows=args.max_rows, long_chain_threshold=args.long_chain_threshold)
+    lines = [
+        "Redirect/backlink reclaim audit",
+        (
+            f"Rows: {result['summary']['backlink_rows']}  "
+            f"Targets checked: {result['summary']['targets_checked']}  "
+            f"Opportunities: {result['summary']['opportunities']}"
+        ),
+    ]
+    lines.extend(
+        f"{item['type']}: {item['target_url']} ({item.get('status') or item.get('redirect_hops')})"
+        for item in result["opportunities"][:25]
+    )
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/redirect_checker.py
+++ b/.claude/skills/seo/scripts/redirect_checker.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Check redirect chains for a URL.
+
+Follows the full redirect chain, reports each hop (status + destination),
+detects mixed HTTP/HTTPS, redirect loops, and chain length issues.
+
+Usage:
+    python redirect_checker.py https://example.com
+    python redirect_checker.py https://example.com http://example.com --json
+"""
+
+import argparse
+import json
+import sys
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_head
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_head
+
+
+HEADERS = default_headers()
+
+
+def check_redirects(url: str, max_redirects: int = 10, timeout: int = 10) -> dict:
+    """
+    Follow and analyze the redirect chain for a URL.
+
+    Args:
+        url: URL to check
+        max_redirects: Maximum redirects to follow
+        timeout: Request timeout in seconds
+
+    Returns:
+        Dictionary with redirect chain analysis
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"https://{url}"
+
+    result = {
+        "url": url,
+        "final_url": None,
+        "chain": [],
+        "total_hops": 0,
+        "total_time_ms": 0,
+        "has_loop": False,
+        "has_mixed_protocol": False,
+        "issues": [],
+        "error": None,
+    }
+
+    seen = set()
+    current = url
+
+    try:
+        for i in range(max_redirects + 1):
+            if current in seen:
+                result["has_loop"] = True
+                result["issues"].append(f"🔴 Redirect loop detected at: {current}")
+                break
+            seen.add(current)
+
+            resp = safe_head(current, timeout=timeout, headers=HEADERS,
+                             allow_redirects=False)
+
+            hop = {
+                "step": i + 1,
+                "url": current,
+                "status": resp.status_code,
+                "time_ms": round(resp.elapsed.total_seconds() * 1000),
+            }
+
+            if resp.status_code in (301, 302, 303, 307, 308):
+                location = resp.headers.get("Location", "")
+                if not location:
+                    hop["error"] = "Redirect with no Location header"
+                    result["chain"].append(hop)
+                    result["issues"].append(f"🔴 Redirect at step {i+1} has no Location header")
+                    break
+
+                # Resolve relative URLs
+                if not urlparse(location).scheme:
+                    from urllib.parse import urljoin
+                    location = urljoin(current, location)
+
+                hop["redirect_to"] = location
+                hop["redirect_type"] = {
+                    301: "permanent (301)",
+                    302: "temporary (302)",
+                    303: "see other (303)",
+                    307: "temporary (307)",
+                    308: "permanent (308)",
+                }.get(resp.status_code, f"unknown ({resp.status_code})")
+
+                result["chain"].append(hop)
+                result["total_time_ms"] += hop["time_ms"]
+                current = location
+            else:
+                # Final destination
+                hop["final"] = True
+                result["chain"].append(hop)
+                result["final_url"] = current
+                result["total_time_ms"] += hop["time_ms"]
+                break
+        else:
+            result["issues"].append(f"🔴 Too many redirects (>{max_redirects})")
+
+    except requests.exceptions.RequestException as e:
+        result["error"] = str(e)
+
+    result["total_hops"] = max(0, len(result["chain"]) - 1)
+
+    # Check for mixed protocol
+    protocols = set()
+    for hop in result["chain"]:
+        protocols.add(urlparse(hop["url"]).scheme)
+    if "http" in protocols and "https" in protocols:
+        result["has_mixed_protocol"] = True
+        result["issues"].append("⚠️ Mixed HTTP/HTTPS in redirect chain")
+
+    # Check chain length
+    if result["total_hops"] > 2:
+        result["issues"].append(
+            f"🔴 Long redirect chain ({result['total_hops']} hops) — degrades crawl efficiency"
+        )
+    elif result["total_hops"] > 1:
+        result["issues"].append(
+            f"⚠️ Redirect chain has {result['total_hops']} hops — aim for max 1"
+        )
+
+    # Check for 302 where 301 should be used
+    for hop in result["chain"]:
+        if hop["status"] == 302:
+            result["issues"].append(
+                f"⚠️ Temporary redirect (302) at step {hop['step']} — "
+                f"use 301 for permanent moves to preserve link equity"
+            )
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check redirect chains")
+    parser.add_argument("urls", nargs="+", help="URL(s) to check")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+
+    results = []
+    for url in args.urls:
+        results.append(check_redirects(url))
+
+    if args.json:
+        output = results if len(results) > 1 else results[0]
+        print(json.dumps(output, indent=2))
+        return
+
+    for result in results:
+        if result["error"]:
+            print(f"Error checking {result['url']}: {result['error']}")
+            continue
+
+        print(f"Redirect Chain — {result['url']}")
+        print("=" * 50)
+
+        if not result["chain"]:
+            print("  No response received")
+            continue
+
+        for hop in result["chain"]:
+            status = hop["status"]
+            time_ms = hop["time_ms"]
+
+            if hop.get("final"):
+                icon = "✅" if 200 <= status < 300 else "🔴"
+                print(f"  {icon} [{status}] {hop['url']} ({time_ms}ms) — FINAL")
+            else:
+                redirect_type = hop.get("redirect_type", "")
+                print(f"  ↪️ [{status}] {hop['url']} ({time_ms}ms)")
+                print(f"       → {hop.get('redirect_to', '?')} ({redirect_type})")
+
+        print(f"\nTotal hops: {result['total_hops']} | Total time: {result['total_time_ms']}ms")
+
+        if result["issues"]:
+            print(f"\nIssues:")
+            for issue in result["issues"]:
+                print(f"  {issue}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/reference_freshness.py
+++ b/.claude/skills/seo/scripts/reference_freshness.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check reference-file freshness markers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import date
+from pathlib import Path
+
+
+UPDATED_RE = re.compile(r"<!--\s*Updated:\s*(\d{4}-\d{2}-\d{2})\s*-->")
+
+
+@dataclass
+class ReferenceStatus:
+    path: str
+    updated: str | None
+    age_days: int | None
+    status: str
+    message: str
+
+
+def check_file(path: Path, today: date, max_age_days: int) -> ReferenceStatus:
+    text = path.read_text(encoding="utf-8")
+    match = UPDATED_RE.search(text)
+    rel = path.as_posix()
+    if not match:
+        return ReferenceStatus(rel, None, None, "error", "missing Updated marker")
+
+    raw_date = match.group(1)
+    try:
+        updated = date.fromisoformat(raw_date)
+    except ValueError:
+        return ReferenceStatus(rel, raw_date, None, "error", "invalid Updated date")
+
+    if updated > today:
+        return ReferenceStatus(rel, raw_date, None, "error", "Updated date is in the future")
+
+    age_days = (today - updated).days
+    if age_days > max_age_days:
+        return ReferenceStatus(
+            rel,
+            raw_date,
+            age_days,
+            "stale",
+            f"older than {max_age_days} days",
+        )
+
+    return ReferenceStatus(rel, raw_date, age_days, "ok", "fresh")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate <!-- Updated: YYYY-MM-DD --> markers in reference markdown files."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="resources/references",
+        help="Reference file or directory to check.",
+    )
+    parser.add_argument("--max-age-days", type=int, default=90, help="Freshness warning threshold.")
+    parser.add_argument(
+        "--fail-stale",
+        action="store_true",
+        help="Return a non-zero exit code for stale files, not only missing/invalid markers.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable results.")
+    args = parser.parse_args()
+
+    target = Path(args.path)
+    if target.is_dir():
+        files = sorted(target.glob("*.md"))
+    else:
+        files = [target]
+
+    today = date.today()
+    statuses = [check_file(path, today, args.max_age_days) for path in files]
+    hard_failures = [item for item in statuses if item.status == "error"]
+    stale = [item for item in statuses if item.status == "stale"]
+
+    if args.json:
+        print(json.dumps([asdict(item) for item in statuses], indent=2, sort_keys=True))
+    else:
+        for item in statuses:
+            label = {"ok": "OK", "stale": "WARN", "error": "ERROR"}[item.status]
+            age = "" if item.age_days is None else f" ({item.age_days} days old)"
+            print(f"{label}: {item.path}: {item.message}{age}")
+
+    if hard_failures or (args.fail_stale and stale):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/seo/scripts/repo_docs_site_checker.py
+++ b/.claude/skills/seo/scripts/repo_docs_site_checker.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Check repository homepage/docs URLs and install CTA paths."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from urllib.parse import urlparse
+
+from github_api import auth_context, fetch_json, get_token, resolve_repo
+from seo_common import fetch_url, print_json_or_text
+
+
+URL_RE = re.compile(r"https?://[^\s)\]\"'>]+")
+
+
+def _readme_urls(path: str) -> list[str]:
+    readme = os.path.join(path, "README.md")
+    if not os.path.exists(readme):
+        return []
+    text = open(readme, "r", encoding="utf-8", errors="replace").read()
+    return sorted(set(URL_RE.findall(text)))
+
+
+def _readme_install_cta(path: str) -> dict:
+    readme = os.path.join(path, "README.md")
+    if not os.path.exists(readme):
+        return {"present": False, "install_mentions": 0, "quickstart_mentions": 0, "code_blocks": 0}
+    text = open(readme, "r", encoding="utf-8", errors="replace").read()
+    lower = text.lower()
+    return {
+        "present": True,
+        "install_mentions": lower.count("install"),
+        "quickstart_mentions": lower.count("quickstart"),
+        "code_blocks": text.count("```"),
+    }
+
+
+def _check_url(url: str, timeout: int) -> dict:
+    fetched = fetch_url(url, timeout=timeout, max_bytes=1_000_000)
+    return {
+        "url": url,
+        "status": fetched.get("status"),
+        "final_url": fetched.get("url"),
+        "redirect_chain": fetched.get("redirect_chain", []),
+        "error": fetched.get("error"),
+        "title_present": "<title" in (fetched.get("text") or "").lower(),
+        "meta_description_present": 'name="description"' in (fetched.get("text") or "").lower() or "name='description'" in (fetched.get("text") or "").lower(),
+    }
+
+
+def check_docs_site(repo: str | None = None, path: str = ".", token: str = "", provider: str = "auto", homepage: str | None = None, timeout: int = 15, max_urls: int = 10) -> dict:
+    ctx = auth_context(token=token)
+    limitations = []
+    metadata = {}
+    resolved_repo = ""
+    try:
+        resolved_repo = resolve_repo(repo, cwd=path)
+        payload = fetch_json(f"/repos/{resolved_repo}", token=token, provider=provider)
+        metadata = payload.get("data") or {}
+    except Exception as exc:
+        limitations.append(f"GitHub metadata unavailable: {exc}")
+
+    candidate_urls = []
+    if homepage:
+        candidate_urls.append(homepage)
+    if metadata.get("homepage"):
+        candidate_urls.append(metadata["homepage"])
+    if resolved_repo:
+        owner, name = resolved_repo.split("/", 1)
+        candidate_urls.extend([f"https://{owner}.github.io/{name}/", f"https://github.com/{resolved_repo}#readme"])
+    for url in _readme_urls(path):
+        host = urlparse(url).netloc.lower()
+        if any(token in host for token in ("github.io", "readthedocs.io", "docs.", "pages.dev", "vercel.app", "netlify.app")):
+            candidate_urls.append(url)
+
+    deduped = []
+    seen = set()
+    for url in candidate_urls:
+        cleaned = url.rstrip(".,")
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            deduped.append(cleaned)
+
+    checks = [_check_url(url, timeout=timeout) for url in deduped[:max_urls]]
+    readme_cta = _readme_install_cta(path)
+    issues = []
+    live_docs = [row for row in checks if row.get("status") and row["status"] < 400]
+    if not checks:
+        issues.append({"severity": "warning", "type": "no_docs_url", "message": "No homepage/docs URL was discovered"})
+    elif not live_docs:
+        issues.append({"severity": "warning", "type": "docs_unavailable", "message": "No checked docs/homepage URL returned a live status"})
+    if readme_cta["present"] and readme_cta["install_mentions"] == 0:
+        issues.append({"severity": "warning", "type": "missing_install_cta", "message": "README does not clearly mention installation"})
+    if any(row.get("status") and row["status"] >= 400 for row in checks):
+        issues.append({"severity": "warning", "type": "broken_docs_url", "message": "At least one docs/homepage URL returned 4xx/5xx"})
+
+    score = 100 - 20 * len([i for i in issues if i["severity"] == "warning"])
+    return {
+        "repo": resolved_repo or repo or "",
+        "auth_context": ctx,
+        "metadata": {"homepage": metadata.get("homepage"), "description": metadata.get("description")},
+        "summary": {"score": max(0, score), "urls_checked": len(checks), "live_urls": len(live_docs)},
+        "readme_install_cta": readme_cta,
+        "url_checks": checks,
+        "issues": issues,
+        "limitations": limitations,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check repository docs/homepage URLs and install CTA")
+    parser.add_argument("--repo", help="Repository slug or URL (defaults to local git origin)")
+    parser.add_argument("--path", default=".", help="Local repository path")
+    parser.add_argument("--homepage", help="Explicit homepage/docs URL")
+    parser.add_argument("--token", help="GitHub token override")
+    parser.add_argument("--provider", choices=["auto", "api", "gh"], default="auto")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = check_docs_site(args.repo, path=args.path, token=get_token(args.token), provider=args.provider, homepage=args.homepage, timeout=args.timeout)
+    lines = [
+        f"Docs site check for {result['repo'] or args.path}",
+        f"Score: {result['summary']['score']}  URLs checked: {result['summary']['urls_checked']}  Live: {result['summary']['live_urls']}",
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}" for issue in result["issues"])
+    lines.extend(f"Limitation: {item}" for item in result["limitations"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/repo_file_inventory.py
+++ b/.claude/skills/seo/scripts/repo_file_inventory.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Inventory repository SEO, docs, demo, and governance files."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from seo_common import print_json_or_text
+
+
+CHECKS = {
+    "core": ["README.md", "LICENSE", "CHANGELOG.md"],
+    "docs": ["docs", "examples", "demo", "site"],
+    "governance": ["CONTRIBUTING.md", "CODE_OF_CONDUCT.md", "SECURITY.md", "SUPPORT.md", "CITATION.cff"],
+    "github": [".github/workflows", ".github/ISSUE_TEMPLATE", ".github/pull_request_template.md", ".github/PULL_REQUEST_TEMPLATE.md", ".github/CODEOWNERS", ".github/dependabot.yml"],
+    "package": ["pyproject.toml", "package.json", "requirements.txt", "setup.py"],
+}
+
+
+def path_exists(root: Path, rel: str) -> bool:
+    return (root / rel).exists()
+
+
+def inventory_repository(path: str = ".") -> dict:
+    root = Path(path).resolve()
+    sections = {}
+    missing = []
+    present = []
+    for section, items in CHECKS.items():
+        rows = []
+        for rel in items:
+            exists = path_exists(root, rel)
+            row = {"path": rel, "present": exists, "type": "directory" if (root / rel).is_dir() else "file"}
+            rows.append(row)
+            (present if exists else missing).append(rel)
+        sections[section] = rows
+
+    readme = root / "README.md"
+    readme_stats = {"present": readme.exists(), "bytes": 0, "headings": 0, "install_mentions": 0, "demo_mentions": 0}
+    if readme.exists():
+        text = readme.read_text(encoding="utf-8", errors="replace")
+        readme_stats.update(
+            {
+                "bytes": len(text.encode("utf-8")),
+                "headings": sum(1 for line in text.splitlines() if line.startswith("#")),
+                "install_mentions": text.lower().count("install"),
+                "demo_mentions": text.lower().count("demo"),
+            }
+        )
+
+    issues = []
+    for rel in ("README.md", "LICENSE"):
+        if rel in missing:
+            issues.append({"severity": "error", "type": "missing_required_file", "path": rel, "message": f"{rel} is missing"})
+    for rel in ("CONTRIBUTING.md", "SECURITY.md", "CHANGELOG.md"):
+        if rel in missing:
+            issues.append({"severity": "warning", "type": "missing_trust_file", "path": rel, "message": f"{rel} improves repository trust and SEO"})
+    if readme_stats["present"] and readme_stats["install_mentions"] == 0:
+        issues.append({"severity": "warning", "type": "readme_install_cta", "path": "README.md", "message": "README has no obvious install call-to-action"})
+
+    score = max(0, round(100 * len(present) / max(1, len(present) + len(missing))) - len([i for i in issues if i["severity"] == "warning"]) * 2)
+    return {
+        "path": str(root),
+        "summary": {"present": len(present), "missing": len(missing), "score": score},
+        "sections": sections,
+        "readme": readme_stats,
+        "issues": issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inventory repository SEO and trust files")
+    parser.add_argument("--path", default=".", help="Repository path (default: current directory)")
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = inventory_repository(args.path)
+    lines = [
+        f"Repository file inventory for {result['path']}",
+        f"Score: {result['summary']['score']}  Present: {result['summary']['present']}  Missing: {result['summary']['missing']}",
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}" for issue in result["issues"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/repo_release_seo.py
+++ b/.claude/skills/seo/scripts/repo_release_seo.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Audit GitHub release cadence and release-note SEO quality."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+
+from github_api import GitHubAPIError, auth_context, fetch_json, get_token, resolve_repo
+from seo_common import print_json_or_text
+
+
+def _parse_date(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _local_tags(cwd: str, limit: int = 20) -> list[dict]:
+    try:
+        output = subprocess.check_output(
+            ["git", "for-each-ref", "--sort=-creatordate", "--format=%(refname:short)%09%(creatordate:iso8601)", f"--count={limit}", "refs/tags"],
+            cwd=cwd,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except Exception:
+        return []
+    rows = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        name, _, date = line.partition("\t")
+        rows.append({"tag_name": name, "name": name, "published_at": date, "body": "", "source": "git_tag"})
+    return rows
+
+
+def _load_changelog(cwd: str) -> dict:
+    path = os.path.join(cwd, "CHANGELOG.md")
+    if not os.path.exists(path):
+        return {"present": False, "bytes": 0, "release_headings": 0}
+    text = open(path, "r", encoding="utf-8", errors="replace").read()
+    return {"present": True, "bytes": len(text.encode("utf-8")), "release_headings": len(re.findall(r"^##\s+", text, flags=re.M))}
+
+
+def _release_quality(release: dict, keywords: list[str]) -> dict:
+    title = release.get("name") or release.get("tag_name") or ""
+    body = release.get("body") or ""
+    text = f"{title}\n{body}".lower()
+    matched = [kw for kw in keywords if kw.lower() in text]
+    return {
+        "tag": release.get("tag_name") or "",
+        "title": title,
+        "published_at": release.get("published_at") or release.get("created_at") or "",
+        "body_length": len(body),
+        "has_summary": len(body.strip()) >= 120,
+        "has_bullets": bool(re.search(r"^\s*[-*]\s+", body, flags=re.M)),
+        "keyword_matches": matched,
+        "draft": bool(release.get("draft")),
+        "prerelease": bool(release.get("prerelease")),
+        "source": release.get("source", "github_release"),
+    }
+
+
+def audit_release_seo(repo: str | None = None, path: str = ".", token: str = "", provider: str = "auto", keywords: list[str] | None = None, limit: int = 20) -> dict:
+    keywords = keywords or []
+    ctx = auth_context(token=token)
+    limitations = []
+    releases = []
+    resolved_repo = ""
+    try:
+        resolved_repo = resolve_repo(repo, cwd=path)
+        payload = fetch_json(f"/repos/{resolved_repo}/releases", token=token, params={"per_page": min(limit, 100)}, provider=provider)
+        releases = payload.get("data") or []
+    except GitHubAPIError as exc:
+        limitations.append(f"GitHub releases unavailable: {exc}")
+    except Exception as exc:
+        limitations.append(f"GitHub releases unavailable: {exc}")
+
+    if not releases:
+        releases = _local_tags(path, limit=limit)
+        if releases:
+            limitations.append("Using local git tags because GitHub releases were unavailable.")
+
+    rows = [_release_quality(r, keywords) for r in releases[:limit]]
+    dates = [dt for dt in (_parse_date(r["published_at"]) for r in rows) if dt]
+    newest_days = None
+    if dates:
+        newest_days = (datetime.now(timezone.utc) - max(dates)).days
+    with_notes = sum(1 for r in rows if r["has_summary"])
+    with_keywords = sum(1 for r in rows if r["keyword_matches"])
+    changelog = _load_changelog(path)
+
+    issues = []
+    if not rows:
+        issues.append({"severity": "warning", "type": "no_releases", "message": "No GitHub releases or local tags were found"})
+    if newest_days is not None and newest_days > 180:
+        issues.append({"severity": "warning", "type": "stale_releases", "message": "Latest release/tag is older than 180 days", "days": newest_days})
+    if rows and with_notes / len(rows) < 0.5:
+        issues.append({"severity": "info", "type": "thin_release_notes", "message": "Most releases have short release notes"})
+    if keywords and rows and with_keywords == 0:
+        issues.append({"severity": "info", "type": "keyword_alignment", "message": "Release notes do not mention target keywords"})
+    if not changelog["present"]:
+        issues.append({"severity": "warning", "type": "missing_changelog", "message": "CHANGELOG.md is missing"})
+
+    score = 100
+    score -= 20 if not rows else 0
+    score -= 15 if newest_days and newest_days > 180 else 0
+    score -= 10 if rows and with_notes / len(rows) < 0.5 else 0
+    score -= 10 if not changelog["present"] else 0
+    return {
+        "repo": resolved_repo or repo or "",
+        "auth_context": ctx,
+        "summary": {
+            "score": max(0, score),
+            "releases_analyzed": len(rows),
+            "latest_release_age_days": newest_days,
+            "release_notes_with_summary": with_notes,
+            "release_notes_with_keywords": with_keywords,
+        },
+        "changelog": changelog,
+        "releases": rows,
+        "issues": issues,
+        "limitations": limitations,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit GitHub release cadence and release-note SEO")
+    parser.add_argument("--repo", help="Repository slug or URL (defaults to local git origin)")
+    parser.add_argument("--path", default=".", help="Local repository path")
+    parser.add_argument("--token", help="GitHub token override")
+    parser.add_argument("--provider", choices=["auto", "api", "gh"], default="auto")
+    parser.add_argument("--keyword", action="append", default=[], help="Target keyword to look for in release notes")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = audit_release_seo(args.repo, path=args.path, token=get_token(args.token), provider=args.provider, keywords=args.keyword, limit=args.limit)
+    lines = [
+        f"Release SEO audit for {result['repo'] or args.path}",
+        f"Score: {result['summary']['score']}  Releases: {result['summary']['releases_analyzed']}  Latest age days: {result['summary']['latest_release_age_days']}",
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}" for issue in result["issues"])
+    lines.extend(f"Limitation: {item}" for item in result["limitations"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/repo_social_preview_checker.py
+++ b/.claude/skills/seo/scripts/repo_social_preview_checker.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Check GitHub repository social-preview readiness signals."""
+
+from __future__ import annotations
+
+import argparse
+
+from github_api import auth_context, fetch_json, get_token, resolve_repo
+from seo_common import print_json_or_text
+
+
+def check_social_preview(repo: str | None = None, path: str = ".", token: str = "", provider: str = "auto") -> dict:
+    ctx = auth_context(token=token)
+    limitations = []
+    metadata = {}
+    resolved_repo = ""
+    try:
+        resolved_repo = resolve_repo(repo, cwd=path)
+        payload = fetch_json(f"/repos/{resolved_repo}", token=token, provider=provider)
+        metadata = payload.get("data") or {}
+    except Exception as exc:
+        limitations.append(f"GitHub metadata unavailable: {exc}")
+
+    description = metadata.get("description") or ""
+    topics = metadata.get("topics") or []
+    homepage = metadata.get("homepage") or ""
+    owner = metadata.get("owner") or {}
+    open_graph_image = metadata.get("open_graph_image_url") or owner.get("avatar_url") or ""
+    issues = []
+    if not metadata:
+        issues.append({"severity": "info", "type": "metadata_unavailable", "message": "GitHub metadata could not be fetched; social preview image cannot be verified through REST fallback"})
+    if metadata and not description:
+        issues.append({"severity": "warning", "type": "missing_description", "message": "Repository description is empty"})
+    if metadata and len(description) > 160:
+        issues.append({"severity": "info", "type": "long_description", "message": "Repository description may truncate in social previews"})
+    if metadata and len(topics) < 3:
+        issues.append({"severity": "warning", "type": "few_topics", "message": "Repository has fewer than three topics"})
+    if metadata and not homepage:
+        issues.append({"severity": "info", "type": "missing_homepage", "message": "Repository homepage URL is empty"})
+    if metadata and not open_graph_image:
+        issues.append({"severity": "info", "type": "social_preview_unknown", "message": "Social preview image was not exposed by available GitHub API data"})
+
+    score = 100
+    score -= 30 if not metadata else 0
+    score -= 20 if metadata and not description else 0
+    score -= 15 if metadata and len(topics) < 3 else 0
+    score -= 10 if metadata and not homepage else 0
+    return {
+        "repo": resolved_repo or repo or "",
+        "auth_context": ctx,
+        "summary": {
+            "score": max(0, score),
+            "description_present": bool(description),
+            "topic_count": len(topics),
+            "homepage_present": bool(homepage),
+            "open_graph_image_detected": bool(open_graph_image),
+        },
+        "metadata": {
+            "name": metadata.get("name"),
+            "description": description,
+            "homepage": homepage,
+            "topics": topics,
+            "open_graph_image_url": open_graph_image,
+        },
+        "issues": issues,
+        "limitations": limitations,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check GitHub repository social-preview readiness")
+    parser.add_argument("--repo", help="Repository slug or URL (defaults to local git origin)")
+    parser.add_argument("--path", default=".", help="Local repository path")
+    parser.add_argument("--token", help="GitHub token override")
+    parser.add_argument("--provider", choices=["auto", "api", "gh"], default="auto")
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = check_social_preview(args.repo, path=args.path, token=get_token(args.token), provider=args.provider)
+    lines = [
+        f"Social preview check for {result['repo'] or args.path}",
+        f"Score: {result['summary']['score']}  Topics: {result['summary']['topic_count']}  Description: {result['summary']['description_present']}",
+    ]
+    lines.extend(f"[{issue['severity']}] {issue['message']}" for issue in result["issues"])
+    lines.extend(f"Limitation: {item}" for item in result["limitations"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/repo_topic_suggester.py
+++ b/.claude/skills/seo/scripts/repo_topic_suggester.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Suggest GitHub topics from repository metadata, README, and competitors."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from collections import Counter
+
+from github_api import auth_context, fetch_json, get_token, resolve_repo
+from seo_common import print_json_or_text
+
+
+STOP_WORDS = {
+    "the", "and", "for", "with", "from", "into", "this", "that", "your", "you", "are", "was", "were",
+    "will", "would", "should", "could", "about", "using", "use", "used", "all", "any", "not", "can",
+    "how", "why", "what", "when", "where", "which", "than", "then", "them", "they", "our", "their",
+}
+
+CANONICAL_TOPICS = {
+    "search-engine-optimization": ["seo", "search engine optimization"],
+    "technical-seo": ["technical seo", "crawlability", "indexability"],
+    "github-seo": ["github seo", "repository seo", "repo seo"],
+    "llm": ["llm", "large language model"],
+    "generative-ai": ["generative ai", "ai search"],
+    "python": ["python"],
+    "cli": ["cli", "command line"],
+    "automation": ["automation", "workflow"],
+    "audit": ["audit", "auditing"],
+    "schema-org": ["schema", "json-ld", "structured data"],
+}
+
+
+def _local_text(path: str) -> str:
+    parts = []
+    for rel in ("README.md", "pyproject.toml", "package.json"):
+        fpath = os.path.join(path, rel)
+        if os.path.exists(fpath):
+            parts.append(open(fpath, "r", encoding="utf-8", errors="replace").read())
+    return "\n".join(parts)
+
+
+def _topicify(token: str) -> str:
+    return re.sub(r"[^a-z0-9-]+", "-", token.lower()).strip("-")[:50]
+
+
+def suggest_topics(repo: str | None = None, path: str = ".", token: str = "", provider: str = "auto", competitors: list[str] | None = None, intent_terms: list[str] | None = None, limit: int = 20) -> dict:
+    competitors = competitors or []
+    intent_terms = intent_terms or []
+    ctx = auth_context(token=token)
+    limitations = []
+    resolved_repo = ""
+    metadata = {}
+    try:
+        resolved_repo = resolve_repo(repo, cwd=path)
+        payload = fetch_json(f"/repos/{resolved_repo}", token=token, provider=provider)
+        metadata = payload.get("data") or {}
+    except Exception as exc:
+        limitations.append(f"GitHub metadata unavailable: {exc}")
+
+    current_topics = set(metadata.get("topics") or [])
+    text = "\n".join([metadata.get("name") or "", metadata.get("description") or "", _local_text(path), " ".join(intent_terms)])
+    lower = text.lower()
+    candidates = Counter()
+    evidence = {}
+
+    for topic, phrases in CANONICAL_TOPICS.items():
+        matched = [phrase for phrase in phrases if phrase in lower]
+        if matched:
+            score = 0
+            for phrase in matched:
+                phrase_hits = lower.count(phrase)
+                phrase_words = len(phrase.split())
+                score += phrase_hits * (20 + max(0, phrase_words - 1) * 12)
+            candidates[topic] += score
+            evidence.setdefault(topic, []).extend(matched)
+
+    words = re.findall(r"[a-z][a-z0-9-]{2,}", lower)
+    for word in words:
+        if word in STOP_WORDS or len(word) > 35:
+            continue
+        candidates[_topicify(word)] += 1
+
+    competitor_topics = Counter()
+    for competitor in competitors:
+        try:
+            slug = resolve_repo(competitor)
+            payload = fetch_json(f"/repos/{slug}", token=token, provider=provider)
+            for topic in payload.get("data", {}).get("topics") or []:
+                competitor_topics[topic] += 1
+        except Exception as exc:
+            limitations.append(f"Competitor topics unavailable for {competitor}: {exc}")
+    for topic, count in competitor_topics.items():
+        candidates[topic] += count * 5
+        evidence.setdefault(topic, []).append("competitor topic")
+
+    suggestions = []
+    for topic, score in candidates.most_common():
+        if topic in current_topics or topic in STOP_WORDS or len(topic) < 3:
+            continue
+        suggestions.append({"topic": topic, "score": score, "evidence": sorted(set(evidence.get(topic, [])))})
+        if len(suggestions) >= limit:
+            break
+
+    issues = []
+    if len(current_topics) < 3:
+        issues.append({"severity": "warning", "type": "few_current_topics", "message": "Repository has fewer than three current topics"})
+    if not suggestions:
+        issues.append({"severity": "info", "type": "no_suggestions", "message": "No new topic suggestions were produced from available evidence"})
+
+    return {
+        "repo": resolved_repo or repo or "",
+        "auth_context": ctx,
+        "summary": {"current_topic_count": len(current_topics), "suggestions": len(suggestions), "competitors_used": len(competitors)},
+        "current_topics": sorted(current_topics),
+        "suggested_topics": suggestions,
+        "competitor_topics": dict(competitor_topics.most_common()),
+        "issues": issues,
+        "limitations": limitations,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Suggest GitHub topics from repo metadata and search-intent terms")
+    parser.add_argument("--repo", help="Repository slug or URL (defaults to local git origin)")
+    parser.add_argument("--path", default=".", help="Local repository path")
+    parser.add_argument("--token", help="GitHub token override")
+    parser.add_argument("--provider", choices=["auto", "api", "gh"], default="auto")
+    parser.add_argument("--competitor", action="append", default=[], help="Competitor owner/repo; can be repeated")
+    parser.add_argument("--intent-term", action="append", default=[], help="Search-intent phrase; can be repeated")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    result = suggest_topics(args.repo, path=args.path, token=get_token(args.token), provider=args.provider, competitors=args.competitor, intent_terms=args.intent_term, limit=args.limit)
+    lines = [
+        f"Topic suggestions for {result['repo'] or args.path}",
+        f"Current topics: {result['summary']['current_topic_count']}  Suggestions: {result['summary']['suggestions']}",
+    ]
+    lines.extend(f"- {row['topic']} (score {row['score']})" for row in result["suggested_topics"][:15])
+    lines.extend(f"Limitation: {item}" for item in result["limitations"])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/review_schema_checker.py
+++ b/.claude/skills/seo/scripts/review_schema_checker.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Check Review and AggregateRating markup for policy and misuse risks."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from schema_required_props import extract_schema_documents, find_schema_nodes
+from seo_common import issue, print_json_or_text
+
+
+SELF_SERVING_TYPES = {"LocalBusiness", "Organization", "Service"}
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def type_names(value: Any) -> set[str]:
+    return {item for item in as_list(value) if isinstance(item, str)}
+
+
+def check_rating_value(value: Any, path: str) -> list[dict[str, Any]]:
+    issues = []
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        issues.append(issue("error", "ratingValue must be numeric", evidence=path))
+        return issues
+    if numeric < 1 or numeric > 5:
+        issues.append(issue("warning", "ratingValue is outside the common 1-5 range", evidence=path))
+    return issues
+
+
+def check_review_schema(documents: list[Any]) -> dict[str, Any]:
+    rows = []
+    issues = []
+    review_nodes = find_schema_nodes(documents, "Review")
+    aggregate_nodes = [row for row in find_schema_nodes(documents) if row["node"].get("aggregateRating")]
+    for row in review_nodes:
+        node = row["node"]
+        row_issues = []
+        for prop in ("itemReviewed", "reviewRating", "author"):
+            if not node.get(prop):
+                row_issues.append(issue("error", f"Review is missing {prop}", evidence=row["path"]))
+        rating = node.get("reviewRating") if isinstance(node.get("reviewRating"), dict) else {}
+        if rating:
+            row_issues.extend(check_rating_value(rating.get("ratingValue"), f"{row['path']}.reviewRating"))
+        if not node.get("reviewBody"):
+            row_issues.append(issue("warning", "Review is missing reviewBody", evidence=row["path"]))
+        if not node.get("datePublished"):
+            row_issues.append(issue("info", "Review is missing datePublished", evidence=row["path"]))
+        rows.append({"path": row["path"], "types": row["types"], "issues": row_issues})
+        issues.extend(row_issues)
+    for row in aggregate_nodes:
+        node = row["node"]
+        agg = node.get("aggregateRating")
+        if not isinstance(agg, dict):
+            continue
+        parent_types = type_names(node.get("@type"))
+        if parent_types & SELF_SERVING_TYPES:
+            issues.append(issue("warning", "AggregateRating on LocalBusiness/Organization/Service can be self-serving and ineligible", evidence=row["path"]))
+        for prop in ("ratingValue", "reviewCount"):
+            if not agg.get(prop):
+                issues.append(issue("error", f"aggregateRating is missing {prop}", evidence=f"{row['path']}.aggregateRating"))
+        if agg.get("ratingValue") is not None:
+            issues.extend(check_rating_value(agg.get("ratingValue"), f"{row['path']}.aggregateRating"))
+    return {"reviews": len(review_nodes), "aggregate_ratings": len(aggregate_nodes), "rows": rows, "issues": issues}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check Review/AggregateRating JSON-LD")
+    parser.add_argument("source", help="URL, HTML file, or JSON-LD file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    documents, meta = extract_schema_documents(args.source, timeout=args.timeout)
+    result = check_review_schema(documents)
+    result.update({"source": args.source, "final_url": meta["final_url"]})
+    lines = [f"Review schema check for {args.source}", f"Reviews: {result['reviews']}  Aggregate ratings: {result['aggregate_ratings']}  Issues: {len(result['issues'])}"]
+    lines.extend(f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/rich_results_guard.py
+++ b/.claude/skills/seo/scripts/rich_results_guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Guardrail checks for rich-result eligibility and retired schema types."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from schema_required_props import extract_schema_documents, find_schema_nodes, schema_type_names
+from seo_common import issue, print_json_or_text
+
+
+DEPRECATED_TYPES = {
+    "SpecialAnnouncement": "retired as a Google rich result on July 31, 2025",
+    "CourseInfo": "retired in June 2025",
+    "EstimatedSalary": "retired in June 2025",
+    "LearningVideo": "retired in June 2025",
+    "ClaimReview": "fact-check rich results discontinued in 2025",
+    "VehicleListing": "vehicle listing structured data discontinued in 2025",
+    "PracticeProblem": "rich result discontinued in late 2025",
+    "Dataset": "rich result discontinued in late 2025",
+}
+
+RESTRICTED_TYPES = {
+    "FAQPage": "eligible mainly for authoritative government and health sites",
+    "HowTo": "no longer broadly shown as a Google rich result",
+}
+
+RICH_RESULT_REQUIRED = {
+    "BreadcrumbList": {"itemListElement"},
+    "Product": {"name", "offers"},
+    "Review": {"itemReviewed", "reviewRating", "author"},
+    "VideoObject": {"name", "description", "thumbnailUrl", "uploadDate"},
+}
+
+
+def guard_rich_results(documents: list[Any]) -> dict[str, Any]:
+    rows = []
+    issues = []
+    for row in find_schema_nodes(documents):
+        node = row["node"]
+        type_names = schema_type_names(node.get("@type"))
+        row_issues = []
+        for type_name in type_names:
+            if type_name in DEPRECATED_TYPES:
+                row_issues.append(issue("error", f"{type_name} is deprecated/restricted: {DEPRECATED_TYPES[type_name]}", evidence=row["path"]))
+            if type_name in RESTRICTED_TYPES:
+                row_issues.append(issue("warning", f"{type_name} has eligibility limits: {RESTRICTED_TYPES[type_name]}", evidence=row["path"]))
+            for prop in sorted(RICH_RESULT_REQUIRED.get(type_name, set())):
+                if not node.get(prop):
+                    row_issues.append(issue("error", f"{type_name} missing rich-result property '{prop}'", evidence=row["path"]))
+        rows.append({"path": row["path"], "types": type_names, "issues": row_issues})
+        issues.extend(row_issues)
+    return {
+        "nodes": len(rows),
+        "rows": rows,
+        "issues": issues,
+        "summary": {
+            "errors": sum(1 for item in issues if item["severity"] == "error"),
+            "warnings": sum(1 for item in issues if item["severity"] == "warning"),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Warn about rich-result eligibility risks in JSON-LD")
+    parser.add_argument("source", help="URL, HTML file, or JSON-LD file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    documents, meta = extract_schema_documents(args.source, timeout=args.timeout)
+    result = guard_rich_results(documents)
+    result.update({"source": args.source, "final_url": meta["final_url"]})
+    lines = [
+        f"Rich results guard for {args.source}",
+        f"Nodes: {result['nodes']}  Errors: {result['summary']['errors']}  Warnings: {result['summary']['warnings']}",
+    ] + [f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/robots_checker.py
+++ b/.claude/skills/seo/scripts/robots_checker.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Parse and analyze robots.txt for SEO and AI crawler management.
+
+Usage:
+    python robots_checker.py https://example.com
+    python robots_checker.py https://example.com --json
+"""
+
+import argparse
+import json
+import sys
+from urllib.parse import urljoin, urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_get
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_get
+
+
+# AI crawlers to check for explicit management
+AI_CRAWLERS = [
+    "GPTBot",
+    "ChatGPT-User",
+    "ClaudeBot",
+    "PerplexityBot",
+    "Google-Extended",
+    "Applebot-Extended",
+    "Bytespider",
+    "CCBot",
+    "anthropic-ai",
+    "FacebookBot",
+    "Amazonbot",
+]
+
+# Standard crawlers for reference
+STANDARD_CRAWLERS = [
+    "Googlebot",
+    "Bingbot",
+    "Yandex",
+    "Baiduspider",
+    "DuckDuckBot",
+]
+
+
+def fetch_robots_txt(url: str, timeout: int = 15) -> dict:
+    """Fetch and parse robots.txt from a domain."""
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"https://{url}"
+        parsed = urlparse(url)
+
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+
+    result = {
+        "url": robots_url,
+        "status": None,
+        "raw": None,
+        "user_agents": {},
+        "sitemaps": [],
+        "crawl_delays": {},
+        "ai_crawler_status": {},
+        "issues": [],
+        "error": None,
+    }
+
+    try:
+        resp = safe_get(robots_url, timeout=timeout, headers=default_headers())
+        result["status"] = resp.status_code
+
+        if resp.status_code == 404:
+            result["issues"].append("🔴 No robots.txt found — all crawlers allowed by default")
+            # Still check AI crawlers
+            for crawler in AI_CRAWLERS:
+                result["ai_crawler_status"][crawler] = "allowed (no robots.txt)"
+            return result
+
+        if resp.status_code != 200:
+            result["error"] = f"HTTP {resp.status_code}"
+            return result
+
+        result["raw"] = resp.text
+        _parse_robots(resp.text, result)
+
+    except requests.exceptions.RequestException as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def _parse_robots(content: str, result: dict):
+    """Parse robots.txt content into structured data."""
+    current_agents = []
+
+    for line in content.splitlines():
+        line = line.strip()
+
+        # Skip comments and empty lines
+        if not line or line.startswith("#"):
+            continue
+
+        # Split on first colon
+        if ":" not in line:
+            continue
+
+        directive, _, value = line.partition(":")
+        directive = directive.strip().lower()
+        value = value.strip()
+
+        if directive == "user-agent":
+            current_agents = [value]
+            if value not in result["user_agents"]:
+                result["user_agents"][value] = {"allow": [], "disallow": []}
+
+        elif directive == "disallow" and current_agents:
+            for agent in current_agents:
+                if agent not in result["user_agents"]:
+                    result["user_agents"][agent] = {"allow": [], "disallow": []}
+                if value:
+                    result["user_agents"][agent]["disallow"].append(value)
+
+        elif directive == "allow" and current_agents:
+            for agent in current_agents:
+                if agent not in result["user_agents"]:
+                    result["user_agents"][agent] = {"allow": [], "disallow": []}
+                result["user_agents"][agent]["allow"].append(value)
+
+        elif directive == "sitemap":
+            result["sitemaps"].append(value)
+
+        elif directive == "crawl-delay" and current_agents:
+            for agent in current_agents:
+                try:
+                    result["crawl_delays"][agent] = float(value)
+                except ValueError:
+                    pass
+
+    # Analyze AI crawler management
+    managed_agents = set(result["user_agents"].keys())
+
+    for crawler in AI_CRAWLERS:
+        if crawler in managed_agents:
+            rules = result["user_agents"][crawler]
+            if rules["disallow"] and "/" in rules["disallow"]:
+                result["ai_crawler_status"][crawler] = "fully blocked"
+            elif rules["disallow"]:
+                result["ai_crawler_status"][crawler] = f"partially blocked ({len(rules['disallow'])} paths)"
+            elif rules["allow"]:
+                result["ai_crawler_status"][crawler] = "explicitly allowed"
+            else:
+                result["ai_crawler_status"][crawler] = "declared but no rules"
+        else:
+            # Check wildcard rules
+            if "*" in managed_agents:
+                wildcard = result["user_agents"]["*"]
+                if wildcard["disallow"] and "/" in wildcard["disallow"]:
+                    result["ai_crawler_status"][crawler] = "blocked by wildcard (*)"
+                else:
+                    result["ai_crawler_status"][crawler] = "not managed (inherits * rules)"
+            else:
+                result["ai_crawler_status"][crawler] = "not managed (allowed by default)"
+
+    # Generate issues
+    unmanaged = [c for c, s in result["ai_crawler_status"].items()
+                 if "not managed" in s or "allowed by default" in s]
+    if unmanaged:
+        result["issues"].append(
+            f"⚠️ {len(unmanaged)} AI crawlers not explicitly managed: {', '.join(unmanaged[:5])}"
+        )
+
+    if not result["sitemaps"]:
+        result["issues"].append("⚠️ No Sitemap directive found in robots.txt")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze robots.txt for SEO and AI crawlers")
+    parser.add_argument("url", help="Website URL or domain")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+    result = fetch_robots_txt(args.url)
+
+    if args.json:
+        # Exclude raw content from JSON for brevity
+        output = {k: v for k, v in result.items() if k != "raw"}
+        print(json.dumps(output, indent=2))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    print(f"robots.txt Analysis — {result['url']}")
+    print("=" * 50)
+    print(f"Status: {result['status']}")
+
+    if result["sitemaps"]:
+        print(f"\nSitemaps ({len(result['sitemaps'])}):")
+        for sm in result["sitemaps"]:
+            print(f"  • {sm}")
+
+    print(f"\nUser-Agents ({len(result['user_agents'])}):")
+    for agent, rules in result["user_agents"].items():
+        allow_count = len(rules["allow"])
+        disallow_count = len(rules["disallow"])
+        print(f"  {agent}: {disallow_count} disallow, {allow_count} allow")
+
+    if result["crawl_delays"]:
+        print(f"\nCrawl Delays:")
+        for agent, delay in result["crawl_delays"].items():
+            print(f"  {agent}: {delay}s")
+
+    print(f"\nAI Crawler Management:")
+    for crawler, status in result["ai_crawler_status"].items():
+        icon = "✅" if "blocked" in status else "⚠️" if "not managed" in status else "ℹ️"
+        print(f"  {icon} {crawler}: {status}")
+
+    if result["issues"]:
+        print(f"\nIssues ({len(result['issues'])}):")
+        for issue in result["issues"]:
+            print(f"  {issue}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/robots_path_tester.py
+++ b/.claude/skills/seo/scripts/robots_path_tester.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Test URL paths against robots.txt for multiple crawlers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from seo_common import fetch_robots, normalize_url, robots_allowed
+
+
+DEFAULT_AGENTS = ["Googlebot", "Bingbot", "GPTBot", "ChatGPT-User", "ClaudeBot", "PerplexityBot", "Google-Extended", "Applebot-Extended", "CCBot"]
+
+
+def test_paths(site: str, paths: list[str], agents: list[str], timeout: int = 15) -> dict:
+    robots = fetch_robots(site, timeout=timeout)
+    rows = []
+    for path in paths:
+        url = normalize_url(path, site)
+        decisions = {}
+        for agent in agents:
+            allowed, rule = robots_allowed(robots.get("parsed"), url, agent)
+            decisions[agent] = {"allowed": allowed, "rule": rule}
+        rows.append({"url": url, "decisions": decisions})
+    return {"site": normalize_url(site), "robots_url": robots["url"], "robots_status": robots["fetch"].get("status"), "rows": rows}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test paths against robots.txt")
+    parser.add_argument("site")
+    parser.add_argument("paths", nargs="+")
+    parser.add_argument("--agent", action="append", help="Crawler user-agent; repeatable")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = test_paths(args.site, args.paths, args.agent or DEFAULT_AGENTS, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        for row in result["rows"]:
+            print(row["url"])
+            for agent, decision in row["decisions"].items():
+                print(f"  {agent}: {'allowed' if decision['allowed'] else 'blocked'} ({decision['rule']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/schema_diff.py
+++ b/.claude/skills/seo/scripts/schema_diff.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Compare existing JSON-LD against a recommended bundled schema template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from schema_required_props import extract_schema_documents, find_schema_nodes
+from schema_template_generator import get_template
+from seo_common import issue, print_json_or_text
+
+
+def prop_set(node: dict[str, Any]) -> set[str]:
+    return {key for key in node if not key.startswith("@")}
+
+
+def diff_schema(source: str, schema_type: str, timeout: int = 15) -> dict[str, Any]:
+    documents, meta = extract_schema_documents(source, timeout=timeout)
+    nodes = find_schema_nodes(documents, schema_type)
+    template = get_template(schema_type, compact=True)
+    recommended_props = prop_set(template)
+    if not nodes:
+        return {
+            "source": source,
+            "final_url": meta["final_url"],
+            "type": schema_type,
+            "matched_nodes": 0,
+            "template": template,
+            "diffs": [],
+            "issues": [issue("error", f"No {schema_type} JSON-LD node found")],
+        }
+    diffs = []
+    issues = []
+    for row in nodes:
+        current = row["node"]
+        current_props = prop_set(current)
+        missing = sorted(recommended_props - current_props)
+        extra = sorted(current_props - recommended_props)
+        changed_types = sorted(set(row["types"]) ^ set([schema_type]))
+        for prop in missing:
+            issues.append(issue("warning", f"Add recommended {schema_type} property '{prop}'", evidence=row["path"]))
+        diffs.append(
+            {
+                "path": row["path"],
+                "current_type": row["types"],
+                "missing_properties": missing,
+                "extra_properties": extra,
+                "type_differences": changed_types,
+                "suggested_patch": {prop: template[prop] for prop in missing if prop in template},
+            }
+        )
+    return {
+        "source": source,
+        "final_url": meta["final_url"],
+        "type": schema_type,
+        "matched_nodes": len(nodes),
+        "template": template,
+        "diffs": diffs,
+        "issues": issues,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Diff current JSON-LD against a bundled schema template")
+    parser.add_argument("source", help="URL, HTML file, or JSON-LD file")
+    parser.add_argument("--type", dest="schema_type", required=True, help="Schema type to compare")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    result = diff_schema(args.source, args.schema_type, timeout=args.timeout)
+    lines = [
+        f"Schema diff for {result['type']} on {args.source}",
+        f"Matched nodes: {result['matched_nodes']}  Issues: {len(result['issues'])}",
+    ]
+    for diff in result["diffs"]:
+        lines.append(f"{diff['path']}: add {', '.join(diff['missing_properties']) or 'nothing'}")
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/schema_required_props.py
+++ b/.claude/skills/seo/scripts/schema_required_props.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Validate required and recommended Schema.org properties in JSON-LD."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Iterable
+from typing import Any
+
+from seo_common import issue, load_html, parse_html, print_json_or_text
+
+
+REQUIRED_PROPS: dict[str, set[str]] = {
+    "Article": {"headline", "author", "datePublished"},
+    "BlogPosting": {"headline", "author", "datePublished"},
+    "BreadcrumbList": {"itemListElement"},
+    "FAQPage": {"mainEntity"},
+    "HowTo": {"name", "step"},
+    "LocalBusiness": {"name", "address", "telephone"},
+    "Organization": {"name", "url"},
+    "Product": {"name", "offers"},
+    "ProductGroup": {"name", "productGroupID", "hasVariant"},
+    "Review": {"itemReviewed", "reviewRating", "author"},
+    "VideoObject": {"name", "description", "thumbnailUrl", "uploadDate"},
+    "WebSite": {"name", "url"},
+}
+
+RECOMMENDED_PROPS: dict[str, set[str]] = {
+    "Article": {"image", "dateModified", "publisher", "mainEntityOfPage"},
+    "BlogPosting": {"image", "dateModified", "publisher", "mainEntityOfPage"},
+    "BreadcrumbList": {"name", "position", "item"},
+    "LocalBusiness": {"url", "image", "geo", "openingHoursSpecification", "sameAs", "aggregateRating"},
+    "Organization": {"logo", "sameAs", "contactPoint"},
+    "Product": {"image", "description", "sku", "brand", "aggregateRating", "review"},
+    "ProductGroup": {"variesBy", "brand", "description"},
+    "Review": {"reviewBody", "datePublished", "publisher"},
+    "VideoObject": {"duration", "contentUrl", "embedUrl", "publisher", "transcript"},
+    "WebSite": {"potentialAction"},
+}
+
+PLACEHOLDER_MARKERS = ("[", "REPLACE", "TODO", "INSERT", "example.com")
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def schema_type_names(value: Any) -> list[str]:
+    names = []
+    for item in as_list(value):
+        if isinstance(item, str):
+            names.append(item)
+    return names
+
+
+def iter_schema_nodes(data: Any, path: str = "$") -> Iterable[tuple[str, dict[str, Any]]]:
+    """Yield every JSON-LD object, including @graph and nested entity objects."""
+    if isinstance(data, list):
+        for index, item in enumerate(data):
+            yield from iter_schema_nodes(item, f"{path}[{index}]")
+        return
+    if not isinstance(data, dict):
+        return
+    yield path, data
+    graph = data.get("@graph")
+    if isinstance(graph, list):
+        for index, item in enumerate(graph):
+            yield from iter_schema_nodes(item, f"{path}.@graph[{index}]")
+    for key, value in data.items():
+        if key in {"@context", "@graph"}:
+            continue
+        if isinstance(value, dict):
+            yield from iter_schema_nodes(value, f"{path}.{key}")
+        elif isinstance(value, list):
+            for index, item in enumerate(value):
+                if isinstance(item, dict):
+                    yield from iter_schema_nodes(item, f"{path}.{key}[{index}]")
+
+
+def load_source_html(source: str, timeout: int = 15) -> tuple[str, str, dict[str, Any]]:
+    """Load local files before falling back to seo_common URL detection."""
+    if os.path.isfile(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), source, {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def extract_schema_documents(source: str, timeout: int = 15) -> tuple[list[Any], dict[str, Any]]:
+    html_or_json, final_url, fetch = load_source_html(source, timeout=timeout)
+    text = (html_or_json or "").strip()
+    documents: list[Any] = []
+    if text.startswith("{") or text.startswith("["):
+        try:
+            documents.append(json.loads(text))
+        except json.JSONDecodeError:
+            pass
+    if not documents and html_or_json:
+        parsed = parse_html(html_or_json, final_url or source)
+        documents.extend(item for item in parsed.get("schema", []) if not (isinstance(item, dict) and item.get("error")))
+    return documents, {"source": source, "final_url": final_url or source, "fetch": fetch}
+
+
+def find_schema_nodes(documents: list[Any], schema_type: str | None = None) -> list[dict[str, Any]]:
+    rows = []
+    for doc_index, doc in enumerate(documents):
+        for path, node in iter_schema_nodes(doc, f"$[{doc_index}]"):
+            types = schema_type_names(node.get("@type"))
+            if not types:
+                continue
+            if schema_type and schema_type not in types:
+                continue
+            rows.append({"path": path, "types": types, "node": node})
+    return rows
+
+
+def has_value(node: dict[str, Any], prop: str) -> bool:
+    if prop not in node:
+        return False
+    value = node[prop]
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict)):
+        return bool(value)
+    return True
+
+
+def contains_placeholder(value: Any) -> bool:
+    text = json.dumps(value, ensure_ascii=False) if not isinstance(value, str) else value
+    upper = text.upper()
+    return any(marker.upper() in upper for marker in PLACEHOLDER_MARKERS)
+
+
+def validate_schema_required_props(documents: list[Any], schema_type: str | None = None) -> dict[str, Any]:
+    rows = []
+    issues = []
+    nodes = find_schema_nodes(documents, schema_type)
+    for row in nodes:
+        node = row["node"]
+        primary_type = row["types"][0]
+        required = set()
+        recommended = set()
+        for type_name in row["types"]:
+            required.update(REQUIRED_PROPS.get(type_name, set()))
+            recommended.update(RECOMMENDED_PROPS.get(type_name, set()))
+        missing_required = sorted(prop for prop in required if not has_value(node, prop))
+        missing_recommended = sorted(prop for prop in recommended if not has_value(node, prop))
+        placeholders = sorted(prop for prop, value in node.items() if contains_placeholder(value))
+        for prop in missing_required:
+            issues.append(issue("error", f"{primary_type} is missing required property '{prop}'", evidence=row["path"]))
+        for prop in missing_recommended:
+            issues.append(issue("warning", f"{primary_type} is missing recommended property '{prop}'", evidence=row["path"]))
+        for prop in placeholders:
+            issues.append(issue("warning", f"{primary_type} property '{prop}' appears to contain placeholder text", evidence=row["path"]))
+        rows.append(
+            {
+                "path": row["path"],
+                "types": row["types"],
+                "missing_required": missing_required,
+                "missing_recommended": missing_recommended,
+                "placeholder_properties": placeholders,
+            }
+        )
+    return {
+        "schema_nodes": len(nodes),
+        "checked_type": schema_type,
+        "rows": rows,
+        "issues": issues,
+        "summary": {
+            "errors": sum(1 for item in issues if item["severity"] == "error"),
+            "warnings": sum(1 for item in issues if item["severity"] == "warning"),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate required/recommended JSON-LD properties")
+    parser.add_argument("source", help="URL, HTML file, or JSON-LD file")
+    parser.add_argument("--type", dest="schema_type", help="Limit checks to one schema type, e.g. Product")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    documents, meta = extract_schema_documents(args.source, timeout=args.timeout)
+    result = validate_schema_required_props(documents, args.schema_type)
+    result.update({"source": args.source, "final_url": meta["final_url"]})
+    lines = [
+        f"Schema required properties for {args.source}",
+        f"Nodes checked: {result['schema_nodes']}  Errors: {result['summary']['errors']}  Warnings: {result['summary']['warnings']}",
+    ] + [f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/schema_template_generator.py
+++ b/.claude/skills/seo/scripts/schema_template_generator.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Generate JSON-LD templates from bundled schema templates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from schema_required_props import load_source_html
+from seo_common import parse_html, print_json_or_text
+
+
+TEMPLATE_PATH = Path(__file__).resolve().parents[1] / "resources" / "schema" / "templates.json"
+
+FALLBACK_TEMPLATES: dict[str, dict[str, Any]] = {
+    "Product": {
+        "type": "Product",
+        "description": "Standard ecommerce product page with Offer, product identifiers, images, and rating/review hooks.",
+        "template": {
+            "@context": "https://schema.org",
+            "@type": "Product",
+            "name": "[Product Name]",
+            "description": "[Product Description]",
+            "image": ["[Product Image URL]"],
+            "sku": "[SKU]",
+            "brand": {"@type": "Brand", "name": "[Brand Name]"},
+            "offers": {
+                "@type": "Offer",
+                "url": "[Product URL]",
+                "price": "[Price]",
+                "priceCurrency": "USD",
+                "availability": "https://schema.org/InStock",
+            },
+        },
+    },
+    "Review": {
+        "type": "Review",
+        "description": "Review markup for first-party or editorial reviews with rating and reviewed entity.",
+        "template": {
+            "@context": "https://schema.org",
+            "@type": "Review",
+            "itemReviewed": {"@type": "Thing", "name": "[Reviewed Item]"},
+            "reviewRating": {"@type": "Rating", "ratingValue": "[1-5]", "bestRating": "5", "worstRating": "1"},
+            "author": {"@type": "Person", "name": "[Reviewer Name]"},
+            "reviewBody": "[Review text]",
+            "datePublished": "[YYYY-MM-DD]",
+        },
+    },
+}
+
+
+def load_templates(path: Path = TEMPLATE_PATH) -> dict[str, dict[str, Any]]:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    templates = {item["type"]: item for item in data.get("templates", [])}
+    templates.update({key: value for key, value in FALLBACK_TEMPLATES.items() if key not in templates})
+    return templates
+
+
+def detect_template_type(source: str, timeout: int = 15) -> str:
+    html, final_url, _ = load_source_html(source, timeout=timeout)
+    parsed = parse_html(html, final_url or source) if html else {}
+    text = " ".join(
+        [
+            parsed.get("title") or "",
+            parsed.get("meta_description") or "",
+            " ".join(parsed.get("headings", {}).get("h1", [])),
+        ]
+    ).lower()
+    schema_types = []
+    for doc in parsed.get("schema", []):
+        if isinstance(doc, dict):
+            value = doc.get("@type")
+            schema_types.extend(value if isinstance(value, list) else [value])
+    for type_name in schema_types:
+        if type_name in load_templates():
+            return type_name
+    if any(word in text for word in ("video", "webinar", "watch")):
+        return "VideoObject"
+    if any(word in text for word in ("product", "price", "buy", "cart")):
+        return "ProductGroup"
+    if any(word in text for word in ("near me", "hours", "location", "appointment")):
+        return "LocalBusiness"
+    if any(word in text for word in ("blog", "guide", "article")):
+        return "BlogPosting"
+    return "WebSite"
+
+
+def get_template(schema_type: str, compact: bool = False) -> dict[str, Any]:
+    templates = load_templates()
+    if schema_type not in templates:
+        available = ", ".join(sorted(templates))
+        raise SystemExit(f"Unknown template type '{schema_type}'. Available: {available}")
+    template = deepcopy(templates[schema_type]["template"])
+    if compact:
+        return template
+    return {
+        "type": schema_type,
+        "description": templates[schema_type].get("description"),
+        "json_ld": template,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a JSON-LD template from bundled schema templates")
+    parser.add_argument("--type", dest="schema_type", help="Schema type to generate")
+    parser.add_argument("--detect-from", help="URL or HTML file to infer a page/schema type")
+    parser.add_argument("--list", action="store_true", help="List available template types")
+    parser.add_argument("--compact", action="store_true", help="Print only the JSON-LD object")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON instead of a script tag")
+    args = parser.parse_args()
+
+    templates = load_templates()
+    if args.list:
+        result = {"templates": [{"type": key, "description": value.get("description")} for key, value in sorted(templates.items())]}
+        print_json_or_text(result, args.json, [item["type"] for item in result["templates"]])
+        return
+    schema_type = args.schema_type or (detect_template_type(args.detect_from, args.timeout) if args.detect_from else None)
+    if not schema_type:
+        raise SystemExit("Provide --type, --detect-from, or --list.")
+    result = get_template(schema_type, compact=args.compact)
+    payload = result if args.compact else result["json_ld"]
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print('<script type="application/ld+json">')
+        print(json.dumps(payload, indent=2))
+        print("</script>")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/security_headers.py
+++ b/.claude/skills/seo/scripts/security_headers.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Check security headers relevant to SEO trust signals.
+
+Validates HTTPS, HSTS, CSP, X-Frame-Options, X-Content-Type-Options,
+Referrer-Policy, and Permissions-Policy.
+
+Usage:
+    python security_headers.py https://example.com
+    python security_headers.py https://example.com --json
+"""
+
+import argparse
+import json
+import sys
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_get
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_get
+
+
+SECURITY_HEADERS = {
+    "strict-transport-security": {
+        "label": "HSTS (Strict-Transport-Security)",
+        "weight": 20,
+        "description": "Forces browsers to use HTTPS. Prevents downgrade attacks.",
+        "recommendation": 'Add header: Strict-Transport-Security: max-age=31536000; includeSubDomains',
+    },
+    "content-security-policy": {
+        "label": "Content-Security-Policy (CSP)",
+        "weight": 15,
+        "description": "Prevents XSS, clickjacking, and code injection.",
+        "recommendation": "Add a Content-Security-Policy header restricting script/style sources.",
+    },
+    "x-frame-options": {
+        "label": "X-Frame-Options",
+        "weight": 10,
+        "description": "Prevents clickjacking by controlling iframe embedding.",
+        "recommendation": "Add header: X-Frame-Options: SAMEORIGIN",
+    },
+    "x-content-type-options": {
+        "label": "X-Content-Type-Options",
+        "weight": 10,
+        "description": "Prevents MIME-type sniffing.",
+        "recommendation": "Add header: X-Content-Type-Options: nosniff",
+    },
+    "referrer-policy": {
+        "label": "Referrer-Policy",
+        "weight": 10,
+        "description": "Controls how much referrer info is shared.",
+        "recommendation": "Add header: Referrer-Policy: strict-origin-when-cross-origin",
+    },
+    "permissions-policy": {
+        "label": "Permissions-Policy",
+        "weight": 10,
+        "description": "Controls browser feature access (camera, microphone, geolocation).",
+        "recommendation": "Add header: Permissions-Policy: camera=(), microphone=(), geolocation=()",
+    },
+}
+
+
+def check_security_headers(url: str, timeout: int = 15) -> dict:
+    """
+    Check security headers for a URL.
+
+    Args:
+        url: URL to check
+        timeout: Request timeout in seconds
+
+    Returns:
+        Dictionary with security header analysis
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = f"https://{url}"
+        parsed = urlparse(url)
+
+    result = {
+        "url": url,
+        "score": 0,
+        "https": False,
+        "headers_present": {},
+        "headers_missing": {},
+        "header_values": {},
+        "issues": [],
+        "recommendations": [],
+        "error": None,
+    }
+
+    try:
+        resp = safe_get(url, timeout=timeout, headers=default_headers(), allow_redirects=True)
+
+        # Check HTTPS
+        if resp.url.startswith("https://"):
+            result["https"] = True
+            result["score"] += 25
+        else:
+            result["issues"].append("🔴 Site not using HTTPS — critical for SEO and trust")
+            result["recommendations"].append("Migrate to HTTPS and set up 301 redirects from HTTP")
+
+        # Check each security header
+        response_headers = {k.lower(): v for k, v in resp.headers.items()}
+
+        for header_key, header_info in SECURITY_HEADERS.items():
+            if header_key in response_headers:
+                value = response_headers[header_key]
+                result["headers_present"][header_info["label"]] = value
+                result["header_values"][header_key] = value
+                result["score"] += header_info["weight"]
+
+                # Validate HSTS specifics
+                if header_key == "strict-transport-security":
+                    if "max-age=" in value.lower():
+                        try:
+                            max_age = int(value.lower().split("max-age=")[1].split(";")[0].strip())
+                            if max_age < 31536000:
+                                result["issues"].append(
+                                    f"⚠️ HSTS max-age is {max_age}s — recommend at least 31536000 (1 year)"
+                                )
+                        except (ValueError, IndexError):
+                            pass
+                    if "includesubdomains" not in value.lower():
+                        result["issues"].append("⚠️ HSTS missing includeSubDomains directive")
+            else:
+                result["headers_missing"][header_info["label"]] = header_info["description"]
+                result["recommendations"].append(
+                    f"{header_info['label']}: {header_info['recommendation']}"
+                )
+
+        # Cap score at 100
+        result["score"] = min(result["score"], 100)
+
+        # Summary issues
+        missing_count = len(result["headers_missing"])
+        if missing_count > 3:
+            result["issues"].append(f"🔴 {missing_count} security headers missing — poor security posture")
+        elif missing_count > 0:
+            result["issues"].append(f"⚠️ {missing_count} security header(s) missing")
+
+    except requests.exceptions.RequestException as e:
+        result["error"] = str(e)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check security headers for SEO")
+    parser.add_argument("url", help="URL to check")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+    result = check_security_headers(args.url)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    print(f"Security Headers — {result['url']}")
+    print("=" * 50)
+
+    # HTTPS status
+    https_icon = "✅" if result["https"] else "🔴"
+    print(f"{https_icon} HTTPS: {'Yes' if result['https'] else 'No'}")
+    print(f"Security Score: {result['score']}/100")
+
+    if result["headers_present"]:
+        print(f"\n✅ Present ({len(result['headers_present'])}):")
+        for header, value in result["headers_present"].items():
+            print(f"  {header}: {value[:80]}")
+
+    if result["headers_missing"]:
+        print(f"\n❌ Missing ({len(result['headers_missing'])}):")
+        for header, desc in result["headers_missing"].items():
+            print(f"  {header}")
+            print(f"    → {desc}")
+
+    if result["issues"]:
+        print(f"\nIssues:")
+        for issue in result["issues"]:
+            print(f"  {issue}")
+
+    if result["recommendations"]:
+        print(f"\nRecommendations:")
+        for rec in result["recommendations"][:5]:
+            print(f"  💡 {rec}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/seo_common.py
+++ b/.claude/skills/seo/scripts/seo_common.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Small shared helpers for standalone SEO CLI scripts."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+from html.parser import HTMLParser
+from typing import Iterable
+from urllib.parse import parse_qs, urljoin, urlparse, urlunparse
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - exercised by users without deps
+    requests = None
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:  # pragma: no cover - exercised by users without deps
+    BeautifulSoup = None
+
+try:
+    from lib.safe_http import AGENTIC_SEO_USER_AGENT, safe_request
+except ImportError:
+    from scripts.lib.safe_http import AGENTIC_SEO_USER_AGENT, safe_request
+
+
+USER_AGENT = AGENTIC_SEO_USER_AGENT
+HTML_CTYPES = ("text/html", "application/xhtml+xml")
+XML_CTYPES = ("xml", "text/plain", "application/octet-stream")
+
+
+def require_requests() -> None:
+    if requests is None:
+        print("Error: requests library required. Install with: pip install requests", file=sys.stderr)
+        sys.exit(1)
+
+
+def require_bs4() -> None:
+    if BeautifulSoup is None:
+        print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4", file=sys.stderr)
+        sys.exit(1)
+
+
+def normalize_url(url: str, base: str | None = None, default_scheme: str = "https") -> str:
+    url = (url or "").strip()
+    if base:
+        url = urljoin(base, url)
+    parsed = urlparse(url)
+    if not parsed.scheme and not base:
+        url = f"{default_scheme}://{url}"
+        parsed = urlparse(url)
+    if parsed.scheme in ("http", "https"):
+        path = parsed.path or "/"
+        parsed = parsed._replace(fragment="", path=path)
+        return urlunparse(parsed)
+    return url
+
+
+def is_responsive_fill_image(img) -> bool:
+    if img.get("data-nimg") == "fill":
+        return True
+    style = re.sub(r"\s+", "", (img.get("style") or "").lower())
+    return "position:absolute" in style and "width:100%" in style and "height:100%" in style
+
+
+def origin(url: str) -> str:
+    parsed = urlparse(normalize_url(url))
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def clean_url(url: str) -> str:
+    parsed = urlparse(normalize_url(url))
+    return urlunparse(parsed._replace(fragment=""))
+
+
+def same_host(a: str, b: str, include_www_variant: bool = True) -> bool:
+    host_a = urlparse(normalize_url(a)).netloc.lower()
+    host_b = urlparse(normalize_url(b)).netloc.lower()
+    if include_www_variant:
+        host_a = host_a[4:] if host_a.startswith("www.") else host_a
+        host_b = host_b[4:] if host_b.startswith("www.") else host_b
+    return host_a == host_b
+
+
+def fetch_url(
+    url: str,
+    method: str = "GET",
+    timeout: int = 15,
+    allow_redirects: bool = True,
+    max_bytes: int = 2_000_000,
+    extra_headers: dict | None = None,
+) -> dict:
+    require_requests()
+    url = normalize_url(url)
+    parsed = urlparse(url)
+    result = {
+        "input_url": url,
+        "url": url,
+        "status": None,
+        "headers": {},
+        "text": "",
+        "bytes": 0,
+        "redirect_chain": [],
+        "error": None,
+    }
+    if parsed.scheme not in ("http", "https"):
+        result["error"] = f"Unsupported URL scheme: {parsed.scheme}"
+        return result
+
+    headers = {"Accept": "text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8"}
+    if extra_headers:
+        headers.update(extra_headers)
+
+    try:
+        response = safe_request(
+            method,
+            url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=allow_redirects,
+            max_response_bytes=max_bytes,
+        )
+        result["url"] = response.url
+        result["status"] = response.status_code
+        result["headers"] = {str(k).lower(): v for k, v in response.headers.items()}
+        result["redirect_chain"] = [r.url for r in response.history]
+
+        if method.upper() != "HEAD":
+            result["bytes"] = len(response.content)
+            result["text"] = response.text
+    except requests.exceptions.RequestException as exc:
+        result["error"] = str(exc)
+    return result
+
+
+def read_urls(values: list[str] | None = None, file_path: str | None = None) -> list[str]:
+    urls: list[str] = []
+    for value in values or []:
+        if value:
+            urls.append(value.strip())
+    if file_path:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            urls.extend(line.strip() for line in fh if line.strip() and not line.lstrip().startswith("#"))
+    seen = set()
+    normalized = []
+    for url in urls:
+        nurl = normalize_url(url)
+        if nurl not in seen:
+            seen.add(nurl)
+            normalized.append(nurl)
+    return normalized
+
+
+def load_html(source: str, timeout: int = 15) -> tuple[str, str, dict]:
+    if re.match(r"^https?://", source, re.I) or "." in source and "/" not in source:
+        fetched = fetch_url(source, timeout=timeout)
+        return fetched.get("text") or "", fetched.get("url") or normalize_url(source), fetched
+    with open(source, "r", encoding="utf-8") as fh:
+        html = fh.read()
+    return html, "", {"url": source, "status": None, "headers": {}, "error": None}
+
+
+def parse_html(html: str, base_url: str = "") -> dict:
+    require_bs4()
+    soup = BeautifulSoup(html or "", "lxml" if "lxml" in sys.modules else "html.parser")
+
+    def text_or_none(tag):
+        return tag.get_text(" ", strip=True) if tag else None
+
+    title = text_or_none(soup.find("title"))
+    meta = {}
+    for tag in soup.find_all("meta"):
+        key = (tag.get("name") or tag.get("property") or tag.get("http-equiv") or "").strip().lower()
+        if key:
+            meta[key] = tag.get("content", "")
+
+    canonical_tag = soup.find("link", rel=lambda value: value and "canonical" in value)
+    canonical = canonical_tag.get("href") if canonical_tag else None
+    if canonical and base_url:
+        canonical = normalize_url(canonical, base_url)
+
+    links = []
+    for tag in soup.find_all("a", href=True):
+        href = tag.get("href", "").strip()
+        if not href or href.startswith(("#", "javascript:", "mailto:", "tel:", "data:")):
+            continue
+        abs_url = normalize_url(href, base_url) if base_url else href
+        links.append({
+            "href": abs_url,
+            "text": tag.get_text(" ", strip=True)[:160],
+            "rel": tag.get("rel") or [],
+        })
+
+    images = []
+    for img in soup.find_all("img"):
+        src = img.get("src") or img.get("data-src") or ""
+        if src and base_url:
+            src = normalize_url(src, base_url)
+        is_responsive_fill = is_responsive_fill_image(img)
+        images.append({
+            "src": src,
+            "alt": img.get("alt"),
+            "width": img.get("width"),
+            "height": img.get("height"),
+            "is_responsive_fill": is_responsive_fill,
+            "loading": img.get("loading"),
+            "srcset": img.get("srcset"),
+            "sizes": img.get("sizes"),
+            "fetchpriority": img.get("fetchpriority"),
+            "decoding": img.get("decoding"),
+        })
+
+    schema = []
+    for script in soup.find_all("script", type=lambda v: v and "ld+json" in v):
+        raw = script.string or script.get_text() or ""
+        try:
+            data = json.loads(raw)
+            schema.append(data)
+        except json.JSONDecodeError:
+            schema.append({"error": "invalid_json", "snippet": raw[:160]})
+
+    for element in soup(["script", "style", "noscript", "template"]):
+        element.decompose()
+    body_text = soup.get_text(" ", strip=True)
+    words = re.findall(r"\b[\w'-]+\b", body_text)
+
+    return {
+        "title": title,
+        "meta_description": meta.get("description"),
+        "meta_robots": meta.get("robots"),
+        "viewport": meta.get("viewport"),
+        "canonical": canonical,
+        "lang": (soup.html.get("lang") if soup.html else None),
+        "headings": {f"h{i}": [h.get_text(" ", strip=True) for h in soup.find_all(f"h{i}") if h.get_text(strip=True)] for i in range(1, 7)},
+        "links": links,
+        "images": images,
+        "schema": schema,
+        "word_count": len(words),
+        "body_text": body_text,
+        "forms": len(soup.find_all("form")),
+        "landmarks": {
+            "main": len(soup.find_all("main")),
+            "nav": len(soup.find_all("nav")),
+            "header": len(soup.find_all("header")),
+            "footer": len(soup.find_all("footer")),
+        },
+        "labels": len(soup.find_all("label")),
+        "inputs": len(soup.find_all(["input", "select", "textarea"])),
+        "buttons": len(soup.find_all(["button"])) + len(soup.find_all("a", role="button")),
+        "soup": soup,
+    }
+
+
+def issue(severity: str, message: str, url: str | None = None, evidence: str | None = None) -> dict:
+    return {"severity": severity, "message": message, "url": url, "evidence": evidence}
+
+
+def parse_robots_txt(content: str) -> dict:
+    groups: list[dict] = []
+    current: dict | None = None
+    sitemaps: list[str] = []
+    crawl_delays: dict[str, float] = {}
+    for raw_line in (content or "").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line or ":" not in line:
+            continue
+        name, value = line.split(":", 1)
+        name = name.strip().lower()
+        value = value.strip()
+        if name == "user-agent":
+            if current is None or current.get("rules"):
+                current = {"agents": [], "rules": []}
+                groups.append(current)
+            current["agents"].append(value.lower())
+        elif name in ("allow", "disallow") and current is not None:
+            current["rules"].append((name, value))
+        elif name == "sitemap":
+            sitemaps.append(value)
+        elif name == "crawl-delay" and current is not None:
+            try:
+                delay = float(value)
+            except ValueError:
+                continue
+            for agent in current["agents"]:
+                crawl_delays[agent] = delay
+    return {"groups": groups, "sitemaps": sitemaps, "crawl_delays": crawl_delays}
+
+
+def _robots_pattern_to_regex(pattern: str) -> re.Pattern:
+    escaped = re.escape(pattern).replace("\\*", ".*")
+    if escaped.endswith("\\$"):
+        escaped = escaped[:-2] + "$"
+    return re.compile("^" + escaped)
+
+
+def robots_allowed(parsed_robots: dict | None, url: str, user_agent: str = "*") -> tuple[bool, str]:
+    if not parsed_robots:
+        return True, "no robots.txt"
+    path = urlparse(normalize_url(url)).path or "/"
+    ua = user_agent.lower()
+    matches: list[tuple[int, str, str]] = []
+    for group in parsed_robots.get("groups", []):
+        agents = group.get("agents", [])
+        if not any(agent == "*" or agent in ua or ua in agent for agent in agents):
+            continue
+        for directive, pattern in group.get("rules", []):
+            if directive == "disallow" and pattern == "":
+                continue
+            if _robots_pattern_to_regex(pattern).search(path):
+                matches.append((len(pattern), directive, pattern))
+    if not matches:
+        return True, "no matching rule"
+    matches.sort(key=lambda item: (item[0], item[1] == "allow"), reverse=True)
+    _, directive, pattern = matches[0]
+    return directive == "allow", f"{directive}: {pattern}"
+
+
+def fetch_robots(site_url: str, timeout: int = 15) -> dict:
+    robots_url = origin(site_url) + "/robots.txt"
+    fetched = fetch_url(robots_url, timeout=timeout, max_bytes=500_000)
+    parsed = parse_robots_txt(fetched.get("text") or "") if fetched.get("status") == 200 else None
+    return {"url": robots_url, "fetch": fetched, "parsed": parsed}
+
+
+def discover_sitemap_urls(site_url: str, timeout: int = 15) -> list[str]:
+    base = origin(site_url)
+    candidates = []
+    robots = fetch_robots(site_url, timeout=timeout)
+    if robots.get("parsed"):
+        candidates.extend(robots["parsed"].get("sitemaps", []))
+    candidates.extend([base + "/sitemap.xml", base + "/sitemap_index.xml", base + "/sitemap-index.xml"])
+    seen = set()
+    output = []
+    for candidate in candidates:
+        url = normalize_url(candidate, base)
+        if url not in seen:
+            seen.add(url)
+            output.append(url)
+    return output
+
+
+def parse_sitemap_xml(xml_text: str, sitemap_url: str = "") -> dict:
+    text = xml_text or ""
+    if text[:2] == "\x1f\x8b":
+        text = gzip.decompress(text.encode("latin1")).decode("utf-8", errors="replace")
+    try:
+        root = ET.fromstring(text.encode("utf-8"))
+    except ET.ParseError as exc:
+        return {"type": "invalid", "urls": [], "sitemaps": [], "error": str(exc)}
+
+    def local(tag: str) -> str:
+        return tag.split("}", 1)[-1]
+
+    urls = []
+    children = list(root)
+    if local(root.tag) == "sitemapindex":
+        for sm in root:
+            loc = sm.findtext("{*}loc") or sm.findtext("loc")
+            if loc:
+                urls.append({"loc": normalize_url(loc, sitemap_url), "lastmod": sm.findtext("{*}lastmod") or sm.findtext("lastmod")})
+        return {"type": "sitemapindex", "urls": [], "sitemaps": urls, "error": None}
+
+    if local(root.tag) == "urlset" or any(local(child.tag) == "url" for child in children):
+        for node in root.findall("{*}url") or root.findall("url"):
+            loc = node.findtext("{*}loc") or node.findtext("loc")
+            if not loc:
+                continue
+            urls.append({
+                "loc": normalize_url(loc, sitemap_url),
+                "lastmod": node.findtext("{*}lastmod") or node.findtext("lastmod"),
+                "changefreq": node.findtext("{*}changefreq") or node.findtext("changefreq"),
+                "priority": node.findtext("{*}priority") or node.findtext("priority"),
+            })
+        return {"type": "urlset", "urls": urls, "sitemaps": [], "error": None}
+
+    return {"type": "unknown", "urls": [], "sitemaps": [], "error": f"Unknown root element: {root.tag}"}
+
+
+def extract_directives(value: str | None) -> set[str]:
+    if not value:
+        return set()
+    cleaned = value.lower().replace(";", ",")
+    return {part.strip() for part in cleaned.split(",") if part.strip()}
+
+
+def print_json_or_text(result: dict, as_json: bool, text_lines: Iterable[str]) -> None:
+    if as_json:
+        print(json.dumps(result, indent=2, sort_keys=False))
+    else:
+        for line in text_lines:
+            print(line)

--- a/.claude/skills/seo/scripts/sitemap_checker.py
+++ b/.claude/skills/seo/scripts/sitemap_checker.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Discover and validate XML sitemaps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+
+from seo_common import (
+    discover_sitemap_urls,
+    fetch_url,
+    issue,
+    normalize_url,
+    parse_html,
+    parse_sitemap_xml,
+    print_json_or_text,
+    same_host,
+)
+
+
+def check_sitemaps(site_url: str, sitemap_urls: list[str] | None = None, fetch_urls: bool = False, timeout: int = 15, max_urls: int = 100) -> dict:
+    sitemap_urls = sitemap_urls or discover_sitemap_urls(site_url, timeout=timeout)
+    result = {
+        "site": normalize_url(site_url),
+        "sitemaps_checked": [],
+        "urls": [],
+        "summary": {"sitemaps": 0, "urls": 0, "indexes": 0, "issues": 0},
+        "issues": [],
+    }
+    queue = list(dict.fromkeys(sitemap_urls))
+    seen_sitemaps = set()
+    seen_urls = set()
+
+    while queue and len(seen_sitemaps) < 25:
+        sm_url = normalize_url(queue.pop(0), site_url)
+        if sm_url in seen_sitemaps:
+            continue
+        seen_sitemaps.add(sm_url)
+        fetched = fetch_url(sm_url, timeout=timeout, max_bytes=8_000_000)
+        entry = {
+            "url": sm_url,
+            "status": fetched.get("status"),
+            "final_url": fetched.get("url"),
+            "redirects": fetched.get("redirect_chain", []),
+            "type": None,
+            "url_count": 0,
+            "sitemap_count": 0,
+            "error": fetched.get("error"),
+        }
+        if fetched.get("status") != 200:
+            result["issues"].append(issue("error", f"Sitemap returned HTTP {fetched.get('status')}", sm_url, fetched.get("error")))
+            result["sitemaps_checked"].append(entry)
+            continue
+        parsed = parse_sitemap_xml(fetched.get("text") or "", sm_url)
+        entry["type"] = parsed["type"]
+        entry["error"] = parsed["error"]
+        entry["url_count"] = len(parsed["urls"])
+        entry["sitemap_count"] = len(parsed["sitemaps"])
+        if parsed["error"]:
+            result["issues"].append(issue("error", f"Invalid sitemap XML: {parsed['error']}", sm_url))
+        if parsed["type"] == "sitemapindex":
+            result["summary"]["indexes"] += 1
+            queue.extend(item["loc"] for item in parsed["sitemaps"])
+        if parsed["type"] == "urlset" and len(parsed["urls"]) > 50000:
+            result["issues"].append(issue("error", "Sitemap exceeds 50,000 URL limit", sm_url, str(len(parsed["urls"]))))
+
+        for row in parsed["urls"]:
+            loc = row["loc"]
+            if loc in seen_urls:
+                result["issues"].append(issue("warning", "Duplicate URL in sitemap set", loc))
+                continue
+            seen_urls.add(loc)
+            url_entry = {"url": loc, **{k: v for k, v in row.items() if k != "loc"}, "checks": {}}
+            if not loc.startswith("https://"):
+                result["issues"].append(issue("warning", "Sitemap URL is not HTTPS", loc))
+            if not same_host(site_url, loc):
+                result["issues"].append(issue("warning", "Sitemap URL is cross-host", loc))
+            if not row.get("lastmod"):
+                result["issues"].append(issue("info", "Sitemap URL missing lastmod", loc))
+            elif not re.match(r"^\d{4}-\d{2}-\d{2}", row["lastmod"]):
+                result["issues"].append(issue("warning", "Sitemap lastmod is not ISO-like", loc, row["lastmod"]))
+            elif row["lastmod"][:10] > datetime.now(timezone.utc).date().isoformat():
+                result["issues"].append(issue("warning", "Sitemap lastmod is in the future", loc, row["lastmod"]))
+
+            if fetch_urls and len(result["urls"]) < max_urls:
+                page = fetch_url(loc, timeout=timeout, max_bytes=1_000_000)
+                url_entry["checks"]["status"] = page.get("status")
+                url_entry["checks"]["final_url"] = page.get("url")
+                url_entry["checks"]["redirects"] = page.get("redirect_chain", [])
+                if page.get("status") and page["status"] >= 400:
+                    result["issues"].append(issue("error", f"Sitemap URL returns HTTP {page['status']}", loc))
+                if page.get("redirect_chain"):
+                    result["issues"].append(issue("warning", "Sitemap URL redirects", loc, " -> ".join(page["redirect_chain"] + [page.get("url", "")])))
+                ctype = page.get("headers", {}).get("content-type", "")
+                if page.get("text") and "html" in ctype:
+                    html = parse_html(page["text"], page.get("url") or loc)
+                    url_entry["checks"]["meta_robots"] = html.get("meta_robots")
+                    url_entry["checks"]["canonical"] = html.get("canonical")
+                    if html.get("meta_robots") and "noindex" in html["meta_robots"].lower():
+                        result["issues"].append(issue("error", "Sitemap URL has meta noindex", loc, html["meta_robots"]))
+                    if html.get("canonical") and normalize_url(html["canonical"]) != normalize_url(page.get("url") or loc):
+                        result["issues"].append(issue("warning", "Canonical does not match sitemap URL", loc, html["canonical"]))
+            result["urls"].append(url_entry)
+        result["sitemaps_checked"].append(entry)
+
+    result["summary"]["sitemaps"] = len(result["sitemaps_checked"])
+    result["summary"]["urls"] = len(result["urls"])
+    result["summary"]["issues"] = len(result["issues"])
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Discover and validate XML sitemaps")
+    parser.add_argument("site", help="Site URL")
+    parser.add_argument("--sitemap", action="append", help="Explicit sitemap URL; can be repeated")
+    parser.add_argument("--fetch-urls", action="store_true", help="Fetch sitemap URLs for status/noindex/canonical checks")
+    parser.add_argument("--max-urls", type=int, default=100, help="Max sitemap URLs to fetch when --fetch-urls is used")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    result = check_sitemaps(args.site, args.sitemap, args.fetch_urls, args.timeout, args.max_urls)
+    lines = [
+        f"Sitemap check for {result['site']}",
+        f"Sitemaps: {result['summary']['sitemaps']}  URLs: {result['summary']['urls']}  Issues: {result['summary']['issues']}",
+    ] + [f"[{i['severity']}] {i['message']}: {i.get('url') or ''}" for i in result["issues"][:25]]
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/sitemap_generator.py
+++ b/.claude/skills/seo/scripts/sitemap_generator.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Generate sitemap XML or sitemap indexes from URL manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from datetime import date
+from urllib.parse import urlparse
+
+from seo_common import normalize_url
+
+
+def read_manifest(path: str | None) -> list[dict]:
+    rows = []
+    lines = sys.stdin.read().splitlines() if not path or path == "-" else open(path, "r", encoding="utf-8").read().splitlines()
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("{"):
+            data = json.loads(line)
+            url = data.get("url") or data.get("loc")
+            if url:
+                rows.append(data | {"url": normalize_url(url)})
+            continue
+        parts = [p.strip() for p in line.split(",")]
+        rows.append({"url": normalize_url(parts[0]), "lastmod": parts[1] if len(parts) > 1 and parts[1] else None})
+    return rows
+
+
+def build_urlset(rows: list[dict], default_lastmod: str | None = None) -> str:
+    ET.register_namespace("", "http://www.sitemaps.org/schemas/sitemap/0.9")
+    root = ET.Element("{http://www.sitemaps.org/schemas/sitemap/0.9}urlset")
+    for row in rows:
+        item = ET.SubElement(root, "url")
+        ET.SubElement(item, "loc").text = row["url"]
+        lastmod = row.get("lastmod") or default_lastmod
+        if lastmod:
+            ET.SubElement(item, "lastmod").text = lastmod
+        if row.get("changefreq"):
+            ET.SubElement(item, "changefreq").text = str(row["changefreq"])
+        if row.get("priority") is not None:
+            ET.SubElement(item, "priority").text = str(row["priority"])
+    return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+
+def build_index(sitemap_urls: list[str], default_lastmod: str | None = None) -> str:
+    ET.register_namespace("", "http://www.sitemaps.org/schemas/sitemap/0.9")
+    root = ET.Element("{http://www.sitemaps.org/schemas/sitemap/0.9}sitemapindex")
+    for url in sitemap_urls:
+        item = ET.SubElement(root, "sitemap")
+        ET.SubElement(item, "loc").text = normalize_url(url)
+        if default_lastmod:
+            ET.SubElement(item, "lastmod").text = default_lastmod
+    return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate sitemap XML from a URL manifest")
+    parser.add_argument("--input", "-i", help="URL manifest file; stdin when omitted. CSV lines: url,lastmod or JSONL")
+    parser.add_argument("--index", action="store_true", help="Treat input as sitemap URLs and emit sitemapindex")
+    parser.add_argument("--lastmod-today", action="store_true", help="Use today's date when lastmod is missing")
+    parser.add_argument("--json", "-j", action="store_true", help="Output metadata JSON instead of XML")
+    args = parser.parse_args()
+
+    rows = read_manifest(args.input)
+    default_lastmod = date.today().isoformat() if args.lastmod_today else None
+    urls = [row["url"] for row in rows]
+    xml = build_index(urls, default_lastmod) if args.index else build_urlset(rows, default_lastmod)
+    result = {
+        "type": "sitemapindex" if args.index else "urlset",
+        "count": len(urls),
+        "hosts": sorted({urlparse(url).netloc for url in urls}),
+        "xml": xml,
+    }
+    print(json.dumps(result, indent=2) if args.json else xml)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/social_meta.py
+++ b/.claude/skills/seo/scripts/social_meta.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Validate Open Graph and Twitter Card meta tags.
+
+Checks og:title, og:description, og:image, og:url, twitter:card, etc.
+against platform requirements and best practices.
+
+Usage:
+    python social_meta.py https://example.com
+    python social_meta.py https://example.com --json
+"""
+
+import argparse
+import json
+import sys
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library required. Install with: pip install requests")
+    sys.exit(1)
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError:
+    print("Error: beautifulsoup4 required. Install with: pip install beautifulsoup4")
+    sys.exit(1)
+
+try:
+    from lib.safe_http import default_headers, safe_get
+except ImportError:
+    from scripts.lib.safe_http import default_headers, safe_get
+
+
+HEADERS = default_headers()
+
+# Required and recommended OG tags
+OG_REQUIREMENTS = {
+    "og:title": {"required": True, "max_length": 60, "min_length": 10},
+    "og:description": {"required": True, "max_length": 200, "min_length": 50},
+    "og:image": {"required": True},
+    "og:url": {"required": True},
+    "og:type": {"required": True},
+    "og:site_name": {"required": False},
+    "og:locale": {"required": False},
+}
+
+# Twitter Card tags
+TWITTER_REQUIREMENTS = {
+    "twitter:card": {"required": True, "valid_values": ["summary", "summary_large_image", "app", "player"]},
+    "twitter:title": {"required": False, "max_length": 70},
+    "twitter:description": {"required": False, "max_length": 200},
+    "twitter:image": {"required": False},
+    "twitter:site": {"required": False},
+    "twitter:creator": {"required": False},
+}
+
+
+def check_social_meta(url: str, timeout: int = 15) -> dict:
+    """
+    Validate social media meta tags for a URL.
+
+    Args:
+        url: URL to check
+        timeout: Request timeout in seconds
+
+    Returns:
+        Dictionary with social meta analysis
+    """
+    result = {
+        "url": url,
+        "score": 0,
+        "og_tags": {},
+        "twitter_tags": {},
+        "og_present": [],
+        "og_missing": [],
+        "twitter_present": [],
+        "twitter_missing": [],
+        "issues": [],
+        "recommendations": [],
+        "preview": {
+            "title": None,
+            "description": None,
+            "image": None,
+            "site_name": None,
+        },
+        "error": None,
+    }
+
+    try:
+        resp = safe_get(url, timeout=timeout, headers=HEADERS)
+        if resp.status_code != 200:
+            result["error"] = f"HTTP {resp.status_code}"
+            return result
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+    except requests.exceptions.RequestException as e:
+        result["error"] = str(e)
+        return result
+
+    total_checks = 0
+    passed_checks = 0
+
+    # Extract Open Graph tags
+    for meta in soup.find_all("meta"):
+        prop = meta.get("property", "")
+        name = meta.get("name", "")
+        content = meta.get("content", "")
+
+        if prop.startswith("og:"):
+            result["og_tags"][prop] = content
+        if name.startswith("twitter:") or prop.startswith("twitter:"):
+            key = name or prop
+            result["twitter_tags"][key] = content
+
+    # Validate OG tags
+    for tag, rules in OG_REQUIREMENTS.items():
+        total_checks += 1
+        value = result["og_tags"].get(tag)
+
+        if value:
+            result["og_present"].append(tag)
+            passed_checks += 1
+
+            # Check length constraints
+            if "max_length" in rules and len(value) > rules["max_length"]:
+                result["issues"].append(
+                    f"⚠️ {tag} is too long ({len(value)} chars, max {rules['max_length']})"
+                )
+            if "min_length" in rules and len(value) < rules["min_length"]:
+                result["issues"].append(
+                    f"⚠️ {tag} is too short ({len(value)} chars, min {rules['min_length']})"
+                )
+
+            # Validate og:image
+            if tag == "og:image":
+                if not value.startswith(("http://", "https://")):
+                    result["issues"].append("⚠️ og:image should be an absolute URL")
+
+            # Validate og:url
+            if tag == "og:url":
+                if not value.startswith(("http://", "https://")):
+                    result["issues"].append("⚠️ og:url should be an absolute URL")
+
+        elif rules["required"]:
+            result["og_missing"].append(tag)
+            result["issues"].append(f"🔴 Missing required: {tag}")
+
+    # Validate Twitter tags
+    for tag, rules in TWITTER_REQUIREMENTS.items():
+        total_checks += 1
+        value = result["twitter_tags"].get(tag)
+
+        if value:
+            result["twitter_present"].append(tag)
+            passed_checks += 1
+
+            if "valid_values" in rules and value not in rules["valid_values"]:
+                result["issues"].append(
+                    f"⚠️ {tag} has invalid value '{value}' — "
+                    f"valid: {', '.join(rules['valid_values'])}"
+                )
+            if "max_length" in rules and len(value) > rules["max_length"]:
+                result["issues"].append(
+                    f"⚠️ {tag} is too long ({len(value)} chars, max {rules['max_length']})"
+                )
+        elif rules["required"]:
+            result["twitter_missing"].append(tag)
+            result["issues"].append(f"⚠️ Missing: {tag}")
+
+    # Calculate score
+    if total_checks > 0:
+        result["score"] = round((passed_checks / total_checks) * 100)
+
+    # Build preview
+    result["preview"]["title"] = (
+        result["og_tags"].get("og:title") or
+        result["twitter_tags"].get("twitter:title") or
+        (soup.title.string if soup.title else None)
+    )
+    result["preview"]["description"] = (
+        result["og_tags"].get("og:description") or
+        result["twitter_tags"].get("twitter:description")
+    )
+    result["preview"]["image"] = (
+        result["og_tags"].get("og:image") or
+        result["twitter_tags"].get("twitter:image")
+    )
+    result["preview"]["site_name"] = result["og_tags"].get("og:site_name", "")
+
+    # Recommendations
+    if not result["og_tags"]:
+        result["recommendations"].append(
+            "Add Open Graph tags for rich social media previews on Facebook, LinkedIn, etc."
+        )
+    if not result["twitter_tags"]:
+        result["recommendations"].append(
+            "Add Twitter Card tags for rich previews on X (Twitter)"
+        )
+    if result["og_tags"].get("og:image") and not result["og_tags"].get("og:image:width"):
+        result["recommendations"].append(
+            "Add og:image:width and og:image:height for optimal rendering (1200×630 recommended)"
+        )
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate social media meta tags")
+    parser.add_argument("url", help="URL to check")
+    parser.add_argument("--json", "-j", action="store_true", help="Output as JSON")
+
+    args = parser.parse_args()
+    result = check_social_meta(args.url)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return
+
+    if result["error"]:
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    print(f"Social Meta Tags — {result['url']}")
+    print("=" * 50)
+    print(f"Score: {result['score']}/100")
+
+    # OG Summary
+    print(f"\nOpen Graph ({len(result['og_present'])}/{len(OG_REQUIREMENTS)}):")
+    for tag in OG_REQUIREMENTS:
+        value = result["og_tags"].get(tag)
+        if value:
+            display = value[:60] + "..." if len(value) > 60 else value
+            print(f"  ✅ {tag}: {display}")
+        else:
+            req = "required" if OG_REQUIREMENTS[tag]["required"] else "optional"
+            icon = "🔴" if req == "required" else "ℹ️"
+            print(f"  {icon} {tag}: missing ({req})")
+
+    # Twitter Summary
+    print(f"\nTwitter Card ({len(result['twitter_present'])}/{len(TWITTER_REQUIREMENTS)}):")
+    for tag in TWITTER_REQUIREMENTS:
+        value = result["twitter_tags"].get(tag)
+        if value:
+            print(f"  ✅ {tag}: {value[:60]}")
+        else:
+            req = "required" if TWITTER_REQUIREMENTS[tag]["required"] else "optional"
+            icon = "⚠️" if req == "required" else "ℹ️"
+            print(f"  {icon} {tag}: missing ({req})")
+
+    # Preview
+    p = result["preview"]
+    if p["title"]:
+        print(f"\nSocial Preview:")
+        print(f"  Title: {p['title']}")
+        print(f"  Description: {(p['description'] or 'None')[:80]}")
+        print(f"  Image: {p['image'] or 'None'}")
+
+    if result["issues"]:
+        print(f"\nIssues:")
+        for issue in result["issues"]:
+            print(f"  {issue}")
+
+    if result["recommendations"]:
+        print(f"\nRecommendations:")
+        for rec in result["recommendations"]:
+            print(f"  💡 {rec}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/third_party_script_audit.py
+++ b/.claude/skills/seo/scripts/third_party_script_audit.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Audit third-party scripts and blocking JavaScript tags."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from urllib.parse import urlparse
+
+from seo_common import BeautifulSoup, fetch_url, load_html, require_bs4, same_host
+
+
+KNOWN_TAGS = {
+    "googletagmanager.com": "Google Tag Manager",
+    "google-analytics.com": "Google Analytics",
+    "googlesyndication.com": "Google Ads",
+    "doubleclick.net": "Google Ads",
+    "connect.facebook.net": "Meta Pixel",
+    "bat.bing.com": "Microsoft Advertising",
+    "hotjar.com": "Hotjar",
+    "clarity.ms": "Microsoft Clarity",
+    "segment.com": "Segment",
+    "cdn.segment.com": "Segment",
+    "intercom.io": "Intercom",
+    "js.stripe.com": "Stripe",
+}
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    path = Path(source)
+    if path.is_file():
+        return path.read_text(encoding="utf-8"), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _script_category(src: str) -> str | None:
+    host = urlparse(src).netloc.lower()
+    for domain, label in KNOWN_TAGS.items():
+        if host == domain or host.endswith(f".{domain}"):
+            return label
+    return None
+
+
+def _is_third_party(src: str, page_url: str) -> bool:
+    if not src.startswith(("http://", "https://")):
+        return False
+    if not page_url.startswith(("http://", "https://")):
+        return True
+    return not same_host(src, page_url)
+
+
+def audit(source: str, fetch_scripts: bool = False, timeout: int = 15) -> dict:
+    html, url, fetched = _load_source(source, timeout=timeout)
+    require_bs4()
+    soup = BeautifulSoup(html or "", "html.parser")
+    scripts = []
+    issues = []
+
+    for tag in soup.find_all("script"):
+        src = tag.get("src") or ""
+        row = {
+            "src": src,
+            "inline": not bool(src),
+            "async": tag.has_attr("async"),
+            "defer": tag.has_attr("defer"),
+            "type": tag.get("type") or "",
+            "third_party": _is_third_party(src, url),
+            "known_tag": _script_category(src),
+            "content_length": None,
+            "status": None,
+            "blocking": bool(src) and not tag.has_attr("async") and not tag.has_attr("defer") and tag.get("type") != "module",
+        }
+        if row["third_party"] and row["blocking"]:
+            issues.append({"severity": "warning", "message": "Third-party script can block rendering", "url": src})
+        if row["third_party"] and not row["known_tag"]:
+            issues.append({"severity": "info", "message": "Unclassified third-party script", "url": src})
+        if fetch_scripts and src.startswith(("http://", "https://")):
+            head = fetch_url(src, method="HEAD", timeout=timeout)
+            row["status"] = head.get("status")
+            length = head.get("headers", {}).get("content-length")
+            row["content_length"] = int(length) if length and length.isdigit() else None
+        scripts.append(row)
+
+    third_party = [row for row in scripts if row["third_party"]]
+    blocking_third_party = [row for row in third_party if row["blocking"]]
+    total_bytes = sum(row["content_length"] or 0 for row in third_party)
+    if len(third_party) >= 8:
+        issues.append({"severity": "warning", "message": "Many third-party script tags detected", "evidence": str(len(third_party))})
+    if total_bytes > 300_000:
+        issues.append({"severity": "warning", "message": "Third-party script transfer size is high", "evidence": f"{total_bytes} bytes"})
+
+    return {
+        "url": url or source,
+        "script_count": len(scripts),
+        "third_party_count": len(third_party),
+        "blocking_third_party_count": len(blocking_third_party),
+        "third_party_bytes": total_bytes if fetch_scripts else None,
+        "issues": issues,
+        "scripts": scripts,
+        "fetch_error": fetched.get("error"),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Audit third-party and blocking script tags")
+    parser.add_argument("source", help="URL or local HTML file")
+    parser.add_argument("--fetch-scripts", action="store_true", help="HEAD external script URLs for status and byte size")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    result = audit(args.source, args.fetch_scripts, args.timeout)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(
+            f"Scripts: {result['script_count']}; third-party: {result['third_party_count']}; "
+            f"blocking third-party: {result['blocking_third_party_count']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/topical_cluster_mapper.py
+++ b/.claude/skills/seo/scripts/topical_cluster_mapper.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Map topical clusters and internal-link coverage from URLs, HTML, or CSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+from collections import Counter, defaultdict
+
+from seo_common import load_html, normalize_url, parse_html
+
+
+STOPWORDS = {
+    "the", "and", "for", "with", "from", "that", "this", "your", "you", "how", "what", "why", "are", "was",
+    "has", "have", "can", "into", "guide", "best", "top", "page", "home", "about", "contact", "our",
+}
+
+
+def _load_source(source: str, timeout: int) -> tuple[str, str, dict]:
+    if os.path.exists(source):
+        with open(source, "r", encoding="utf-8") as fh:
+            return fh.read(), "", {"url": source, "status": None, "headers": {}, "error": None}
+    return load_html(source, timeout=timeout)
+
+
+def _topic_from_text(text: str) -> str:
+    words = [word for word in re.findall(r"[a-z][a-z0-9'-]{2,}", (text or "").lower()) if word not in STOPWORDS]
+    if not words:
+        return "uncategorized"
+    return Counter(words).most_common(1)[0][0]
+
+
+def _split_links(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [part.strip() for part in re.split(r"[\s,;|]+", value) if part.strip()]
+
+
+def _rows_from_csv(path: str) -> list[dict]:
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows = []
+        for row in reader:
+            title = row.get("title") or row.get("Title") or ""
+            topic = row.get("topic") or row.get("Topic") or _topic_from_text(title)
+            cluster = row.get("cluster") or row.get("Cluster") or topic
+            rows.append({
+                "url": normalize_url(row.get("url") or row.get("URL") or row.get("page") or ""),
+                "title": title,
+                "topic": topic,
+                "cluster": cluster,
+                "parent": row.get("parent") or row.get("hub") or row.get("Hub") or "",
+                "links": [normalize_url(link) for link in _split_links(row.get("links") or row.get("Links"))],
+            })
+    return [row for row in rows if row["url"]]
+
+
+def _row_from_source(source: str, timeout: int) -> dict:
+    html, url, _ = _load_source(source, timeout)
+    parsed = parse_html(html, url)
+    title = parsed.get("title") or " ".join(parsed.get("headings", {}).get("h1", []))
+    topic = _topic_from_text(f"{title} {' '.join(sum((v for v in parsed.get('headings', {}).values()), []))}")
+    return {
+        "url": normalize_url(url or source),
+        "title": title,
+        "topic": topic,
+        "cluster": topic,
+        "parent": "",
+        "links": [normalize_url(link["href"]) for link in parsed.get("links", [])],
+    }
+
+
+def map_clusters(rows: list[dict]) -> dict:
+    by_cluster: dict[str, list[dict]] = defaultdict(list)
+    known_urls = {row["url"] for row in rows}
+    for row in rows:
+        by_cluster[row["cluster"] or "uncategorized"].append(row)
+
+    clusters = {}
+    issues = []
+    for cluster, pages in sorted(by_cluster.items()):
+        url_set = {page["url"] for page in pages}
+        internal_edges = []
+        inbound = Counter()
+        outbound_counts = Counter()
+        for page in pages:
+            for link in page.get("links", []):
+                if link in url_set:
+                    internal_edges.append({"from": page["url"], "to": link})
+                    inbound[link] += 1
+                    outbound_counts[page["url"]] += 1
+
+        explicit_hubs = [page for page in pages if page.get("parent") in ("", page["url"]) and re.search(r"(hub|guide|topic|pillar|overview)", page.get("title", ""), re.I)]
+        candidate_hub = None
+        if explicit_hubs:
+            candidate_hub = explicit_hubs[0]["url"]
+        elif pages:
+            candidate_hub = max(pages, key=lambda page: inbound[page["url"]] + outbound_counts[page["url"]])["url"]
+
+        missing_links = []
+        if candidate_hub:
+            for page in pages:
+                if page["url"] == candidate_hub:
+                    continue
+                if page["url"] not in [edge["to"] for edge in internal_edges if edge["from"] == candidate_hub]:
+                    missing_links.append({"from": candidate_hub, "to": page["url"], "reason": "hub_not_linking_to_spoke"})
+                if candidate_hub not in page.get("links", []):
+                    missing_links.append({"from": page["url"], "to": candidate_hub, "reason": "spoke_not_linking_to_hub"})
+
+        orphan_candidates = [page["url"] for page in pages if inbound[page["url"]] == 0 and page["url"] in known_urls]
+        if len(pages) > 1 and not internal_edges:
+            issues.append({"severity": "warning", "message": f"Cluster '{cluster}' has no detected internal links."})
+        if orphan_candidates:
+            issues.append({"severity": "info", "message": f"Cluster '{cluster}' has {len(orphan_candidates)} orphan candidate(s)."})
+
+        clusters[cluster] = {
+            "page_count": len(pages),
+            "hub": candidate_hub,
+            "topics": sorted({page.get("topic") for page in pages if page.get("topic")}),
+            "internal_edges": internal_edges,
+            "missing_links": missing_links[:100],
+            "orphan_candidates": orphan_candidates,
+        }
+
+    total_missing = sum(len(cluster["missing_links"]) for cluster in clusters.values())
+    total_edges = sum(len(cluster["internal_edges"]) for cluster in clusters.values())
+    score = max(0, 100 - min(60, total_missing * 4) - (20 if total_edges == 0 and len(rows) > 1 else 0))
+    return {"page_count": len(rows), "cluster_count": len(clusters), "score": score, "clusters": clusters, "issues": issues}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Map topical clusters from a CSV manifest or URL/local HTML inputs.")
+    parser.add_argument("sources", nargs="*", help="URL or local HTML files")
+    parser.add_argument("--csv", dest="csv_path", help="CSV with url,title,topic,cluster,parent,links columns")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+
+    rows = []
+    if args.csv_path:
+        rows.extend(_rows_from_csv(args.csv_path))
+    rows.extend(_row_from_source(source, args.timeout) for source in args.sources)
+    result = map_clusters(rows)
+    print(json.dumps(result, indent=2) if args.json else f"Score: {result['score']} Clusters: {result['cluster_count']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/url_quality.py
+++ b/.claude/skills/seo/scripts/url_quality.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Analyze URL hygiene and variant risks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter, defaultdict
+from urllib.parse import parse_qs, urlparse
+
+from seo_common import read_urls
+
+
+FACET_PARAMS = {"sort", "filter", "color", "size", "brand", "price", "min_price", "max_price", "page", "view", "category", "tag"}
+TRACKING_PREFIXES = ("utm_", "fbclid", "gclid", "msclkid")
+
+
+def analyze_urls(urls: list[str]) -> dict:
+    rows = []
+    path_variants = defaultdict(list)
+    for url in urls:
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query, keep_blank_values=True)
+        path = parsed.path or "/"
+        flags = []
+        if len(url) > 115:
+            flags.append("long_url")
+        if any(ch.isupper() for ch in path):
+            flags.append("uppercase_path")
+        if "_" in path:
+            flags.append("underscore_in_path")
+        if re.search(r"/(tag|category|author|page)/\d+/?$", path):
+            flags.append("thin_archive_pattern")
+        if len([seg for seg in path.split("/") if seg]) > 5:
+            flags.append("deep_path")
+        if params:
+            flags.append("has_parameters")
+        if any(key.startswith(TRACKING_PREFIXES) for key in params):
+            flags.append("tracking_parameters")
+        if any(key in FACET_PARAMS for key in params):
+            flags.append("facet_parameters")
+        normalized_key = (parsed.netloc.lower().removeprefix("www."), path.lower().rstrip("/") or "/", tuple(sorted(params)))
+        path_variants[normalized_key].append(url)
+        rows.append({"url": url, "path": path, "param_count": len(params), "params": sorted(params), "flags": flags, "score": max(0, 100 - 12 * len(flags))})
+
+    variants = {str(key): vals for key, vals in path_variants.items() if len(vals) > 1}
+    flag_counts = Counter(flag for row in rows for flag in row["flags"])
+    return {"count": len(rows), "flag_counts": dict(flag_counts), "variant_groups": variants, "rows": rows}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze URL quality")
+    parser.add_argument("urls", nargs="*")
+    parser.add_argument("--url-file")
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = analyze_urls(read_urls(args.urls, args.url_file))
+    print(json.dumps(result, indent=2) if args.json else "\n".join(f"{r['score']}\t{','.join(r['flags']) or 'ok'}\t{r['url']}" for r in result["rows"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/validate_schema.py
+++ b/.claude/skills/seo/scripts/validate_schema.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Post-edit schema validation helper.
+
+Validates JSON-LD schema after file edits. Returns exit code 2 to block
+if critical validation errors found.
+
+Example usage:
+  python3 validate_schema.py path/to/file.html
+"""
+
+import json
+import re
+import sys
+import os
+from typing import List
+
+
+def validate_jsonld(content: str) -> List[str]:
+    """Validate JSON-LD blocks in HTML content."""
+    errors = []
+    pattern = r'<script\s+type=["\']application/ld\+json["\']\s*>(.*?)</script>'
+    blocks = re.findall(pattern, content, re.DOTALL | re.IGNORECASE)
+
+    if not blocks:
+        return []  # No schema found — not an error
+
+    for i, block in enumerate(blocks, 1):
+        block = block.strip()
+        try:
+            data = json.loads(block)
+        except json.JSONDecodeError as e:
+            errors.append(f"Block {i}: Invalid JSON — {e}")
+            continue
+
+        if isinstance(data, list):
+            for item in data:
+                errors.extend(_validate_schema_object(item, i))
+        elif isinstance(data, dict):
+            errors.extend(_validate_schema_object(data, i))
+
+    return errors
+
+
+def _validate_schema_object(obj: dict, block_num: int) -> List[str]:
+    """Validate a single schema object."""
+    errors = []
+    prefix = f"Block {block_num}"
+
+    # Check @context
+    if "@context" not in obj:
+        errors.append(f"{prefix}: Missing @context")
+    elif obj["@context"] not in ("https://schema.org", "http://schema.org"):
+        errors.append(f"{prefix}: @context should be 'https://schema.org'")
+
+    # Check @type
+    if "@type" not in obj:
+        errors.append(f"{prefix}: Missing @type")
+
+    # Check for placeholder text
+    placeholders = [
+        "[Business Name]",
+        "[City]",
+        "[State]",
+        "[Phone]",
+        "[Address]",
+        "[Your",
+        "[INSERT",
+        "REPLACE",
+        "[URL]",
+        "[Email]",
+    ]
+    text = json.dumps(obj)
+    for p in placeholders:
+        if p.lower() in text.lower():
+            errors.append(f"{prefix}: Contains placeholder text: {p}")
+
+    # Check for deprecated types
+    schema_type = obj.get("@type", "")
+    deprecated = {
+        "HowTo": "deprecated September 2023",
+        "SpecialAnnouncement": "deprecated July 31, 2025",
+        "CourseInfo": "retired June 2025",
+        "EstimatedSalary": "retired June 2025",
+        "LearningVideo": "retired June 2025",
+        "ClaimReview": "retired June 2025 — fact-check rich results discontinued",
+        "VehicleListing": "retired June 2025 — vehicle listing structured data discontinued",
+        "PracticeProblem": "retired late 2025 — rich results discontinued",
+        "Dataset": "retired late 2025 — rich results discontinued",
+    }
+    if schema_type in deprecated:
+        errors.append(f"{prefix}: @type '{schema_type}' is {deprecated[schema_type]}")
+
+    # Check for restricted types used incorrectly
+    restricted = {"FAQPage": "restricted to government and healthcare sites only (Aug 2023)"}
+    if schema_type in restricted:
+        errors.append(f"{prefix}: @type '{schema_type}' is {restricted[schema_type]} — verify site qualifies")
+
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(0)
+
+    filepath = sys.argv[1]
+
+    if not os.path.isfile(filepath):
+        sys.exit(0)
+
+    # Only validate HTML-like files
+    valid_extensions = (".html", ".htm", ".jsx", ".tsx", ".vue", ".svelte", ".php", ".ejs")
+    if not filepath.endswith(valid_extensions):
+        sys.exit(0)
+
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+    except (OSError, IOError):
+        sys.exit(0)
+
+    errors = validate_jsonld(content)
+
+    if not errors:
+        sys.exit(0)
+
+    # Categorize errors
+    critical_keywords = ["placeholder", "deprecated", "retired"]
+    critical = [e for e in errors if any(kw in e.lower() for kw in critical_keywords)]
+    warnings = [e for e in errors if e not in critical]
+
+    if warnings:
+        print("⚠️  Schema validation warnings:")
+        for w in warnings:
+            print(f"  - {w}")
+
+    if critical:
+        print("🛑 Schema validation ERRORS (blocking):")
+        for e in critical:
+            print(f"  - {e}")
+        sys.exit(2)  # Block the edit
+
+    sys.exit(1)  # Warnings only — proceed
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/validate_skill_inventory.py
+++ b/.claude/skills/seo/scripts/validate_skill_inventory.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate documented skill, agent, and script inventory counts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+SKILL = ROOT / "SKILL.md"
+WIKI_SCRIPT_INVENTORY = ROOT / "wiki" / "Script-Inventory.md"
+SKILLS_DIR = ROOT / "resources" / "skills"
+AGENTS_DIR = ROOT / "resources" / "agents"
+SCRIPTS_DIR = ROOT / "scripts"
+
+
+def list_files(directory: Path, pattern: str) -> list[Path]:
+    return sorted(path for path in directory.glob(pattern) if path.is_file())
+
+
+def documented_count(text: str, patterns: list[str]) -> int | None:
+    for pattern in patterns:
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate README.md and SKILL.md inventory counts against files on disk."
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable results.")
+    args = parser.parse_args()
+
+    readme_exists = README.exists()
+    readme_text = README.read_text(encoding="utf-8") if readme_exists else ""
+    wiki_inventory_exists = WIKI_SCRIPT_INVENTORY.exists()
+    wiki_inventory_text = WIKI_SCRIPT_INVENTORY.read_text(encoding="utf-8") if wiki_inventory_exists else ""
+    skill_text = SKILL.read_text(encoding="utf-8")
+
+    skill_files = list_files(SKILLS_DIR, "*.md")
+    agent_files = list_files(AGENTS_DIR, "*.md")
+    python_scripts = [path for path in list_files(SCRIPTS_DIR, "*.py") if path.name != "__init__.py"]
+    shell_scripts = list_files(SCRIPTS_DIR, "*.sh")
+    all_scripts = sorted(python_scripts + shell_scripts)
+
+    expected = {
+        "skills": len(skill_files),
+        "agents": len(agent_files),
+        "scripts": len(all_scripts),
+        "python_scripts": len(python_scripts),
+        "shell_scripts": len(shell_scripts),
+    }
+
+    observed = {
+        "readme_skills": documented_count(readme_text, [r"Specialized sub-skills:\s*`?(\d+)`?"]),
+        "readme_agents": documented_count(readme_text, [r"Specialist agents:\s*`?(\d+)`?"]),
+        "readme_scripts": documented_count(readme_text, [r"Scripts in `scripts/`:\s*`?(\d+)`?"]),
+        "readme_python_scripts": documented_count(readme_text, [r"`?(\d+)`?\s+Python"]),
+        "readme_shell_scripts": documented_count(readme_text, [r"`?(\d+)`?\s+shell"]),
+        "skill_intro_scripts": documented_count(skill_text, [r"and\s+(\d+)\s+scripts"]),
+    }
+
+    errors: list[str] = []
+
+    checks = {"skill_intro_scripts": "scripts"}
+    if readme_exists:
+        checks.update({
+            "readme_skills": "skills",
+            "readme_agents": "agents",
+            "readme_scripts": "scripts",
+            "readme_python_scripts": "python_scripts",
+            "readme_shell_scripts": "shell_scripts",
+        })
+    for observed_key, expected_key in checks.items():
+        if observed[observed_key] != expected[expected_key]:
+            errors.append(
+                f"{observed_key}={observed[observed_key]!r}, expected {expected[expected_key]}"
+            )
+
+    for path in skill_files:
+        rel = path.relative_to(ROOT).as_posix()
+        if rel not in skill_text:
+            errors.append(f"SKILL.md does not reference {rel}")
+        if readme_exists and rel not in readme_text:
+            errors.append(f"README.md does not reference {rel}")
+
+    if readme_exists:
+        for path in all_scripts:
+            name = path.name
+            if name not in readme_text and name not in wiki_inventory_text:
+                errors.append(f"script inventory docs do not list {name}")
+
+    payload = {
+        "expected": expected,
+        "observed": observed,
+        "readme_present": readme_exists,
+        "wiki_inventory_present": wiki_inventory_exists,
+        "skills": [path.name for path in skill_files],
+        "agents": [path.name for path in agent_files],
+        "scripts": [path.name for path in all_scripts],
+        "errors": errors,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            "Inventory: "
+            f"{expected['skills']} skills, "
+            f"{expected['agents']} agents, "
+            f"{expected['scripts']} scripts "
+            f"({expected['python_scripts']} Python + {expected['shell_scripts']} shell)"
+        )
+        if errors:
+            print("Errors:")
+            for error in errors:
+                print(f"- {error}")
+        else:
+            print("OK: documented inventory matches files on disk.")
+            if not readme_exists:
+                print("Note: README.md not present; README inventory checks were skipped.")
+
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/seo/scripts/video_schema_checker.py
+++ b/.claude/skills/seo/scripts/video_schema_checker.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Check VideoObject JSON-LD for video rich-result readiness."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from typing import Any
+
+from schema_required_props import extract_schema_documents, find_schema_nodes
+from seo_common import issue, print_json_or_text
+
+
+ISO_DURATION_RE = re.compile(r"^P(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}")
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def check_video_schema(documents: list[Any]) -> dict[str, Any]:
+    rows = []
+    issues = []
+    videos = find_schema_nodes(documents, "VideoObject")
+    for row in videos:
+        node = row["node"]
+        row_issues = []
+        for prop in ("name", "description", "thumbnailUrl", "uploadDate"):
+            if not node.get(prop):
+                row_issues.append(issue("error", f"VideoObject is missing {prop}", evidence=row["path"]))
+        if node.get("uploadDate") and not DATE_RE.match(str(node["uploadDate"])):
+            row_issues.append(issue("warning", "uploadDate should be ISO-like YYYY-MM-DD or datetime", evidence=row["path"]))
+        if node.get("duration") and not ISO_DURATION_RE.match(str(node["duration"])):
+            row_issues.append(issue("warning", "duration should be ISO 8601, e.g. PT2M30S", evidence=row["path"]))
+        if not node.get("contentUrl") and not node.get("embedUrl"):
+            row_issues.append(issue("error", "VideoObject needs contentUrl or embedUrl", evidence=row["path"]))
+        if not node.get("publisher"):
+            row_issues.append(issue("warning", "VideoObject is missing publisher", evidence=row["path"]))
+        if not node.get("transcript") and not node.get("caption"):
+            row_issues.append(issue("info", "VideoObject is missing transcript/caption signal", evidence=row["path"]))
+        clips = [part for part in as_list(node.get("hasPart")) if isinstance(part, dict) and part.get("@type") == "Clip"]
+        if clips:
+            for index, clip in enumerate(clips):
+                for prop in ("name", "startOffset", "url"):
+                    if clip.get(prop) in (None, ""):
+                        row_issues.append(issue("warning", f"Clip is missing {prop}", evidence=f"{row['path']}.hasPart[{index}]"))
+        actions = [action for action in as_list(node.get("potentialAction")) if isinstance(action, dict)]
+        if actions and not any(action.get("@type") == "SeekToAction" for action in actions):
+            row_issues.append(issue("info", "potentialAction exists but no SeekToAction found", evidence=row["path"]))
+        rows.append({"path": row["path"], "issues": row_issues})
+        issues.extend(row_issues)
+    return {"videos": len(videos), "rows": rows, "issues": issues}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check VideoObject JSON-LD")
+    parser.add_argument("source", help="URL, HTML file, or JSON-LD file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true", help="Output JSON")
+    args = parser.parse_args()
+    documents, meta = extract_schema_documents(args.source, timeout=args.timeout)
+    result = check_video_schema(documents)
+    result.update({"source": args.source, "final_url": meta["final_url"]})
+    lines = [f"Video schema check for {args.source}", f"Videos: {result['videos']}  Issues: {len(result['issues'])}"]
+    lines.extend(f"[{item['severity']}] {item['message']} {item.get('evidence') or ''}" for item in result["issues"][:30])
+    print_json_or_text(result, args.json, lines)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/seo/scripts/visual_regression_snapshot.py
+++ b/.claude/skills/seo/scripts/visual_regression_snapshot.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Create or compare visual regression snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+try:
+    from playwright.sync_api import sync_playwright, TimeoutError as PlaywrightTimeout
+except ImportError:  # pragma: no cover - optional dependency
+    sync_playwright = None
+    PlaywrightTimeout = TimeoutError
+
+
+VIEWPORTS = {
+    "desktop": {"width": 1440, "height": 900},
+    "tablet": {"width": 768, "height": 1024},
+    "mobile": {"width": 390, "height": 844},
+}
+
+
+def file_fingerprint(path: Path) -> dict:
+    data = path.read_bytes()
+    return {
+        "path": str(path),
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def compare_files(baseline: Path, current: Path) -> dict:
+    before = file_fingerprint(baseline)
+    after = file_fingerprint(current)
+    return {
+        "baseline": before,
+        "current": after,
+        "changed": before["sha256"] != after["sha256"],
+        "byte_delta": after["bytes"] - before["bytes"],
+        "pixel_diff": None,
+        "note": "Install Pillow to add pixel-level diff metrics." if not _pillow_available() else "",
+    }
+
+
+def _pillow_available() -> bool:
+    try:
+        import PIL.Image  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def compare_pixels(baseline: Path, current: Path) -> dict:
+    try:
+        from PIL import Image, ImageChops
+    except ImportError:
+        return compare_files(baseline, current)
+
+    try:
+        before = Image.open(baseline).convert("RGBA")
+        after = Image.open(current).convert("RGBA")
+    except Exception as exc:
+        report = compare_files(baseline, current)
+        report["note"] = f"Pixel diff unavailable: {exc}"
+        return report
+    report = compare_files(baseline, current)
+    if before.size != after.size:
+        report["pixel_diff"] = {
+            "same_dimensions": False,
+            "baseline_size": before.size,
+            "current_size": after.size,
+            "changed_pixels": None,
+            "changed_ratio": None,
+        }
+        return report
+
+    diff = ImageChops.difference(before, after)
+    bbox = diff.getbbox()
+    changed_pixels = 0
+    if bbox:
+        changed_pixels = sum(1 for pixel in diff.getdata() if pixel != (0, 0, 0, 0))
+    total = before.size[0] * before.size[1]
+    report["pixel_diff"] = {
+        "same_dimensions": True,
+        "baseline_size": before.size,
+        "current_size": after.size,
+        "changed_pixels": changed_pixels,
+        "changed_ratio": round(changed_pixels / total, 6) if total else 0,
+        "bounding_box": bbox,
+    }
+    return report
+
+
+def capture_url(url: str, output_dir: Path, viewport: str, timeout_ms: int, full_page: bool) -> dict:
+    if sync_playwright is None:
+        return {"success": False, "error": "playwright is not installed"}
+    if viewport not in VIEWPORTS:
+        return {"success": False, "error": f"unknown viewport: {viewport}"}
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output = output_dir / f"{viewport}.png"
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page(viewport=VIEWPORTS[viewport])
+            page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+            page.screenshot(path=str(output), full_page=full_page)
+            browser.close()
+        return {"success": True, "url": url, "viewport": viewport, "output": str(output), **file_fingerprint(output)}
+    except PlaywrightTimeout:
+        return {"success": False, "url": url, "viewport": viewport, "error": f"render timed out after {timeout_ms}ms"}
+    except Exception as exc:  # pragma: no cover - browser/runtime dependent
+        return {"success": False, "url": url, "viewport": viewport, "error": str(exc)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Create or compare visual regression snapshots")
+    parser.add_argument("--url", help="URL to capture")
+    parser.add_argument("--output-dir", default="screenshots/visual-regression")
+    parser.add_argument("--viewport", choices=VIEWPORTS.keys(), default="desktop")
+    parser.add_argument("--all", action="store_true", help="Capture all viewport presets")
+    parser.add_argument("--full-page", action="store_true")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout in seconds")
+    parser.add_argument("--baseline", help="Baseline image path for comparison")
+    parser.add_argument("--current", help="Current image path for comparison")
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+
+    if args.baseline and args.current:
+        report = compare_pixels(Path(args.baseline), Path(args.current))
+    elif args.url:
+        viewports = VIEWPORTS.keys() if args.all else [args.viewport]
+        captures = [
+            capture_url(args.url, Path(args.output_dir), viewport, args.timeout * 1000, args.full_page)
+            for viewport in viewports
+        ]
+        report = {"captures": captures, "success": all(item.get("success") for item in captures)}
+    else:
+        parser.error("provide either --url or --baseline plus --current")
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/seo/scripts/x_robots_header_checker.py
+++ b/.claude/skills/seo/scripts/x_robots_header_checker.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Inspect X-Robots-Tag headers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from seo_common import extract_directives, fetch_url, read_urls
+
+
+def check_headers(urls: list[str], timeout: int = 15) -> dict:
+    rows = []
+    for url in urls:
+        fetched = fetch_url(url, method="HEAD", timeout=timeout)
+        if fetched.get("status") in (405, 403) or fetched.get("error"):
+            fetched = fetch_url(url, method="GET", timeout=timeout, max_bytes=100_000)
+        headers = fetched.get("headers", {})
+        value = headers.get("x-robots-tag") or headers.get("X-Robots-Tag")
+        directives = sorted(extract_directives(value))
+        rows.append({
+            "url": url,
+            "status": fetched.get("status"),
+            "final_url": fetched.get("url"),
+            "x_robots_tag": value,
+            "directives": directives,
+            "indexing_effect": "blocked" if "noindex" in directives or "none" in directives else "allowed",
+            "follow_effect": "blocked" if "nofollow" in directives or "none" in directives else "allowed",
+            "archive_effect": "blocked" if "noarchive" in directives else "allowed",
+            "snippet_rules": [d for d in directives if d.startswith(("max-snippet", "max-image-preview", "max-video-preview", "nosnippet"))],
+            "error": fetched.get("error"),
+        })
+    return {"count": len(rows), "rows": rows}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check X-Robots-Tag headers")
+    parser.add_argument("urls", nargs="*")
+    parser.add_argument("--url-file")
+    parser.add_argument("--timeout", type=int, default=15)
+    parser.add_argument("--json", "-j", action="store_true")
+    args = parser.parse_args()
+    result = check_headers(read_urls(args.urls, args.url_file), args.timeout)
+    print(json.dumps(result, indent=2) if args.json else "\n".join(f"{r['indexing_effect']}\t{r['x_robots_tag'] or '-'}\t{r['url']}" for r in result["rows"]))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Replaces the simple SEO reference guide with [Agentic SEO Skill](https://github.com/Bhanunamikaze/Agentic-SEO-Skill) v3.0.1 — a full SEO analysis toolkit with 16 sub-skills, 10 specialist agents, and 89 Python scripts.

## Why

The previous SEO skill was just a cheat sheet (meta tags, OG, etc.). This is an actionable analysis toolkit that actually runs audits against live URLs — crawls pages, validates schema, checks robots.txt, runs PageSpeed Insights, and generates prioritized reports.

## Changes

-  — updated skill definition
-  — 89 Python scripts (fetch, parse, validate, audit, report)
-  — sub-skills, agents, references, templates

## Usage

After restart, try:
- `Run SEO audit for https://arcadeum.io`
- `Check schema markup on my homepage`
- `Analyze Core Web Vitals for my site`