### PR TITLE
fix(web,mobile): visually differentiate completed rooms (ARC-834)

### DIFF
--- a/apps/mobile/pages/GamesScreen/GameDetailScreen.components.tsx
+++ b/apps/mobile/pages/GamesScreen/GameDetailScreen.components.tsx
@@ -99,9 +99,10 @@ export function RoomCard({ room, joiningRoomId, onJoinRoom }: RoomCardProps) {
     hostRaw === 'mystery captain' ? t('games.rooms.mysteryHost') : hostRaw;
   const isJoining = joiningRoomId === room.id;
   const isPrivate = room.visibility === 'private';
+  const isCompleted = room.status === 'completed';
 
   return (
-    <ThemedView style={styles.roomCard}>
+    <ThemedView style={[styles.roomCard, isCompleted && styles.roomCardCompleted]}>
       <View style={styles.roomHeader}>
         <ThemedText type="defaultSemiBold" style={styles.roomTitle}>
           {room.name}

--- a/apps/mobile/pages/GamesScreen/components/RoomCard.tsx
+++ b/apps/mobile/pages/GamesScreen/components/RoomCard.tsx
@@ -83,8 +83,10 @@ export function RoomCard({
   const gameLabel =
     gameName === 'Unknown game' ? t('games.rooms.unknownGame') : gameName;
 
+  const isCompleted = room.status === 'completed';
+
   return (
-    <ThemedView style={styles.card}>
+    <ThemedView style={[styles.card, isCompleted && styles.cardCompleted]}>
       <View style={styles.header}>
         <ThemedText type="defaultSemiBold" style={styles.title}>
           {room.name}
@@ -207,6 +209,9 @@ function createStyles(palette: Palette) {
         offset: { width: 0, height: 4 },
         elevation: 2,
       }),
+    },
+    cardCompleted: {
+      opacity: 0.6,
     },
     header: {
       flexDirection: 'row',

--- a/apps/mobile/pages/GamesScreen/styles/roomItem.ts
+++ b/apps/mobile/pages/GamesScreen/styles/roomItem.ts
@@ -31,6 +31,9 @@ export const getRoomItemStyles = (palette: Palette) => {
         elevation: 2,
       }),
     },
+    roomCardCompleted: {
+      opacity: 0.6,
+    },
     roomHeader: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/apps/web/src/app/[locale]/games/RoomCardComponent.module.scss
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.module.scss
@@ -141,6 +141,35 @@
   z-index: 10;
 }
 
+.roomCard.completed {
+  opacity: 0.6;
+}
+
+.roomCard.completed::before {
+  display: none;
+}
+
+.roomCard.completed::after {
+  display: none;
+}
+
+.roomCard.completed .roomTitle {
+  animation: none;
+  background: linear-gradient(135deg, #9ca3af 0%, #6b7280 50%, #9ca3af 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.roomCard.completed:hover::before {
+  opacity: 0;
+  animation: none;
+}
+
+.roomCard.completed:hover::after {
+  opacity: 0;
+  animation: none;
+}
+
 @media (max-width: 768px) {
   .roomCard {
     padding: 1.5rem !important;

--- a/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
@@ -74,10 +74,13 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
     [],
   );
 
+  const isCompleted = room.status === 'completed';
+
   return (
     <StyledRoomCard
       viewMode={viewMode}
-      className={cardStyles.roomCard}
+      status={isCompleted ? 'completed' : undefined}
+      className={`${cardStyles.roomCard} ${isCompleted ? cardStyles.completed : ''}`}
       data-testid="room-card"
     >
       <StyledRoomHeader viewMode={viewMode}>

--- a/apps/web/src/app/[locale]/games/room-card.styles.tsx
+++ b/apps/web/src/app/[locale]/games/room-card.styles.tsx
@@ -47,6 +47,18 @@ export const StyledRoomCard = styled(YStack, {
         flexWrap: 'wrap',
       },
     },
+    status: {
+      completed: {
+        borderColor: 'rgba(107, 114, 128, 0.2)',
+        hoverStyle: {
+          scale: 1,
+          y: 0,
+          borderColor: 'rgba(107, 114, 128, 0.2)',
+          backgroundColor: '$glassBg',
+          boxShadow: 'none',
+        },
+      },
+    },
   } as const,
 
   defaultVariants: {


### PR DESCRIPTION
## What
Completed rooms are now visually distinct from lobby and in-progress rooms — they appear dimmed with muted styling to indicate the game has ended.

## Why
All room cards (lobby, in-progress, completed) looked identical in the room list. Users couldn't tell at a glance which rooms were finished, leading to confusion when browsing available games.

## Changes
- **Web (`apps/web`):**
  - `room-card.styles.tsx` — Added `completed` variant to `StyledRoomCard` with subdued border and disabled hover effects
  - `RoomCardComponent.tsx` — Passes `status` prop and `completed` CSS class when room is completed
  - `RoomCardComponent.module.scss` — Completed cards get `opacity: 0.6`, hidden glow/sweep pseudo-elements, disabled hover animations, and gray title gradient

- **Mobile (`apps/mobile`):**
  - `components/RoomCard.tsx` — Applies `cardCompleted` style (opacity 0.6) for completed rooms
  - `GameDetailScreen.components.tsx` — Same treatment for the game detail page room card
  - `styles/roomItem.ts` — Added `roomCardCompleted` style with opacity 0.6