### PR TITLE
fix(web): use double curly braces for appName interpolation in HomeHero

### DIFF
--- a/apps/web/src/app/[locale]/home/components/HomeHero.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeHero.tsx
@@ -13,10 +13,10 @@ export default async function HomeHero() {
 
   const kicker = homeCopy.kicker ?? 'Free online board games';
   const tagline =
-    homeCopy.tagline?.replace('{appName}', appConfig.appName) ??
+    homeCopy.tagline?.replace('{{appName}}', appConfig.appName) ??
     `${appConfig.appName} is the ultimate platform to play board games online with friends.`;
   const description =
-    homeCopy.description?.replace('{appName}', appConfig.appName) ??
+    homeCopy.description?.replace('{{appName}}', appConfig.appName) ??
     `Enjoy a wide variety of board games and tabletop experiences online. Create real-time game rooms, invite your friends, and let ${appConfig.appName} handle rules, scoring, and turns so you can focus on the fun.`;
   const primaryLabel = homeCopy.primaryCtaLabel ?? 'Get started';
   const supportLabel = homeCopy.supportCtaLabel ?? 'Support the developers';


### PR DESCRIPTION
## What
Fixed `HomeHero.tsx` to use `{{appName}}` (double curly braces) instead of `{appName}` when replacing translation placeholders. The translations already used `{{appName}}` but the code was looking for `{appName}`, causing the literal text to render instead of the interpolated value.

## Why
The `useTranslation().t()` function uses `interpolateParams()` which expects `{{key}}` syntax. The HomeHero was using single braces, so placeholders like `{{appName}}` in the tagline and description were never replaced — rendering as literal `{appName}` text.

## Changes
- `HomeHero.tsx`: Updated `.replace()` calls to use `{{appName}}` matching the translation format