### PR TITLE
ci(release): install playwright browsers before e2e tests

### DIFF
--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -151,7 +151,9 @@ jobs:
                     createPost(input: {
                       text: $text
                       channelId: $channelId
-                      schedulingType: now
+                      schedulingType: automatic
+                      mode: shareNow
+                      assets: []
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -137,24 +137,33 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "post"),
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook"),
                   (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None),
                   (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None),
               ]
 
-              for channel_id, text, name, post_type in channels:
+              for channel_id, text, name, metadata_key in channels:
                   if not channel_id:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
+                  if metadata_key:
+                      metadata_json = json.dumps({metadata_key: {"type": "post"}})
+                  else:
+                      metadata_json = "{}"
+                  variables = {
+                      "text": text,
+                      "channelId": channel_id,
+                      "metadata": json.loads(metadata_json),
+                  }
                   query = """
-                  mutation CreatePost($text: String!, $channelId: ChannelId!) {
+                  mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
                     createPost(input: {
                       text: $text
                       channelId: $channelId
                       schedulingType: automatic
                       mode: shareNow
                       assets: []
-                      %(type_field)s
+                      metadata: $metadata
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }
@@ -165,12 +174,6 @@ jobs:
                     }
                   }
                   """
-                  type_field = f'type: "{post_type}"' if post_type else ""
-                  query = query % {"type_field": type_field}
-                  variables = {
-                      "text": text,
-                      "channelId": channel_id,
-                  }
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
                   print(f"{name} response: {resp.status_code} {resp.text}")

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -137,12 +137,12 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook"),
-                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None),
-                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None),
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook", "addToQueue"),
+                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None, "shareNow"),
+                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None, "shareNow"),
               ]
 
-              for channel_id, text, name, metadata_key in channels:
+              for channel_id, text, name, metadata_key, mode in channels:
                   if not channel_id:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
@@ -161,7 +161,7 @@ jobs:
                       text: $text
                       channelId: $channelId
                       schedulingType: automatic
-                      mode: shareNow
+                      mode: %s
                       assets: []
                       metadata: $metadata
                     }) {
@@ -173,7 +173,7 @@ jobs:
                       }
                     }
                   }
-                  """
+                  """ % mode
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
                   print(f"{name} response: {resp.status_code} {resp.text}")

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -89,13 +89,6 @@ jobs:
           print(f"Saved {len(clean_updates)} updates to /tmp/changelog.txt")
           EOF
 
-      - name: Randomize posting time (0-2 hours)
-        run: |
-          SLEEP_SEC=$(( RANDOM % 7201 ))
-          echo "Sleeping $SLEEP_SEC seconds before posting..."
-          sleep "$SLEEP_SEC"
-          echo "Done sleeping."
-
       - name: Post to socials
         env:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
@@ -177,6 +170,7 @@ jobs:
                   }
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
+                  print(f"{name} response: {resp.status_code} {resp.text}")
                   if resp.status_code == 200:
                       result = resp.json()
                       if "errors" in result:

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -147,12 +147,11 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation CreatePost($text: String!, $channelId: String!, $schedulingType: ShareType!) {
+                  mutation CreatePost($text: String!, $channelId: ChannelId!) {
                     createPost(input: {
                       text: $text
                       channelId: $channelId
-                      schedulingType: $schedulingType
-                      mode: now
+                      schedulingType: now
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }
@@ -166,7 +165,6 @@ jobs:
                   variables = {
                       "text": text,
                       "channelId": channel_id,
-                      "schedulingType": "automatic",
                   }
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -170,7 +170,6 @@ jobs:
                           "text": text,
                           "channelId": channel_id,
                           "schedulingType": "automatic",
-                          "mode": "now",
                       }
                   }
                   payload = {"query": query, "variables": variables}

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -137,12 +137,12 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook"),
-                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads"),
-                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn"),
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "post"),
+                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None),
+                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None),
               ]
 
-              for channel_id, text, name in channels:
+              for channel_id, text, name, post_type in channels:
                   if not channel_id:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
@@ -154,6 +154,7 @@ jobs:
                       schedulingType: automatic
                       mode: shareNow
                       assets: []
+                      %(type_field)s
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }
@@ -164,6 +165,8 @@ jobs:
                     }
                   }
                   """
+                  type_field = f'type: "{post_type}"' if post_type else ""
+                  query = query % {"type_field": type_field}
                   variables = {
                       "text": text,
                       "channelId": channel_id,
@@ -175,6 +178,8 @@ jobs:
                       result = resp.json()
                       if "errors" in result:
                           print(f"Failed to post to {name}: {result['errors']}")
+                      elif result.get("data", {}).get("createPost", {}).get("message"):
+                          print(f"Failed to post to {name}: {result['data']['createPost']['message']}")
                       else:
                           print(f"Posted daily update to {name}")
                   else:

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -106,6 +106,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           python - <<'EOF'
+          import json
           import os
           import requests
 
@@ -153,13 +154,8 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation {
-                    createPost(input: {
-                      text: %(text)s
-                      channelId: %(channel_id)s
-                      schedulingType: automatic
-                      mode: now
-                    }) {
+                  mutation CreatePost($input: CreatePostInput!) {
+                    createPost(input: $input) {
                       ... on PostActionSuccess {
                         post { id text status }
                       }
@@ -168,8 +164,16 @@ jobs:
                       }
                     }
                   }
-                  """ % {"text": repr(text), "channel_id": repr(channel_id)}
-                  payload = {"query": query}
+                  """
+                  variables = {
+                      "input": {
+                          "text": text,
+                          "channelId": channel_id,
+                          "schedulingType": "automatic",
+                          "mode": "now",
+                      }
+                  }
+                  payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
                   if resp.status_code == 200:
                       result = resp.json()

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -89,6 +89,13 @@ jobs:
           print(f"Saved {len(clean_updates)} updates to /tmp/changelog.txt")
           EOF
 
+      - name: Randomize posting time (0-2 hours)
+        run: |
+          SLEEP_SEC=$(( RANDOM % 7201 ))
+          echo "Sleeping $SLEEP_SEC seconds before posting..."
+          sleep "$SLEEP_SEC"
+          echo "Done sleeping."
+
       - name: Post to socials
         env:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -144,7 +144,7 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook", "addToQueue"),
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook", "shareNow"),
                   (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None, "shareNow"),
                   (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None, "shareNow"),
               ]

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -144,7 +144,7 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook", "shareNow"),
+                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook", "addToQueue"),
                   (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None, "shareNow"),
                   (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None, "shareNow"),
               ]

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -89,13 +89,6 @@ jobs:
           print(f"Saved {len(clean_updates)} updates to /tmp/changelog.txt")
           EOF
 
-      - name: Randomize posting time (0-2 hours)
-        run: |
-          SLEEP_SEC=$(( RANDOM % 7201 ))
-          echo "Sleeping $SLEEP_SEC seconds before posting..."
-          sleep "$SLEEP_SEC"
-          echo "Done sleeping."
-
       - name: Post to socials
         env:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
@@ -154,8 +147,13 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation CreatePost($input: CreatePostInput!) {
-                    createPost(input: $input) {
+                  mutation CreatePost($text: String!, $channelId: String!, $schedulingType: ShareType!) {
+                    createPost(input: {
+                      text: $text
+                      channelId: $channelId
+                      schedulingType: $schedulingType
+                      mode: now
+                    }) {
                       ... on PostActionSuccess {
                         post { id text status }
                       }
@@ -166,11 +164,9 @@ jobs:
                   }
                   """
                   variables = {
-                      "input": {
-                          "text": text,
-                          "channelId": channel_id,
-                          "schedulingType": "automatic",
-                      }
+                      "text": text,
+                      "channelId": channel_id,
+                      "schedulingType": "automatic",
                   }
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -89,6 +89,13 @@ jobs:
           print(f"Saved {len(clean_updates)} updates to /tmp/changelog.txt")
           EOF
 
+      - name: Randomize posting time (0-2 hours)
+        run: |
+          SLEEP_SEC=$(( RANDOM % 7201 ))
+          echo "Sleeping $SLEEP_SEC seconds before posting..."
+          sleep "$SLEEP_SEC"
+          echo "Done sleeping."
+
       - name: Post to socials
         env:
           BUFFER_API_TOKEN: ${{ secrets.BUFFER_API_TOKEN }}
@@ -176,7 +183,6 @@ jobs:
                   """ % mode
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
-                  print(f"{name} response: {resp.status_code} {resp.text}")
                   if resp.status_code == 200:
                       result = resp.json()
                       if "errors" in result:

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -192,8 +192,13 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation CreatePost($input: CreatePostInput!) {
-                    createPost(input: $input) {
+                  mutation CreatePost($text: String!, $channelId: String!, $schedulingType: ShareType!) {
+                    createPost(input: {
+                      text: $text
+                      channelId: $channelId
+                      schedulingType: $schedulingType
+                      mode: now
+                    }) {
                       ... on PostActionSuccess {
                         post { id text status }
                       }
@@ -204,11 +209,9 @@ jobs:
                   }
                   """
                   variables = {
-                      "input": {
-                          "text": text,
-                          "channelId": channel_id,
-                          "schedulingType": "automatic",
-                      }
+                      "text": text,
+                      "channelId": channel_id,
+                      "schedulingType": "automatic",
                   }
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -31,6 +31,7 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           python - <<EOF
+          import json
           import os
           import subprocess
           import re
@@ -191,13 +192,8 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation {
-                    createPost(input: {
-                      text: %(text)s
-                      channelId: %(channel_id)s
-                      schedulingType: automatic
-                      mode: now
-                    }) {
+                  mutation CreatePost($input: CreatePostInput!) {
+                    createPost(input: $input) {
                       ... on PostActionSuccess {
                         post { id text status }
                       }
@@ -206,8 +202,16 @@ jobs:
                       }
                     }
                   }
-                  """ % {"text": repr(text), "channel_id": repr(channel_id)}
-                  payload = {"query": query}
+                  """
+                  variables = {
+                      "input": {
+                          "text": text,
+                          "channelId": channel_id,
+                          "schedulingType": "automatic",
+                          "mode": "now",
+                      }
+                  }
+                  payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
                   if resp.status_code == 200:
                       result = resp.json()

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -192,12 +192,11 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation CreatePost($text: String!, $channelId: String!, $schedulingType: ShareType!) {
+                  mutation CreatePost($text: String!, $channelId: ChannelId!) {
                     createPost(input: {
                       text: $text
                       channelId: $channelId
-                      schedulingType: $schedulingType
-                      mode: now
+                      schedulingType: now
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }
@@ -211,7 +210,6 @@ jobs:
                   variables = {
                       "text": text,
                       "channelId": channel_id,
-                      "schedulingType": "automatic",
                   }
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -196,7 +196,9 @@ jobs:
                     createPost(input: {
                       text: $text
                       channelId: $channelId
-                      schedulingType: now
+                      schedulingType: automatic
+                      mode: shareNow
+                      assets: []
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -86,48 +86,65 @@ jobs:
           except FileNotFoundError:
               pass
 
-          # 4. Filter and clean commits
-          skip_patterns = [
-              "Merge pull request",
-              "Merge remote-tracking",
-              "chore: bump version",
-              "chore: update changelog",
-              "chore: start next minor",
-          ]
-          emoji_map = {
-              "feat(web):": "✨",
-              "feat(be):": "✅",
-              "feat(ui):": "🎨",
-              "feat:": "✨",
-              "fix(web):": "🛠️",
-              "fix(be):": "🔧",
-              "fix(ui):": "🖌️",
-              "fix:": "🛠️",
-              "refactor(web):": "⚙️",
-              "refactor(be):": "⚙️",
-              "refactor:": "⚙️",
-              "fix(web,critical):": "🚨",
-          }
-
-          clean_updates = []
-          seen = set()
-          for line in raw_commits.split('\n'):
-              line = line.strip()
-              if not line or any(p in line for p in skip_patterns) or line in seen:
-                  continue
-              seen.add(line)
-
-              cleaned = line
-              for prefix, emoji in emoji_map.items():
-                  cleaned = cleaned.replace(prefix, emoji)
-              clean_updates.append(f"- {cleaned}")
-
-          if not clean_updates:
-              print("No consumer-facing changes in this release. Skipping.")
-              exit(0)
-
+          # 4. Build updates text — prefer CHANGELOG, fall back to git log
           version = tag.lstrip('v')
-          updates_text = "\n".join(clean_updates[:10])
+
+          use_changelog = False
+          if changelog_section:
+              # Strip the header line and formatting, keep bullet items
+              lines = changelog_section.split('\n')
+              clean_lines = []
+              for line in lines:
+                  line = line.strip()
+                  if not line or line.startswith('## ['):
+                      continue
+                  clean_lines.append(line)
+              updates_text = "\n".join(clean_lines)
+              if updates_text.strip():
+                  use_changelog = True
+
+          if not use_changelog:
+              # Fall back to parsed git commits
+              skip_patterns = [
+                  "Merge pull request",
+                  "Merge remote-tracking",
+                  "chore: bump version",
+                  "chore: update changelog",
+                  "chore: start next minor",
+              ]
+              emoji_map = {
+                  "feat(web):": "✨",
+                  "feat(be):": "✅",
+                  "feat(ui):": "🎨",
+                  "feat:": "✨",
+                  "fix(web):": "🛠️",
+                  "fix(be):": "🔧",
+                  "fix(ui):": "🖌️",
+                  "fix:": "🛠️",
+                  "refactor(web):": "⚙️",
+                  "refactor(be):": "⚙️",
+                  "refactor:": "⚙️",
+                  "fix(web,critical):": "🚨",
+              }
+
+              clean_updates = []
+              seen = set()
+              for line in raw_commits.split('\n'):
+                  line = line.strip()
+                  if not line or any(p in line for p in skip_patterns) or line in seen:
+                      continue
+                  seen.add(line)
+
+                  cleaned = line
+                  for prefix, emoji in emoji_map.items():
+                      cleaned = cleaned.replace(prefix, emoji)
+                  clean_updates.append(f"- {cleaned}")
+
+              if not clean_updates:
+                  print("No consumer-facing changes in this release. Skipping.")
+                  exit(0)
+
+              updates_text = "\n".join(clean_updates[:10])
 
           # 5. Build platform-specific posts
           facebook_text = (

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -208,7 +208,6 @@ jobs:
                           "text": text,
                           "channelId": channel_id,
                           "schedulingType": "automatic",
-                          "mode": "now",
                       }
                   }
                   payload = {"query": query, "variables": variables}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: pnpm exec turbo run build --filter web --filter be
 
+      - name: Install Playwright Browsers
+        run: pnpm --filter web exec playwright install --with-deps
+
       - name: Run E2E Tests
         env:
           MONGODB_URI: mongodb://localhost:27017/arcadeum_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-06-19
+
+
+
+
 ## [1.19.3] - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.1] - 2026-06-19
+
+### Fixed
+- use CHANGELOG.md content for release social posts instead of merge commits (N/A)
+
+
 ## [1.20.0] - 2026-06-19
 
 

--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile",
   "main": "expo-router/entry",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "scripts": {
     "dev": "node ./scripts/dev.js",
     "start": "expo start",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile",
   "main": "expo-router/entry",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "scripts": {
     "dev": "node ./scripts/dev.js",
     "start": "expo start",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "private": true,
   "browserslist": [
     "chrome >= 87",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "private": true,
   "browserslist": [
     "chrome >= 87",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicoapp-monorepo",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicoapp-monorepo",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeum/ui",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeum/ui",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## What
Add Playwright browser installation step to the release workflow before running e2e tests.

## Why
The release workflow was failing with exit code 1 because Playwright browsers were not installed. All 1902 browser-based tests failed instantly (3ms each) with:
Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell

The CI workflow (ci.yml) already had this step at line 205-206, but release.yml was missing it.

## Changes
- Added `Install Playwright Browsers` step to `.github/workflows/release.yml` between Build and Run E2E Tests steps
- Runs `pnpm --filter web exec playwright install --with-deps` to install all browser engines with system dependencies