### PR TITLE
feat(tg-bot): add PumpFun transaction monitor Telegram bot

### DIFF
--- a/apps/tg-bot/.env.example
+++ b/apps/tg-bot/.env.example
@@ -1,0 +1,13 @@
+# Telegram Bot
+TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_CHAT_ID=your-chat-id-or-channel-id
+
+# Solana
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+SOLANA_WS_URL=wss://api.mainnet-beta.solana.com
+
+# PumpFun Token Contract Address (CA) to monitor
+PUMPFUN_MINT_ADDRESS=your-token-mint-address
+
+# PumpFun Program ID (default mainnet)
+PUMPFUN_PROGRAM_ID=6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P

--- a/apps/tg-bot/eslint.config.mjs
+++ b/apps/tg-bot/eslint.config.mjs
@@ -1,0 +1,43 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+      sourceType: 'commonjs',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      'max-lines': ['error', { max: 500, skipBlankLines: true, skipComments: true }],
+    },
+  },
+  {
+    files: ['**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/unbound-method': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+    },
+  },
+);

--- a/apps/tg-bot/nest-cli.json
+++ b/apps/tg-bot/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/apps/tg-bot/package.json
+++ b/apps/tg-bot/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "tg-bot",
+  "version": "1.0.0",
+  "description": "Telegram bot for PumpFun transaction monitoring",
+  "private": true,
+  "license": "UNLICENSED",
+  "scripts": {
+    "build": "nest build",
+    "dev": "rm -rf dist && nest start --watch",
+    "start": "nest start",
+    "start:prod": "node dist/src/main",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage"
+  },
+  "dependencies": {
+    "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.2",
+    "@nestjs/core": "^11.0.1",
+    "@nestjs/schedule": "^6.1.3",
+    "@solana/web3.js": "^1.98.4",
+    "dotenv": "^16.5.0",
+    "grammy": "^1.35.0",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.2.0",
+    "@eslint/js": "^9.18.0",
+    "@nestjs/cli": "^11.0.0",
+    "@nestjs/schematics": "^11.0.0",
+    "@nestjs/testing": "^11.0.1",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.10.7",
+    "eslint": "^9.18.0",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-prettier": "^5.2.2",
+    "globals": "^16.0.0",
+    "jest": "^30.0.0",
+    "prettier": "^3.4.2",
+    "source-map-support": "^0.5.21",
+    "ts-jest": "^29.2.5",
+    "ts-loader": "^9.5.2",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.7.3",
+    "typescript-eslint": "^8.20.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.(spec|integration-spec)\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@solana|uuid|rpc-websockets)/)"
+    ],
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/apps/tg-bot/src/app.module.ts
+++ b/apps/tg-bot/src/app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { PumpFunModule } from './pumpfun/pumpfun.module';
+import { TelegramModule } from './telegram/telegram.module';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true }),
+    PumpFunModule,
+    TelegramModule,
+  ],
+})
+export class AppModule {}

--- a/apps/tg-bot/src/main.ts
+++ b/apps/tg-bot/src/main.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const logger = new Logger('TgBot');
+  const app = await NestFactory.create(AppModule);
+
+  const port = process.env.TG_BOT_PORT ?? 4001;
+  await app.listen(port);
+  logger.log(`[TG Bot] Listening on port ${port}`);
+}
+
+void bootstrap();

--- a/apps/tg-bot/src/pumpfun/pumpfun-listener.service.spec.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun-listener.service.spec.ts
@@ -63,7 +63,7 @@ describe('PumpFunListenerService', () => {
     it('should return null if tx has no meta', () => {
       const result = (
         service as unknown as {
-          parseTransaction: typeof service['parseTransaction'];
+          parseTransaction: (typeof service)['parseTransaction'];
         }
       ).parseTransaction(
         {
@@ -83,7 +83,7 @@ describe('PumpFunListenerService', () => {
       const buyerWallet = 'BuyerWallet1111111111111111111111111111111';
       const result = (
         service as unknown as {
-          parseTransaction: typeof service['parseTransaction'];
+          parseTransaction: (typeof service)['parseTransaction'];
         }
       ).parseTransaction(
         {
@@ -133,16 +133,14 @@ describe('PumpFunListenerService', () => {
       Buffer.from(SELL_DISCRIMINATOR).copy(sellDiscB64);
       const result = (
         service as unknown as {
-          parseTransaction: typeof service['parseTransaction'];
+          parseTransaction: (typeof service)['parseTransaction'];
         }
       ).parseTransaction(
         {
           meta: {
             innerInstructions: [
               {
-                instructions: [
-                  { data: sellDiscB64.toString('base64') },
-                ],
+                instructions: [{ data: sellDiscB64.toString('base64') }],
               },
             ],
             preBalances: [500_000_000, 1_000_000_000],
@@ -185,7 +183,7 @@ describe('PumpFunListenerService', () => {
     it('should return null if no token balance change found', () => {
       const result = (
         service as unknown as {
-          parseTransaction: typeof service['parseTransaction'];
+          parseTransaction: (typeof service)['parseTransaction'];
         }
       ).parseTransaction(
         {
@@ -198,9 +196,7 @@ describe('PumpFunListenerService', () => {
           },
           transaction: {
             message: {
-              staticAccountKeys: [
-                makeAccountKey(PUMPFUN_PROGRAM),
-              ],
+              staticAccountKeys: [makeAccountKey(PUMPFUN_PROGRAM)],
             },
           },
         } as never,
@@ -214,7 +210,7 @@ describe('PumpFunListenerService', () => {
       const wallet = 'TestWallet111111111111111111111111111111111';
       const result = (
         service as unknown as {
-          parseTransaction: typeof service['parseTransaction'];
+          parseTransaction: (typeof service)['parseTransaction'];
         }
       ).parseTransaction(
         {

--- a/apps/tg-bot/src/pumpfun/pumpfun-listener.service.spec.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun-listener.service.spec.ts
@@ -1,0 +1,259 @@
+import { PumpFunListenerService } from './pumpfun-listener.service';
+import { ConfigService } from '@nestjs/config';
+import { TelegramService } from '../telegram/telegram.service';
+import { createHash } from 'crypto';
+
+const SELL_DISCRIMINATOR = createHash('sha256')
+  .update('global:sell')
+  .digest()
+  .subarray(0, 8);
+
+jest.mock('@solana/web3.js', () => {
+  return {
+    PublicKey: jest.fn().mockImplementation((key: string) => ({
+      toBase58: () => key,
+    })),
+    Connection: jest.fn().mockImplementation(() => ({
+      getSignaturesForAddress: jest.fn(),
+      getTransaction: jest.fn(),
+    })),
+    LAMPORTS_PER_SOL: 1_000_000_000,
+  };
+});
+
+describe('PumpFunListenerService', () => {
+  let service: PumpFunListenerService;
+  let mockTelegram: { sendTransaction: jest.Mock };
+
+  const MINT = '7aRVHPcJnsGWBZMNe2igQsLQmQb4LCCtpuiJgxHjpump';
+
+  beforeEach(() => {
+    mockTelegram = { sendTransaction: jest.fn().mockResolvedValue(undefined) };
+    const env: Record<string, string> = {
+      SOLANA_RPC_URL: 'https://rpc.example.com',
+      SOLANA_WS_URL: 'wss://rpc.example.com',
+      PUMPFUN_MINT_ADDRESS: MINT,
+    };
+    const mockConfig = { get: jest.fn((key: string) => env[key]) };
+
+    service = new PumpFunListenerService(
+      mockConfig as unknown as ConfigService,
+      mockTelegram as unknown as TelegramService,
+    );
+  });
+
+  describe('constructor', () => {
+    it('should throw if PUMPFUN_MINT_ADDRESS is missing', () => {
+      const emptyConfig = { get: () => undefined };
+      expect(
+        () =>
+          new PumpFunListenerService(
+            emptyConfig as unknown as ConfigService,
+            mockTelegram as unknown as TelegramService,
+          ),
+      ).toThrow('PUMPFUN_MINT_ADDRESS is required');
+    });
+  });
+
+  describe('parseTransaction', () => {
+    const makeAccountKey = (base58: string) => ({
+      toBase58: () => base58,
+    });
+
+    it('should return null if tx has no meta', () => {
+      const result = (
+        service as unknown as {
+          parseTransaction: typeof service['parseTransaction'];
+        }
+      ).parseTransaction(
+        {
+          meta: null,
+          transaction: {
+            message: { staticAccountKeys: [] },
+          },
+        } as never,
+        'sig1',
+      );
+      expect(result).toBeNull();
+    });
+
+    const PUMPFUN_PROGRAM = '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P';
+
+    it('should detect buy from token balance increase', () => {
+      const buyerWallet = 'BuyerWallet1111111111111111111111111111111';
+      const result = (
+        service as unknown as {
+          parseTransaction: typeof service['parseTransaction'];
+        }
+      ).parseTransaction(
+        {
+          meta: {
+            innerInstructions: [],
+            preBalances: [1_000_000_000, 500_000_000],
+            postBalances: [500_000_000, 1_500_000_000],
+            preTokenBalances: [
+              {
+                accountIndex: 0,
+                mint: MINT,
+                owner: buyerWallet,
+                uiTokenAmount: { amount: '0', decimals: 6 },
+              },
+            ],
+            postTokenBalances: [
+              {
+                accountIndex: 0,
+                mint: MINT,
+                owner: buyerWallet,
+                uiTokenAmount: { amount: '1000000000', decimals: 6 },
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              staticAccountKeys: [
+                makeAccountKey(PUMPFUN_PROGRAM),
+                makeAccountKey(buyerWallet),
+              ],
+            },
+          },
+        } as never,
+        'buy_sig',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('buy');
+      expect(result!.wallet).toBe(buyerWallet);
+      expect(result!.tokenAmount).toBe(1000);
+      expect(result!.signature).toBe('buy_sig');
+    });
+
+    it('should detect sell from token balance decrease', () => {
+      const sellerWallet = 'SellerWallet111111111111111111111111111111';
+      const sellDiscB64 = Buffer.alloc(32);
+      Buffer.from(SELL_DISCRIMINATOR).copy(sellDiscB64);
+      const result = (
+        service as unknown as {
+          parseTransaction: typeof service['parseTransaction'];
+        }
+      ).parseTransaction(
+        {
+          meta: {
+            innerInstructions: [
+              {
+                instructions: [
+                  { data: sellDiscB64.toString('base64') },
+                ],
+              },
+            ],
+            preBalances: [500_000_000, 1_000_000_000],
+            postBalances: [1_000_000_000, 500_000_000],
+            preTokenBalances: [
+              {
+                accountIndex: 1,
+                mint: MINT,
+                owner: sellerWallet,
+                uiTokenAmount: { amount: '2000000000', decimals: 6 },
+              },
+            ],
+            postTokenBalances: [
+              {
+                accountIndex: 1,
+                mint: MINT,
+                owner: sellerWallet,
+                uiTokenAmount: { amount: '500000000', decimals: 6 },
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              staticAccountKeys: [
+                makeAccountKey(PUMPFUN_PROGRAM),
+                makeAccountKey(sellerWallet),
+              ],
+            },
+          },
+        } as never,
+        'sell_sig',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('sell');
+      expect(result!.wallet).toBe(sellerWallet);
+      expect(result!.tokenAmount).toBe(1500);
+    });
+
+    it('should return null if no token balance change found', () => {
+      const result = (
+        service as unknown as {
+          parseTransaction: typeof service['parseTransaction'];
+        }
+      ).parseTransaction(
+        {
+          meta: {
+            innerInstructions: [],
+            preBalances: [1_000_000_000],
+            postBalances: [1_000_000_000],
+            preTokenBalances: [],
+            postTokenBalances: [],
+          },
+          transaction: {
+            message: {
+              staticAccountKeys: [
+                makeAccountKey(PUMPFUN_PROGRAM),
+              ],
+            },
+          },
+        } as never,
+        'no_change_sig',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should calculate SOL amount from balance difference', () => {
+      const wallet = 'TestWallet111111111111111111111111111111111';
+      const result = (
+        service as unknown as {
+          parseTransaction: typeof service['parseTransaction'];
+        }
+      ).parseTransaction(
+        {
+          meta: {
+            innerInstructions: [],
+            preBalances: [2_000_000_000, 1_000_000_000],
+            postBalances: [1_000_000_000, 2_000_000_000],
+            preTokenBalances: [
+              {
+                accountIndex: 0,
+                mint: MINT,
+                owner: wallet,
+                uiTokenAmount: { amount: '0', decimals: 6 },
+              },
+            ],
+            postTokenBalances: [
+              {
+                accountIndex: 0,
+                mint: MINT,
+                owner: wallet,
+                uiTokenAmount: { amount: '500000000', decimals: 6 },
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              staticAccountKeys: [
+                makeAccountKey(PUMPFUN_PROGRAM),
+                makeAccountKey(wallet),
+              ],
+            },
+          },
+        } as never,
+        'sol_sig',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.solAmount).toBeCloseTo(1.0);
+      expect(result!.tokenAmount).toBe(500);
+    });
+  });
+});

--- a/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
@@ -1,0 +1,284 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  Connection,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+  type VersionedTransactionResponse,
+} from '@solana/web3.js';
+import { createHash } from 'crypto';
+import { TelegramService } from '../telegram/telegram.service';
+
+const BUY_DISCRIMINATOR = createHash('sha256')
+  .update('global:buy')
+  .digest()
+  .subarray(0, 8);
+
+const SELL_DISCRIMINATOR = createHash('sha256')
+  .update('global:sell')
+  .digest()
+  .subarray(0, 8);
+
+interface ParsedTransaction {
+  type: 'buy' | 'sell';
+  wallet: string;
+  tokenAmount: number;
+  solAmount: number;
+  signature: string;
+}
+
+@Injectable()
+export class PumpFunListenerService implements OnModuleInit {
+  private readonly logger = new Logger(PumpFunListenerService.name);
+  private readonly connection: Connection;
+  private readonly mintAddress: PublicKey;
+  private readonly pumpfunProgramId: PublicKey;
+  private seenSignatures = new Set<string>();
+  private static readonly POLL_INTERVAL_MS = 10_000;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly telegram: TelegramService,
+  ) {
+    const rpcUrl =
+      this.config.get<string>('SOLANA_RPC_URL') ??
+      'https://api.mainnet-beta.solana.com';
+    const wsUrl =
+      this.config.get<string>('SOLANA_WS_URL') ??
+      rpcUrl.replace('https', 'wss');
+
+    this.connection = new Connection(rpcUrl, {
+      wsEndpoint: wsUrl,
+      commitment: 'confirmed',
+    });
+
+    const mint = this.config.get<string>('PUMPFUN_MINT_ADDRESS') ?? '';
+    if (!mint) {
+      throw new Error('PUMPFUN_MINT_ADDRESS is required');
+    }
+    this.mintAddress = new PublicKey(mint);
+
+    const programId =
+      this.config.get<string>('PUMPFUN_PROGRAM_ID') ??
+      '6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P';
+    this.pumpfunProgramId = new PublicKey(programId);
+  }
+
+  async onModuleInit() {
+    await this.startPolling();
+  }
+
+  private async startPolling() {
+    const mint = this.mintAddress.toBase58();
+    this.logger.log(`Polling transactions for mint: ${mint}`);
+    this.logger.log(`Poll interval: ${PumpFunListenerService.POLL_INTERVAL_MS}ms`);
+
+    while (true) {
+      try {
+        await this.pollTransactions();
+      } catch (err) {
+        this.logger.error(`Poll error: ${err}`);
+      }
+      await new Promise((r) =>
+        setTimeout(r, PumpFunListenerService.POLL_INTERVAL_MS),
+      );
+    }
+  }
+
+  private async pollTransactions() {
+    const signatures = await this.connection.getSignaturesForAddress(
+      this.mintAddress,
+      { limit: 20 },
+    );
+
+    const newSigs = signatures.filter(
+      (s) => !this.seenSignatures.has(s.signature) && !s.err,
+    );
+
+    for (const sig of newSigs) {
+      this.seenSignatures.add(sig.signature);
+    }
+
+    if (newSigs.length > 0) {
+      this.logger.log(`Found ${newSigs.length} new transaction(s)`);
+    }
+
+    for (const sig of newSigs) {
+      try {
+        const tx = await this.connection.getTransaction(sig.signature, {
+          maxSupportedTransactionVersion: 0,
+          commitment: 'confirmed',
+        });
+
+        if (!tx) continue;
+
+        const parsed = this.parseTransaction(tx, sig.signature);
+        if (!parsed) continue;
+
+        await this.telegram.sendTransaction(parsed);
+      } catch (err) {
+        this.logger.error(`Failed to process ${sig.signature}: ${err}`);
+      }
+    }
+
+    if (this.seenSignatures.size > 500) {
+      const arr = Array.from(this.seenSignatures);
+      this.seenSignatures = new Set(arr.slice(-200));
+    }
+  }
+
+  private getAccountKeys(
+    tx: VersionedTransactionResponse,
+  ): string[] {
+    const msg = tx.transaction.message;
+    const accountKeys = msg.staticAccountKeys ?? [];
+    return accountKeys.map((k) => k.toBase58());
+  }
+
+  private parseTransaction(
+    tx: VersionedTransactionResponse,
+    signature: string,
+  ): ParsedTransaction | null {
+    if (!tx.meta) return null;
+
+    const accounts = this.getAccountKeys(tx);
+    const mintBase58 = this.mintAddress.toBase58();
+
+    let type: 'buy' | 'sell' | null = null;
+
+    if (tx.meta.innerInstructions) {
+      for (const inner of tx.meta.innerInstructions) {
+        for (const ix of inner.instructions) {
+          if ('data' in ix && ix.data) {
+            const data = Buffer.from(ix.data, 'base64');
+            if (data.length >= 8) {
+              const disc = data.subarray(0, 8);
+              if (disc.equals(BUY_DISCRIMINATOR)) {
+                type = 'buy';
+                break;
+              }
+              if (disc.equals(SELL_DISCRIMINATOR)) {
+                type = 'sell';
+                break;
+              }
+            }
+          }
+        }
+        if (type) break;
+      }
+    }
+
+    if (!type) {
+      const programIdBase58 = this.pumpfunProgramId.toBase58();
+      if (!accounts.includes(programIdBase58)) return null;
+
+      const prePostDiff = tx.meta.preBalances.map(
+        (pre, i) => pre - (tx.meta?.postBalances[i] ?? 0),
+      );
+
+      const hasSolOutflow = prePostDiff.some((d) => d > 0);
+      const hasSolInflow = prePostDiff.some((d) => d < 0);
+
+      if (hasSolOutflow && hasSolInflow) {
+        type = 'buy';
+      } else if (hasSolOutflow) {
+        type = 'sell';
+      } else {
+        return null;
+      }
+    }
+
+    const wallet =
+      type === 'buy'
+        ? this.findWalletFromTokenBalance(tx, mintBase58, 'increase')
+        : this.findWalletFromTokenBalance(tx, mintBase58, 'decrease');
+
+    if (!wallet) return null;
+
+    const solAmount = this.extractSolAmount(tx, wallet);
+    const tokenAmount = this.extractTokenAmount(tx, wallet, mintBase58);
+
+    if (solAmount === 0 && tokenAmount === 0) return null;
+
+    return {
+      type,
+      wallet,
+      tokenAmount: Math.abs(tokenAmount),
+      solAmount: Math.abs(solAmount),
+      signature,
+    };
+  }
+
+  private findWalletFromTokenBalance(
+    tx: VersionedTransactionResponse,
+    mintBase58: string,
+    direction: 'increase' | 'decrease',
+  ): string | null {
+    if (!tx.meta) return null;
+
+    const preTokenBalances = tx.meta.preTokenBalances ?? [];
+    const postTokenBalances = tx.meta.postTokenBalances ?? [];
+
+    for (let i = 0; i < postTokenBalances.length; i++) {
+      const post = postTokenBalances[i];
+      if (post.mint !== mintBase58 || !post.owner) continue;
+
+      const pre = preTokenBalances.find(
+        (p) => p.accountIndex === post.accountIndex && p.mint === mintBase58,
+      );
+
+      const postAmount = Number(post.uiTokenAmount.amount);
+      const preAmount = pre ? Number(pre.uiTokenAmount.amount) : 0;
+
+      if (direction === 'increase' && postAmount > preAmount) {
+        return post.owner ?? null;
+      }
+      if (direction === 'decrease' && preAmount > postAmount) {
+        return pre?.owner ?? post.owner ?? null;
+      }
+    }
+
+    return null;
+  }
+
+  private extractSolAmount(
+    tx: VersionedTransactionResponse,
+    wallet: string,
+  ): number {
+    if (!tx.meta) return 0;
+
+    const accounts = this.getAccountKeys(tx);
+    const walletIdx = accounts.indexOf(wallet);
+
+    if (walletIdx === -1) return 0;
+
+    const pre = tx.meta.preBalances[walletIdx] ?? 0;
+    const post = tx.meta.postBalances[walletIdx] ?? 0;
+
+    return (pre - post) / LAMPORTS_PER_SOL;
+  }
+
+  private extractTokenAmount(
+    tx: VersionedTransactionResponse,
+    wallet: string,
+    mintBase58: string,
+  ): number {
+    if (!tx.meta) return 0;
+
+    const preTokenBalances = tx.meta.preTokenBalances ?? [];
+    const postTokenBalances = tx.meta.postTokenBalances ?? [];
+
+    const pre = preTokenBalances.find(
+      (b) => b.owner === wallet && b.mint === mintBase58,
+    );
+    const post = postTokenBalances.find(
+      (b) => b.owner === wallet && b.mint === mintBase58,
+    );
+
+    const preAmount = pre ? Number(pre.uiTokenAmount.amount) : 0;
+    const postAmount = post ? Number(post.uiTokenAmount.amount) : 0;
+
+    const decimals = post?.uiTokenAmount.decimals ?? 6;
+    return (postAmount - preAmount) / 10 ** decimals;
+  }
+}

--- a/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
@@ -141,7 +141,6 @@ export class PumpFunListenerService implements OnModuleInit {
   ): ParsedTransaction | null {
     if (!tx.meta) return null;
 
-    const accounts = this.getAccountKeys(tx);
     const mintBase58 = this.mintAddress.toBase58();
 
     const preTokenBalances = tx.meta.preTokenBalances ?? [];

--- a/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
@@ -144,6 +144,9 @@ export class PumpFunListenerService implements OnModuleInit {
     const accounts = this.getAccountKeys(tx);
     const mintBase58 = this.mintAddress.toBase58();
 
+    const preTokenBalances = tx.meta.preTokenBalances ?? [];
+    const postTokenBalances = tx.meta.postTokenBalances ?? [];
+
     let type: 'buy' | 'sell' | null = null;
 
     if (tx.meta.innerInstructions) {
@@ -169,8 +172,11 @@ export class PumpFunListenerService implements OnModuleInit {
     }
 
     if (!type) {
-      const programIdBase58 = this.pumpfunProgramId.toBase58();
-      if (!accounts.includes(programIdBase58)) return null;
+      const hasMintInTokens =
+        preTokenBalances.some((b) => b.mint === mintBase58) ||
+        postTokenBalances.some((b) => b.mint === mintBase58);
+
+      if (!hasMintInTokens) return null;
 
       const prePostDiff = tx.meta.preBalances.map(
         (pre, i) => pre - (tx.meta?.postBalances[i] ?? 0),

--- a/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun-listener.service.ts
@@ -71,7 +71,9 @@ export class PumpFunListenerService implements OnModuleInit {
   private async startPolling() {
     const mint = this.mintAddress.toBase58();
     this.logger.log(`Polling transactions for mint: ${mint}`);
-    this.logger.log(`Poll interval: ${PumpFunListenerService.POLL_INTERVAL_MS}ms`);
+    this.logger.log(
+      `Poll interval: ${PumpFunListenerService.POLL_INTERVAL_MS}ms`,
+    );
 
     while (true) {
       try {
@@ -127,9 +129,7 @@ export class PumpFunListenerService implements OnModuleInit {
     }
   }
 
-  private getAccountKeys(
-    tx: VersionedTransactionResponse,
-  ): string[] {
+  private getAccountKeys(tx: VersionedTransactionResponse): string[] {
     const msg = tx.transaction.message;
     const accountKeys = msg.staticAccountKeys ?? [];
     return accountKeys.map((k) => k.toBase58());

--- a/apps/tg-bot/src/pumpfun/pumpfun.module.ts
+++ b/apps/tg-bot/src/pumpfun/pumpfun.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PumpFunListenerService } from './pumpfun-listener.service';
+import { TelegramModule } from '../telegram/telegram.module';
+
+@Module({
+  imports: [TelegramModule],
+  providers: [PumpFunListenerService],
+})
+export class PumpFunModule {}

--- a/apps/tg-bot/src/telegram/telegram.module.ts
+++ b/apps/tg-bot/src/telegram/telegram.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { TelegramService } from './telegram.service';
+
+@Global()
+@Module({
+  providers: [TelegramService],
+  exports: [TelegramService],
+})
+export class TelegramModule {}

--- a/apps/tg-bot/src/telegram/telegram.service.spec.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.spec.ts
@@ -44,18 +44,20 @@ describe('TelegramService', () => {
       return env[key];
     });
 
-    service = new TelegramService(
-      { get: configGet } as unknown as ConfigService,
-    );
+    service = new TelegramService({
+      get: configGet,
+    } as unknown as ConfigService);
   });
 
   describe('onModuleInit', () => {
     it('should throw if TELEGRAM_BOT_TOKEN is missing', () => {
       const configGet = jest.fn(() => undefined);
-      const svc = new TelegramService(
-        { get: configGet } as unknown as ConfigService,
+      const svc = new TelegramService({
+        get: configGet,
+      } as unknown as ConfigService);
+      expect(() => svc.onModuleInit()).toThrow(
+        'TELEGRAM_BOT_TOKEN is required',
       );
-      expect(() => svc.onModuleInit()).toThrow('TELEGRAM_BOT_TOKEN is required');
     });
 
     it('should throw if TELEGRAM_CHAT_ID is missing', () => {
@@ -63,9 +65,9 @@ describe('TelegramService', () => {
         if (key === 'TELEGRAM_BOT_TOKEN') return BOT_TOKEN;
         return undefined;
       });
-      const svc = new TelegramService(
-        { get: configGet } as unknown as ConfigService,
-      );
+      const svc = new TelegramService({
+        get: configGet,
+      } as unknown as ConfigService);
       expect(() => svc.onModuleInit()).toThrow('TELEGRAM_CHAT_ID is required');
     });
 
@@ -89,7 +91,10 @@ describe('TelegramService', () => {
       });
 
       expect(mockSendMessage).toHaveBeenCalledTimes(1);
-      const [chatId, message, opts] = mockSendMessage.mock.calls[0];
+      const call = mockSendMessage.mock.calls[0] as unknown[];
+      const chatId = call[0] as string;
+      const message = call[1] as string;
+      const opts = call[2] as { parse_mode: string };
       expect(chatId).toBe(CHAT_ID);
       expect(opts).toEqual({ parse_mode: 'HTML' });
       expect(message).toContain('BOUGHT');
@@ -111,7 +116,7 @@ describe('TelegramService', () => {
         signature: 'sell_sig_456',
       });
 
-      const [, message] = mockSendMessage.mock.calls[0];
+      const message = (mockSendMessage.mock.calls[0] as unknown[])[1] as string;
       expect(message).toContain('SOLD');
       expect(message).toContain('Seller11111111');
     });
@@ -125,7 +130,7 @@ describe('TelegramService', () => {
         signature: 'pct_sig',
       });
 
-      const [, message] = mockSendMessage.mock.calls[0];
+      const message = (mockSendMessage.mock.calls[0] as unknown[])[1] as string;
       expect(message).toContain('1.0000%');
     });
 
@@ -138,7 +143,7 @@ describe('TelegramService', () => {
         signature: 'small_sig',
       });
 
-      const [, message] = mockSendMessage.mock.calls[0];
+      const message = (mockSendMessage.mock.calls[0] as unknown[])[1] as string;
       expect(message).toContain('0.0001%');
     });
 

--- a/apps/tg-bot/src/telegram/telegram.service.spec.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.spec.ts
@@ -1,0 +1,159 @@
+import { ConfigService } from '@nestjs/config';
+import { TelegramService } from './telegram.service';
+
+jest.mock('grammy', () => {
+  const mockSendMessage = jest.fn().mockResolvedValue({});
+  const mockStart = jest.fn();
+  const mockStop = jest.fn();
+  const mockCommand = jest.fn();
+
+  return {
+    Bot: jest.fn().mockImplementation(() => ({
+      api: { sendMessage: mockSendMessage },
+      command: mockCommand,
+      start: mockStart,
+      stop: mockStop,
+    })),
+    __mockSendMessage: mockSendMessage,
+    __mockStart: mockStart,
+    __mockStop: mockStop,
+    __mockCommand: mockCommand,
+  };
+});
+
+describe('TelegramService', () => {
+  let service: TelegramService;
+  let mockSendMessage: jest.Mock;
+
+  const BOT_TOKEN = '123456:ABC-TEST';
+  const CHAT_ID = '-1001234567890';
+  const MINT = '7aRVHPcJnsGWBZMNe2igQsLQmQb4LCCtpuiJgxHjpump';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const grammyMock = jest.requireMock('grammy');
+    mockSendMessage = grammyMock.__mockSendMessage;
+
+    const configGet = jest.fn((key: string) => {
+      const env: Record<string, string> = {
+        TELEGRAM_BOT_TOKEN: BOT_TOKEN,
+        TELEGRAM_CHAT_ID: CHAT_ID,
+        PUMPFUN_MINT_ADDRESS: MINT,
+      };
+      return env[key];
+    });
+
+    service = new TelegramService(
+      { get: configGet } as unknown as ConfigService,
+    );
+  });
+
+  describe('onModuleInit', () => {
+    it('should throw if TELEGRAM_BOT_TOKEN is missing', () => {
+      const configGet = jest.fn(() => undefined);
+      const svc = new TelegramService(
+        { get: configGet } as unknown as ConfigService,
+      );
+      expect(() => svc.onModuleInit()).toThrow('TELEGRAM_BOT_TOKEN is required');
+    });
+
+    it('should throw if TELEGRAM_CHAT_ID is missing', () => {
+      const configGet = jest.fn((key: string) => {
+        if (key === 'TELEGRAM_BOT_TOKEN') return BOT_TOKEN;
+        return undefined;
+      });
+      const svc = new TelegramService(
+        { get: configGet } as unknown as ConfigService,
+      );
+      expect(() => svc.onModuleInit()).toThrow('TELEGRAM_CHAT_ID is required');
+    });
+
+    it('should initialize successfully with valid config', () => {
+      expect(() => service.onModuleInit()).not.toThrow();
+    });
+  });
+
+  describe('sendTransaction', () => {
+    beforeEach(() => {
+      service.onModuleInit();
+    });
+
+    it('should send buy notification with correct format', async () => {
+      await service.sendTransaction({
+        type: 'buy',
+        wallet: '3xKp9mNq2vL8',
+        tokenAmount: 1_250_000,
+        solAmount: 0.5,
+        signature: 'tx_sig_123',
+      });
+
+      expect(mockSendMessage).toHaveBeenCalledTimes(1);
+      const [chatId, message, opts] = mockSendMessage.mock.calls[0];
+      expect(chatId).toBe(CHAT_ID);
+      expect(opts).toEqual({ parse_mode: 'HTML' });
+      expect(message).toContain('BOUGHT');
+      expect(message).toContain('3xKp9mNq2vL8');
+      expect(message).toContain('1,250,000');
+      expect(message).toContain('ARC');
+      expect(message).toContain('0.5000');
+      expect(message).toContain('SOL');
+      expect(message).toContain('solscan.io/tx/tx_sig_123');
+      expect(message).toContain('pump.fun/coin/' + MINT);
+    });
+
+    it('should send sell notification', async () => {
+      await service.sendTransaction({
+        type: 'sell',
+        wallet: 'Seller11111111',
+        tokenAmount: 500_000,
+        solAmount: 0.25,
+        signature: 'sell_sig_456',
+      });
+
+      const [, message] = mockSendMessage.mock.calls[0];
+      expect(message).toContain('SOLD');
+      expect(message).toContain('Seller11111111');
+    });
+
+    it('should calculate percentage of total supply correctly', async () => {
+      await service.sendTransaction({
+        type: 'buy',
+        wallet: 'Wallet111',
+        tokenAmount: 10_000_000,
+        solAmount: 0.1,
+        signature: 'pct_sig',
+      });
+
+      const [, message] = mockSendMessage.mock.calls[0];
+      expect(message).toContain('1.0000%');
+    });
+
+    it('should handle small percentage values', async () => {
+      await service.sendTransaction({
+        type: 'buy',
+        wallet: 'Wallet222',
+        tokenAmount: 1234,
+        solAmount: 0.001,
+        signature: 'small_sig',
+      });
+
+      const [, message] = mockSendMessage.mock.calls[0];
+      expect(message).toContain('0.0001%');
+    });
+
+    it('should log error if sendMessage fails', async () => {
+      mockSendMessage.mockRejectedValueOnce(new Error('Telegram API error'));
+
+      await expect(
+        service.sendTransaction({
+          type: 'buy',
+          wallet: 'W1',
+          tokenAmount: 100,
+          solAmount: 0.01,
+          signature: 'err_sig',
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/tg-bot/src/telegram/telegram.service.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Bot, type Context } from 'grammy';
+
+interface TransactionData {
+  type: 'buy' | 'sell';
+  wallet: string;
+  tokenAmount: number;
+  solAmount: number;
+  signature: string;
+}
+
+@Injectable()
+export class TelegramService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(TelegramService.name);
+  private bot!: Bot;
+  private chatId!: string;
+  private mintAddress!: string;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    const token = this.config.get<string>('TELEGRAM_BOT_TOKEN');
+    if (!token) {
+      throw new Error('TELEGRAM_BOT_TOKEN is required');
+    }
+
+    this.chatId = this.config.get<string>('TELEGRAM_CHAT_ID') ?? '';
+    if (!this.chatId) {
+      throw new Error('TELEGRAM_CHAT_ID is required');
+    }
+
+    this.mintAddress = this.config.get<string>('PUMPFUN_MINT_ADDRESS') ?? '';
+
+    this.bot = new Bot(token);
+    this.registerCommands();
+    this.logger.log('Telegram bot initialized');
+  }
+
+  async onModuleDestroy() {
+    await this.bot.stop();
+  }
+
+  private registerCommands() {
+    this.bot.command('start', (ctx: Context) =>
+      ctx.reply(
+        'PumpFun Transaction Monitor is active.\n' +
+          `Monitoring: ${this.mintAddress}\n` +
+          'You will receive buy/sell notifications in this chat.',
+      ),
+    );
+
+    this.bot.command('status', (ctx: Context) =>
+      ctx.reply(
+        `Monitoring: ${this.mintAddress}\n` +
+          `Chat ID: ${this.chatId}\n` +
+          'Status: Active',
+      ),
+    );
+
+    void this.bot.start({
+      onStart: () => this.logger.log('Bot polling started'),
+    });
+  }
+
+  async sendTransaction(tx: TransactionData) {
+    const emoji = tx.type === 'buy' ? '🟢' : '🔴';
+    const action = tx.type === 'buy' ? 'BOUGHT' : 'SOLD';
+    const totalSupply = 1_000_000_000;
+    const pct = ((tx.tokenAmount / totalSupply) * 100).toFixed(4);
+
+    const message =
+      `${emoji} <b>${action}</b>\n\n` +
+      `<code>${tx.wallet}</code>\n` +
+      `<b>${tx.tokenAmount.toLocaleString('en-US', { maximumFractionDigits: 2 })}</b> ARC (${pct}%)\n` +
+      `<b>${tx.solAmount.toFixed(4)}</b> SOL\n\n` +
+      `<a href="https://solscan.io/tx/${tx.signature}">Solscan</a> | <a href="https://pump.fun/coin/${this.mintAddress}">PumpFun</a>`;
+
+    try {
+      await this.bot.api.sendMessage(this.chatId, message, {
+        parse_mode: 'HTML',
+      });
+      this.logger.log(`Sent ${tx.type} notification`);
+    } catch (err) {
+      this.logger.error(`Failed to send Telegram message: ${err}`);
+    }
+  }
+}

--- a/apps/tg-bot/src/telegram/telegram.service.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Bot, type Context } from 'grammy';
 

--- a/apps/tg-bot/tsconfig.build.json
+++ b/apps/tg-bot/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+}

--- a/apps/tg-bot/tsconfig.json
+++ b/apps/tg-bot/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "strictBindCallApply": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare": "husky",
     "dev": "turbo run dev --parallel --filter be --filter web --filter \"@arcadeum/ui\"",
     "dev:all": "turbo run dev --parallel && cd packages/ui && pnpm run dev",
+    "dev:tg-bot": "pnpm --filter tg-bot dev",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "test": "turbo run test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,97 @@ importers:
         specifier: ~5.9.2
         version: 5.9.3
 
+  apps/tg-bot:
+    dependencies:
+      '@nestjs/common':
+        specifier: ^11.0.1
+        version: 11.1.8(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/config':
+        specifier: ^4.0.2
+        version: 4.0.2(@nestjs/common@11.1.8(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.1
+        version: 11.1.8(@nestjs/common@11.1.8(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.8)(@nestjs/websockets@11.1.8)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/schedule':
+        specifier: ^6.1.3
+        version: 6.1.3(@nestjs/common@11.1.8(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.8)
+      '@solana/web3.js':
+        specifier: ^1.98.4
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.6.1
+      grammy:
+        specifier: ^1.35.0
+        version: 1.44.0
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+    devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.2.0
+        version: 3.3.1
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.1
+      '@nestjs/cli':
+        specifier: ^11.0.0
+        version: 11.0.10(@types/node@22.19.1)(esbuild@0.27.2)
+      '@nestjs/schematics':
+        specifier: ^11.0.0
+        version: 11.0.9(chokidar@4.0.3)(typescript@5.9.3)
+      '@nestjs/testing':
+        specifier: ^11.0.1
+        version: 11.1.8(@nestjs/common@11.1.8(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.8)(@nestjs/platform-express@11.1.8)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
+      '@types/node':
+        specifier: ^22.10.7
+        version: 22.19.1
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.1(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.0.1
+        version: 10.1.8(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.2.2
+        version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.4.2)
+      globals:
+        specifier: ^16.0.0
+        version: 16.5.0
+      jest:
+        specifier: ^30.0.0
+        version: 30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.27.2))(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3))
+      prettier:
+        specifier: ^3.4.2
+        version: 3.4.2
+      source-map-support:
+        specifier: ^0.5.21
+        version: 0.5.21
+      ts-jest:
+        specifier: ^29.2.5
+        version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.27.2)(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.1)(esbuild-register@3.6.0(esbuild@0.27.2))(ts-node@10.9.2(@types/node@22.19.1)(typescript@5.9.3)))(typescript@5.9.3)
+      ts-loader:
+        specifier: ^9.5.2
+        version: 9.5.4(typescript@5.9.3)(webpack@5.100.2(esbuild@0.27.2))
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.19.1)(typescript@5.9.3)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.20.0
+        version: 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+
   apps/web:
     dependencies:
       '@arcadeum/ui':
@@ -1795,7 +1886,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@54.0.15':
     resolution: {integrity: sha512-tgaKFeYNRjZssPueZMm1+2cRek6mxEsthPoBX6NzQeDlzIzYBBpnAR6xH95UO6A7r0vduBeL2acIAV1Y5aSGJQ==}
@@ -2046,6 +2137,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@grammyjs/types@3.28.0':
+    resolution: {integrity: sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==}
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -7235,6 +7329,10 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
@@ -8350,6 +8448,10 @@ packages:
   gradle-to-js@2.0.1:
     resolution: {integrity: sha512-is3hDn9zb8XXnjbEeAEIqxTpLHUiGBqjegLmXPuyMBfKAggpadWFku4/AP8iYAGBX6qR9/5UIUIp47V0XI3aMw==}
     hasBin: true
+
+  grammy@1.44.0:
+    resolution: {integrity: sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==}
+    engines: {node: ^12.20.0 || >=14.13.1}
 
   graphql-tag@2.12.6:
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
@@ -15191,6 +15293,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@grammyjs/types@3.28.0': {}
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -17098,7 +17202,7 @@ snapshots:
       debug: 4.4.3(supports-color@8.1.1)
       invariant: 2.2.4
       metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.3(bufferutil@4.1.0)
       metro-core: 0.83.3
       semver: 7.7.3
     transitivePeerDependencies:
@@ -24432,15 +24536,17 @@ snapshots:
 
   dotenv-expand@11.0.7:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.6.1
 
   dotenv-expand@12.0.1:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.6.1
 
   dotenv@16.3.1: {}
 
   dotenv@16.4.7: {}
+
+  dotenv@16.6.1: {}
 
   dotenv@17.2.3: {}
 
@@ -24840,9 +24946,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.50.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.1(jiti@2.6.1))
       globals: 16.5.0
@@ -24858,7 +24964,7 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -24884,6 +24990,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.39.1(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -24895,33 +25016,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -24944,7 +25050,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24955,7 +25061,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24973,7 +25079,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -26016,6 +26122,16 @@ snapshots:
     dependencies:
       lodash.merge: 4.6.2
 
+  grammy@1.44.0:
+    dependencies:
+      '@grammyjs/types': 3.28.0
+      abort-controller: 3.0.0
+      debug: 4.4.3(supports-color@8.1.1)
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   graphql-tag@2.12.6(graphql@16.8.1):
     dependencies:
       graphql: 16.8.1
@@ -26497,7 +26613,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.1.0)):
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
@@ -26588,7 +26704,7 @@ snapshots:
       delay: 5.0.0
       es6-promisify: 5.0.0
       eyes: 0.1.8
-      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.1.0))
       json-stringify-safe: 5.0.1
       stream-json: 1.9.1
       uuid: 8.3.2
@@ -27933,21 +28049,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
-    dependencies:
-      connect: 3.7.0
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      metro-cache: 0.83.3
-      metro-core: 0.83.3
-      metro-runtime: 0.83.3
-      yaml: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   metro-core@0.83.2:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -28270,7 +28371,7 @@ snapshots:
       metro-babel-transformer: 0.83.3
       metro-cache: 0.83.3
       metro-cache-key: 0.83.3
-      metro-config: 0.83.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      metro-config: 0.83.3(bufferutil@4.1.0)
       metro-core: 0.83.3
       metro-file-map: 0.83.3
       metro-resolver: 0.83.3


### PR DESCRIPTION
## Summary
- Standalone NestJS app that monitors Solana for PumpFun buy/sell transactions on a specific token and posts formatted notifications to Telegram
- Polls `getSignaturesForAddress` every 10s for reliable monitoring without WebSocket rate limits
- Detects buy/sell via instruction discriminators (SHA256 of `global:buy`/`global:sell`) and token balance changes

## What's included
- `apps/tg-bot/` — standalone NestJS app with PumpFun listener + Telegram service
- Polling-based approach (reliable, no WS dependency)
- Buy/sell detection with wallet, amount, % of supply, SOL value, and Solscan/PumpFun links
- 14 unit tests covering transaction parsing and message formatting
- `.env.example` for easy setup

## How to use
1. Copy `.env.example` to `.env` and fill in `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `PUMPFUN_MINT_ADDRESS`
2. Run `pnpm dev:tg-bot`