### PR TITLE
fix(web): tic tac toe turn badge visibility and name display (ARC-839)

### DIFF
--- a/apps/web/src/features/games/lib/index.ts
+++ b/apps/web/src/features/games/lib/index.ts
@@ -1,17 +1,12 @@
 // Export all game libraries
-export {
-  GameFactory,
-  gameFactory,
-  useGameFactory
-} from "./gameFactory";
+export { GameFactory, gameFactory, useGameFactory } from './gameFactory';
 
 export {
   GameConfigManager,
   gameConfigManager,
-  useGameConfig
-} from "./gameConfig";
+  useGameConfig,
+} from './gameConfig';
 
-export {
-  GamePropsFactory,
-  GamePropsGuards
-} from "./gameProps";
+export { GamePropsFactory, GamePropsGuards } from './gameProps';
+
+export { resolveDisplayName } from './resolveDisplayName';

--- a/apps/web/src/features/games/lib/resolveDisplayName.ts
+++ b/apps/web/src/features/games/lib/resolveDisplayName.ts
@@ -1,0 +1,44 @@
+interface MemberLike {
+  id: string;
+  displayName: string;
+}
+
+/**
+ * Resolve a user ID to a human-readable display name.
+ *
+ * Handles the three common cases that every game widget faces:
+ * 1. The local player → "You" (or custom `youLabel`)
+ * 2. Bot IDs (`bot-…`) → "Bot 1", "Bot 2", … (ordered by `playerOrder`)
+ * 3. Room members → `displayName` from the room payload
+ *
+ * Falls back to the raw ID (or `fallback`) when nothing else matches.
+ */
+export function resolveDisplayName(
+  id: string | null | undefined,
+  opts: {
+    currentUserId?: string | null;
+    members?: MemberLike[];
+    playerOrder?: string[];
+    youLabel?: string;
+    botLabel?: string;
+    fallback?: string;
+  } = {},
+): string {
+  if (!id) return opts.fallback ?? '';
+  if (id === opts.currentUserId) return opts.youLabel ?? 'You';
+
+  if (id.startsWith('bot-')) {
+    const botOrder =
+      opts.playerOrder?.filter((p) => p.startsWith('bot-')) ?? [];
+    const idx = botOrder.indexOf(id);
+    const label = opts.botLabel ?? 'Bot';
+    if (idx !== -1) return `${label} ${idx + 1}`;
+    return label;
+  }
+
+  const member = opts.members?.find((m) => m.id === id);
+  if (member?.displayName && member.displayName !== 'Unknown')
+    return member.displayName;
+
+  return opts.fallback ?? id;
+}

--- a/apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx
@@ -2,6 +2,7 @@
 
 import { XStack, YStack } from 'tamagui';
 import { InGameAvatar } from '@/features/games/ui';
+import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useCascadeTheme } from '../lib/CascadeThemeContext';
 import styles from './CascadeGame.module.css';
@@ -41,7 +42,7 @@ export function TurnBadge({
         {currentEntryId ? (
           <InGameAvatar
             playerId={currentEntryId}
-            name={shortId(currentEntryId, members)}
+            name={resolveDisplayName(currentEntryId, { members })}
             size="sm"
             data-testid="cascade-turn-avatar"
           />
@@ -52,7 +53,7 @@ export function TurnBadge({
               ? t('games.cascade_v1.board.yourTurn')
               : currentEntryId
                 ? t('games.cascade_v1.board.waitingOn', {
-                    player: shortId(currentEntryId, members),
+                    player: resolveDisplayName(currentEntryId, { members }),
                   })
                 : t('games.cascade_v1.board.waiting')}
           </span>
@@ -94,14 +95,4 @@ export function TurnBadge({
       </XStack>
     </XStack>
   );
-}
-
-function shortId(
-  id: string,
-  members?: Array<{ id: string; displayName: string }>,
-): string {
-  if (id.startsWith('bot-')) return 'Bot';
-  const member = members?.find((m) => m.id === id);
-  if (member?.displayName) return member.displayName;
-  return id.slice(0, 6) + '…';
 }

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -12,6 +12,7 @@ import { useSeaBattleActions } from '../hooks/useSeaBattleActions';
 import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { useRematch } from '@/features/games/hooks';
 import { useGameChatIntegration } from '@/features/games/hooks';
+import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
 import {
   GameWidgetContainer,
   type TurnStatusVariant,
@@ -217,29 +218,15 @@ export const SeaBattleGame = memo(function SeaBattleGame({
     !!session?.id && dismissedForSessionId === session.id;
 
   const resolveDisplayNameBound = useCallback(
-    (id?: string | null, fallback?: string | null) => {
-      if (!currentUserId || !room) return fallback || id || '';
-      if (id === currentUserId)
-        return t('games.sea_battle_v1.table.players.you');
-
-      // Bot ids always get a sequential label, even if the backend
-      // stamped them with a placeholder displayName like "Unknown".
-      if (id?.startsWith('bot-')) {
-        const botOrder =
-          snapshot?.playerOrder.filter((pId) => pId.startsWith('bot-')) || [];
-        const botIndex = botOrder.indexOf(id);
-        if (botIndex !== -1) {
-          return `${t('games.lobby.bot' as TranslationKey)} ${botIndex + 1}`;
-        }
-        return 'Bot';
-      }
-
-      const member = room.members?.find((m) => m.id === id);
-      if (member?.displayName && member.displayName !== 'Unknown')
-        return member.displayName;
-
-      return fallback || id || '';
-    },
+    (id?: string | null, fallback?: string | null) =>
+      resolveDisplayName(id, {
+        currentUserId,
+        members: room?.members,
+        playerOrder: snapshot?.playerOrder,
+        youLabel: t('games.sea_battle_v1.table.players.you'),
+        botLabel: t('games.lobby.bot' as TranslationKey),
+        fallback: fallback ?? undefined,
+      }),
     [currentUserId, room, t, snapshot],
   );
 

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -12,6 +12,7 @@ import {
   useGameResultModal,
 } from '@/features/games/hooks';
 import { computeGameResult } from '@/features/games/lib/computeGameResult';
+import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type { TicTacToeGameProps } from '../types';
 import { useTicTacToeState } from '../hooks/useTicTacToeState';
@@ -79,21 +80,12 @@ function TicTacToeGameImpl({
   });
 
   const resolveDisplayNameBound = useCallback(
-    (id?: string | null) => {
-      if (!currentUserId || !room) return id || '';
-      if (id === currentUserId) return 'You';
-      if (id?.startsWith('bot-')) {
-        const botOrder =
-          snapshot?.playerOrder.filter((pId) => pId.startsWith('bot-')) || [];
-        const botIndex = botOrder.indexOf(id);
-        if (botIndex !== -1) return `Bot ${botIndex + 1}`;
-        return 'Bot';
-      }
-      const member = room.members?.find((m) => m.id === id);
-      if (member?.displayName && member.displayName !== 'Unknown')
-        return member.displayName;
-      return id || '';
-    },
+    (id?: string | null) =>
+      resolveDisplayName(id, {
+        currentUserId,
+        members: room?.members,
+        playerOrder: snapshot?.playerOrder,
+      }),
     [currentUserId, room, snapshot],
   );
 

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -78,11 +78,34 @@ function TicTacToeGameImpl({
     userId: currentUserId,
   });
 
+  const resolveDisplayNameBound = useCallback(
+    (id?: string | null) => {
+      if (!currentUserId || !room) return id || '';
+      if (id === currentUserId) return 'You';
+      if (id?.startsWith('bot-')) {
+        const botOrder =
+          snapshot?.playerOrder.filter((pId) => pId.startsWith('bot-')) || [];
+        const botIndex = botOrder.indexOf(id);
+        if (botIndex !== -1) return `Bot ${botIndex + 1}`;
+        return 'Bot';
+      }
+      const member = room.members?.find((m) => m.id === id);
+      if (member?.displayName && member.displayName !== 'Unknown')
+        return member.displayName;
+      return id || '';
+    },
+    [currentUserId, room, snapshot],
+  );
+
   // Pipe engine logs into the shared GameChat and send chat via the generic
   // session history-note event (the BE appends it to the session logs and
   // rebroadcasts, so it shows in the shared panel + popup).
   const sendChat = useGameChatSend(roomId, currentUserId, 'tic_tac_toe_v1');
-  useGameChatIntegration(snapshot?.logs as never, sendChat);
+  useGameChatIntegration(
+    snapshot?.logs as never,
+    sendChat,
+    resolveDisplayNameBound,
+  );
 
   const { rematchLoading, handleRematch } = useRematch({ roomId });
 
@@ -166,6 +189,7 @@ function TicTacToeGameImpl({
             players={snapshot.players}
             teams={snapshot.teams}
             myTurn={myTurn}
+            resolveName={resolveDisplayNameBound}
           />
           <TicTacToeBoard
             board={snapshot.board}

--- a/apps/web/src/widgets/TicTacToeGame/ui/TurnBadge.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/TurnBadge.tsx
@@ -51,7 +51,9 @@ export function TurnBadge({
       paddingVertical="$2"
       paddingHorizontal="$3"
       borderRadius={999}
-      backgroundColor={myTurn ? '$green5' : '$backgroundHover'}
+      backgroundColor={myTurn ? '$green10' : '$backgroundHover'}
+      borderWidth={myTurn ? 0 : 1}
+      borderColor="$borderColor"
       alignSelf="center"
       alignItems="center"
       gap="$2"
@@ -64,7 +66,7 @@ export function TurnBadge({
           data-testid="ttt-turn-avatar"
         />
       ) : null}
-      <Text fontWeight="700" color={theme.textColor}>
+      <Text fontWeight="700" color={myTurn ? '$white' : theme.textColor}>
         {myTurn ? 'Your turn' : `${display}'s turn`}
       </Text>
     </XStack>


### PR DESCRIPTION
## What
- Add shared `resolveDisplayName()` utility in `features/games/lib` for ID-to-name resolution
- Handles local player ('You'), bots ('Bot 1', 'Bot 2'), and room member display name lookup
- Supports i18n labels via `youLabel`/`botLabel` options
- Pass resolver to `TurnBadge` and `useGameChatIntegration` for both in-game and header indicators
- Improve turn badge visibility: `` background, `` text, border for non-active state

## Why
The tic tac toe turn indicator was hardly visible and showed raw user IDs instead of player names. The same ID-to-name resolution logic was duplicated across TicTacToe, SeaBattle, and Cascade games.

## Changes
- `apps/web/src/features/games/lib/resolveDisplayName.ts` — new shared utility
- `apps/web/src/features/games/lib/index.ts` — export the utility
- `apps/web/src/widgets/TicTacToeGame/ui/Game.tsx` — use shared resolver, pass to TurnBadge + useGameChatIntegration
- `apps/web/src/widgets/TicTacToeGame/ui/TurnBadge.tsx` — improved visibility
- `apps/web/src/widgets/SeaBattleGame/ui/Game.tsx` — replaced inline resolver with shared utility
- `apps/web/src/widgets/CascadeGame/ui/TurnBadge.tsx` — replaced shortId with shared utility