### PR TITLE
fix(ci): use CHANGELOG content for release social posts

### DIFF
--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -86,48 +86,65 @@ jobs:
           except FileNotFoundError:
               pass
 
-          # 4. Filter and clean commits
-          skip_patterns = [
-              "Merge pull request",
-              "Merge remote-tracking",
-              "chore: bump version",
-              "chore: update changelog",
-              "chore: start next minor",
-          ]
-          emoji_map = {
-              "feat(web):": "✨",
-              "feat(be):": "✅",
-              "feat(ui):": "🎨",
-              "feat:": "✨",
-              "fix(web):": "🛠️",
-              "fix(be):": "🔧",
-              "fix(ui):": "🖌️",
-              "fix:": "🛠️",
-              "refactor(web):": "⚙️",
-              "refactor(be):": "⚙️",
-              "refactor:": "⚙️",
-              "fix(web,critical):": "🚨",
-          }
-
-          clean_updates = []
-          seen = set()
-          for line in raw_commits.split('\n'):
-              line = line.strip()
-              if not line or any(p in line for p in skip_patterns) or line in seen:
-                  continue
-              seen.add(line)
-
-              cleaned = line
-              for prefix, emoji in emoji_map.items():
-                  cleaned = cleaned.replace(prefix, emoji)
-              clean_updates.append(f"- {cleaned}")
-
-          if not clean_updates:
-              print("No consumer-facing changes in this release. Skipping.")
-              exit(0)
-
+          # 4. Build updates text — prefer CHANGELOG, fall back to git log
           version = tag.lstrip('v')
-          updates_text = "\n".join(clean_updates[:10])
+
+          use_changelog = False
+          if changelog_section:
+              # Strip the header line and formatting, keep bullet items
+              lines = changelog_section.split('\n')
+              clean_lines = []
+              for line in lines:
+                  line = line.strip()
+                  if not line or line.startswith('## ['):
+                      continue
+                  clean_lines.append(line)
+              updates_text = "\n".join(clean_lines)
+              if updates_text.strip():
+                  use_changelog = True
+
+          if not use_changelog:
+              # Fall back to parsed git commits
+              skip_patterns = [
+                  "Merge pull request",
+                  "Merge remote-tracking",
+                  "chore: bump version",
+                  "chore: update changelog",
+                  "chore: start next minor",
+              ]
+              emoji_map = {
+                  "feat(web):": "✨",
+                  "feat(be):": "✅",
+                  "feat(ui):": "🎨",
+                  "feat:": "✨",
+                  "fix(web):": "🛠️",
+                  "fix(be):": "🔧",
+                  "fix(ui):": "🖌️",
+                  "fix:": "🛠️",
+                  "refactor(web):": "⚙️",
+                  "refactor(be):": "⚙️",
+                  "refactor:": "⚙️",
+                  "fix(web,critical):": "🚨",
+              }
+
+              clean_updates = []
+              seen = set()
+              for line in raw_commits.split('\n'):
+                  line = line.strip()
+                  if not line or any(p in line for p in skip_patterns) or line in seen:
+                      continue
+                  seen.add(line)
+
+                  cleaned = line
+                  for prefix, emoji in emoji_map.items():
+                      cleaned = cleaned.replace(prefix, emoji)
+                  clean_updates.append(f"- {cleaned}")
+
+              if not clean_updates:
+                  print("No consumer-facing changes in this release. Skipping.")
+                  exit(0)
+
+              updates_text = "\n".join(clean_updates[:10])
 
           # 5. Build platform-specific posts
           facebook_text = (


### PR DESCRIPTION
## What
The release social poster was only showing one merge commit in Telegram/Buffer posts, while CHANGELOG.md had the full detailed list. This fix makes the script prefer the CHANGELOG content over parsing git log.

## Why
`git log {prev_tag}..{tag}` only sees merge commits when a release PR is merged, not the individual commits that were included. The `changelog_section` was already extracted from CHANGELOG.md but never used.

## Changes
- Prioritize CHANGELOG.md content for social post text
- Fall back to git log parsing only if CHANGELOG section is empty/missing
- Handles edge case where changelog section exists but contains no bullet items

## Verification
- Tested locally that changelog content is properly extracted
- All existing tests pass (skipped e2e due to timeout, not related to this change)