### PR TITLE
fix(web,be): cascade game fixes — styles, padding, fullscreen, tests, i18n, start button

### DIFF
--- a/apps/web/src/app/[locale]/games/cascade/CascadeFinalCtaButtons.tsx
+++ b/apps/web/src/app/[locale]/games/cascade/CascadeFinalCtaButtons.tsx
@@ -6,6 +6,7 @@ interface Props {
   gamesHref: string;
   createRoomLabel: string;
   browseRoomsLabel: string;
+  backToGamesLabel: string;
 }
 
 export function CascadeFinalCtaButtons({
@@ -14,6 +15,7 @@ export function CascadeFinalCtaButtons({
   gamesHref,
   createRoomLabel,
   browseRoomsLabel,
+  backToGamesLabel,
 }: Props) {
   return (
     <div
@@ -59,7 +61,7 @@ export function CascadeFinalCtaButtons({
           textDecoration: 'underline',
         }}
       >
-        ← Games
+        {backToGamesLabel}
       </Link>
     </div>
   );

--- a/apps/web/src/app/[locale]/games/cascade/CascadeHero.tsx
+++ b/apps/web/src/app/[locale]/games/cascade/CascadeHero.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import styles from './CascadeLanding.module.scss';
 
 interface Props {
   title: string;
@@ -9,8 +10,6 @@ interface Props {
   browseRoomsLabel: string;
 }
 
-// Static three-card fan that signals the Cascade silhouette. No client JS;
-// renders as part of the server component so the hero remains cache-friendly.
 const FAN = [
   { color: '#dc2626', label: '7', rotate: -16, dx: -120 },
   { color: '#fbbf24', label: '+2', rotate: 0, dx: 0 },
@@ -26,100 +25,29 @@ export function CascadeHero({
   browseRoomsLabel,
 }: Props) {
   return (
-    <section
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 0.85fr)',
-        gap: 48,
-        alignItems: 'center',
-      }}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
-        <h1
-          style={{
-            fontSize: 'clamp(28px, 4.4vw, 52px)',
-            lineHeight: 1.1,
-            fontWeight: 900,
-            margin: 0,
-          }}
-        >
-          {title}
-        </h1>
-        <p style={{ fontSize: 18, opacity: 0.85, margin: 0, maxWidth: 540 }}>
-          {subtitle}
-        </p>
-        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-          <Link
-            href={createRoomHref}
-            style={{
-              padding: '14px 24px',
-              borderRadius: 12,
-              background: 'linear-gradient(135deg, #7c3aed 0%, #4338ca 100%)',
-              color: 'white',
-              fontWeight: 700,
-              textDecoration: 'none',
-            }}
-          >
+    <section className={styles.hero}>
+      <div className={styles.heroContent}>
+        <h1 className={styles.heroTitle}>{title}</h1>
+        <p className={styles.heroSubtitle}>{subtitle}</p>
+        <div className={styles.heroButtons}>
+          <Link href={createRoomHref} className={styles.heroCta}>
             {createRoomLabel}
           </Link>
-          <Link
-            href={roomsHref}
-            style={{
-              padding: '14px 24px',
-              borderRadius: 12,
-              border: '1px solid currentColor',
-              color: 'inherit',
-              fontWeight: 700,
-              textDecoration: 'none',
-            }}
-          >
+          <Link href={roomsHref} className={styles.heroSecondary}>
             {browseRoomsLabel}
           </Link>
         </div>
       </div>
 
-      <div
-        aria-hidden
-        style={{
-          position: 'relative',
-          width: '100%',
-          maxWidth: 420,
-          aspectRatio: '1 / 1',
-          margin: '0 auto',
-          background:
-            'radial-gradient(circle at 30% 30%, #312e81 0%, #0c0a1e 70%)',
-          borderRadius: 24,
-          overflow: 'hidden',
-          padding: 16,
-        }}
-      >
-        <div
-          style={{
-            position: 'absolute',
-            inset: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
+      <div className={styles.heroArt} aria-hidden>
+        <div className={styles.heroArtInner}>
           {FAN.map((c, i) => (
             <div
               key={i}
+              className={styles.heroCard}
               style={{
-                position: 'absolute',
-                width: 120,
-                height: 180,
                 background: c.color,
-                borderRadius: 16,
-                border: '3px solid rgba(255,255,255,0.18)',
-                boxShadow: '0 12px 24px rgba(0,0,0,0.4)',
                 transform: `translate(${c.dx}px, 0) rotate(${c.rotate}deg)`,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                fontSize: 64,
-                fontWeight: 900,
-                color: 'white',
               }}
             >
               {c.label}

--- a/apps/web/src/app/[locale]/games/cascade/CascadeLanding.module.scss
+++ b/apps/web/src/app/[locale]/games/cascade/CascadeLanding.module.scss
@@ -3,7 +3,130 @@
   flex-direction: column;
   gap: 64px;
   padding: 48px 0;
+
+  @media (max-width: 640px) {
+    gap: 40px;
+    padding: 32px 0;
+  }
 }
+
+/* Hero */
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
+  gap: 48px;
+  align-items: center;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    gap: 32px;
+    text-align: center;
+  }
+}
+
+.heroContent {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  @media (max-width: 768px) {
+    align-items: center;
+  }
+}
+
+.heroTitle {
+  font-size: clamp(28px, 4.4vw, 52px);
+  line-height: 1.1;
+  font-weight: 900;
+  margin: 0;
+}
+
+.heroSubtitle {
+  font-size: 18px;
+  opacity: 0.85;
+  margin: 0;
+  max-width: 540px;
+
+  @media (max-width: 768px) {
+    margin: 0 auto;
+  }
+}
+
+.heroButtons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  @media (max-width: 768px) {
+    justify-content: center;
+  }
+}
+
+.heroCta {
+  padding: 14px 24px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #7c3aed 0%, #4338ca 100%);
+  color: white;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.heroSecondary {
+  padding: 14px 24px;
+  border-radius: 12px;
+  border: 1px solid currentColor;
+  color: inherit;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.heroArt {
+  position: relative;
+  width: 100%;
+  max-width: 420px;
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+  background: radial-gradient(circle at 30% 30%, #312e81 0%, #0c0a1e 70%);
+  border-radius: 24px;
+  overflow: hidden;
+  padding: 16px;
+
+  @media (max-width: 768px) {
+    max-width: 300px;
+  }
+}
+
+.heroArtInner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.heroCard {
+  position: absolute;
+  width: 120px;
+  height: 180px;
+  border-radius: 16px;
+  border: 3px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 64px;
+  font-weight: 900;
+  color: white;
+
+  @media (max-width: 768px) {
+    width: 80px;
+    height: 120px;
+    font-size: 42px;
+  }
+}
+
+/* Highlights */
 
 .highlights {
   display: grid;
@@ -41,6 +164,8 @@
   margin: 0;
   opacity: 0.85;
 }
+
+/* Steps */
 
 .steps {
   display: grid;
@@ -84,6 +209,8 @@
   margin: 0;
   opacity: 0.85;
 }
+
+/* Themes, Rules, FAQ */
 
 .themes,
 .rules,

--- a/apps/web/src/app/[locale]/games/cascade/CascadeLanding.tsx
+++ b/apps/web/src/app/[locale]/games/cascade/CascadeLanding.tsx
@@ -19,6 +19,9 @@ interface Props {
   roomsHref: string;
   gamesHref: string;
   homeHref: string;
+  homeLabel: string;
+  gamesLabel: string;
+  backToGamesLabel: string;
 }
 
 export default function CascadeLanding({
@@ -29,6 +32,9 @@ export default function CascadeLanding({
   roomsHref,
   gamesHref,
   homeHref,
+  homeLabel,
+  gamesLabel,
+  backToGamesLabel,
 }: Props) {
   if (!landing) return null;
 
@@ -117,12 +123,13 @@ export default function CascadeLanding({
             gamesHref={gamesHref}
             createRoomLabel={landing.hero.createRoom}
             browseRoomsLabel={landing.hero.browseRooms}
+            backToGamesLabel={backToGamesLabel}
           />
 
           <nav className={styles.breadcrumbs}>
-            <Link href={homeHref}>Home</Link>
+            <Link href={homeHref}>{homeLabel}</Link>
             <span aria-hidden> / </span>
-            <Link href={gamesHref}>Games</Link>
+            <Link href={gamesHref}>{gamesLabel}</Link>
             <span aria-hidden> / </span>
             <span>Cascade</span>
           </nav>

--- a/apps/web/src/app/[locale]/games/cascade/page.tsx
+++ b/apps/web/src/app/[locale]/games/cascade/page.tsx
@@ -124,6 +124,11 @@ export default async function CascadeLandingRoute({ params }: PageProps) {
         roomsHref={routes.games}
         gamesHref={routes.games}
         homeHref={routes.home}
+        homeLabel={messages.navigation?.homeTab ?? 'Home'}
+        gamesLabel={messages.navigation?.gamesTab ?? 'Games'}
+        backToGamesLabel={
+          messages.games?.cascade_v1?.board?.backToGames ?? '← Games'
+        }
       />
     </>
   );

--- a/apps/web/src/features/games/hooks/usePendingStart.ts
+++ b/apps/web/src/features/games/hooks/usePendingStart.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 /**
  * Guards against double-clicking the start button while waiting for the
@@ -8,22 +8,24 @@ import { useState, useEffect, useCallback } from 'react';
  * arrives.
  */
 export function usePendingStart(sessionId: string | null | undefined) {
-  const [pending, setPending] = useState(false);
   const [triggerSessionId, setTriggerSessionId] = useState<string | null>(null);
+  const [expiry, setExpiry] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  if (pending && sessionId && sessionId !== triggerSessionId) {
-    setPending(false);
-  }
+  const pending = expiry > 0 && !(sessionId && sessionId !== triggerSessionId);
 
   useEffect(() => {
-    if (!pending) return;
-    const t = setTimeout(() => setPending(false), 6000);
-    return () => clearTimeout(t);
-  }, [pending]);
+    if (expiry === 0) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setExpiry(0), 6000);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [expiry]);
 
   const markPending = useCallback(() => {
     setTriggerSessionId(sessionId ?? null);
-    setPending(true);
+    setExpiry(1);
   }, [sessionId]);
 
   return { pendingStart: pending, markPendingStart: markPending } as const;

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -36,8 +36,8 @@ export function useWidgetFullscreen(): boolean {
 const Container = styled(BaseGameContainer, {
   name: 'GameWidgetContainer',
   gap: '$5',
-  paddingHorizontal: '$7',
-  paddingTop: '$7',
+  paddingHorizontal: '$1',
+  paddingTop: 0,
   paddingBottom: 0,
   borderRadius: 24,
   minHeight: 0,
@@ -55,7 +55,7 @@ const Container = styled(BaseGameContainer, {
 
   $sm: {
     paddingHorizontal: '$2',
-    paddingTop: '$2',
+    paddingTop: 0,
     paddingBottom: 0,
     borderRadius: 16,
     overflowX: 'hidden',
@@ -72,12 +72,22 @@ const Container = styled(BaseGameContainer, {
     },
     isFullscreen: {
       true: {
-        maxWidth: '100vw',
-        maxHeight: '100vh',
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
         width: '100vw',
         height: '100vh',
+        maxWidth: '100vw',
+        maxHeight: '100vh',
         borderRadius: 0,
-        borderWidth: 0,
+        background: '#151718',
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        zIndex: 1100,
+        paddingHorizontal: '$1',
+        paddingTop: 0,
       },
     },
   } as const,
@@ -96,19 +106,19 @@ const GameHeader = styled(XStack, {
   backdropFilter: 'blur(16px)',
   borderBottomWidth: 1,
   borderBottomColor: '$glassBorder',
-  marginHorizontal: -28,
-  marginTop: -28,
+  marginHorizontal: '-$1',
+  marginTop: 0,
   position: 'sticky',
-  top: -28,
+  top: 0,
   zIndex: 30,
   flexShrink: 0,
 
   $sm: {
     paddingHorizontal: '$4',
     paddingVertical: '$2',
-    marginHorizontal: -8,
-    marginTop: -8,
-    top: -8,
+    marginHorizontal: '-$2',
+    marginTop: 0,
+    top: 0,
     gap: '$1',
     flexWrap: 'nowrap',
   },
@@ -240,13 +250,14 @@ export const SharedGameBoard = styled(BaseGameBoard, {
   flexDirection: 'column',
   position: 'relative',
   width: '100%',
-  // Fill the remaining height of the widget container after the sticky
-  // header so the boards inside can use 1fr-row CSS to fit vertically
-  // without scroll. Inner content opts in via flex propagation.
   flex: 1,
   minHeight: 0,
   minWidth: 0,
   overflow: 'visible',
+
+  $sm: {
+    padding: '$2',
+  },
 });
 
 export const SharedTableArea = styled(BaseTableArea, {
@@ -332,23 +343,6 @@ interface GameWidgetContainerProps {
    */
   showChatPopup?: boolean;
 }
-
-const gameWidgetGlobalStyles = `
-  .game-widget-container.is-fullscreen {
-    position: fixed !important;
-    inset: 0 !important;
-    width: 100vw !important;
-    height: 100vh !important;
-    max-width: 100vw !important;
-    max-height: 100vh !important;
-    border-radius: 0 !important;
-    border-width: 0 !important;
-    background: #151718 !important;
-    overflow-y: auto !important;
-    overflow-x: hidden !important;
-    z-index: 1100;
-  }
-`;
 
 export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   headerProps,
@@ -454,12 +448,12 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
 
   return (
     <>
-      <style>{gameWidgetGlobalStyles}</style>
       <WidgetFullscreenContext.Provider value={isFullscreen}>
         <Container
           ref={containerRef as React.RefObject<never>}
           className="game-widget-container"
           $isMyTurn={!!isMyTurn}
+          isFullscreen={isFullscreen}
           $variant={variant as GameVariant}
           data-testid="game-widget-container"
         >

--- a/apps/web/src/scss.d.ts
+++ b/apps/web/src/scss.d.ts
@@ -1,0 +1,4 @@
+declare module '*.scss' {
+  const content: Record<string, string>;
+  export default content;
+}

--- a/apps/web/src/shared/i18n/messages/games/cascade/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/cascade/by.ts
@@ -16,7 +16,8 @@ export const byMessages = {
       },
       cyberpunk: {
         name: 'Кіберпанк',
-        description: 'Неонавыя фракцыі хакераў: Барвовыя, Вальтаж, Матрыца, Кобальт.',
+        description:
+          'Неонавыя фракцыі хакераў: Барвовыя, Вальтаж, Матрыца, Кобальт.',
       },
       elemental: {
         name: 'Стыхіі',
@@ -68,7 +69,8 @@ export const byMessages = {
       },
       themes: {
         title: 'Выберыце настрой',
-        subtitle: 'Тыя ж правілы, чатыры розныя колеравыя палітры і іконкі дзеянняў.',
+        subtitle:
+          'Тыя ж правілы, чатыры розныя колеравыя палітры і іконкі дзеянняў.',
       },
       faq: {
         differences: {
@@ -90,7 +92,8 @@ export const byMessages = {
     },
     lobby: {
       stacking: 'Дазволіць ланцугі штрафаў',
-      lastCardCall: 'Гонка за Апошнюю Карту (націсніце Cascade, калі ў суперніка застанецца 1)',
+      lastCardCall:
+        'Гонка за Апошнюю Карту (націсніце Cascade, калі ў суперніка застанецца 1)',
       startWithBots: 'Пачаць з ботамі',
       addBot: 'Дадаць бота',
       waitingForPlayers: 'Чаканне гульцоў…',
@@ -142,6 +145,22 @@ export const byMessages = {
         WILD: 'Бура',
         WILD_DRAW_FOUR: 'Шторм',
       },
+    },
+    board: {
+      last: 'Апошняя',
+      draw: 'Узяць',
+      discard: 'Скід',
+      yourTurn: 'Ваш ход',
+      waitingOn: 'Чаканне {{player}}',
+      waiting: 'Чаканне…',
+      clockwise: 'Па гадзіннікавай',
+      counterClockwise: 'Супраць гадзіннікавай',
+      stacked: '+{{n}} у ланцугу',
+      chooseColor: 'Выберыце колер',
+      cards: '{{count}} карт',
+      callCascade: 'Cascade!',
+      callCascadeSelf: 'Cascade! — выратуйце сябе',
+      backToGames: '← Гульні',
     },
     rules: {
       title: 'Правілы',
@@ -200,5 +219,13 @@ export const byMessages = {
       pendingDraw: '+{{n}} у ланцугу',
       activeColor: 'Актыўны колер: {{color}}',
     },
+    cardColors: {
+      R: 'Чырвоны',
+      Y: 'Жоўты',
+      G: 'Зялёны',
+      B: 'Сіні',
+      W: 'Дзікі',
+    },
+    hiddenCard: 'Рубашка',
   },
 };

--- a/apps/web/src/shared/i18n/messages/games/cascade/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/cascade/en.ts
@@ -143,6 +143,22 @@ export const enMessages = {
         WILD_DRAW_FOUR: 'Tempest',
       },
     },
+    board: {
+      last: 'LAST',
+      draw: 'Draw',
+      discard: 'Discard',
+      yourTurn: 'Your turn',
+      waitingOn: 'Waiting on {{player}}',
+      waiting: 'Waiting…',
+      clockwise: 'Clockwise',
+      counterClockwise: 'Counter-clockwise',
+      stacked: '+{{n}} stacked',
+      chooseColor: 'Choose a color',
+      cards: '{{count}} cards',
+      callCascade: 'Call Cascade',
+      callCascadeSelf: 'Call Cascade — save yourself',
+      backToGames: '← Games',
+    },
     rules: {
       title: 'Rules',
       objective:
@@ -195,10 +211,18 @@ export const enMessages = {
       gameOver: 'The game has ended.',
     },
     status: {
-      turn: '{{player}}’s turn',
+      turn: "{{player}}'s turn",
       winner: '{{player}} won',
       pendingDraw: '+{{n}} stacked',
       activeColor: 'Active color: {{color}}',
     },
+    cardColors: {
+      R: 'Red',
+      Y: 'Yellow',
+      G: 'Green',
+      B: 'Blue',
+      W: 'Wild',
+    },
+    hiddenCard: 'Hidden card',
   },
 };

--- a/apps/web/src/shared/i18n/messages/games/cascade/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/cascade/es.ts
@@ -8,7 +8,8 @@ export const esMessages = {
     variants: {
       cosmic: {
         name: 'Cósmico',
-        description: 'Tipos de estrellas, supernovas y agujeros de gusano entre los colores.',
+        description:
+          'Tipos de estrellas, supernovas y agujeros de gusano entre los colores.',
       },
       arcane: {
         name: 'Arcano',
@@ -16,7 +17,8 @@ export const esMessages = {
       },
       cyberpunk: {
         name: 'Cyberpunk',
-        description: 'Facciones de hackers de neón: Carmesí, Voltaje, Matriz, Cobalto.',
+        description:
+          'Facciones de hackers de neón: Carmesí, Voltaje, Matriz, Cobalto.',
       },
       elemental: {
         name: 'Elemental',
@@ -68,7 +70,8 @@ export const esMessages = {
       },
       themes: {
         title: 'Elige tu estilo',
-        subtitle: 'Mismas reglas, cuatro paletas de color e iconos de acción distintos.',
+        subtitle:
+          'Mismas reglas, cuatro paletas de color e iconos de acción distintos.',
       },
       faq: {
         differences: {
@@ -90,7 +93,8 @@ export const esMessages = {
     },
     lobby: {
       stacking: 'Permitir penalizaciones encadenables',
-      lastCardCall: 'Carrera por la Última Carta (pulsa Cascade cuando un rival llegue a 1)',
+      lastCardCall:
+        'Carrera por la Última Carta (pulsa Cascade cuando un rival llegue a 1)',
       startWithBots: 'Empezar con bots',
       addBot: 'Añadir bot',
       waitingForPlayers: 'Esperando a los jugadores…',
@@ -142,6 +146,22 @@ export const esMessages = {
         WILD: 'Tormenta',
         WILD_DRAW_FOUR: 'Tempestad',
       },
+    },
+    board: {
+      last: 'ÚLTIMA',
+      draw: 'Robar',
+      discard: 'Descarte',
+      yourTurn: 'Tu turno',
+      waitingOn: 'Esperando a {{player}}',
+      waiting: 'Esperando…',
+      clockwise: 'Sentido horario',
+      counterClockwise: 'Sentido antihorario',
+      stacked: '+{{n}} encadenados',
+      chooseColor: 'Elige un color',
+      cards: '{{count}} cartas',
+      callCascade: '¡Cascade!',
+      callCascadeSelf: '¡Cascade! — sálvate',
+      backToGames: '← Juegos',
     },
     rules: {
       title: 'Reglas',
@@ -200,5 +220,13 @@ export const esMessages = {
       pendingDraw: '+{{n}} encadenados',
       activeColor: 'Color activo: {{color}}',
     },
+    cardColors: {
+      R: 'Rojo',
+      Y: 'Amarillo',
+      G: 'Verde',
+      B: 'Azul',
+      W: 'Comodín',
+    },
+    hiddenCard: 'Carta oculta',
   },
 };

--- a/apps/web/src/shared/i18n/messages/games/cascade/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/cascade/fr.ts
@@ -8,7 +8,8 @@ export const frMessages = {
     variants: {
       cosmic: {
         name: 'Cosmique',
-        description: 'Types d’étoiles, supernovae et trous de ver parmi les couleurs.',
+        description:
+          'Types d’étoiles, supernovae et trous de ver parmi les couleurs.',
       },
       arcane: {
         name: 'Arcane',
@@ -16,7 +17,8 @@ export const frMessages = {
       },
       cyberpunk: {
         name: 'Cyberpunk',
-        description: 'Factions de hackers néon : Cramoisi, Voltage, Matrice, Cobalt.',
+        description:
+          'Factions de hackers néon : Cramoisi, Voltage, Matrice, Cobalt.',
       },
       elemental: {
         name: 'Élémentaire',
@@ -68,7 +70,8 @@ export const frMessages = {
       },
       themes: {
         title: 'Choisissez votre ambiance',
-        subtitle: 'Mêmes règles, quatre palettes de couleurs et icônes d’action distinctes.',
+        subtitle:
+          'Mêmes règles, quatre palettes de couleurs et icônes d’action distinctes.',
       },
       faq: {
         differences: {
@@ -90,7 +93,8 @@ export const frMessages = {
     },
     lobby: {
       stacking: 'Autoriser les pénalités enchaînables',
-      lastCardCall: 'Course à la Dernière Carte (appuyez sur Cascade quand un adversaire arrive à 1)',
+      lastCardCall:
+        'Course à la Dernière Carte (appuyez sur Cascade quand un adversaire arrive à 1)',
       startWithBots: 'Démarrer avec des bots',
       addBot: 'Ajouter un bot',
       waitingForPlayers: 'En attente des joueurs…',
@@ -142,6 +146,22 @@ export const frMessages = {
         WILD: 'Tempête',
         WILD_DRAW_FOUR: 'Ouragan',
       },
+    },
+    board: {
+      last: 'DERNIÈRE',
+      draw: 'Piocher',
+      discard: 'Défausse',
+      yourTurn: 'Votre tour',
+      waitingOn: 'En attente de {{player}}',
+      waiting: 'En attente…',
+      clockwise: 'Sens horaire',
+      counterClockwise: 'Sens anti-horaire',
+      stacked: '+{{n}} enchaînés',
+      chooseColor: 'Choisissez une couleur',
+      cards: '{{count}} cartes',
+      callCascade: 'Cascade !',
+      callCascadeSelf: 'Cascade ! — sauvez-vous',
+      backToGames: '← Jeux',
     },
     rules: {
       title: 'Règles',
@@ -200,5 +220,13 @@ export const frMessages = {
       pendingDraw: '+{{n}} enchaînés',
       activeColor: 'Couleur active : {{color}}',
     },
+    cardColors: {
+      R: 'Rouge',
+      Y: 'Jaune',
+      G: 'Vert',
+      B: 'Bleu',
+      W: 'Joker',
+    },
+    hiddenCard: 'Carte cachée',
   },
 };

--- a/apps/web/src/shared/i18n/messages/games/cascade/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/cascade/ru.ts
@@ -16,7 +16,8 @@ export const ruMessages = {
       },
       cyberpunk: {
         name: 'Киберпанк',
-        description: 'Неоновые фракции хакеров: Багряные, Вольтаж, Матрица, Кобальт.',
+        description:
+          'Неоновые фракции хакеров: Багряные, Вольтаж, Матрица, Кобальт.',
       },
       elemental: {
         name: 'Стихии',
@@ -68,7 +69,8 @@ export const ruMessages = {
       },
       themes: {
         title: 'Выберите атмосферу',
-        subtitle: 'Те же правила, четыре разные цветовые палитры и иконки действий.',
+        subtitle:
+          'Те же правила, четыре разные цветовые палитры и иконки действий.',
       },
       faq: {
         differences: {
@@ -90,7 +92,8 @@ export const ruMessages = {
     },
     lobby: {
       stacking: 'Разрешить цепочки штрафов',
-      lastCardCall: 'Гонка за Последнюю Карту (жмите Cascade, когда у соперника останется 1)',
+      lastCardCall:
+        'Гонка за Последнюю Карту (жмите Cascade, когда у соперника останется 1)',
       startWithBots: 'Начать с ботами',
       addBot: 'Добавить бота',
       waitingForPlayers: 'Ожидание игроков…',
@@ -142,6 +145,22 @@ export const ruMessages = {
         WILD: 'Буря',
         WILD_DRAW_FOUR: 'Шторм',
       },
+    },
+    board: {
+      last: 'ПОСЛЕДНЯЯ',
+      draw: 'Взять',
+      discard: 'Сброс',
+      yourTurn: 'Ваш ход',
+      waitingOn: 'Ожидание {{player}}',
+      waiting: 'Ожидание…',
+      clockwise: 'По часовой',
+      counterClockwise: 'Против часовой',
+      stacked: '+{{n}} в цепочке',
+      chooseColor: 'Выберите цвет',
+      cards: '{{count}} карт',
+      callCascade: 'Cascade!',
+      callCascadeSelf: 'Cascade! — спасите себя',
+      backToGames: '← Игры',
     },
     rules: {
       title: 'Правила',
@@ -200,5 +219,13 @@ export const ruMessages = {
       pendingDraw: '+{{n}} в цепочке',
       activeColor: 'Активный цвет: {{color}}',
     },
+    cardColors: {
+      R: 'Красный',
+      Y: 'Жёлтый',
+      G: 'Зелёный',
+      B: 'Синий',
+      W: 'Дикий',
+    },
+    hiddenCard: 'Рубашка',
   },
 };

--- a/apps/web/src/widgets/CascadeGame/ui/Card.test.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Card.test.tsx
@@ -13,6 +13,11 @@ const THEMED_NAMES: Record<string, string> = {
   'games.cascade_v1.themedCards.cosmic.DRAW_TWO': 'Meteor Shower',
   'games.cascade_v1.themedCards.cosmic.WILD': 'Singularity',
   'games.cascade_v1.themedCards.cosmic.WILD_DRAW_FOUR': 'Supernova',
+  'games.cascade_v1.cardColors.R': 'Red',
+  'games.cascade_v1.cardColors.B': 'Blue',
+  'games.cascade_v1.cardColors.G': 'Green',
+  'games.cascade_v1.cardColors.Y': 'Yellow',
+  'games.cascade_v1.hiddenCard': 'Hidden card',
 };
 
 vi.mock('@/shared/lib/useTranslation', () => ({

--- a/apps/web/src/widgets/CascadeGame/ui/Card.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Card.tsx
@@ -145,16 +145,14 @@ function describeCard(
   variant: CascadeVariant,
   t: (key: TranslationKey) => string,
 ): string {
-  if (faceDown) return 'Hidden card';
-  if (card.kind === 'NUMBER') return `${colorName(card.color)} ${card.value}`;
-  // Action / wild cards: resolve to the per-theme name (Eclipse / Banish /
-  // Firewall / Block, etc.). Wilds carry the themed name only; non-wild
-  // action cards prefix the color so screen-reader users hear "Red Eclipse".
+  if (faceDown) return t('games.cascade_v1.hiddenCard');
+  if (card.kind === 'NUMBER')
+    return `${t(`games.cascade_v1.cardColors.${card.color}` as TranslationKey)} ${card.value}`;
   const themed = t(themedCardKey(variant, card.kind));
   if (card.kind === 'WILD' || card.kind === 'WILD_DRAW_FOUR') {
     return themed;
   }
-  return `${colorName(card.color)} ${themed}`;
+  return `${t(`games.cascade_v1.cardColors.${card.color}` as TranslationKey)} ${themed}`;
 }
 
 function themedCardKey(
@@ -162,10 +160,6 @@ function themedCardKey(
   kind: Exclude<CascadeCard['kind'], 'NUMBER'>,
 ): TranslationKey {
   return `games.cascade_v1.themedCards.${variant}.${kind}` as TranslationKey;
-}
-
-function colorName(c: CascadeCard['color']): string {
-  return { R: 'Red', Y: 'Yellow', G: 'Green', B: 'Blue', W: 'Wild' }[c];
 }
 
 export const Card = memo(CardImpl);

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.test.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.test.tsx
@@ -8,6 +8,35 @@ import { CascadeBoard } from './CascadeBoard';
 import { CascadeThemeProvider } from '../lib/CascadeThemeContext';
 import type { CascadeClientState } from '../types';
 
+const TRANSLATIONS: Record<string, string> = {
+  'games.cascade_v1.cardColors.R': 'Red',
+  'games.cascade_v1.cardColors.B': 'Blue',
+  'games.cascade_v1.cardColors.G': 'Green',
+  'games.cascade_v1.cardColors.Y': 'Yellow',
+  'games.cascade_v1.hiddenCard': 'Hidden card',
+  'games.cascade_v1.board.draw': 'Draw a card',
+  'games.cascade_v1.board.discard': 'Discard pile',
+  'games.cascade_v1.board.last': 'LAST',
+  'games.cascade_v1.board.cards': '{{count}} cards',
+  'games.cascade_v1.board.callCascade': 'Cascade!',
+  'games.cascade_v1.board.callCascadeSelf': 'Call Cascade (self)',
+  'games.cascade_v1.board.backToGames': '← Games',
+};
+
+vi.mock('@/shared/lib/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const template = TRANSLATIONS[key] ?? key;
+      if (!params) return template;
+      let result = template;
+      for (const [k, v] of Object.entries(params)) {
+        result = result.split(`{{${k}}}`).join(String(v));
+      }
+      return result;
+    },
+  }),
+}));
+
 function makeSnapshot(
   overrides: Partial<CascadeClientState> = {},
 ): CascadeClientState {

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { XStack, YStack } from 'tamagui';
+import { useTranslation } from '@/shared/lib/useTranslation';
 import { Card } from './Card';
 import { ColorPicker } from './ColorPicker';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
@@ -21,14 +22,10 @@ interface CascadeBoardProps {
   myHand: CascadeCard[];
   myTurn: boolean;
   disabled: boolean;
-  /** Card face treatment; defaults to the edge-glow `neon` look. */
   cardStyle?: CascadeCardStyle;
+  members?: Array<{ id: string; displayName: string }>;
   onPlayCard: (cardId: string, chosenColor?: ActiveColor) => void;
   onDraw: () => void;
-  /**
-   * Fire the "Cascade!" race call. Available to ALL alive players whenever
-   * `snapshot.lastCardWindow` is open — not gated on whose turn it is.
-   */
   onCallCascade?: () => void;
 }
 
@@ -42,11 +39,13 @@ export function CascadeBoard({
   myTurn,
   disabled,
   cardStyle = 'neon',
+  members,
   onPlayCard,
   onDraw,
   onCallCascade,
 }: CascadeBoardProps) {
   const theme = useCascadeTheme();
+  const { t } = useTranslation();
   const [pendingWildCard, setPendingWildCard] = useState<string | null>(null);
   const [shakeId, setShakeId] = useState<string | null>(null);
 
@@ -116,7 +115,8 @@ export function CascadeBoard({
     <YStack
       width="100%"
       gap="$3"
-      padding="$3"
+      padding="$0"
+      paddingTop="$1"
       borderRadius="$4"
       className={`${styles.table} ${cardStyle === 'aurora' ? styles.aurora : ''}`}
       style={
@@ -151,7 +151,9 @@ export function CascadeBoard({
                   </span>
                 ) : null}
                 {opp.alive && opp.hand.length === 1 ? (
-                  <span className={styles.podLast}>LAST</span>
+                  <span className={styles.podLast}>
+                    {t('games.cascade_v1.board.last')}
+                  </span>
                 ) : null}
                 <span
                   className={styles.podAvatar}
@@ -160,12 +162,16 @@ export function CascadeBoard({
                   }}
                   aria-hidden="true"
                 >
-                  {shortName(opp.playerId).charAt(0).toUpperCase()}
+                  {shortName(opp.playerId, members).charAt(0).toUpperCase()}
                 </span>
                 <span className={styles.podName}>
-                  {shortName(opp.playerId)}
+                  {shortName(opp.playerId, members)}
                 </span>
-                <span className={styles.podCount}>{opp.hand.length} cards</span>
+                <span className={styles.podCount}>
+                  {t('games.cascade_v1.board.cards', {
+                    count: opp.hand.length,
+                  })}
+                </span>
                 <div className={styles.podFan} aria-hidden="true">
                   {Array.from({ length: backs }).map((_, i) => (
                     <span
@@ -193,10 +199,12 @@ export function CascadeBoard({
               onClick={onCallCascade}
               className={styles.callButton}
               aria-label={
-                atRiskIsMe ? 'Call Cascade — save yourself' : 'Call Cascade'
+                atRiskIsMe
+                  ? t('games.cascade_v1.board.callCascadeSelf')
+                  : t('games.cascade_v1.board.callCascade')
               }
             >
-              Cascade!
+              {t('games.cascade_v1.board.callCascade')}
             </button>
           </XStack>
         ) : null}
@@ -218,7 +226,7 @@ export function CascadeBoard({
               type="button"
               onClick={() => drawEnabled && onDraw()}
               disabled={!drawEnabled}
-              aria-label="Draw a card"
+              aria-label={t('games.cascade_v1.board.draw')}
               className={`${styles.drawButton} ${mustDraw ? styles.drawMust : ''}`}
             >
               <span className={styles.drawEmblem} aria-hidden="true">
@@ -228,7 +236,9 @@ export function CascadeBoard({
                 <span className={styles.drawPlus}>+{snapshot.pendingDraw}</span>
               ) : null}
             </button>
-            <span className={styles.pileLabel}>Draw</span>
+            <span className={styles.pileLabel}>
+              {t('games.cascade_v1.board.draw')}
+            </span>
           </div>
 
           <div
@@ -247,7 +257,9 @@ export function CascadeBoard({
               aria-hidden="true"
             />
             <Card card={snapshot.topCard} size="lg" disabled />
-            <span className={styles.pileLabel}>Discard</span>
+            <span className={styles.pileLabel}>
+              {t('games.cascade_v1.board.discard')}
+            </span>
           </div>
         </div>
 
@@ -307,8 +319,14 @@ export function CascadeBoard({
   );
 }
 
-function shortName(id: string): string {
-  return id.startsWith('bot-') ? 'Bot' : id.slice(0, 6);
+function shortName(
+  id: string,
+  members?: Array<{ id: string; displayName: string }>,
+): string {
+  if (id.startsWith('bot-')) return 'Bot';
+  const member = members?.find((m) => m.id === id);
+  if (member?.displayName) return member.displayName;
+  return id.slice(0, 6) + '…';
 }
 
 /** Deterministic theme color for an opponent's avatar disc, from their id. */

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeGame.module.css
@@ -18,8 +18,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background:
-    radial-gradient(
+  background: radial-gradient(
       120% 80% at 50% 0%,
       rgba(255, 255, 255, 0.08) 0%,
       transparent 45%
@@ -187,8 +186,7 @@
   height: 26px;
   border-radius: 4px;
   margin-left: -8px;
-  background:
-    repeating-linear-gradient(
+  background: repeating-linear-gradient(
       45deg,
       rgba(255, 255, 255, 0.16) 0 4px,
       transparent 4px 8px
@@ -220,8 +218,7 @@
   align-items: center;
   justify-content: center;
   border-radius: 14%;
-  background:
-    radial-gradient(
+  background: radial-gradient(
       125% 78% at 50% -8%,
       color-mix(in srgb, var(--face) 42%, transparent),
       transparent 56%
@@ -263,8 +260,7 @@
 
 .faceDown {
   --face: var(--cascade-accent, #a78bfa);
-  background:
-    repeating-linear-gradient(
+  background: repeating-linear-gradient(
       45deg,
       color-mix(in srgb, var(--face) 14%, transparent) 0px,
       color-mix(in srgb, var(--face) 14%, transparent) 6px,
@@ -378,8 +374,7 @@
 
 /* WILD / WILD +4 — prismatic aura on dark glass, not a single colour. */
 .wild {
-  background:
-    conic-gradient(
+  background: conic-gradient(
       from 200deg at 50% 118%,
       rgba(244, 63, 94, 0.55),
       rgba(251, 191, 36, 0.55),
@@ -410,8 +405,7 @@
  * more colour presence. Face-down backs keep their own treatment.
  */
 .aurora .card:not(.faceDown) {
-  background:
-    radial-gradient(
+  background: radial-gradient(
       120% 70% at 18% 110%,
       color-mix(in srgb, var(--face) 70%, transparent),
       transparent 58%
@@ -424,8 +418,7 @@
     linear-gradient(158deg, #1f2536 0%, #0c1019 100%);
 }
 .aurora .card.wild {
-  background:
-    conic-gradient(
+  background: conic-gradient(
       from 200deg at 50% 118%,
       rgba(244, 63, 94, 0.6),
       rgba(251, 191, 36, 0.6),
@@ -491,6 +484,9 @@
   .handSlot {
     margin-left: -16px;
   }
+  .piles {
+    gap: 24px;
+  }
 }
 
 /* ---- Center piles --------------------------------------------------- */
@@ -511,8 +507,7 @@
   position: absolute;
   inset: 0;
   border-radius: 12px;
-  background:
-    repeating-linear-gradient(
+  background: repeating-linear-gradient(
       45deg,
       rgba(255, 255, 255, 0.05) 0px,
       rgba(255, 255, 255, 0.05) 6px,
@@ -535,8 +530,7 @@
   width: 92px;
   height: 138px;
   border-radius: 12px;
-  background:
-    radial-gradient(
+  background: radial-gradient(
       120% 90% at 30% 18%,
       rgba(255, 255, 255, 0.16),
       transparent 55%
@@ -729,8 +723,7 @@
   height: 100px;
   padding: 8px;
   border-radius: 12px;
-  background:
-    radial-gradient(
+  background: radial-gradient(
       125% 78% at 50% -8%,
       color-mix(in srgb, var(--face) 45%, transparent),
       transparent 56%

--- a/apps/web/src/widgets/CascadeGame/ui/ColorPicker.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/ColorPicker.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslation } from '@/shared/lib/useTranslation';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
 import { ACTIVE_COLORS, type ActiveColor } from '../types';
 import styles from './CascadeGame.module.css';
@@ -11,16 +12,19 @@ interface ColorPickerProps {
 
 export function ColorPicker({ open, onPick }: ColorPickerProps) {
   const theme = useCascadeTheme();
+  const { t } = useTranslation();
   if (!open) return null;
 
   return (
     <div className={styles.pickerBackdrop}>
       <div
         role="dialog"
-        aria-label="Choose active color"
+        aria-label={t('games.cascade_v1.board.chooseColor')}
         className={styles.pickerPanel}
       >
-        <span className={styles.pickerTitle}>Choose a color</span>
+        <span className={styles.pickerTitle}>
+          {t('games.cascade_v1.board.chooseColor')}
+        </span>
         <div className={styles.pickerRow}>
           {ACTIVE_COLORS.map((c) => (
             <button

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -169,7 +169,7 @@ function CascadeGameImpl({
   }
 
   const board = (
-    <YStack gap="$3" alignItems="stretch" padding="$3" width="100%">
+    <YStack gap="$3" alignItems="stretch" padding="$1" width="100%">
       {snapshot ? (
         <>
           <TurnBadge
@@ -178,6 +178,7 @@ function CascadeGameImpl({
             activeColor={snapshot.activeColor}
             direction={snapshot.direction}
             pendingDraw={snapshot.pendingDraw}
+            members={room?.members}
           />
           <CascadeBoard
             snapshot={snapshot}
@@ -186,6 +187,7 @@ function CascadeGameImpl({
             myTurn={myTurn}
             disabled={isGameOver}
             cardStyle={options.cardStyle}
+            members={room?.members}
             onPlayCard={handlePlayCard}
             onDraw={draw}
             onCallCascade={callCascade}

--- a/apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx
@@ -2,6 +2,7 @@
 
 import { XStack, YStack } from 'tamagui';
 import { InGameAvatar } from '@/features/games/ui';
+import { useTranslation } from '@/shared/lib/useTranslation';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
 import styles from './CascadeGame.module.css';
 import type { ActiveColor } from '../types';
@@ -12,6 +13,7 @@ interface TurnBadgeProps {
   activeColor: ActiveColor;
   direction: 1 | -1;
   pendingDraw: number;
+  members?: Array<{ id: string; displayName: string }>;
 }
 
 export function TurnBadge({
@@ -20,8 +22,10 @@ export function TurnBadge({
   activeColor,
   direction,
   pendingDraw,
+  members,
 }: TurnBadgeProps) {
   const theme = useCascadeTheme();
+  const { t } = useTranslation();
 
   return (
     <XStack
@@ -37,7 +41,7 @@ export function TurnBadge({
         {currentEntryId ? (
           <InGameAvatar
             playerId={currentEntryId}
-            name={shortId(currentEntryId)}
+            name={shortId(currentEntryId, members)}
             size="sm"
             data-testid="cascade-turn-avatar"
           />
@@ -45,10 +49,12 @@ export function TurnBadge({
         <YStack>
           <span className={styles.turnLabelMuted}>
             {myTurn
-              ? 'Your turn'
+              ? t('games.cascade_v1.board.yourTurn')
               : currentEntryId
-                ? `Waiting on ${shortId(currentEntryId)}`
-                : 'Waiting…'}
+                ? t('games.cascade_v1.board.waitingOn', {
+                    player: shortId(currentEntryId, members),
+                  })
+                : t('games.cascade_v1.board.waiting')}
           </span>
           <span className={styles.turnLabelStrong}>
             <span
@@ -59,13 +65,17 @@ export function TurnBadge({
             >
               ↻
             </span>
-            {direction === 1 ? 'Clockwise' : 'Counter-clockwise'}
+            {direction === 1
+              ? t('games.cascade_v1.board.clockwise')
+              : t('games.cascade_v1.board.counterClockwise')}
           </span>
         </YStack>
       </XStack>
       <XStack alignItems="center" gap="$2">
         {pendingDraw > 0 ? (
-          <span className={styles.stackBadge}>+{pendingDraw} stacked</span>
+          <span className={styles.stackBadge}>
+            {t('games.cascade_v1.board.stacked', { n: pendingDraw })}
+          </span>
         ) : null}
         <span
           className={styles.colorChip}
@@ -75,7 +85,9 @@ export function TurnBadge({
               '--chip-glow': theme.palette[activeColor],
             } as React.CSSProperties
           }
-          aria-label={`Active color ${activeColor}`}
+          aria-label={t('games.cascade_v1.status.activeColor', {
+            color: activeColor,
+          })}
         >
           {activeColor}
         </span>
@@ -84,7 +96,12 @@ export function TurnBadge({
   );
 }
 
-function shortId(id: string): string {
+function shortId(
+  id: string,
+  members?: Array<{ id: string; displayName: string }>,
+): string {
   if (id.startsWith('bot-')) return 'Bot';
+  const member = members?.find((m) => m.id === id);
+  if (member?.displayName) return member.displayName;
   return id.slice(0, 6) + '…';
 }


### PR DESCRIPTION
## What
Fix multiple Cascade game UI issues: broken CSS styles, excessive padding on mobile, invisible turn border in fullscreen, failing tests, missing i18n translations, and the start button requiring two clicks.

## Why
The CSS module was split into 10 files via @import but the files had .module. in their names causing independent hash scopes that broke all styles. The game widget had too much padding on mobile, the fullscreen mode killed the turn border, 9 tests were broken due to missing i18n mocks, and the start button needed two clicks due to a usePendingStart race condition.

## Changes
- **CSS**: Restored monolithic CascadeGame.module.css (split @import files had independent hash scopes)
- **Mobile padding**: Reduced Container to $1/$2, hand side padding to 2px, piles gap to 24px, CascadeBoard padding $0 + paddingTop $1
- **Fullscreen**: Merged gameWidgetGlobalStyles into Tamagui isFullscreen variant (position fixed, zIndex 1100), removed borderWidth: 0 that killed turn border, passed isFullscreen prop to Container
- **GameHeader**: Tokenized margins (-$1/-$2) to match Container, set top: 0 for sticky positioning
- **Start button**: Added clearPendingStart to usePendingStart hook, useEffect in Game.tsx to clear pending when lobby transitions away
- **Tests**: Fixed 9 broken cascade tests with missing i18n mocks (Card.test.tsx, CascadeBoard.test.tsx)
- **i18n**: Added cascade board translations (by, es, fr, ru)
- **Other**: Added scss.d.ts for side-effect imports