### PR TITLE
fix(web): prevent false connection lost overlay on room enter (ARC-830)

### DIFF
--- a/apps/web/src/shared/hooks/useIdleReconnect.ts
+++ b/apps/web/src/shared/hooks/useIdleReconnect.ts
@@ -28,9 +28,16 @@ export function useIdleReconnect({
   const isConnected = useGameStore((s: GameState) => s.isConnected);
   const room = useGameStore((s: GameState) => s.room);
   const [isReconnecting, setIsReconnecting] = useState(false);
+  const [wasConnected, setWasConnected] = useState(false);
   const reconnectingRef = useRef(false);
 
-  const isDisconnected = enabled && !isConnected && !!room;
+  useEffect(() => {
+    if (isConnected) {
+      setWasConnected(true);
+    }
+  }, [isConnected]);
+
+  const isDisconnected = enabled && !isConnected && !!room && wasConnected;
 
   const reconnect = useCallback(() => {
     if (reconnectingRef.current || !accessToken) return;

--- a/apps/web/src/shared/hooks/useIdleReconnect.ts
+++ b/apps/web/src/shared/hooks/useIdleReconnect.ts
@@ -36,9 +36,6 @@ export function useIdleReconnect({
     if (isConnected) {
       wasConnectedRef.current = true;
     }
-  }, [isConnected]);
-
-  useEffect(() => {
     const next = enabled && !isConnected && !!room && wasConnectedRef.current;
     queueMicrotask(() => setIsDisconnected(next));
   }, [isConnected, enabled, room]);

--- a/apps/web/src/shared/hooks/useIdleReconnect.ts
+++ b/apps/web/src/shared/hooks/useIdleReconnect.ts
@@ -28,16 +28,20 @@ export function useIdleReconnect({
   const isConnected = useGameStore((s: GameState) => s.isConnected);
   const room = useGameStore((s: GameState) => s.room);
   const [isReconnecting, setIsReconnecting] = useState(false);
-  const [wasConnected, setWasConnected] = useState(false);
+  const [isDisconnected, setIsDisconnected] = useState(false);
   const reconnectingRef = useRef(false);
+  const wasConnectedRef = useRef(false);
 
   useEffect(() => {
     if (isConnected) {
-      setWasConnected(true);
+      wasConnectedRef.current = true;
     }
   }, [isConnected]);
 
-  const isDisconnected = enabled && !isConnected && !!room && wasConnected;
+  useEffect(() => {
+    const next = enabled && !isConnected && !!room && wasConnectedRef.current;
+    queueMicrotask(() => setIsDisconnected(next));
+  }, [isConnected, enabled, room]);
 
   const reconnect = useCallback(() => {
     if (reconnectingRef.current || !accessToken) return;


### PR DESCRIPTION
## What
Prevents the "Connection Lost" overlay from flashing when entering a game room.

## Why
When a user navigates to a room, `room` data is set from server initial data before the socket connects. The `useIdleReconnect` hook computed `isDisconnected = enabled && !isConnected && !!room`, which was `true` during the ~50-500ms connection window — showing a false "connection lost" overlay on every fresh page load.

## Changes
- Added `wasConnected` state to `useIdleReconnect` that latches `true` once the socket has connected at least once
- `isDisconnected` now requires `wasConnected` to be true, so the overlay only appears after a real connection drops