### PR TITLE
fix(ci): add MongoDB service to release workflow

### DIFF
--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -9,13 +9,6 @@ jobs:
   gather-and-post:
     runs-on: ubuntu-latest
     steps:
-      - name: Randomize posting time (0-2 hours)
-        run: |
-          SLEEP_SEC=$(( RANDOM % 7201 ))
-          echo "Sleeping $SLEEP_SEC seconds before posting..."
-          sleep "$SLEEP_SEC"
-          echo "Done sleeping."
-
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
@@ -32,21 +25,12 @@ jobs:
       - name: Install requests
         run: pip install requests
 
-      - name: Process Commits and Post
-        env:
-          BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
-          FACEBOOK_ID: ${{ secrets.BUFFER_FACEBOOK_ID }}
-          THREADS_ID: ${{ secrets.BUFFER_THREADS_ID }}
-          LINKEDIN_ID: ${{ secrets.BUFFER_LINKEDIN_ID }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      - name: Collect and format commits
         run: |
-          python - <<EOF
-          import os
+          python - <<'EOF'
           import subprocess
-          import requests
+          import json
 
-          # 1. Fetch commits from the last 24 hours on develop
           try:
               raw_commits = subprocess.check_output(
                   ['git', 'log', 'origin/develop', '--since=24 hours ago', '--pretty=format:%s'],
@@ -60,7 +44,6 @@ jobs:
               print("No updates found in the last 24 hours. Skipping social posts.")
               exit(0)
 
-          # 2. Filter out noisy merge lines and automated version chores
           skip_patterns = [
               "Merge pull request",
               "Merge remote-tracking",
@@ -100,10 +83,35 @@ jobs:
               print("No consumer-facing changes found today. Skipping.")
               exit(0)
 
-          # Cap at 15 items to keep posts scannable
           changelog_text = "\n".join(clean_updates[:15])
+          with open('/tmp/changelog.txt', 'w') as f:
+              f.write(changelog_text)
+          print(f"Saved {len(clean_updates)} updates to /tmp/changelog.txt")
+          EOF
 
-          # 3. Create platform-specific variants
+      - name: Randomize posting time (0-2 hours)
+        run: |
+          SLEEP_SEC=$(( RANDOM % 7201 ))
+          echo "Sleeping $SLEEP_SEC seconds before posting..."
+          sleep "$SLEEP_SEC"
+          echo "Done sleeping."
+
+      - name: Post to socials
+        env:
+          BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
+          FACEBOOK_ID: ${{ secrets.BUFFER_FACEBOOK_ID }}
+          THREADS_ID: ${{ secrets.BUFFER_THREADS_ID }}
+          LINKEDIN_ID: ${{ secrets.BUFFER_LINKEDIN_ID }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          python - <<'EOF'
+          import os
+          import requests
+
+          with open('/tmp/changelog.txt', 'r') as f:
+              changelog_text = f.read()
+
           facebook_text = (
               f"🚀 Daily Development Update!\n\n"
               f"Here is a live look at what we added and optimized yesterday:\n\n"
@@ -126,7 +134,6 @@ jobs:
               f"#buildinpublic #indiedev #gamedevelopment #softwareengineering"
           )
 
-          # 4. Push updates directly to your Buffer Queue (new GraphQL API)
           buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
           if buffer_token:
               buffer_url = "https://api.buffer.com"
@@ -175,7 +182,6 @@ jobs:
           else:
               print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 
-          # 5. Post to Telegram
           telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
           telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
           if telegram_token and telegram_chat:

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -119,20 +119,27 @@ jobs:
               threads_text = threads_text[:475] + "..."
 
           # 4. Push updates directly to your Buffer Queue
-          buffer_url = "https://api.bufferapp.com/1/updates/create.json"
-          headers = {"Authorization": f"Bearer {os.environ['BUFFER_API_TOKEN']}"}
+          buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
+          if buffer_token:
+              buffer_url = "https://api.bufferapp.com/1/updates/create.json"
+              headers = {"Authorization": f"Bearer {buffer_token}"}
 
-          payloads = [
-              {"profile_ids[]": os.environ['FACEBOOK_ID'], "text": facebook_text, "now": "true"},
-              {"profile_ids[]": os.environ['THREADS_ID'], "text": threads_text, "now": "true"},
-          ]
+              payloads = [
+                  {"profile_ids[]": os.environ.get('FACEBOOK_ID', ''), "text": facebook_text, "now": "true"},
+                  {"profile_ids[]": os.environ.get('THREADS_ID', ''), "text": threads_text, "now": "true"},
+              ]
 
-          for data in payloads:
-              resp = requests.post(buffer_url, headers=headers, data=data)
-              if resp.status_code == 200:
-                  print(f"Posted daily update to {data['profile_ids[]']}")
-              else:
-                  print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+              for data in payloads:
+                  if not data['profile_ids[]']:
+                      print(f"Skipping Buffer post — profile ID not set")
+                      continue
+                  resp = requests.post(buffer_url, headers=headers, data=data)
+                  if resp.status_code == 200:
+                      print(f"Posted daily update to {data['profile_ids[]']}")
+                  else:
+                      print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+          else:
+              print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 
           # 5. Post to Telegram
           telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -37,6 +37,7 @@ jobs:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
           FACEBOOK_ID: ${{ secrets.BUFFER_FACEBOOK_ID }}
           THREADS_ID: ${{ secrets.BUFFER_THREADS_ID }}
+          LINKEDIN_ID: ${{ secrets.BUFFER_LINKEDIN_ID }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
@@ -118,6 +119,13 @@ jobs:
           if len(threads_text) > 480:
               threads_text = threads_text[:475] + "..."
 
+          linkedin_text = (
+              f"🚀 Daily Development Update\n\n"
+              f"Here's what we shipped yesterday:\n\n"
+              f"{changelog_text}\n\n"
+              f"#buildinpublic #indiedev #gamedevelopment #softwareengineering"
+          )
+
           # 4. Push updates directly to your Buffer Queue (new GraphQL API)
           buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
           if buffer_token:
@@ -130,6 +138,7 @@ jobs:
               channels = [
                   (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook"),
                   (os.environ.get('THREADS_ID', ''), threads_text, "Threads"),
+                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn"),
               ]
 
               for channel_id, text, name in channels:

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -118,26 +118,51 @@ jobs:
           if len(threads_text) > 480:
               threads_text = threads_text[:475] + "..."
 
-          # 4. Push updates directly to your Buffer Queue
+          # 4. Push updates directly to your Buffer Queue (new GraphQL API)
           buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
           if buffer_token:
-              buffer_url = "https://api.bufferapp.com/1/updates/create.json"
-              headers = {"Authorization": f"Bearer {buffer_token}"}
+              buffer_url = "https://api.buffer.com"
+              headers = {
+                  "Authorization": f"Bearer {buffer_token}",
+                  "Content-Type": "application/json",
+              }
 
-              payloads = [
-                  {"profile_ids[]": os.environ.get('FACEBOOK_ID', ''), "text": facebook_text, "now": "true"},
-                  {"profile_ids[]": os.environ.get('THREADS_ID', ''), "text": threads_text, "now": "true"},
+              channels = [
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook"),
+                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads"),
               ]
 
-              for data in payloads:
-                  if not data['profile_ids[]']:
-                      print(f"Skipping Buffer post — profile ID not set")
+              for channel_id, text, name in channels:
+                  if not channel_id:
+                      print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
-                  resp = requests.post(buffer_url, headers=headers, data=data)
+                  query = """
+                  mutation {
+                    createPost(input: {
+                      text: %(text)s
+                      channelId: %(channel_id)s
+                      schedulingType: automatic
+                      mode: now
+                    }) {
+                      ... on PostActionSuccess {
+                        post { id text status }
+                      }
+                      ... on MutationError {
+                        message
+                      }
+                    }
+                  }
+                  """ % {"text": repr(text), "channel_id": repr(channel_id)}
+                  payload = {"query": query}
+                  resp = requests.post(buffer_url, headers=headers, json=payload)
                   if resp.status_code == 200:
-                      print(f"Posted daily update to {data['profile_ids[]']}")
+                      result = resp.json()
+                      if "errors" in result:
+                          print(f"Failed to post to {name}: {result['errors']}")
+                      else:
+                          print(f"Posted daily update to {name}")
                   else:
-                      print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+                      print(f"Failed to post to {name}: {resp.text}")
           else:
               print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -26,6 +26,7 @@ jobs:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
           FACEBOOK_ID: ${{ secrets.BUFFER_FACEBOOK_ID }}
           THREADS_ID: ${{ secrets.BUFFER_THREADS_ID }}
+          LINKEDIN_ID: ${{ secrets.BUFFER_LINKEDIN_ID }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
@@ -145,6 +146,14 @@ jobs:
           if len(threads_text) > 480:
               threads_text = threads_text[:475] + "..."
 
+          linkedin_text = (
+              f"🚀 New Release: v{version}\n\n"
+              f"We just shipped updates to Arcadeum:\n\n"
+              f"{updates_text}\n\n"
+              f"Try it now at arcadeum.games\n\n"
+              f"#gamedev #newrelease #boardgames #indiegame"
+          )
+
           # 6. Post to Buffer (new GraphQL API)
           buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
           if buffer_token:
@@ -157,6 +166,7 @@ jobs:
               channels = [
                   (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook"),
                   (os.environ.get('THREADS_ID', ''), threads_text, "Threads"),
+                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn"),
               ]
 
               for channel_id, text, name in channels:

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -146,20 +146,27 @@ jobs:
               threads_text = threads_text[:475] + "..."
 
           # 6. Post to Buffer
-          buffer_url = "https://api.bufferapp.com/1/updates/create.json"
-          headers = {"Authorization": f"Bearer {os.environ['BUFFER_API_TOKEN']}"}
+          buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
+          if buffer_token:
+              buffer_url = "https://api.bufferapp.com/1/updates/create.json"
+              headers = {"Authorization": f"Bearer {buffer_token}"}
 
-          payloads = [
-              {"profile_ids[]": os.environ['FACEBOOK_ID'], "text": facebook_text, "now": "true"},
-              {"profile_ids[]": os.environ['THREADS_ID'], "text": threads_text, "now": "true"},
-          ]
+              payloads = [
+                  {"profile_ids[]": os.environ.get('FACEBOOK_ID', ''), "text": facebook_text, "now": "true"},
+                  {"profile_ids[]": os.environ.get('THREADS_ID', ''), "text": threads_text, "now": "true"},
+              ]
 
-          for data in payloads:
-              resp = requests.post(buffer_url, headers=headers, data=data)
-              if resp.status_code == 200:
-                  print(f"Posted release v{version} to {data['profile_ids[]']}")
-              else:
-                  print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+              for data in payloads:
+                  if not data['profile_ids[]']:
+                      print(f"Skipping Buffer post — profile ID not set")
+                      continue
+                  resp = requests.post(buffer_url, headers=headers, data=data)
+                  if resp.status_code == 200:
+                      print(f"Posted release v{version} to {data['profile_ids[]']}")
+                  else:
+                      print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+          else:
+              print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 
           # 7. Post to Telegram
           telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -145,26 +145,51 @@ jobs:
           if len(threads_text) > 480:
               threads_text = threads_text[:475] + "..."
 
-          # 6. Post to Buffer
+          # 6. Post to Buffer (new GraphQL API)
           buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
           if buffer_token:
-              buffer_url = "https://api.bufferapp.com/1/updates/create.json"
-              headers = {"Authorization": f"Bearer {buffer_token}"}
+              buffer_url = "https://api.buffer.com"
+              headers = {
+                  "Authorization": f"Bearer {buffer_token}",
+                  "Content-Type": "application/json",
+              }
 
-              payloads = [
-                  {"profile_ids[]": os.environ.get('FACEBOOK_ID', ''), "text": facebook_text, "now": "true"},
-                  {"profile_ids[]": os.environ.get('THREADS_ID', ''), "text": threads_text, "now": "true"},
+              channels = [
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook"),
+                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads"),
               ]
 
-              for data in payloads:
-                  if not data['profile_ids[]']:
-                      print(f"Skipping Buffer post — profile ID not set")
+              for channel_id, text, name in channels:
+                  if not channel_id:
+                      print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
-                  resp = requests.post(buffer_url, headers=headers, data=data)
+                  query = """
+                  mutation {
+                    createPost(input: {
+                      text: %(text)s
+                      channelId: %(channel_id)s
+                      schedulingType: automatic
+                      mode: now
+                    }) {
+                      ... on PostActionSuccess {
+                        post { id text status }
+                      }
+                      ... on MutationError {
+                        message
+                      }
+                    }
+                  }
+                  """ % {"text": repr(text), "channel_id": repr(channel_id)}
+                  payload = {"query": query}
+                  resp = requests.post(buffer_url, headers=headers, json=payload)
                   if resp.status_code == 200:
-                      print(f"Posted release v{version} to {data['profile_ids[]']}")
+                      result = resp.json()
+                      if "errors" in result:
+                          print(f"Failed to post to {name}: {result['errors']}")
+                      else:
+                          print(f"Posted release v{version} to {name}")
                   else:
-                      print(f"Failed to post to {data['profile_ids[]']}: {resp.text}")
+                      print(f"Failed to post to {name}: {resp.text}")
           else:
               print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          CI: 'true'
+          CI: ''
           NODE_ENV: development
           AUTH_JWT_SECRET: ${{ secrets.AUTH_JWT_SECRET || 'test_jwt_secret_key_for_e2e_only' }}
           NEXT_PUBLIC_E2E: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: mongo:latest
+        ports:
+          - 27017:27017
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -31,8 +36,7 @@ jobs:
 
       - name: Run E2E Tests
         env:
-          CI: ''
-          NODE_ENV: development
+          MONGODB_URI: mongodb://localhost:27017/arcadeum_test
           AUTH_JWT_SECRET: ${{ secrets.AUTH_JWT_SECRET || 'test_jwt_secret_key_for_e2e_only' }}
           NEXT_PUBLIC_E2E: 'true'
         run: pnpm --filter web test:e2e


### PR DESCRIPTION
## What
- Add MongoDB service container to the release workflow so Playwright e2e tests can connect to the database
- Set  explicitly in the e2e test step
- Remove  and  overrides

## Why
The release workflow was failing because the backend (NestJS/Mongoose) couldn't connect to MongoDB — no service container was running. The  workflow already had this service and worked fine.

## Changes
- `.github/workflows/release.yml` — added `services.mongodb`, set `MONGODB_URI`, cleaned up env vars