### PR TITLE
fix(be,web): fix cascade lobby double-click start and hydration mismatch

### DIFF
--- a/apps/be/src/games/cascade/cascade.service.ts
+++ b/apps/be/src/games/cascade/cascade.service.ts
@@ -106,8 +106,9 @@ export class CascadeService implements OnModuleInit, OnModuleDestroy {
     });
 
     await this.roomsService.updateRoomStatus(roomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
     await this.realtimeService.emitGameStarted(
-      room,
+      updatedRoom,
       session,
       async (s, pId) => {
         const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
@@ -122,7 +123,7 @@ export class CascadeService implements OnModuleInit, OnModuleDestroy {
     );
 
     const updatedSession = await this.afterSessionStep(session);
-    return { room, session: updatedSession };
+    return { room: updatedRoom, session: updatedSession };
   }
 
   async playCard(userId: string, roomId: string, payload: PlayCardPayload) {

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -136,28 +136,30 @@ export default async function LocaleLayout({
   ];
 
   return (
-    <LanguageProvider locale={locale}>
-      <PWAProvider>
-        <SoundProvider>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              minHeight: '100dvh',
-            }}
-          >
-            <JsonLd id={`json-ld-locale-${locale}`} data={localeJsonLd} />
-            <RouteChangeAnnouncer />
-            <AnnouncementBanner />
-            <Header />
-            <main style={{ flex: 1 }}>
-              <Suspense>{children}</Suspense>
-            </main>
-            <LayoutFooter />
-          </div>
-          {authToken ? <WalletLiveBridge authToken={authToken} /> : null}
-        </SoundProvider>
-      </PWAProvider>
-    </LanguageProvider>
+    <>
+      <JsonLd id={`json-ld-locale-${locale}`} data={localeJsonLd} />
+      <LanguageProvider locale={locale}>
+        <PWAProvider>
+          <SoundProvider>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                minHeight: '100dvh',
+              }}
+            >
+              <RouteChangeAnnouncer />
+              <AnnouncementBanner />
+              <Header />
+              <main style={{ flex: 1 }}>
+                <Suspense>{children}</Suspense>
+              </main>
+              <LayoutFooter />
+            </div>
+            {authToken ? <WalletLiveBridge authToken={authToken} /> : null}
+          </SoundProvider>
+        </PWAProvider>
+      </LanguageProvider>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- **Cascade lobby double-click**: The start button required two clicks because `updateRoomStatus('in_progress')` updated the DB but the in-memory `room` object passed to `emitGameStarted()` still had `status: 'lobby'`, so the client never transitioned out of the lobby view.
- **Hydration mismatch**: The `JsonLd` `<script>` tag was rendered inside client component boundaries (`LanguageProvider`/`PWAProvider`/`SoundProvider`), causing React to strip it during hydration and produce a server/client mismatch.

## Changes
- `cascade.service.ts`: Spread the room with updated `status: 'in_progress'` before passing to `emitGameStarted` and the return value
- `layout.tsx`: Move `JsonLd` outside all `'use client'` provider boundaries so it renders purely server-side

## Testing
- All unit tests pass (1074 BE + 1102 web)
- TypeScript typechecks clean
- Build succeeds