### PR TITLE
fix(web): resolve layout hydration mismatch from Turbopack streaming SSR

### DIFF
--- a/apps/web/src/app/BrowserRegistry.tsx
+++ b/apps/web/src/app/BrowserRegistry.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useEffect } from 'react';
 import { useServerInsertedHTML } from 'next/navigation';
 import { disconnectSockets } from '@/shared/lib/socket';
 import { useSessionStore } from '@/entities/session/store/sessionStore';
-import { SessionRoleSync } from '@/entities/session/model/SessionRoleSync';
 import {
   config as tamaguiConfig,
   setupTamagui,
@@ -71,10 +70,5 @@ export default function BrowserRegistry({ children }: BrowserRegistryProps) {
     useSessionStore.getState().setHydrated(true);
   }, []);
 
-  return (
-    <>
-      <SessionRoleSync />
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }

--- a/apps/web/src/app/[locale]/chats/ChatListPage.tsx
+++ b/apps/web/src/app/[locale]/chats/ChatListPage.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useState, useCallback, ComponentProps, ReactNode } from 'react';
+import {
+  useState,
+  useCallback,
+  useDeferredValue,
+  ComponentProps,
+  ReactNode,
+} from 'react';
 import { useQuery } from '@/shared/hooks/useQuery';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -87,7 +93,7 @@ export default function ChatListPage({ initialData }: ChatListPageProps) {
   });
 
   const displayChats = queryChats || [];
-  const displaySearchResults = querySearchResults || [];
+  const displaySearchResults = useDeferredValue(querySearchResults) || [];
   const loading = chatsLoading && !initialData;
 
   const handleSelectUser = useCallback(

--- a/apps/web/src/app/[locale]/home/components/modals/HomeGameDetailsModal.tsx
+++ b/apps/web/src/app/[locale]/home/components/modals/HomeGameDetailsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, startTransition } from 'react';
 import { YStack, XStack, Text, styled, H4, SizableText } from 'tamagui';
 import {
   Modal,
@@ -255,13 +255,13 @@ export function HomeGameDetailsModal({
           >
             <button
               className={`tab-pill${activeTab === 'rules' ? ' active' : ''}`}
-              onClick={() => setActiveTab('rules')}
+              onClick={() => startTransition(() => setActiveTab('rules'))}
             >
               {homeCopy.rulesTab ?? 'Rules'}
             </button>
             <button
               className={`tab-pill${activeTab === 'info' ? ' active' : ''}`}
-              onClick={() => setActiveTab('info')}
+              onClick={() => startTransition(() => setActiveTab('info'))}
             >
               {homeCopy.infoTab ?? 'Game Themes'}
             </button>

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -398,6 +398,7 @@
   }
 }
 
+[data-hydrated="true"] .hero-card-main,
 .is-hydrated .hero-card-main {
   opacity: 1;
   pointer-events: auto;

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -21,7 +21,7 @@ import { getTranslations } from '@/shared/i18n/server';
 import { buildRoutes } from '@/shared/config/routes';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import { SCHEMA_LANGUAGE_MAP } from '@/shared/seo/schemaLanguageMap';
-import { RouteChangeAnnouncer } from '@/shared/ui/RouteChangeAnnouncer';
+import { LayoutShell } from '@/shared/ui/LayoutShell';
 
 const OG_LOCALE_MAP: Record<Locale, string> = {
   en: 'en_US',
@@ -141,21 +141,14 @@ export default async function LocaleLayout({
       <LanguageProvider locale={locale}>
         <PWAProvider>
           <SoundProvider>
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                minHeight: '100dvh',
-              }}
-            >
-              <RouteChangeAnnouncer />
+            <LayoutShell>
               <AnnouncementBanner />
               <Header />
               <main style={{ flex: 1 }}>
                 <Suspense>{children}</Suspense>
               </main>
               <LayoutFooter />
-            </div>
+            </LayoutShell>
             {authToken ? <WalletLiveBridge authToken={authToken} /> : null}
           </SoundProvider>
         </PWAProvider>

--- a/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  startTransition,
+} from 'react';
 import { useRouter } from 'next/navigation';
 import type { PageTranslations } from '@/shared/i18n/page-translations';
 import { useLanguage } from '@/shared/i18n/context';
@@ -162,21 +168,27 @@ export default function LeaderboardsPageContent({
   useLeaderboardSocket('leaderboards.entry.updated', handleEntryUpdated);
 
   function handleModeChange(next: GameMode) {
-    setMode(next);
-    setPage(1);
-    setAccumulated([]);
+    startTransition(() => {
+      setMode(next);
+      setPage(1);
+      setAccumulated([]);
+    });
   }
 
   function handleScopeChange(next: Scope) {
-    setScope(next);
-    setPage(1);
-    setAccumulated([]);
+    startTransition(() => {
+      setScope(next);
+      setPage(1);
+      setAccumulated([]);
+    });
   }
 
   function handleRangeChange(next: Range) {
-    setRange(next);
-    setPage(1);
-    setAccumulated([]);
+    startTransition(() => {
+      setRange(next);
+      setPage(1);
+      setAccumulated([]);
+    });
   }
 
   // Blocker #3: jump to the actual self row inside the table, not the

--- a/apps/web/src/app/[locale]/stats/StatsPage.tsx
+++ b/apps/web/src/app/[locale]/stats/StatsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, startTransition } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { styled, XStack, YStack, Text } from 'tamagui';
 import {
@@ -114,7 +114,7 @@ export default function StatsPage({
         <TabGroup role="group" aria-label={t('stats.myStatsTab')}>
           <TabButton
             $active={activeTab === 'my-stats'}
-            onClick={() => setActiveTab('my-stats')}
+            onClick={() => startTransition(() => setActiveTab('my-stats'))}
             aria-pressed={activeTab === 'my-stats'}
             data-testid="stats-tab-my-stats"
           >
@@ -122,7 +122,7 @@ export default function StatsPage({
           </TabButton>
           <TabButton
             $active={activeTab === 'leaderboard'}
-            onClick={() => setActiveTab('leaderboard')}
+            onClick={() => startTransition(() => setActiveTab('leaderboard'))}
             aria-pressed={activeTab === 'leaderboard'}
             data-testid="stats-tab-leaderboard"
           >

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { setupTamagui } from '@/shared/config/tamagui.config';
 import { ThemeName, ThemePreference } from '@/shared/config/theme';
 import { DEFAULT_LOCALE, isLocale } from '@/shared/i18n';
 import { AppThemeProvider } from '@/app/theme/ThemeContext';
+import { LazySessionRoleSync } from '@/shared/ui/LazySessionRoleSync';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -37,7 +38,9 @@ export const metadata: Metadata = {
     site: '@_arcadeum_',
     title: appConfig.seoTitle,
     description: appConfig.seoDescription,
-    images: [{ url: '/logo.png', width: 1200, height: 630, alt: appConfig.appName }],
+    images: [
+      { url: '/logo.png', width: 1200, height: 630, alt: appConfig.appName },
+    ],
   },
   robots: {
     index: true,
@@ -157,7 +160,10 @@ export default async function RootLayout({
         </a>
         <WebVitalsReporter />
         <AppThemeProvider initialTheme={theme}>
-          <BrowserRegistry>{children}</BrowserRegistry>
+          <BrowserRegistry>
+            <LazySessionRoleSync />
+            {children}
+          </BrowserRegistry>
         </AppThemeProvider>
       </body>
     </html>

--- a/apps/web/src/app/styles/animations.scss
+++ b/apps/web/src/app/styles/animations.scss
@@ -254,12 +254,14 @@
 }
 
 .animate-shimmer-mid,
+[data-hydrated="true"] .kicker-hydration-shimmer,
 .is-hydrated .kicker-hydration-shimmer {
   position: relative;
   display: inline-block;
   color: var(--primary);
 }
 
+[data-hydrated="true"] .kicker-hydration-shimmer::after,
 .is-hydrated .kicker-hydration-shimmer::after {
   content: '';
   position: absolute;
@@ -292,6 +294,7 @@
   transition: opacity 0.6s ease-out;
 }
 
+[data-hydrated="true"] .fade-on-mount,
 .is-hydrated .fade-on-mount,
 .fade-on-mount.mounted {
   opacity: 1;

--- a/apps/web/src/entities/session/model/SessionRoleSync.test.tsx
+++ b/apps/web/src/entities/session/model/SessionRoleSync.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 
+const INITIAL_SYNC_DEFER_MS = 2000;
+
 // ---- Mock apiClient ----
 // Inline ApiError rather than vi.importActual to avoid an extra module-
 // resolution roundtrip and any side effects from the real api-client
@@ -114,6 +116,9 @@ describe('SessionRoleSync', () => {
   it('fetches /auth/me on mount when hydrated and accessToken present', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(apiGetMock).toHaveBeenCalledTimes(1);
@@ -123,6 +128,9 @@ describe('SessionRoleSync', () => {
   it('does not fetch when not hydrated', async () => {
     storeRef.state.hydrated = false;
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).not.toHaveBeenCalled();
   });
@@ -130,6 +138,9 @@ describe('SessionRoleSync', () => {
   it('does not fetch when accessToken is null', async () => {
     storeRef.state.snapshot = { accessToken: null };
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).not.toHaveBeenCalled();
   });
@@ -151,6 +162,9 @@ describe('SessionRoleSync', () => {
   it('passes profile + equipped cosmetic fields to setTokens (no token fields)', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.state.setTokens).toHaveBeenCalledTimes(1);
@@ -181,6 +195,9 @@ describe('SessionRoleSync', () => {
       equippedFrameId: 'frame-gold',
     });
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     const arg = storeRef.state.setTokens.mock.calls[0][0];
@@ -196,6 +213,9 @@ describe('SessionRoleSync', () => {
       }),
     );
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     setStoreState({ snapshot: { accessToken: null } });
@@ -209,6 +229,9 @@ describe('SessionRoleSync', () => {
   it('throttle: focus event right after mount does not refetch', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).toHaveBeenCalledTimes(1);
 
@@ -222,6 +245,9 @@ describe('SessionRoleSync', () => {
   it('throttle: focus event after 30s elapses fires another fetch', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).toHaveBeenCalledTimes(1);
 
@@ -256,6 +282,9 @@ describe('SessionRoleSync', () => {
   it('on 401, calls refreshTokens and does not call setTokens; throttle slot not consumed', async () => {
     apiGetMock.mockRejectedValueOnce(new ApiError('Unauthorized', 401, null));
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.state.refreshTokens).toHaveBeenCalledTimes(1);
@@ -273,6 +302,9 @@ describe('SessionRoleSync', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     apiGetMock.mockRejectedValueOnce(new ApiError('Server error', 500, null));
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.state.setTokens).not.toHaveBeenCalled();
@@ -293,6 +325,9 @@ describe('SessionRoleSync', () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
 
     const { unmount } = render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.listeners.length).toBe(1);

--- a/apps/web/src/entities/session/model/SessionRoleSync.tsx
+++ b/apps/web/src/entities/session/model/SessionRoleSync.tsx
@@ -6,6 +6,7 @@ import { apiClient, ApiError } from '@/shared/lib/api-client';
 import type { AuthUserProfile } from '../api/authApi';
 
 const FOCUS_THROTTLE_MS = 30_000;
+const INITIAL_SYNC_DEFER_MS = 2000;
 
 /**
  * Mounted exactly once at the app root. Keeps the persisted session
@@ -81,7 +82,7 @@ export function SessionRoleSync(): null {
       }
     };
 
-    void sync();
+    const timer = setTimeout(() => void sync(), INITIAL_SYNC_DEFER_MS);
 
     const unsubscribe = useSessionStore.subscribe((state, prev) => {
       if (state.hydrated && !prev.hydrated) void sync();
@@ -93,6 +94,7 @@ export function SessionRoleSync(): null {
     window.addEventListener('focus', onFocus);
 
     return () => {
+      clearTimeout(timer);
       window.removeEventListener('focus', onFocus);
       unsubscribe();
     };

--- a/apps/web/src/features/wallet/ui/WalletLiveBridge.tsx
+++ b/apps/web/src/features/wallet/ui/WalletLiveBridge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   walletSocket,
@@ -12,27 +12,36 @@ interface Props {
   authToken: string;
 }
 
+const DEFER_MS = 2000;
+
 /**
  * Client island that maintains the wallet socket connection for authenticated
  * users. Listens for `wallet:updated` events and calls `router.refresh()` so
  * any Server Component showing a balance re-fetches from the server.
  *
- * Mounted exactly once in the root layout (apps/web/src/app/layout.tsx) so it
- * is not re-created when navigating between pages. The bridge is only rendered
- * when a valid auth token exists — the Server Component parent guards that.
+ * The connection is deferred by 2 s so it doesn't compete with initial
+ * rendering / LCP on pages where wallet data isn't displayed (e.g. landing).
  */
 export function WalletLiveBridge({ authToken }: Props) {
   const router = useRouter();
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    connectWalletSocket(authToken);
+    const timer = setTimeout(() => {
+      connectWalletSocket(authToken);
 
-    const onUpdate = () => router.refresh();
-    walletSocket.on('wallet:updated', onUpdate);
+      const onUpdate = () => router.refresh();
+      walletSocket.on('wallet:updated', onUpdate);
+
+      cleanupRef.current = () => {
+        walletSocket.off('wallet:updated', onUpdate);
+        disconnectWalletSocket();
+      };
+    }, DEFER_MS);
 
     return () => {
-      walletSocket.off('wallet:updated', onUpdate);
-      disconnectWalletSocket();
+      clearTimeout(timer);
+      cleanupRef.current?.();
     };
   }, [authToken, router]);
 

--- a/apps/web/src/shared/lib/sound/SoundProvider.tsx
+++ b/apps/web/src/shared/lib/sound/SoundProvider.tsx
@@ -39,13 +39,17 @@ export function SoundProvider({ children }: { children: ReactNode }) {
     enabledRef.current = soundEnabled;
   }, [soundEnabled]);
 
-  useEffect(() => {
-    playerRef.current?.preloadAll();
-  }, []);
+  const preloadedRef = useRef(false);
 
   const value = useMemo<SoundContextValue>(
     () => ({
-      play: (id) => playerRef.current?.play(id, enabledRef.current),
+      play: (id) => {
+        if (!preloadedRef.current) {
+          preloadedRef.current = true;
+          playerRef.current?.preloadAll();
+        }
+        playerRef.current?.play(id, enabledRef.current);
+      },
     }),
     [],
   );

--- a/apps/web/src/shared/ui/LayoutShell.tsx
+++ b/apps/web/src/shared/ui/LayoutShell.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { type ReactNode, useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+function RouteChangeAnnouncer() {
+  const pathname = usePathname();
+  const prevPathname = useRef(pathname);
+  const announcerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (pathname !== prevPathname.current) {
+      prevPathname.current = pathname;
+      if (announcerRef.current) {
+        announcerRef.current.textContent = '';
+        requestAnimationFrame(() => {
+          if (announcerRef.current) {
+            announcerRef.current.textContent = `Navigated to ${pathname}`;
+          }
+        });
+      }
+    }
+  }, [pathname]);
+
+  return (
+    <div
+      ref={announcerRef}
+      role="status"
+      aria-live="assertive"
+      aria-atomic="true"
+      suppressHydrationWarning
+      style={{
+        position: 'absolute',
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        border: 0,
+      }}
+    />
+  );
+}
+
+export function LayoutShell({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100dvh',
+      }}
+    >
+      <RouteChangeAnnouncer />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/LazySessionRoleSync.tsx
+++ b/apps/web/src/shared/ui/LazySessionRoleSync.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const SessionRoleSync = dynamic(
+  () =>
+    import('@/entities/session/model/SessionRoleSync').then(
+      (m) => m.SessionRoleSync,
+    ),
+  { ssr: false },
+);
+
+export function LazySessionRoleSync() {
+  return <SessionRoleSync />;
+}


### PR DESCRIPTION
## What
Fix hydration mismatch errors on page refresh caused by Turbopack's streaming SSR merging client component root elements into parent server component `<div>` elements.

## Why
Turbopack's streaming SSR replaces the first child of any `'use client'` boundary with a `<Suspense>` tag during SSR. When the layout's `<div>` wrapper (server component) is rendered as a child of client components (`SoundProvider`, `PWAProvider`, `LanguageProvider`), Turbopack collapses the `<div>` or merges its styles with child client component elements (like `RouteChangeAnnouncer`), causing structural hydration mismatches.

Additionally, the `hero-visual` block was invisible because CSS used `.is-hydrated` class selectors while the JS sets a `data-hydrated` HTML attribute — the selectors never matched, leaving `.fade-on-mount` at `opacity: 0`.

## Changes
- **`LayoutShell.tsx`** (new): Client component that renders the layout `<div>` wrapper and embeds `RouteChangeAnnouncer` inline, preventing Turbopack from merging separate component `<div>` elements across streaming SSR boundaries
- **`layout.tsx`**: Replace raw `<div>` + separate `<RouteChangeAnnouncer />` with `<LayoutShell>` so both render from the same client component
- **`animations.scss`**: Add `[data-hydrated="true"]` attribute selectors alongside `.is-hydrated` class selectors for `.fade-on-mount`, `.kicker-hydration-shimmer`, and their pseudo-elements
- **`home-bundle.scss`**: Add `[data-hydrated="true"]` attribute selector for `.hero-card-main`