### PR TITLE
fix(ARC-837): show join room button only for lobby rooms

### DIFF
--- a/apps/mobile/pages/GamesScreen/GameDetailScreen.components.tsx
+++ b/apps/mobile/pages/GamesScreen/GameDetailScreen.components.tsx
@@ -11,7 +11,7 @@ import {
   formatRoomTimestamp,
   getRoomStatusLabel,
 } from './roomUtils';
-import type { GameRoomSummary } from './api/gamesApi';
+import { GAME_ROOM_STATUS, type GameRoomSummary } from './api/gamesApi';
 
 export function Section({
   title,
@@ -99,10 +99,12 @@ export function RoomCard({ room, joiningRoomId, onJoinRoom }: RoomCardProps) {
     hostRaw === 'mystery captain' ? t('games.rooms.mysteryHost') : hostRaw;
   const isJoining = joiningRoomId === room.id;
   const isPrivate = room.visibility === 'private';
-  const isCompleted = room.status === 'completed';
+  const isCompleted = room.status === GAME_ROOM_STATUS.COMPLETED;
 
   return (
-    <ThemedView style={[styles.roomCard, isCompleted && styles.roomCardCompleted]}>
+    <ThemedView
+      style={[styles.roomCard, isCompleted && styles.roomCardCompleted]}
+    >
       <View style={styles.roomHeader}>
         <ThemedText type="defaultSemiBold" style={styles.roomTitle}>
           {room.name}
@@ -154,32 +156,34 @@ export function RoomCard({ room, joiningRoomId, onJoinRoom }: RoomCardProps) {
             {t('games.rooms.created', { timestamp: createdLabel })}
           </ThemedText>
         </View>
-        <TouchableOpacity
-          style={[
-            styles.roomJoinButton,
-            isJoining && styles.roomJoinButtonDisabled,
-          ]}
-          onPress={() => onJoinRoom(room)}
-          disabled={isJoining}
-        >
-          {isJoining ? (
-            <ActivityIndicator
-              size="small"
-              color={styles.roomJoinButtonText.color as string}
-            />
-          ) : (
-            <>
-              <IconSymbol
-                name="arrow.right.circle.fill"
-                size={18}
+        {room.status === GAME_ROOM_STATUS.LOBBY && (
+          <TouchableOpacity
+            style={[
+              styles.roomJoinButton,
+              isJoining && styles.roomJoinButtonDisabled,
+            ]}
+            onPress={() => onJoinRoom(room)}
+            disabled={isJoining}
+          >
+            {isJoining ? (
+              <ActivityIndicator
+                size="small"
                 color={styles.roomJoinButtonText.color as string}
               />
-              <ThemedText style={styles.roomJoinButtonText}>
-                {t('games.common.joinRoom')}
-              </ThemedText>
-            </>
-          )}
-        </TouchableOpacity>
+            ) : (
+              <>
+                <IconSymbol
+                  name="arrow.right.circle.fill"
+                  size={18}
+                  color={styles.roomJoinButtonText.color as string}
+                />
+                <ThemedText style={styles.roomJoinButtonText}>
+                  {t('games.common.joinRoom')}
+                </ThemedText>
+              </>
+            )}
+          </TouchableOpacity>
+        )}
       </View>
     </ThemedView>
   );

--- a/apps/mobile/pages/GamesScreen/api/gamesApi.ts
+++ b/apps/mobile/pages/GamesScreen/api/gamesApi.ts
@@ -26,6 +26,15 @@ export interface GameOptions {
   idleTimerEnabled?: boolean;
 }
 
+export const GAME_ROOM_STATUS = {
+  LOBBY: 'lobby',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+} as const;
+
+export type GameRoomStatus =
+  (typeof GAME_ROOM_STATUS)[keyof typeof GAME_ROOM_STATUS];
+
 export interface GameRoomSummary {
   id: string;
   gameId: string;
@@ -35,7 +44,7 @@ export interface GameRoomSummary {
   playerCount: number;
   maxPlayers: number | null;
   createdAt: string;
-  status: 'lobby' | 'in_progress' | 'completed';
+  status: GameRoomStatus;
   inviteCode?: string;
   host?: GameRoomMemberSummary;
   members?: GameRoomMemberSummary[];

--- a/apps/mobile/pages/GamesScreen/components/RoomCard.tsx
+++ b/apps/mobile/pages/GamesScreen/components/RoomCard.tsx
@@ -11,7 +11,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useThemedStyles, type Palette } from '@/hooks/useThemedStyles';
 import { useTranslation } from '@/lib/i18n';
 import { platformShadow } from '@/lib/platformShadow';
-import type { GameRoomSummary } from '../api/gamesApi';
+import { GAME_ROOM_STATUS, type GameRoomSummary } from '../api/gamesApi';
 import {
   formatRoomGame,
   formatRoomHost,
@@ -39,9 +39,9 @@ export function RoomCard({
   const { t } = useTranslation();
 
   const statusStyle =
-    room.status === 'lobby'
+    room.status === GAME_ROOM_STATUS.LOBBY
       ? styles.statusLobby
-      : room.status === 'in_progress'
+      : room.status === GAME_ROOM_STATUS.IN_PROGRESS
         ? styles.statusInProgress
         : styles.statusCompleted;
 
@@ -83,7 +83,7 @@ export function RoomCard({
   const gameLabel =
     gameName === 'Unknown game' ? t('games.rooms.unknownGame') : gameName;
 
-  const isCompleted = room.status === 'completed';
+  const isCompleted = room.status === GAME_ROOM_STATUS.COMPLETED;
 
   return (
     <ThemedView style={[styles.card, isCompleted && styles.cardCompleted]}>
@@ -164,29 +164,34 @@ export function RoomCard({
               {t('games.common.watchRoom')}
             </ThemedText>
           </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.joinButton, isJoining && styles.joinButtonDisabled]}
-            onPress={onJoin}
-            disabled={isJoining}
-          >
-            {isJoining ? (
-              <ActivityIndicator
-                size="small"
-                color={styles.joinButtonText.color as string}
-              />
-            ) : (
-              <>
-                <IconSymbol
-                  name="arrow.right.circle.fill"
-                  size={18}
+          {room.status === GAME_ROOM_STATUS.LOBBY && (
+            <TouchableOpacity
+              style={[
+                styles.joinButton,
+                isJoining && styles.joinButtonDisabled,
+              ]}
+              onPress={onJoin}
+              disabled={isJoining}
+            >
+              {isJoining ? (
+                <ActivityIndicator
+                  size="small"
                   color={styles.joinButtonText.color as string}
                 />
-                <ThemedText style={styles.joinButtonText}>
-                  {t('games.common.joinRoom')}
-                </ThemedText>
-              </>
-            )}
-          </TouchableOpacity>
+              ) : (
+                <>
+                  <IconSymbol
+                    name="arrow.right.circle.fill"
+                    size={18}
+                    color={styles.joinButtonText.color as string}
+                  />
+                  <ThemedText style={styles.joinButtonText}>
+                    {t('games.common.joinRoom')}
+                  </ThemedText>
+                </>
+              )}
+            </TouchableOpacity>
+          )}
         </View>
       </View>
     </ThemedView>

--- a/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
@@ -5,7 +5,7 @@ import {
   useTranslation,
   type TranslationKey,
 } from '@/shared/lib/useTranslation';
-import type { GameRoomSummary } from '@/shared/types/games';
+import { GAME_ROOM_STATUS, type GameRoomSummary } from '@/shared/types/games';
 import { resolveGameDisplayInfo } from '@/features/games/lib/variantRegistry';
 import cardStyles from './RoomCardComponent.module.scss';
 import {
@@ -74,7 +74,7 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
     [],
   );
 
-  const isCompleted = room.status === 'completed';
+  const isCompleted = room.status === GAME_ROOM_STATUS.COMPLETED;
 
   return (
     <StyledRoomCard
@@ -238,14 +238,16 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
       )}
 
       <StyledRoomActions viewMode={viewMode}>
-        <LinkButton
-          href={routes.gameRoom(room.id)}
-          variant="primary"
-          size="md"
-          flex={viewMode === 'grid' ? 1 : 0}
-        >
-          {t('games.common.joinRoom')}
-        </LinkButton>
+        {room.status === GAME_ROOM_STATUS.LOBBY && (
+          <LinkButton
+            href={routes.gameRoom(room.id)}
+            variant="primary"
+            size="md"
+            flex={viewMode === 'grid' ? 1 : 0}
+          >
+            {t('games.common.joinRoom')}
+          </LinkButton>
+        )}
         <LinkButton
           href={`${routes.gameRoom(room.id)}?mode=watch`}
           variant="secondary"

--- a/apps/web/src/shared/types/games.ts
+++ b/apps/web/src/shared/types/games.ts
@@ -29,6 +29,15 @@ export interface GameOptions {
   [key: string]: unknown;
 }
 
+export const GAME_ROOM_STATUS = {
+  LOBBY: 'lobby',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+} as const;
+
+export type GameRoomStatus =
+  (typeof GAME_ROOM_STATUS)[keyof typeof GAME_ROOM_STATUS];
+
 export interface GameRoomSummary {
   id: string;
   gameId: string;
@@ -38,7 +47,7 @@ export interface GameRoomSummary {
   playerCount: number;
   maxPlayers: number | null;
   createdAt: string;
-  status: 'lobby' | 'in_progress' | 'completed';
+  status: GameRoomStatus;
   notes?: string | null;
   inviteCode?: string;
   gameOptions?: GameOptions;


### PR DESCRIPTION
## Summary
- Hide "Join Room" button on room cards when room status is not `lobby`
- Add `GAME_ROOM_STATUS` constant and `GameRoomStatus` type to web and mobile shared types

## Changes
- **Web**: Conditionally render join button in `RoomCardComponent` only for lobby rooms
- **Mobile**: Conditionally render join button in `RoomCard` and `GameDetailScreen` `RoomCard` only for lobby rooms
- **Both**: Replace inline string literal status comparisons with `GAME_ROOM_STATUS` constants

## Why
The backend already rejects joins for non-lobby rooms, but the UI was still showing the button for `in_progress` and `completed` rooms, leading to confusing failed join attempts.