### PR TITLE
fix(be): enforce first-click-wins for cascade call race condition

### DIFF
--- a/apps/be/src/games/cascade/cascade-bot.service.ts
+++ b/apps/be/src/games/cascade/cascade-bot.service.ts
@@ -22,7 +22,14 @@ const MOVE_DELAY_MS = { min: 400, max: 1100 };
  * call them out manually.
  */
 const SELF_REFLEX_MS = { min: 200, max: 700 };
-const OTHER_REFLEX_MS = { min: 1500, max: 3500 };
+const OTHER_REFLEX_MS = { min: 800, max: 2500 };
+
+/** Error substrings that indicate a lost cascade-call race — expected. */
+const CASCADE_RACE_ERRORS = [
+  'No Cascade window',
+  'Someone already called Cascade',
+  'Invalid action',
+];
 
 @Injectable()
 export class CascadeBotService {
@@ -110,7 +117,10 @@ export class CascadeBotService {
             // the engine rejects post-close calls. Anything else is
             // worth logging.
             const message = err instanceof Error ? err.message : String(err);
-            if (!message.includes('No Cascade window')) {
+            const isExpectedLoss = CASCADE_RACE_ERRORS.some((e) =>
+              message.includes(e),
+            );
+            if (!isExpectedLoss) {
               this.logger.debug(
                 `Bot ${player.playerId} cascade call lost the race: ${message}`,
               );

--- a/apps/be/src/games/cascade/cascade-bot.service.ts
+++ b/apps/be/src/games/cascade/cascade-bot.service.ts
@@ -28,7 +28,6 @@ const OTHER_REFLEX_MS = { min: 800, max: 2500 };
 const CASCADE_RACE_ERRORS = [
   'No Cascade window',
   'Someone already called Cascade',
-  'Invalid action',
 ];
 
 @Injectable()

--- a/apps/be/src/games/cascade/cascade.service.ts
+++ b/apps/be/src/games/cascade/cascade.service.ts
@@ -36,6 +36,8 @@ const WATCHDOG_STALE_THRESHOLD_MS = 20000;
 export class CascadeService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(CascadeService.name);
   private watchdogInterval: NodeJS.Timeout | null = null;
+  /** Per-room mutex to serialize action execution and prevent TOCTOU races. */
+  private readonly roomLocks = new Map<string, Promise<void>>();
 
   constructor(
     private readonly roomsService: GameRoomsService,
@@ -149,19 +151,37 @@ export class CascadeService implements OnModuleInit, OnModuleDestroy {
     action: string,
     payload: unknown,
   ) {
-    const session = await this.sessionsService.findSessionByRoom(roomId);
-    if (!session) throw new Error('Session not found');
-
-    const updatedSession = await this.sessionsService.executeAction({
-      sessionId: session.id,
-      userId,
-      action,
-      payload,
+    // Serialize all actions per room to prevent race conditions (e.g. two
+    // concurrent call_cascade requests both passing validation on the same
+    // snapshot).
+    const prev = this.roomLocks.get(roomId) ?? Promise.resolve();
+    let release: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
     });
+    this.roomLocks.set(roomId, next);
+    await prev;
 
-    await this.afterSessionStep(updatedSession);
-    await this.emitSessionUpdate(updatedSession);
-    return updatedSession;
+    try {
+      const session = await this.sessionsService.findSessionByRoom(roomId);
+      if (!session) throw new Error('Session not found');
+
+      const updatedSession = await this.sessionsService.executeAction({
+        sessionId: session.id,
+        userId,
+        action,
+        payload,
+      });
+
+      await this.afterSessionStep(updatedSession);
+      await this.emitSessionUpdate(updatedSession);
+      return updatedSession;
+    } finally {
+      release!();
+      if (this.roomLocks.get(roomId) === next) {
+        this.roomLocks.delete(roomId);
+      }
+    }
   }
 
   private async afterSessionStep(session: GameSessionSummary) {

--- a/apps/be/src/games/engines/cascade/cascade.engine.last-card.spec.ts
+++ b/apps/be/src/games/engines/cascade/cascade.engine.last-card.spec.ts
@@ -114,6 +114,26 @@ describe('CascadeEngine — Last-Card race (Cascade call)', () => {
     expect(secondCall.success).toBe(false);
   });
 
+  it('calledBy set after first call — second call on post-call state is rejected', () => {
+    const openState = engine.executeAction(
+      setupOneCardLeft('a'),
+      'play_card',
+      ctx('a'),
+      { cardId: 'play' },
+    ).state!;
+    // b calls first
+    const afterB = engine.executeAction(openState, 'call_cascade', ctx('b'));
+    expect(afterB.success).toBe(true);
+    expect(afterB.state!.lastCardWindow).toBeNull();
+    // c calls on post-call state — rejected (window closed)
+    const afterC = engine.executeAction(
+      afterB.state!,
+      'call_cascade',
+      ctx('c'),
+    );
+    expect(afterC.success).toBe(false);
+  });
+
   it('window auto-closes when the at-risk player takes their next turn (draws)', () => {
     const openState = engine.executeAction(
       setupOneCardLeft('a'),

--- a/apps/be/src/games/engines/cascade/cascade.engine.last-card.ts
+++ b/apps/be/src/games/engines/cascade/cascade.engine.last-card.ts
@@ -42,6 +42,9 @@ export function validateCallCascade(
   if (!state.lastCardWindow) {
     return { ok: false, error: 'No Cascade window is open' };
   }
+  if (state.lastCardWindow.calledBy) {
+    return { ok: false, error: 'Someone already called Cascade' };
+  }
   const caller = state.players.find((p) => p.playerId === userId);
   if (!caller) return { ok: false, error: 'Player not in game' };
   if (!caller.alive) return { ok: false, error: 'Player is out' };
@@ -58,6 +61,7 @@ export function applyCallCascade(
 
   const next = helpers.cloneState(state);
   const window = next.lastCardWindow!;
+  window.calledBy = context.userId;
   const isSelf = context.userId === window.playerId;
 
   if (isSelf) {

--- a/apps/be/src/games/engines/cascade/cascade.types.ts
+++ b/apps/be/src/games/engines/cascade/cascade.types.ts
@@ -47,6 +47,8 @@ export interface CascadeOptions {
 export interface LastCardWindow {
   playerId: string;
   openedAt: string;
+  /** The first player who called Cascade — used to enforce "first click wins". */
+  calledBy?: string;
 }
 
 export interface CascadePlayer extends GamePlayerState {

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -194,19 +194,8 @@ export class GameSessionsService {
       timestamp: new Date(),
     };
 
-    // Validate the action
-    const isValid = engine.validateAction(
-      session.state as unknown as BaseGameState,
-      action,
-      context,
-      payload,
-    );
-
-    if (!isValid) {
-      throw new BadRequestException('Invalid action');
-    }
-
-    // Execute the action
+    // Execute the action (engines validate internally and return errorResult
+    // with the actual error message on failure).
     const result = engine.executeAction(
       session.state as unknown as BaseGameState,
       action,
@@ -215,7 +204,7 @@ export class GameSessionsService {
     );
 
     if (!result.success) {
-      throw new BadRequestException(result.error || 'Action failed');
+      throw new BadRequestException(result.error || 'Invalid action');
     }
 
     // Update session with new state


### PR DESCRIPTION
## What
Fix the cascade call race condition so the first player to click Cascade wins, and propagate actual validation error messages instead of generic "Invalid action".

## Why
Two concurrent `call_cascade` requests could both read the same state snapshot, pass validation, and both penalise the victim — last write wins. Also, the generic "Invalid action" error masked the real reason (e.g. "Someone already called Cascade").

## Changes
- **Per-room mutex in `CascadeService`** — serializes all action execution per room to prevent TOCTOU race conditions
- **`calledBy` field on `LastCardWindow`** — engine-level defense-in-depth tracks the first caller
- **`validateCallCascade` rejects if `calledBy` already set** — double-call protection at the engine layer
- **Propagate actual error messages** — removed redundant `validateAction` call in `GameSessionsService`; engines already validate inside `executeAction` and return the real error string
- **Bot race-error detection** — recognise "Someone already called Cascade" as expected race loss; tighten `OTHER_REFLEX_MS` to 800-2500ms so bots are snappier but humans still have a real chance
- **New test** — `calledBy set after first call — second call on post-call state is rejected`

## Files
- `apps/be/src/games/cascade/cascade.service.ts` — per-room promise mutex
- `apps/be/src/games/engines/cascade/cascade.engine.last-card.ts` — `calledBy` tracking + validation
- `apps/be/src/games/engines/cascade/cascade.types.ts` — `calledBy` on `LastCardWindow`
- `apps/be/src/games/engines/cascade/cascade.engine.last-card.spec.ts` — new test
- `apps/be/src/games/cascade/cascade-bot.service.ts` — race-error detection + reflex tuning
- `apps/be/src/games/sessions/game-sessions.service.ts` — propagate engine error messages