### PR TITLE
fix(web): hero card hover overlap and click fix

### DIFF
--- a/apps/web/src/app/BrowserRegistry.tsx
+++ b/apps/web/src/app/BrowserRegistry.tsx
@@ -4,7 +4,6 @@ import { ReactNode, useEffect } from 'react';
 import { useServerInsertedHTML } from 'next/navigation';
 import { disconnectSockets } from '@/shared/lib/socket';
 import { useSessionStore } from '@/entities/session/store/sessionStore';
-import { SessionRoleSync } from '@/entities/session/model/SessionRoleSync';
 import {
   config as tamaguiConfig,
   setupTamagui,
@@ -71,10 +70,5 @@ export default function BrowserRegistry({ children }: BrowserRegistryProps) {
     useSessionStore.getState().setHydrated(true);
   }, []);
 
-  return (
-    <>
-      <SessionRoleSync />
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }

--- a/apps/web/src/app/[locale]/chats/ChatListPage.tsx
+++ b/apps/web/src/app/[locale]/chats/ChatListPage.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useState, useCallback, ComponentProps, ReactNode } from 'react';
+import {
+  useState,
+  useCallback,
+  useDeferredValue,
+  ComponentProps,
+  ReactNode,
+} from 'react';
 import { useQuery } from '@/shared/hooks/useQuery';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -87,7 +93,7 @@ export default function ChatListPage({ initialData }: ChatListPageProps) {
   });
 
   const displayChats = queryChats || [];
-  const displaySearchResults = querySearchResults || [];
+  const displaySearchResults = useDeferredValue(querySearchResults) || [];
   const loading = chatsLoading && !initialData;
 
   const handleSelectUser = useCallback(

--- a/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
+++ b/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
@@ -12,6 +12,16 @@ import { CARD_VARIANTS } from '@/features/games/lib/criticalVariants';
 
 const HERO_VARIANT_IDS = ['fantasy', 'galaxy', 'steampunk'] as const;
 const MAX_TILT_DEG = 8;
+const FAN_OFFSET = 65;
+
+function indexFromPointerX(clientX: number, stack: HTMLDivElement): number {
+  const rect = stack.getBoundingClientRect();
+  const cx = rect.left + rect.width / 2;
+  const dx = clientX - cx;
+  if (dx < -FAN_OFFSET / 2) return 0;
+  if (dx > FAN_OFFSET / 2) return 2;
+  return 1;
+}
 
 export function HeroCardStack({ playLabel }: { playLabel: string }) {
   const stackRef = useRef<HTMLDivElement>(null);
@@ -24,34 +34,32 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
     return { id, nameKey: v?.name ?? '', bgImage: v?.bgImage };
   });
 
-  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    const stack = stackRef.current;
-    if (!stack) return;
-    if (
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    )
-      return;
-    const rect = stack.getBoundingClientRect();
-    const px = (e.clientX - rect.left) / rect.width - 0.5;
-    const py = (e.clientY - rect.top) / rect.height - 0.5;
-    stack.style.setProperty('--tilt-x', `${px * MAX_TILT_DEG * 2}deg`);
-    stack.style.setProperty('--tilt-y', `${-py * MAX_TILT_DEG * 2}deg`);
-  };
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const stack = stackRef.current;
+      if (!stack) return;
+      if (
+        typeof window !== 'undefined' &&
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+      )
+        return;
+      const rect = stack.getBoundingClientRect();
+      const px = (e.clientX - rect.left) / rect.width - 0.5;
+      const py = (e.clientY - rect.top) / rect.height - 0.5;
+      stack.style.setProperty('--tilt-x', `${px * MAX_TILT_DEG * 2}deg`);
+      stack.style.setProperty('--tilt-y', `${-py * MAX_TILT_DEG * 2}deg`);
+      setHoveredIndex(indexFromPointerX(e.clientX, stack));
+    },
+    [],
+  );
 
-  const handlePointerLeave = () => {
+  const handlePointerLeave = useCallback(() => {
     const stack = stackRef.current;
     if (!stack) return;
     stack.style.setProperty('--tilt-x', '0deg');
     stack.style.setProperty('--tilt-y', '0deg');
     setHoveredIndex(null);
-  };
-
-  const handleCardEnter = useCallback(
-    (index: number) => setHoveredIndex(index),
-    [],
-  );
-  const handleCardLeave = useCallback(() => setHoveredIndex(null), []);
+  }, []);
 
   return (
     <div data-testid="hero-visual" className="hero-visual-main fade-on-mount">
@@ -64,7 +72,7 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
       >
         {heroCards.map((card, index) => {
           const isLast = index === heroCards.length - 1;
-          const x = (index - 1) * 65;
+          const x = (index - 1) * FAN_OFFSET;
           const rotate = `${(index - 1) * 12}deg`;
           const y = index * -15;
           const isActive = hoveredIndex === index;
@@ -84,8 +92,6 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
                 } as React.CSSProperties
               }
               data-testid={`hero-card-${index}`}
-              onPointerEnter={() => handleCardEnter(index)}
-              onPointerLeave={handleCardLeave}
             >
               {card.bgImage ? (
                 <Image

--- a/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
+++ b/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useRef, useState, useCallback } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import {
@@ -15,6 +15,7 @@ const MAX_TILT_DEG = 8;
 
 export function HeroCardStack({ playLabel }: { playLabel: string }) {
   const stackRef = useRef<HTMLDivElement>(null);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const { t } = useTranslation();
   const routes = useRoutes();
 
@@ -43,7 +44,14 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
     if (!stack) return;
     stack.style.setProperty('--tilt-x', '0deg');
     stack.style.setProperty('--tilt-y', '0deg');
+    setHoveredIndex(null);
   };
+
+  const handleCardEnter = useCallback(
+    (index: number) => setHoveredIndex(index),
+    [],
+  );
+  const handleCardLeave = useCallback(() => setHoveredIndex(null), []);
 
   return (
     <div data-testid="hero-visual" className="hero-visual-main fade-on-mount">
@@ -59,22 +67,25 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
           const x = (index - 1) * 65;
           const rotate = `${(index - 1) * 12}deg`;
           const y = index * -15;
+          const isActive = hoveredIndex === index;
 
           return (
             <div
               key={index}
-              className="hero-card-main"
+              className={`hero-card-main${isActive ? ' hero-card-active' : ''}`}
               style={
                 {
                   '--card-x': `${x}px`,
                   '--card-y': `${y}px`,
                   '--card-rotate': rotate,
                   '--card-scale': isLast ? 1 : 0.95,
-                  zIndex: index,
+                  zIndex: isActive ? 100 : index,
                   opacity: isLast ? 1 : 0.8,
                 } as React.CSSProperties
               }
               data-testid={`hero-card-${index}`}
+              onPointerEnter={() => handleCardEnter(index)}
+              onPointerLeave={handleCardLeave}
             >
               {card.bgImage ? (
                 <Image

--- a/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
+++ b/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
@@ -26,6 +26,7 @@ function indexFromPointerX(clientX: number, stack: HTMLDivElement): number {
 export function HeroCardStack({ playLabel }: { playLabel: string }) {
   const stackRef = useRef<HTMLDivElement>(null);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const pointerDownRef = useRef(false);
   const { t } = useTranslation();
   const routes = useRoutes();
 
@@ -48,7 +49,24 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
       const py = (e.clientY - rect.top) / rect.height - 0.5;
       stack.style.setProperty('--tilt-x', `${px * MAX_TILT_DEG * 2}deg`);
       stack.style.setProperty('--tilt-y', `${-py * MAX_TILT_DEG * 2}deg`);
-      setHoveredIndex(indexFromPointerX(e.clientX, stack));
+      if (!pointerDownRef.current) {
+        setHoveredIndex(indexFromPointerX(e.clientX, stack));
+      }
+    },
+    [],
+  );
+
+  const handlePointerDown = useCallback(() => {
+    pointerDownRef.current = true;
+  }, []);
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      pointerDownRef.current = false;
+      const stack = stackRef.current;
+      if (stack) {
+        setHoveredIndex(indexFromPointerX(e.clientX, stack));
+      }
     },
     [],
   );
@@ -58,6 +76,7 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
     if (!stack) return;
     stack.style.setProperty('--tilt-x', '0deg');
     stack.style.setProperty('--tilt-y', '0deg');
+    pointerDownRef.current = false;
     setHoveredIndex(null);
   }, []);
 
@@ -68,6 +87,8 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
         className="hero-card-stack-main hero-card-stack"
         data-testid="hero-card-stack"
         onPointerMove={handlePointerMove}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
         onPointerLeave={handlePointerLeave}
       >
         {heroCards.map((card, index) => {

--- a/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
+++ b/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
@@ -92,8 +92,9 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
           const isActive = hoveredIndex === index;
 
           return (
-            <div
+            <Link
               key={index}
+              href={`${routes.gameCreate}?variant=${card.id}`}
               className={`hero-card-main${isActive ? ' hero-card-active' : ''}`}
               style={
                 {
@@ -125,14 +126,13 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
                 {t(card.nameKey as TranslationKey) || card.nameKey}
               </div>
               <div className="hero-card-brand">CRITICAL</div>
-              <Link
-                href={`${routes.gameCreate}?variant=${card.id}`}
+              <span
                 className="hero-card-play-cta"
                 data-testid={`hero-play-cta-${index}`}
               >
                 {playLabel}
-              </Link>
-            </div>
+              </span>
+            </Link>
           );
         })}
       </div>

--- a/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
+++ b/apps/web/src/app/[locale]/home/components/HeroCardStack.tsx
@@ -60,16 +60,9 @@ export function HeroCardStack({ playLabel }: { playLabel: string }) {
     pointerDownRef.current = true;
   }, []);
 
-  const handlePointerUp = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      pointerDownRef.current = false;
-      const stack = stackRef.current;
-      if (stack) {
-        setHoveredIndex(indexFromPointerX(e.clientX, stack));
-      }
-    },
-    [],
-  );
+  const handlePointerUp = useCallback(() => {
+    pointerDownRef.current = false;
+  }, []);
 
   const handlePointerLeave = useCallback(() => {
     const stack = stackRef.current;

--- a/apps/web/src/app/[locale]/home/components/modals/HomeGameDetailsModal.tsx
+++ b/apps/web/src/app/[locale]/home/components/modals/HomeGameDetailsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, startTransition } from 'react';
 import { YStack, XStack, Text, styled, H4, SizableText } from 'tamagui';
 import {
   Modal,
@@ -255,13 +255,13 @@ export function HomeGameDetailsModal({
           >
             <button
               className={`tab-pill${activeTab === 'rules' ? ' active' : ''}`}
-              onClick={() => setActiveTab('rules')}
+              onClick={() => startTransition(() => setActiveTab('rules'))}
             >
               {homeCopy.rulesTab ?? 'Rules'}
             </button>
             <button
               className={`tab-pill${activeTab === 'info' ? ' active' : ''}`}
-              onClick={() => setActiveTab('info')}
+              onClick={() => startTransition(() => setActiveTab('info'))}
             >
               {homeCopy.infoTab ?? 'Game Themes'}
             </button>

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -376,16 +376,21 @@
     0 1px 0 rgba(255, 255, 255, 0.6) inset,
     0 8px 22px rgba(0, 0, 0, 0.45);
   pointer-events: none;
-  transition: transform 0.22s ease;
+  opacity: 0;
+  transition:
+    opacity 0.22s ease,
+    transform 0.22s ease;
   white-space: nowrap;
 }
 
 .hero-card-active .hero-card-play-cta {
+  opacity: 1;
   transform: translate(-50%, -50%) scale(1);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .hero-card-play-cta {
+    transition: opacity 0.15s ease;
     transform: translate(-50%, -50%) scale(1);
   }
 }

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -381,7 +381,8 @@
   white-space: nowrap;
 }
 
-.hero-card-main:hover .hero-card-play-cta {
+.hero-card-main:hover .hero-card-play-cta,
+.hero-card-active .hero-card-play-cta {
   opacity: 1;
   pointer-events: auto;
   transform: translate(-50%, -50%) scale(1);
@@ -404,7 +405,8 @@
   pointer-events: auto;
 }
 
-.hero-card-main:hover {
+.hero-card-main:hover,
+.hero-card-active {
   transform: translate(var(--card-x), calc(var(--card-y) - 20px))
     rotate(var(--card-rotate)) scale(1.05) !important;
   z-index: 100 !important;
@@ -430,7 +432,8 @@
   transition: transform 1.6s ease;
 }
 
-.hero-card-main:hover::after {
+.hero-card-main:hover::after,
+.hero-card-active::after {
   transform: translateX(100%);
 }
 

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -286,6 +286,9 @@
     opacity 0.6s ease-out,
     box-shadow 0.3s ease;
   pointer-events: none;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
 }
 
 .hero-card-image {
@@ -372,28 +375,17 @@
   box-shadow:
     0 1px 0 rgba(255, 255, 255, 0.6) inset,
     0 8px 22px rgba(0, 0, 0, 0.45);
-  opacity: 0;
   pointer-events: none;
-  transition:
-    opacity 0.22s ease,
-    transform 0.22s ease,
-    background 0.22s ease;
+  transition: transform 0.22s ease;
   white-space: nowrap;
 }
 
 .hero-card-active .hero-card-play-cta {
-  opacity: 1;
-  pointer-events: auto;
   transform: translate(-50%, -50%) scale(1);
-}
-
-.hero-card-play-cta:hover {
-  background: #ffffff;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .hero-card-play-cta {
-    transition: opacity 0.15s ease;
     transform: translate(-50%, -50%) scale(1);
   }
 }

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -381,7 +381,6 @@
   white-space: nowrap;
 }
 
-.hero-card-main:hover .hero-card-play-cta,
 .hero-card-active .hero-card-play-cta {
   opacity: 1;
   pointer-events: auto;
@@ -405,7 +404,6 @@
   pointer-events: auto;
 }
 
-.hero-card-main:hover,
 .hero-card-active {
   transform: translate(var(--card-x), calc(var(--card-y) - 20px))
     rotate(var(--card-rotate)) scale(1.05) !important;
@@ -432,14 +430,13 @@
   transition: transform 1.6s ease;
 }
 
-.hero-card-main:hover::after,
 .hero-card-active::after {
   transform: translateX(100%);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .hero-card-main::after,
-  .hero-card-main:hover::after {
+  .hero-card-active::after {
     transition: none;
     transform: translateX(-100%);
   }

--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -398,6 +398,7 @@
   }
 }
 
+[data-hydrated="true"] .hero-card-main,
 .is-hydrated .hero-card-main {
   opacity: 1;
   pointer-events: auto;

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -21,7 +21,7 @@ import { getTranslations } from '@/shared/i18n/server';
 import { buildRoutes } from '@/shared/config/routes';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import { SCHEMA_LANGUAGE_MAP } from '@/shared/seo/schemaLanguageMap';
-import { RouteChangeAnnouncer } from '@/shared/ui/RouteChangeAnnouncer';
+import { LayoutShell } from '@/shared/ui/LayoutShell';
 
 const OG_LOCALE_MAP: Record<Locale, string> = {
   en: 'en_US',
@@ -141,21 +141,14 @@ export default async function LocaleLayout({
       <LanguageProvider locale={locale}>
         <PWAProvider>
           <SoundProvider>
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                minHeight: '100dvh',
-              }}
-            >
-              <RouteChangeAnnouncer />
+            <LayoutShell>
               <AnnouncementBanner />
               <Header />
               <main style={{ flex: 1 }}>
                 <Suspense>{children}</Suspense>
               </main>
               <LayoutFooter />
-            </div>
+            </LayoutShell>
             {authToken ? <WalletLiveBridge authToken={authToken} /> : null}
           </SoundProvider>
         </PWAProvider>

--- a/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
@@ -167,28 +167,24 @@ export default function LeaderboardsPageContent({
   );
   useLeaderboardSocket('leaderboards.entry.updated', handleEntryUpdated);
 
-  function handleModeChange(next: GameMode) {
+  function resetAndSet<T>(setter: (v: T) => void, next: T) {
     startTransition(() => {
-      setMode(next);
+      setter(next);
       setPage(1);
       setAccumulated([]);
     });
+  }
+
+  function handleModeChange(next: GameMode) {
+    resetAndSet(setMode, next);
   }
 
   function handleScopeChange(next: Scope) {
-    startTransition(() => {
-      setScope(next);
-      setPage(1);
-      setAccumulated([]);
-    });
+    resetAndSet(setScope, next);
   }
 
   function handleRangeChange(next: Range) {
-    startTransition(() => {
-      setRange(next);
-      setPage(1);
-      setAccumulated([]);
-    });
+    resetAndSet(setRange, next);
   }
 
   // Blocker #3: jump to the actual self row inside the table, not the

--- a/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
+++ b/apps/web/src/app/[locale]/leaderboards/LeaderboardsPageContent.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  startTransition,
+} from 'react';
 import { useRouter } from 'next/navigation';
 import type { PageTranslations } from '@/shared/i18n/page-translations';
 import { useLanguage } from '@/shared/i18n/context';
@@ -162,21 +168,27 @@ export default function LeaderboardsPageContent({
   useLeaderboardSocket('leaderboards.entry.updated', handleEntryUpdated);
 
   function handleModeChange(next: GameMode) {
-    setMode(next);
-    setPage(1);
-    setAccumulated([]);
+    startTransition(() => {
+      setMode(next);
+      setPage(1);
+      setAccumulated([]);
+    });
   }
 
   function handleScopeChange(next: Scope) {
-    setScope(next);
-    setPage(1);
-    setAccumulated([]);
+    startTransition(() => {
+      setScope(next);
+      setPage(1);
+      setAccumulated([]);
+    });
   }
 
   function handleRangeChange(next: Range) {
-    setRange(next);
-    setPage(1);
-    setAccumulated([]);
+    startTransition(() => {
+      setRange(next);
+      setPage(1);
+      setAccumulated([]);
+    });
   }
 
   // Blocker #3: jump to the actual self row inside the table, not the

--- a/apps/web/src/app/[locale]/stats/StatsPage.tsx
+++ b/apps/web/src/app/[locale]/stats/StatsPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, startTransition } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { styled, XStack, YStack, Text } from 'tamagui';
 import {
@@ -114,7 +114,7 @@ export default function StatsPage({
         <TabGroup role="group" aria-label={t('stats.myStatsTab')}>
           <TabButton
             $active={activeTab === 'my-stats'}
-            onClick={() => setActiveTab('my-stats')}
+            onClick={() => startTransition(() => setActiveTab('my-stats'))}
             aria-pressed={activeTab === 'my-stats'}
             data-testid="stats-tab-my-stats"
           >
@@ -122,7 +122,7 @@ export default function StatsPage({
           </TabButton>
           <TabButton
             $active={activeTab === 'leaderboard'}
-            onClick={() => setActiveTab('leaderboard')}
+            onClick={() => startTransition(() => setActiveTab('leaderboard'))}
             aria-pressed={activeTab === 'leaderboard'}
             data-testid="stats-tab-leaderboard"
           >

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { setupTamagui } from '@/shared/config/tamagui.config';
 import { ThemeName, ThemePreference } from '@/shared/config/theme';
 import { DEFAULT_LOCALE, isLocale } from '@/shared/i18n';
 import { AppThemeProvider } from '@/app/theme/ThemeContext';
+import { LazySessionRoleSync } from '@/shared/ui/LazySessionRoleSync';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -37,7 +38,9 @@ export const metadata: Metadata = {
     site: '@_arcadeum_',
     title: appConfig.seoTitle,
     description: appConfig.seoDescription,
-    images: [{ url: '/logo.png', width: 1200, height: 630, alt: appConfig.appName }],
+    images: [
+      { url: '/logo.png', width: 1200, height: 630, alt: appConfig.appName },
+    ],
   },
   robots: {
     index: true,
@@ -157,7 +160,10 @@ export default async function RootLayout({
         </a>
         <WebVitalsReporter />
         <AppThemeProvider initialTheme={theme}>
-          <BrowserRegistry>{children}</BrowserRegistry>
+          <BrowserRegistry>
+            <LazySessionRoleSync />
+            {children}
+          </BrowserRegistry>
         </AppThemeProvider>
       </body>
     </html>

--- a/apps/web/src/app/styles/animations.scss
+++ b/apps/web/src/app/styles/animations.scss
@@ -254,12 +254,14 @@
 }
 
 .animate-shimmer-mid,
+[data-hydrated="true"] .kicker-hydration-shimmer,
 .is-hydrated .kicker-hydration-shimmer {
   position: relative;
   display: inline-block;
   color: var(--primary);
 }
 
+[data-hydrated="true"] .kicker-hydration-shimmer::after,
 .is-hydrated .kicker-hydration-shimmer::after {
   content: '';
   position: absolute;
@@ -292,6 +294,7 @@
   transition: opacity 0.6s ease-out;
 }
 
+[data-hydrated="true"] .fade-on-mount,
 .is-hydrated .fade-on-mount,
 .fade-on-mount.mounted {
   opacity: 1;

--- a/apps/web/src/entities/session/model/SessionRoleSync.test.tsx
+++ b/apps/web/src/entities/session/model/SessionRoleSync.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, act } from '@testing-library/react';
 
+const INITIAL_SYNC_DEFER_MS = 2000;
+
 // ---- Mock apiClient ----
 // Inline ApiError rather than vi.importActual to avoid an extra module-
 // resolution roundtrip and any side effects from the real api-client
@@ -114,6 +116,9 @@ describe('SessionRoleSync', () => {
   it('fetches /auth/me on mount when hydrated and accessToken present', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(apiGetMock).toHaveBeenCalledTimes(1);
@@ -123,6 +128,9 @@ describe('SessionRoleSync', () => {
   it('does not fetch when not hydrated', async () => {
     storeRef.state.hydrated = false;
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).not.toHaveBeenCalled();
   });
@@ -130,6 +138,9 @@ describe('SessionRoleSync', () => {
   it('does not fetch when accessToken is null', async () => {
     storeRef.state.snapshot = { accessToken: null };
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).not.toHaveBeenCalled();
   });
@@ -151,6 +162,9 @@ describe('SessionRoleSync', () => {
   it('passes profile + equipped cosmetic fields to setTokens (no token fields)', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.state.setTokens).toHaveBeenCalledTimes(1);
@@ -181,6 +195,9 @@ describe('SessionRoleSync', () => {
       equippedFrameId: 'frame-gold',
     });
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     const arg = storeRef.state.setTokens.mock.calls[0][0];
@@ -196,6 +213,9 @@ describe('SessionRoleSync', () => {
       }),
     );
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     setStoreState({ snapshot: { accessToken: null } });
@@ -209,6 +229,9 @@ describe('SessionRoleSync', () => {
   it('throttle: focus event right after mount does not refetch', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).toHaveBeenCalledTimes(1);
 
@@ -222,6 +245,9 @@ describe('SessionRoleSync', () => {
   it('throttle: focus event after 30s elapses fires another fetch', async () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
     expect(apiGetMock).toHaveBeenCalledTimes(1);
 
@@ -256,6 +282,9 @@ describe('SessionRoleSync', () => {
   it('on 401, calls refreshTokens and does not call setTokens; throttle slot not consumed', async () => {
     apiGetMock.mockRejectedValueOnce(new ApiError('Unauthorized', 401, null));
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.state.refreshTokens).toHaveBeenCalledTimes(1);
@@ -273,6 +302,9 @@ describe('SessionRoleSync', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     apiGetMock.mockRejectedValueOnce(new ApiError('Server error', 500, null));
     render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.state.setTokens).not.toHaveBeenCalled();
@@ -293,6 +325,9 @@ describe('SessionRoleSync', () => {
     apiGetMock.mockResolvedValueOnce(PROFILE);
 
     const { unmount } = render(<SessionRoleSync />);
+    act(() => {
+      vi.advanceTimersByTime(INITIAL_SYNC_DEFER_MS);
+    });
     await flushPromises();
 
     expect(storeRef.listeners.length).toBe(1);

--- a/apps/web/src/entities/session/model/SessionRoleSync.tsx
+++ b/apps/web/src/entities/session/model/SessionRoleSync.tsx
@@ -6,6 +6,7 @@ import { apiClient, ApiError } from '@/shared/lib/api-client';
 import type { AuthUserProfile } from '../api/authApi';
 
 const FOCUS_THROTTLE_MS = 30_000;
+const INITIAL_SYNC_DEFER_MS = 2000;
 
 /**
  * Mounted exactly once at the app root. Keeps the persisted session
@@ -81,7 +82,7 @@ export function SessionRoleSync(): null {
       }
     };
 
-    void sync();
+    const timer = setTimeout(() => void sync(), INITIAL_SYNC_DEFER_MS);
 
     const unsubscribe = useSessionStore.subscribe((state, prev) => {
       if (state.hydrated && !prev.hydrated) void sync();
@@ -93,6 +94,7 @@ export function SessionRoleSync(): null {
     window.addEventListener('focus', onFocus);
 
     return () => {
+      clearTimeout(timer);
       window.removeEventListener('focus', onFocus);
       unsubscribe();
     };

--- a/apps/web/src/features/wallet/ui/WalletLiveBridge.tsx
+++ b/apps/web/src/features/wallet/ui/WalletLiveBridge.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   walletSocket,
@@ -12,27 +12,36 @@ interface Props {
   authToken: string;
 }
 
+const DEFER_MS = 2000;
+
 /**
  * Client island that maintains the wallet socket connection for authenticated
  * users. Listens for `wallet:updated` events and calls `router.refresh()` so
  * any Server Component showing a balance re-fetches from the server.
  *
- * Mounted exactly once in the root layout (apps/web/src/app/layout.tsx) so it
- * is not re-created when navigating between pages. The bridge is only rendered
- * when a valid auth token exists — the Server Component parent guards that.
+ * The connection is deferred by 2 s so it doesn't compete with initial
+ * rendering / LCP on pages where wallet data isn't displayed (e.g. landing).
  */
 export function WalletLiveBridge({ authToken }: Props) {
   const router = useRouter();
+  const cleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    connectWalletSocket(authToken);
+    const timer = setTimeout(() => {
+      connectWalletSocket(authToken);
 
-    const onUpdate = () => router.refresh();
-    walletSocket.on('wallet:updated', onUpdate);
+      const onUpdate = () => router.refresh();
+      walletSocket.on('wallet:updated', onUpdate);
+
+      cleanupRef.current = () => {
+        walletSocket.off('wallet:updated', onUpdate);
+        disconnectWalletSocket();
+      };
+    }, DEFER_MS);
 
     return () => {
-      walletSocket.off('wallet:updated', onUpdate);
-      disconnectWalletSocket();
+      clearTimeout(timer);
+      cleanupRef.current?.();
     };
   }, [authToken, router]);
 

--- a/apps/web/src/shared/lib/sound/SoundProvider.tsx
+++ b/apps/web/src/shared/lib/sound/SoundProvider.tsx
@@ -39,13 +39,17 @@ export function SoundProvider({ children }: { children: ReactNode }) {
     enabledRef.current = soundEnabled;
   }, [soundEnabled]);
 
-  useEffect(() => {
-    playerRef.current?.preloadAll();
-  }, []);
+  const preloadedRef = useRef(false);
 
   const value = useMemo<SoundContextValue>(
     () => ({
-      play: (id) => playerRef.current?.play(id, enabledRef.current),
+      play: (id) => {
+        if (!preloadedRef.current) {
+          preloadedRef.current = true;
+          playerRef.current?.preloadAll();
+        }
+        playerRef.current?.play(id, enabledRef.current);
+      },
     }),
     [],
   );

--- a/apps/web/src/shared/ui/LayoutShell.tsx
+++ b/apps/web/src/shared/ui/LayoutShell.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { type ReactNode, useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+
+function RouteChangeAnnouncer() {
+  const pathname = usePathname();
+  const prevPathname = useRef(pathname);
+  const announcerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (pathname !== prevPathname.current) {
+      prevPathname.current = pathname;
+      if (announcerRef.current) {
+        announcerRef.current.textContent = '';
+        requestAnimationFrame(() => {
+          if (announcerRef.current) {
+            announcerRef.current.textContent = `Navigated to ${pathname}`;
+          }
+        });
+      }
+    }
+  }, [pathname]);
+
+  return (
+    <div
+      ref={announcerRef}
+      role="status"
+      aria-live="assertive"
+      aria-atomic="true"
+      suppressHydrationWarning
+      style={{
+        position: 'absolute',
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        border: 0,
+      }}
+    />
+  );
+}
+
+export function LayoutShell({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100dvh',
+      }}
+    >
+      <RouteChangeAnnouncer />
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/LazySessionRoleSync.tsx
+++ b/apps/web/src/shared/ui/LazySessionRoleSync.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const SessionRoleSync = dynamic(
+  () =>
+    import('@/entities/session/model/SessionRoleSync').then(
+      (m) => m.SessionRoleSync,
+    ),
+  { ssr: false },
+);
+
+export function LazySessionRoleSync() {
+  return <SessionRoleSync />;
+}


### PR DESCRIPTION
## What
- Fix hero card hover overlap race condition with x-position math instead of CSS :hover or per-card pointer events
- Freeze hoveredIndex during pointer-down to prevent play button disappearing mid-click
- Remove hoveredIndex recalc on pointerup so click reaches play button
- Make entire hero card clickable, play label is just a decorative badge

## Why
Cards overlap spatially (65px offset, 280px wide), CSS :hover and bounding-box onPointerEnter cause z-index race conditions. Play button was unreliable as a small click target inside overlapping cards.

## Changes
- `apps/web/src/app/[zone]/home/components/HeroCardStack.tsx` — indexFromPointerX() for hover detection, pointerDownRef freezes hover during clicks
- `apps/web/src/app/[zone]/home/components/styles/home-bundle.scss` — :hover removed, .hero-card-active badge visibility