### PR TITLE
fix(web): enable touch drag and tap-to-move for ship placement on mobile (ARC-831)

### DIFF
--- a/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
@@ -96,6 +96,28 @@ function boardWithout(
   return next;
 }
 
+function findCellFromPoint(
+  x: number,
+  y: number,
+): { row: number; col: number } | null {
+  const el = document.elementFromPoint(x, y) as HTMLElement | null;
+  if (!el) return null;
+  let current: HTMLElement | null = el;
+  while (current && current !== document.body) {
+    const r = current.dataset?.row;
+    const c = current.dataset?.col;
+    if (r !== undefined && c !== undefined) {
+      const row = parseInt(r, 10);
+      const col = parseInt(c, 10);
+      if (!isNaN(row) && !isNaN(col)) return { row, col };
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+const TOUCH_DRAG_THRESHOLD = 10;
+
 export function useDragPlacement({
   board,
   isVertical,
@@ -114,6 +136,30 @@ export function useDragPlacement({
   const dragMode = useRef<DragMode>(null);
   const draggingShipId = useRef<string | null>(null);
   const boardDragOrigin = useRef<BoardDragOrigin | null>(null);
+
+  const touchRef = useRef<{
+    active: boolean;
+    started: boolean;
+    startX: number;
+    startY: number;
+    shipId: string | null;
+    origin: BoardDragOrigin | null;
+  }>({
+    active: false,
+    started: false,
+    startX: 0,
+    startY: 0,
+    shipId: null,
+    origin: null,
+  });
+  const touchDragJustEnded = useRef(false);
+  const boardRef = useRef(board);
+  const onMoveShipRef = useRef(onMoveShip);
+
+  useEffect(() => {
+    boardRef.current = board;
+    onMoveShipRef.current = onMoveShip;
+  });
 
   useEffect(() => {
     isTouchDevice.current = window.matchMedia('(pointer: coarse)').matches;
@@ -281,6 +327,148 @@ export function useDragPlacement({
     clearDragState();
   }, [clearDragState]);
 
+  const onTouchBoardPointerDown = useCallback(
+    (row: number, col: number, e: React.PointerEvent) => {
+      if (!isTouchDevice.current || placementComplete) return;
+
+      const ship = ships.find((s) =>
+        s.cells.some((c) => c.row === row && c.col === col),
+      );
+      if (!ship) return;
+
+      const orientation = getOrientation(ship.cells);
+      const anchorOffset = ship.cells.findIndex(
+        (c) => c.row === row && c.col === col,
+      );
+
+      touchRef.current = {
+        active: true,
+        started: false,
+        startX: e.clientX,
+        startY: e.clientY,
+        shipId: ship.id,
+        origin: {
+          shipId: ship.id,
+          originalCells: ship.cells,
+          orientation,
+          anchorOffset: anchorOffset >= 0 ? anchorOffset : 0,
+        },
+      };
+
+      const onMove = (me: PointerEvent) => {
+        const t = touchRef.current;
+        if (!t.active || !t.origin) return;
+
+        if (!t.started) {
+          const dx = me.clientX - t.startX;
+          const dy = me.clientY - t.startY;
+          if (
+            Math.abs(dx) < TOUCH_DRAG_THRESHOLD &&
+            Math.abs(dy) < TOUCH_DRAG_THRESHOLD
+          )
+            return;
+
+          t.started = true;
+          draggingShipId.current = t.shipId;
+          dragMode.current = 'board';
+          boardDragOrigin.current = t.origin;
+          setDraggingCells(t.origin.originalCells);
+          setIsDragging(true);
+          setSelectedShipId(null);
+        }
+
+        const cell = findCellFromPoint(me.clientX, me.clientY);
+        if (cell && t.origin) {
+          const shipDef = SHIPS.find((s) => s.id === t.shipId);
+          if (!shipDef) return;
+          const vertical = t.origin.orientation === 'v';
+          const startRow = vertical
+            ? cell.row - t.origin.anchorOffset
+            : cell.row;
+          const startCol = vertical
+            ? cell.col
+            : cell.col - t.origin.anchorOffset;
+          const cells = getCells(startRow, startCol, shipDef.size, vertical);
+          const virtualBoard = boardWithout(
+            boardRef.current,
+            t.origin.originalCells,
+          );
+          if (cells && canPlace(cells, virtualBoard)) {
+            setHoveredCells(cells);
+            setIsInvalidHover?.(false);
+          } else {
+            setHoveredCells([]);
+            setIsInvalidHover?.(true);
+          }
+        }
+      };
+
+      const onUp = (ue: PointerEvent) => {
+        const t = touchRef.current;
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+
+        if (t.started && t.shipId && t.origin) {
+          const cell = findCellFromPoint(ue.clientX, ue.clientY);
+          if (cell) {
+            const shipDef = SHIPS.find((s) => s.id === t.shipId);
+            if (shipDef) {
+              const vertical = t.origin.orientation === 'v';
+              const startRow = vertical
+                ? cell.row - t.origin.anchorOffset
+                : cell.row;
+              const startCol = vertical
+                ? cell.col
+                : cell.col - t.origin.anchorOffset;
+              const cells = getCells(
+                startRow,
+                startCol,
+                shipDef.size,
+                vertical,
+              );
+              const virtualBoard = boardWithout(
+                boardRef.current,
+                t.origin.originalCells,
+              );
+              if (
+                cells &&
+                canPlace(cells, virtualBoard) &&
+                !cellsEqual(cells, t.origin.originalCells)
+              ) {
+                onMoveShipRef.current(t.shipId, cells);
+              }
+            }
+          }
+          clearDragState();
+          touchDragJustEnded.current = true;
+          setTimeout(() => {
+            touchDragJustEnded.current = false;
+          }, 300);
+        }
+
+        touchRef.current = {
+          active: false,
+          started: false,
+          startX: 0,
+          startY: 0,
+          shipId: null,
+          origin: null,
+        };
+      };
+
+      document.addEventListener('pointermove', onMove, { passive: false });
+      document.addEventListener('pointerup', onUp);
+    },
+    [
+      ships,
+      placementComplete,
+      setSelectedShipId,
+      setHoveredCells,
+      setIsInvalidHover,
+      clearDragState,
+    ],
+  );
+
   return {
     getDragProps,
     getBoardCellDragProps,
@@ -290,5 +478,10 @@ export function useDragPlacement({
     handleDragEnd,
     isDragging,
     draggingCells,
+    onTouchBoardPointerDown,
+    touchDragJustEnded,
+    resetTouchDragJustEnded: useCallback(() => {
+      touchDragJustEnded.current = false;
+    }, []),
   };
 }

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.test.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.test.ts
@@ -1,0 +1,161 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useMobileShipMove } from './useMobileShipMove';
+import { BOARD_SIZE, CELL_STATE, type CellState, type Ship } from '../types';
+
+function emptyBoard(): CellState[][] {
+  return Array.from({ length: BOARD_SIZE }, () =>
+    Array.from<CellState>({ length: BOARD_SIZE }).fill(CELL_STATE.EMPTY),
+  );
+}
+
+function boardWithShip(ship: Ship): CellState[][] {
+  const b = emptyBoard();
+  for (const cell of ship.cells) {
+    b[cell.row][cell.col] = CELL_STATE.SHIP;
+  }
+  return b;
+}
+
+const battleship: Ship = {
+  id: 'battleship-1',
+  name: 'Battleship',
+  size: 4,
+  hits: 0,
+  sunk: false,
+  cells: [
+    { row: 0, col: 0 },
+    { row: 0, col: 1 },
+    { row: 0, col: 2 },
+    { row: 0, col: 3 },
+  ],
+};
+
+function setup(
+  overrides: Partial<Parameters<typeof useMobileShipMove>[0]> = {},
+) {
+  const onMoveShip = vi.fn();
+  const setHoveredCells = vi.fn();
+  const setIsInvalidHover = vi.fn();
+  const board = boardWithShip(battleship);
+
+  const result = renderHook(() =>
+    useMobileShipMove({
+      ships: [battleship],
+      board,
+      isPlacementComplete: false,
+      isMobile: true,
+      onMoveShip,
+      setHoveredCells,
+      setIsInvalidHover,
+      ...overrides,
+    }),
+  );
+  return { result, onMoveShip, setHoveredCells, setIsInvalidHover };
+}
+
+describe('useMobileShipMove', () => {
+  it('returns false for empty cells on mobile (no ship to pick up)', () => {
+    const { result } = setup();
+    let consumed: boolean = false;
+    act(() => {
+      consumed = result.result.current.handleCellClick(5, 5);
+    });
+    expect(consumed).toBe(false);
+  });
+
+  it('returns true and sets movingShipId when tapping a placed ship on mobile', () => {
+    const { result, setHoveredCells, setIsInvalidHover } = setup();
+    act(() => {
+      const consumed = result.result.current.handleCellClick(0, 0);
+      expect(consumed).toBe(true);
+    });
+    expect(result.result.current.movingShipId).toBe('battleship-1');
+    expect(setHoveredCells).toHaveBeenCalledWith([]);
+    expect(setIsInvalidHover).toHaveBeenCalledWith(false);
+  });
+
+  it('does not start moving when isMobile is false (desktop)', () => {
+    const { result } = setup({ isMobile: false });
+    let consumed: boolean = false;
+    act(() => {
+      consumed = result.result.current.handleCellClick(0, 0);
+    });
+    expect(consumed).toBe(false);
+    expect(result.result.current.movingShipId).toBeNull();
+  });
+
+  it('starts moving when isMobile is false but device has coarse pointer', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(pointer: coarse)',
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    const { result } = setup({ isMobile: false });
+    act(() => {
+      const consumed = result.result.current.handleCellClick(0, 0);
+      expect(consumed).toBe(true);
+    });
+    expect(result.result.current.movingShipId).toBe('battleship-1');
+  });
+
+  it('does not start moving when placement is complete', () => {
+    const { result } = setup({ isPlacementComplete: true });
+    let consumed: boolean = false;
+    act(() => {
+      consumed = result.result.current.handleCellClick(0, 0);
+    });
+    expect(consumed).toBe(false);
+    expect(result.result.current.movingShipId).toBeNull();
+  });
+
+  it('moves ship to a valid empty position on second tap', () => {
+    const { result, onMoveShip } = setup();
+    act(() => {
+      result.result.current.handleCellClick(0, 0);
+    });
+    expect(result.result.current.movingShipId).toBe('battleship-1');
+
+    act(() => {
+      result.result.current.handleCellClick(5, 5);
+    });
+    expect(onMoveShip).toHaveBeenCalledWith('battleship-1', [
+      { row: 5, col: 5 },
+      { row: 5, col: 6 },
+      { row: 5, col: 7 },
+      { row: 5, col: 8 },
+    ]);
+    expect(result.result.current.movingShipId).toBeNull();
+  });
+
+  it('cancels move when tapping the same ship', () => {
+    const { result, onMoveShip } = setup();
+    act(() => {
+      result.result.current.handleCellClick(0, 0);
+    });
+    expect(result.result.current.movingShipId).toBe('battleship-1');
+
+    act(() => {
+      result.result.current.handleCellClick(0, 1);
+    });
+    expect(result.result.current.movingShipId).toBeNull();
+    expect(onMoveShip).not.toHaveBeenCalled();
+  });
+
+  it('keeps moving state when destination is out of bounds (retry allowed)', () => {
+    const { result, onMoveShip } = setup();
+    act(() => {
+      result.result.current.handleCellClick(0, 0);
+    });
+
+    act(() => {
+      result.result.current.handleCellClick(0, 9);
+    });
+    expect(result.result.current.movingShipId).toBe('battleship-1');
+    expect(onMoveShip).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { ShipCell, CellState, Ship } from '../types';
 import { BOARD_SIZE, CELL_STATE } from '../types';
 
@@ -8,6 +8,7 @@ interface UseMobileShipMoveArgs {
   ships: Ship[];
   board: CellState[][];
   isPlacementComplete: boolean;
+  isMobile: boolean;
   onMoveShip: (shipId: string, cells: ShipCell[]) => void;
   setHoveredCells: (cells: ShipCell[]) => void;
   setIsInvalidHover: (v: boolean) => void;
@@ -66,11 +67,17 @@ export function useMobileShipMove({
   ships,
   board,
   isPlacementComplete,
+  isMobile,
   onMoveShip,
   setHoveredCells,
   setIsInvalidHover,
 }: UseMobileShipMoveArgs) {
   const [movingShipId, setMovingShipId] = useState<string | null>(null);
+  const isTouchDevice = useRef(false);
+
+  useEffect(() => {
+    isTouchDevice.current = window.matchMedia('(pointer: coarse)').matches;
+  }, []);
 
   const clearMovingState = useCallback(() => {
     setMovingShipId(null);
@@ -80,12 +87,6 @@ export function useMobileShipMove({
 
   const handleCellClick = useCallback(
     (row: number, col: number): boolean => {
-      const media =
-        typeof window !== 'undefined'
-          ? window.matchMedia('(pointer: coarse)')
-          : null;
-      const isCoarse = media?.matches ?? false;
-
       // Mobile tap-to-move flow: user tapped a placed ship to relocate it
       if (movingShipId) {
         const movingShip = ships.find((s) => s.id === movingShipId);
@@ -117,7 +118,7 @@ export function useMobileShipMove({
       }
 
       // Mobile: tap on a placed ship cell → start moving it
-      if (isCoarse && !isPlacementComplete) {
+      if ((isMobile || isTouchDevice.current) && !isPlacementComplete) {
         const shipOnCell = ships.find((s) =>
           s.cells.some((c) => c.row === row && c.col === col),
         );
@@ -136,6 +137,7 @@ export function useMobileShipMove({
       ships,
       board,
       isPlacementComplete,
+      isMobile,
       onMoveShip,
       clearMovingState,
       setHoveredCells,

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/PlacementBoardGrid.tsx
@@ -50,6 +50,7 @@ interface PlacementBoardCellProps {
   isShipHead: boolean;
   draggable: boolean;
   onDragStart: (e: DragEvent<HTMLElement>) => void;
+  onPointerDown?: (e: React.PointerEvent) => void;
   rIndex: number;
   cIndex: number;
   onMouseEnter: (row: number, col: number) => void;
@@ -80,6 +81,7 @@ const PlacementBoardCell = memo(
     isShipHead,
     draggable,
     onDragStart,
+    onPointerDown,
     rIndex,
     cIndex,
     onMouseEnter,
@@ -169,6 +171,7 @@ const PlacementBoardCell = memo(
         className={classNames}
         draggable={draggable}
         onDragStart={onDragStart}
+        onPointerDown={onPointerDown}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={onMouseLeave}
         onPointerEnter={handleMouseEnter}
@@ -214,6 +217,11 @@ interface PlacementBoardGridProps {
   shipHeadKeys: Set<string>;
   isPlacementComplete: boolean;
   movingShipCells?: ShipCell[];
+  onTouchBoardPointerDown?: (
+    row: number,
+    col: number,
+    e: React.PointerEvent,
+  ) => void;
   onCellHover: (row: number, col: number) => void;
   onMouseLeave: () => void;
   onCellClick: (row: number, col: number) => void;
@@ -237,6 +245,7 @@ export const PlacementBoardGrid = memo(
     shipHeadKeys,
     isPlacementComplete,
     movingShipCells,
+    onTouchBoardPointerDown,
     onCellHover,
     onMouseLeave,
     onCellClick,
@@ -317,6 +326,11 @@ export const PlacementBoardGrid = memo(
                     isShipHead={isShipHead}
                     draggable={dragProps.draggable}
                     onDragStart={dragProps.onDragStart}
+                    onPointerDown={
+                      isShipCell && onTouchBoardPointerDown
+                        ? (e) => onTouchBoardPointerDown(rIndex, cIndex, e)
+                        : undefined
+                    }
                     rIndex={rIndex}
                     cIndex={cIndex}
                     onMouseEnter={onCellHover}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/placement-utils.ts
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/placement-utils.ts
@@ -1,0 +1,26 @@
+import type { ShipCell, CellState } from '../../types';
+import { BOARD_SIZE, CELL_STATE } from '../../types';
+
+export function createEmptyBoard(): CellState[][] {
+  return Array(BOARD_SIZE)
+    .fill(null)
+    .map(() => Array(BOARD_SIZE).fill(CELL_STATE.EMPTY));
+}
+
+export function getCellsForPlacement(
+  startRow: number,
+  startCol: number,
+  size: number,
+  isVertical: boolean,
+): ShipCell[] | null {
+  const cells: ShipCell[] = [];
+  for (let i = 0; i < size; i++) {
+    const row = isVertical ? startRow + i : startRow;
+    const col = isVertical ? startCol : startCol + i;
+    if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) {
+      return null;
+    }
+    cells.push({ row, col });
+  }
+  return cells;
+}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -15,6 +15,10 @@ import { PlacementHeader, GameBoardWrapper, BoardContainer } from './styles';
 import { useSeaBattleTheme } from '../lib/SeaBattleThemeContext';
 import { useDragPlacement } from '../hooks/useDragPlacement';
 import { useMobileShipMove } from '../hooks/useMobileShipMove';
+import {
+  createEmptyBoard,
+  getCellsForPlacement,
+} from './ShipPlacement/placement-utils';
 
 interface ShipPlacementBoardProps {
   currentPlayer: SeaBattlePlayerState | null;
@@ -45,6 +49,8 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   const [isInvalidHover, setIsInvalidHover] = useState(false);
   const { t } = useTranslation();
   const theme = useSeaBattleTheme();
+  const media = useMedia();
+  const isMobile = !media.gtMd;
 
   const serverShips = useMemo<Ship[]>(
     () => currentPlayer?.ships ?? [],
@@ -131,6 +137,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     ships,
     board,
     isPlacementComplete,
+    isMobile,
     onMoveShip: handleMoveShip,
     setHoveredCells,
     setIsInvalidHover,
@@ -156,6 +163,9 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     onDragLeave,
     handleDragEnd,
     draggingCells,
+    onTouchBoardPointerDown,
+    touchDragJustEnded,
+    resetTouchDragJustEnded,
   } = useDragPlacement({
     board,
     isVertical,
@@ -310,7 +320,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     setIsInvalidHover(false);
   }, [handleCellHover]);
 
-  const handleCellClick = useCallback(
+  const handleCellClickInner = useCallback(
     (row: number, col: number) => {
       // Mobile tap-to-move: handled by hook; returns true if consumed
       if (handleMobileCellClick(row, col)) {
@@ -349,13 +359,19 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     ],
   );
 
+  const handleCellClick = (row: number, col: number) => {
+    if (touchDragJustEnded.current) {
+      resetTouchDragJustEnded();
+      return;
+    }
+    handleCellClickInner(row, col);
+  };
+
   const handleRotate = useCallback(() => {
     setIsVertical((prev) => !prev);
   }, []);
 
   const isAllShipsPlaced = unplacedShips.length === 0;
-  const media = useMedia();
-  const isMobile = !media.gtMd;
 
   const shipPaletteEl = (
     <ShipPaletteSection
@@ -423,6 +439,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       onMouseLeave={handleMouseLeave}
       onCellClick={handleCellClick}
       onCellRotateInPlace={handleRotateInPlace}
+      onTouchBoardPointerDown={onTouchBoardPointerDown}
       onDragOver={onDragOver}
       onDrop={onDrop}
       onDragLeave={onDragLeave}
@@ -472,27 +489,3 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   );
 });
 ShipPlacementBoard.displayName = 'ShipPlacementBoard';
-
-function createEmptyBoard(): CellState[][] {
-  return Array(BOARD_SIZE)
-    .fill(null)
-    .map(() => Array(BOARD_SIZE).fill(CELL_STATE.EMPTY));
-}
-
-function getCellsForPlacement(
-  startRow: number,
-  startCol: number,
-  size: number,
-  isVertical: boolean,
-): ShipCell[] | null {
-  const cells: ShipCell[] = [];
-  for (let i = 0; i < size; i++) {
-    const row = isVertical ? startRow + i : startRow;
-    const col = isVertical ? startCol : startCol + i;
-    if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) {
-      return null;
-    }
-    cells.push({ row, col });
-  }
-  return cells;
-}

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss
@@ -151,6 +151,7 @@
   overflow: hidden;
   box-sizing: border-box;
   pointer-events: auto;
+  touch-action: none;
 }
 
 .sb-board-with-labels-layout {


### PR DESCRIPTION
## What
Enables touch-based ship dragging and tap-to-move during Sea Battle placement on mobile web.

## Why
HTML5 drag-and-drop is disabled on touch devices, so users on mobile web couldn't move ships after placement. The tap-to-move fallback was also gated on viewport width (`isMobile`) instead of pointer type, so tablets and landscape phones got no interaction at all.

## Changes
- **`useDragPlacement.ts`**: Added `onTouchBoardPointerDown` handler using pointer events — tracks drag start, movement threshold (10px), hover preview via `elementFromPoint`, and drop via document-level listeners
- **`useMobileShipMove.ts`**: Added `pointer: coarse` detection alongside `isMobile` so tap-to-move works on all touch devices regardless of viewport width
- **`PlacementBoardGrid.tsx`**: Wired `onPointerDown` on ship cells to the new touch drag handler
- **`ShipPlacementBoard.tsx`**: Wired touch drag and click-suppression after drag to prevent stale taps
- **`placement-utils.ts`**: Extracted `createEmptyBoard` and `getCellsForPlacement` helpers (keeps `ShipPlacementBoard.tsx` under 500 lines)
- **`animations.scss`**: Added `touch-action: none` to board grid to prevent scroll interference during drag
- **`useMobileShipMove.test.ts`**: Added test for coarse-pointer path when `isMobile` is false