### PR TITLE
fix(web): game result modal mobile + footer fixes

### DIFF
--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -139,12 +139,22 @@ export default async function LocaleLayout({
     <LanguageProvider locale={locale}>
       <PWAProvider>
         <SoundProvider>
-          <JsonLd id={`json-ld-locale-${locale}`} data={localeJsonLd} />
-          <RouteChangeAnnouncer />
-          <AnnouncementBanner />
-          <Header />
-          <Suspense>{children}</Suspense>
-          <LayoutFooter />
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              minHeight: '100dvh',
+            }}
+          >
+            <JsonLd id={`json-ld-locale-${locale}`} data={localeJsonLd} />
+            <RouteChangeAnnouncer />
+            <AnnouncementBanner />
+            <Header />
+            <main style={{ flex: 1 }}>
+              <Suspense>{children}</Suspense>
+            </main>
+            <LayoutFooter />
+          </div>
           {authToken ? <WalletLiveBridge authToken={authToken} /> : null}
         </SoundProvider>
       </PWAProvider>

--- a/apps/web/src/features/games/ui/GameResultModal.tsx
+++ b/apps/web/src/features/games/ui/GameResultModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
-import { styled, YStack, XStack, H1, Paragraph, Text } from 'tamagui';
+import { styled, YStack, XStack, H1, Paragraph, Text, useMedia } from 'tamagui';
 import { Button, CloseIcon, LinkButton } from '@arcadeum/ui';
 import { useSyncExternalStore } from 'react';
 import { TranslationKey } from '@/shared/lib/useTranslation';
@@ -34,11 +34,11 @@ interface GameResultModalProps {
 // --- Internal Styled Components ---
 
 const StyledBackdrop = styled(YStack, {
-  position: 'absolute',
+  position: 'fixed',
   top: 0,
   left: 0,
-  right: 0,
-  bottom: 0,
+  width: '100vw',
+  height: '100dvh',
   zIndex: 1199,
   backgroundColor: 'rgba(0, 0, 0, 0.85)',
   backdropFilter: 'blur(12px)',
@@ -75,6 +75,8 @@ const ContentWrapper = styled(YStack, {
   shadowOffset: { width: 0, height: 40 },
   maxWidth: '90%',
   width: 520,
+  maxHeight: '90dvh',
+  overflowY: 'auto',
   position: 'relative',
   borderTopColor: 'rgba(255, 255, 255, 0.2)',
   borderLeftColor: 'rgba(255, 255, 255, 0.15)',
@@ -138,6 +140,14 @@ const StyledResultContent = styled(Dialog.Content, {
   backgroundColor: 'transparent',
   borderWidth: 0,
   padding: 0,
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100vw',
+  height: '100dvh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
   x: 0,
   y: 0,
   scale: 1,
@@ -181,6 +191,7 @@ export function GameResultModal({
     () => false,
   );
 
+  const media = useMedia();
   const { play } = useSound();
   // Play the result sting once when the modal opens (not on every re-render).
   const playedForRef = useRef<GameResultKind | null>(null);
@@ -219,7 +230,12 @@ export function GameResultModal({
             </Dialog.Description>
           </VisuallyHidden>
 
-          <ContentWrapper className="animate-entrance">
+          <ContentWrapper
+            className="animate-entrance"
+            padding={media.sm ? '$5' : '$10'}
+            borderRadius={media.sm ? 24 : 40}
+            width={media.sm ? '95%' : 520}
+          >
             {onClose && (
               <XStack position="absolute" top="$4" right="$4">
                 <CloseButton onClick={onClose} data-testid="modal-close-button">
@@ -249,7 +265,7 @@ export function GameResultModal({
               {onRematch && (
                 <Button
                   variant={isVictory ? 'primary' : 'secondary'}
-                  size="lg"
+                  size={media.sm ? 'md' : 'lg'}
                   onClick={onRematch}
                   disabled={rematchLoading}
                   data-testid="rematch-button"
@@ -269,7 +285,11 @@ export function GameResultModal({
               </HomeLink>
 
               {onClose && (
-                <Button variant="ghost" onClick={onClose} size="md">
+                <Button
+                  variant="ghost"
+                  onClick={onClose}
+                  size={media.sm ? 'sm' : 'md'}
+                >
                   {t('games.table.modals.common.close' as TranslationKey)}
                 </Button>
               )}

--- a/apps/web/src/features/games/ui/VictoryCelebration.tsx
+++ b/apps/web/src/features/games/ui/VictoryCelebration.tsx
@@ -7,11 +7,11 @@ export type CelebrationTone = 'victory' | 'defeat' | 'draw';
 
 const Layer = styled(YStack, {
   name: 'VictoryCelebrationLayer',
-  position: 'absolute',
+  position: 'fixed',
   top: 0,
   left: 0,
-  right: 0,
-  bottom: 0,
+  width: '100vw',
+  height: '100dvh',
   pointerEvents: 'none',
   overflow: 'hidden',
   zIndex: 0,

--- a/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/CascadeBoard.tsx
@@ -116,7 +116,7 @@ export function CascadeBoard({
       width="100%"
       gap="$3"
       padding="$0"
-      paddingTop="$1"
+      paddingTop="$4"
       borderRadius="$4"
       className={`${styles.table} ${cardStyle === 'aurora' ? styles.aurora : ''}`}
       style={

--- a/apps/web/src/widgets/footer/ui/LayoutFooter.tsx
+++ b/apps/web/src/widgets/footer/ui/LayoutFooter.tsx
@@ -14,6 +14,10 @@ const PAGINATED_ROUTES = new Set<string>([
   '/stats',
 ]);
 
+// Game room routes where the footer should be hidden — players don't need
+// navigation links while actively playing.
+const GAME_ROOM_PATTERN = /\/rooms\//;
+
 export default function LayoutFooter() {
   const pathname = usePathname();
   const mounted = useIsMounted();
@@ -26,5 +30,6 @@ export default function LayoutFooter() {
   // ChunkLoadError on navigation. Static import + mount gate avoids both.
   if (!mounted) return null;
   if (pathname && PAGINATED_ROUTES.has(pathname)) return null;
+  if (pathname && GAME_ROOM_PATTERN.test(pathname)) return null;
   return <AppFooter />;
 }


### PR DESCRIPTION
## What
Fix game result modal being cut off on mobile and make footer sticky on mobile while hiding it during gameplay.

## Why
- The win/lose modal used `position: absolute` which didn't cover the full viewport on mobile browsers (where address bars resize the viewport)
- The modal had no max-height constraint, causing content to overflow
- The footer scrolled away with content on mobile instead of staying at the bottom
- The footer was visible during active game sessions, which is unnecessary

## Changes
- **GameResultModal.tsx**: Changed backdrop and content wrapper from `absolute` to `fixed` positioning with viewport dimensions (`100vw`/`100dvh`); added `maxHeight: 90dvh` with `overflowY: auto`; responsive sizing via `useMedia` for smaller padding/radius/button sizes on mobile
- **VictoryCelebration.tsx**: Changed celebration layer from `absolute` to `fixed` positioning to cover full viewport on mobile
- **layout.tsx**: Wrapped page content in flex column with `min-height: 100dvh` so footer sticks to bottom
- **LayoutFooter.tsx**: Hidden on game room routes (`/rooms/`) where footer is not needed
- **CascadeBoard.tsx**: Increased table top padding from `$1` to `$4`