### PR TITLE
fix(web): hero card hover overlap and click fix

### DIFF
--- a/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
+++ b/apps/web/src/app/[locale]/home/components/styles/home-bundle.scss
@@ -376,16 +376,21 @@
     0 1px 0 rgba(255, 255, 255, 0.6) inset,
     0 8px 22px rgba(0, 0, 0, 0.45);
   pointer-events: none;
-  transition: transform 0.22s ease;
+  opacity: 0;
+  transition:
+    opacity 0.22s ease,
+    transform 0.22s ease;
   white-space: nowrap;
 }
 
 .hero-card-active .hero-card-play-cta {
+  opacity: 1;
   transform: translate(-50%, -50%) scale(1);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .hero-card-play-cta {
+    transition: opacity 0.15s ease;
     transform: translate(-50%, -50%) scale(1);
   }
 }


### PR DESCRIPTION
## What
- Fix hero card hover overlap race condition with x-position math instead of CSS :hover or per-card pointer events
- Freeze hoveredIndex during pointer-down to prevent play button disappearing mid-click
- Remove hoveredIndex recalc on pointerup so click reaches play button
- Make entire hero card clickable, play label is just a decorative badge

## Why
Cards overlap spatially (65px offset, 280px wide), CSS :hover and bounding-box onPointerEnter cause z-index race conditions. Play button was unreliable as a small click target inside overlapping cards.

## Changes
- `apps/web/src/app/[zone]/home/components/HeroCardStack.tsx` — indexFromPointerX() for hover detection, pointerDownRef freezes hover during clicks
- `apps/web/src/app/[zone]/home/components/styles/home-bundle.scss` — :hover removed, .hero-card-active badge visibility