### PR TITLE
ci(release): install playwright browsers before e2e tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: pnpm exec turbo run build --filter web --filter be
 
+      - name: Install Playwright Browsers
+        run: pnpm --filter web exec playwright install --with-deps
+
       - name: Run E2E Tests
         env:
           MONGODB_URI: mongodb://localhost:27017/arcadeum_test


### PR DESCRIPTION
## What
Add Playwright browser installation step to the release workflow before running e2e tests.

## Why
The release workflow was failing with exit code 1 because Playwright browsers were not installed. All 1902 browser-based tests failed instantly (3ms each) with:
Error: browserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell

The CI workflow (ci.yml) already had this step at line 205-206, but release.yml was missing it.

## Changes
- Added `Install Playwright Browsers` step to `.github/workflows/release.yml` between Build and Run E2E Tests steps
- Runs `pnpm --filter web exec playwright install --with-deps` to install all browser engines with system dependencies