### PR TITLE
fix(web): wrap children in Suspense to prevent async cleanup error

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
@@ -142,7 +143,7 @@ export default async function LocaleLayout({
           <RouteChangeAnnouncer />
           <AnnouncementBanner />
           <Header />
-          {children}
+          <Suspense>{children}</Suspense>
           <LayoutFooter />
           {authToken ? <WalletLiveBridge authToken={authToken} /> : null}
         </SoundProvider>


### PR DESCRIPTION
## What
Wraps `{children}` in a `<Suspense>` boundary inside the locale layout (`apps/web/src/app/[locale]/layout.tsx`).

## Why
Async server component pages (stats, history, games, etc.) suspend at the top level via `await params` and `await searchParams` **before** reaching their own internal `<Suspense>` boundaries. Without a parent Suspense in the layout, React walks up the component tree looking for a fallback, fails to find one, and triggers the internal error:

> We are cleaning up async info that was not on the parent Suspense boundary. This is a bug in React.

This is a known React 19 / Next.js App Router issue when no Suspense boundary exists between an async page and the root layout.

## Changes
- Added `import { Suspense } from 'react'` to locale layout
- Wrapped `{children}` with `<Suspense>{children}</Suspense>`

The bare `<Suspense>` (no fallback) is intentional — each page already defines its own loading UI. The parent boundary just needs to exist to satisfy React's async cleanup tracking.

## Verification
- Lint, typecheck, build: all pass
- BE unit tests: 1074 passed
- Web unit tests: 1102 passed