### PR TITLE
fix(e2e): use domcontentloaded instead of load for Mobile Safari reliability

### DIFF
--- a/apps/web/e2e/auth-extended.spec.ts
+++ b/apps/web/e2e/auth-extended.spec.ts
@@ -75,7 +75,9 @@ test.describe('Auth Extended', () => {
 
     // 3. Verify session is cleared and redirected
     await Promise.all([
-      page.waitForURL(/\/(en|es|fr|ru|by)(\/(auth|login))?\/?$/, {}),
+      page.waitForURL(/\/(en|es|fr|ru|by)(\/(auth|login))?\/?$/, {
+        waitUntil: 'domcontentloaded',
+      }),
       logoutBtn.click({ force: true }),
     ]);
   });

--- a/apps/web/e2e/footer-github.spec.ts
+++ b/apps/web/e2e/footer-github.spec.ts
@@ -6,7 +6,7 @@ test.describe('Footer GitHub Link', () => {
 
   async function scrollToFooter(page: import('@playwright/test').Page) {
     await navigateTo(page, '/');
-    await page.waitForLoadState('load');
+    await page.waitForLoadState('domcontentloaded');
     for (let i = 0; i < 3; i++) {
       await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
     }

--- a/apps/web/e2e/footer-links.spec.ts
+++ b/apps/web/e2e/footer-links.spec.ts
@@ -9,7 +9,7 @@ test.describe('Footer Links', () => {
   // Navigate and scroll to footer, waiting for it to render
   async function scrollToFooter(page: import('@playwright/test').Page) {
     await navigateTo(page, '/');
-    await page.waitForLoadState('load');
+    await page.waitForLoadState('domcontentloaded');
     // Ensure the footer is attached to the DOM
     const footer = page.locator('footer').first();
     await footer.waitFor({ state: 'attached' });


### PR DESCRIPTION
## What
Replaces `waitForLoadState("load")` with `waitForLoadState("domcontentloaded")` in footer E2E tests and adds `{ waitUntil: "domcontentloaded" }` to the logout `waitForURL` in auth-extended test.

## Why
Mobile Safari often fails to fire the `load` event (due to lazy-loaded resources, service workers, or WebKit quirks), causing three E2E tests to time out after 30s. The `navigateTo` helper already waits for hydration markers (`data-hydrated` / `data-app-ready`), so the page is guaranteed interactive by the time these assertions run — `load` was unnecessarily strict.

## Changes
- `footer-github.spec.ts:9` — `waitForLoadState("load")` → `waitForLoadState("domcontentloaded")`
- `footer-links.spec.ts:12` — `waitForLoadState("load")` → `waitForLoadState("domcontentloaded")`
- `auth-extended.spec.ts:78` — added `{ waitUntil: "domcontentloaded" }` to `waitForURL`