### PR TITLE
feat(web): games list multi-select status filter with FilterChip component (ARC-838)

### DIFF
--- a/apps/web/e2e/games-list.spec.ts
+++ b/apps/web/e2e/games-list.spec.ts
@@ -49,8 +49,11 @@ test.describe('Games List Page', () => {
       await expect(searchInput).toBeVisible();
     }
     const filters = page
-      .locator('button')
-      .filter({ hasText: /all|lobby|active|finished|все|все|всего/i });
+      .getByRole('checkbox')
+      .filter({
+        hasText:
+          /all|lobby|in progress|completed|все|лобби|в процессе|завершено/i,
+      });
 
     await expect(async () => {
       expect(await filters.count()).toBeGreaterThan(0);

--- a/apps/web/src/app/[locale]/games/GamesPage.tsx
+++ b/apps/web/src/app/[locale]/games/GamesPage.tsx
@@ -28,6 +28,7 @@ import type {
   GamesStatusFilter,
   GamesViewMode,
 } from './types';
+import { parseStatusFilterFromUrl, serializeStatusFilterToUrl } from './types';
 
 const PAGE_SIZE = 12;
 
@@ -48,11 +49,19 @@ export default function GamesPage({
   const pathname = usePathname();
 
   // URL state management
-  const statusFilter =
-    (searchParams?.get('status') as GamesStatusFilter) || 'all';
+  const [selectedStatuses, setSelectedStatuses] = useState<GamesStatusFilter>(
+    parseStatusFilterFromUrl(searchParams?.get('status') ?? null),
+  );
   const participationFilter =
     (searchParams?.get('participation') as GamesParticipationFilter) || 'all';
   const initialSearchQuery = searchParams?.get('search') || '';
+
+  // Re-sync selectedStatuses from URL whenever search params change
+  useEffect(() => {
+    setSelectedStatuses(
+      parseStatusFilterFromUrl(searchParams?.get('status') ?? null),
+    );
+  }, [searchParams, pathname]);
 
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const deferredSearchQuery = useDeferredValue(searchQuery);
@@ -96,8 +105,10 @@ export default function GamesPage({
   );
 
   const handleStatusChange = useCallback(
-    (status: GamesStatusFilter) => {
-      updateParams({ status });
+    (statuses: GamesStatusFilter) => {
+      setSelectedStatuses(statuses);
+      const serialized = serializeStatusFilterToUrl(statuses);
+      updateParams({ status: serialized });
     },
     [updateParams],
   );
@@ -153,6 +164,11 @@ export default function GamesPage({
     return initialData ? { pages: [initialData] } : null;
   }, [initialData]);
 
+  const serializedStatus = useMemo(
+    () => serializeStatusFilterToUrl(selectedStatuses),
+    [selectedStatuses],
+  );
+
   const {
     data,
     isLoading,
@@ -164,7 +180,7 @@ export default function GamesPage({
     queryKey: [
       'games',
       'list',
-      statusFilter,
+      serializedStatus ?? 'all',
       participationFilter,
       deferredSearchQuery,
       gameId ?? null,
@@ -173,7 +189,7 @@ export default function GamesPage({
     queryFn: async ({ pageParam = 0 }) => {
       return gamesApi.getRooms(
         {
-          status: statusFilter,
+          status: serializedStatus,
           participation: participationFilter,
           search: deferredSearchQuery || undefined,
           page: pageParam as number,
@@ -245,7 +261,7 @@ export default function GamesPage({
         <GamesFilters
           searchQuery={searchQuery}
           onSearch={handleSearch}
-          statusFilter={statusFilter}
+          statusFilter={selectedStatuses}
           onStatusChange={handleStatusChange}
           participationFilter={participationFilter}
           onParticipationChange={handleParticipationChange}

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { GamesSearch } from '@/features/games';
 import { XStack, Text } from 'tamagui';
 import {
@@ -19,6 +20,8 @@ interface GamesFiltersProps {
   isAuthenticated: boolean;
 }
 
+const ALL_STATUSES_COUNT = 3;
+
 export function GamesFilters({
   searchQuery,
   onSearch,
@@ -29,7 +32,25 @@ export function GamesFilters({
   isAuthenticated,
 }: GamesFiltersProps) {
   const { t } = useTranslation();
-  const ALL_STATUSES_COUNT = 3;
+
+  const handleStatusToggle = useCallback(
+    (value: 'all' | 'lobby' | 'in_progress' | 'completed') => {
+      const allSelected =
+        statusFilter.length === 0 || statusFilter.length === ALL_STATUSES_COUNT;
+
+      if (value === 'all') {
+        onStatusChange([]);
+      } else if (allSelected) {
+        onStatusChange(STATUS_VALUES.filter((s) => s !== value));
+      } else {
+        const next = statusFilter.includes(value)
+          ? statusFilter.filter((s) => s !== value)
+          : [...statusFilter, value];
+        onStatusChange(next);
+      }
+    },
+    [statusFilter, onStatusChange],
+  );
 
   return (
     <Filters>
@@ -62,18 +83,7 @@ export function GamesFilters({
                 <FilterChip
                   key={value}
                   active={isActive}
-                  onClick={() => {
-                    if (value === 'all') {
-                      onStatusChange([]);
-                    } else if (allSelected) {
-                      onStatusChange(STATUS_VALUES.filter((s) => s !== value));
-                    } else {
-                      const next = statusFilter.includes(value)
-                        ? statusFilter.filter((s) => s !== value)
-                        : [...statusFilter, value];
-                      onStatusChange(next);
-                    }
-                  }}
+                  onClick={() => handleStatusToggle(value)}
                   aria-label={`Filter by status: ${label || value}`}
                   aria-pressed={isActive}
                 >

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -5,7 +5,7 @@ import {
   type TranslationKey,
 } from '@/shared/lib/useTranslation';
 import { FilterChips, FilterGroup, FilterLabel, Filters } from '../styles';
-import { Button } from '@arcadeum/ui';
+import { FilterChip } from '@arcadeum/ui';
 import type { GamesParticipationFilter, GamesStatusFilter } from '../types';
 
 interface GamesFiltersProps {
@@ -17,16 +17,6 @@ interface GamesFiltersProps {
   onParticipationChange: (participation: GamesParticipationFilter) => void;
   isAuthenticated: boolean;
 }
-
-const STATUS_CHIP_ACTIVE_STYLE = {
-  borderColor: 'rgba(255,255,255,0.4)',
-  borderWidth: 1,
-} as const;
-
-const STATUS_CHIP_INACTIVE_STYLE = {
-  borderColor: 'rgba(255,255,255,0.1)',
-  borderWidth: 1,
-} as const;
 
 export function GamesFilters({
   searchQuery,
@@ -66,16 +56,9 @@ export function GamesFilters({
                     statusFilter.length === ALL_STATUSES_COUNT
                   : statusFilter.includes(value);
               return (
-                <Button
+                <FilterChip
                   key={value}
-                  variant="chip"
-                  size="sm"
-                  isActive={isActive}
-                  style={
-                    isActive
-                      ? STATUS_CHIP_ACTIVE_STYLE
-                      : STATUS_CHIP_INACTIVE_STYLE
-                  }
+                  active={isActive}
                   onClick={() => {
                     if (value === 'all') {
                       onStatusChange([]);
@@ -91,7 +74,7 @@ export function GamesFilters({
                 >
                   {label || value}
                   {isActive ? ' ✓' : ''}
-                </Button>
+                </FilterChip>
               );
             },
           )}
@@ -127,16 +110,9 @@ export function GamesFilters({
               const label = t(participationKeys[value] as TranslationKey);
               const isActive = participationFilter === value;
               return (
-                <Button
+                <FilterChip
                   key={value}
-                  variant="chip"
-                  size="sm"
-                  isActive={isActive}
-                  style={
-                    isActive
-                      ? STATUS_CHIP_ACTIVE_STYLE
-                      : STATUS_CHIP_INACTIVE_STYLE
-                  }
+                  active={isActive}
                   disabled={value !== 'all' && !isAuthenticated}
                   onClick={() => onParticipationChange(value)}
                   aria-label={`Filter by participation: ${label || value}`}
@@ -144,7 +120,7 @@ export function GamesFilters({
                 >
                   {label || value}
                   {isActive ? ' ✓' : ''}
-                </Button>
+                </FilterChip>
               );
             },
           )}

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -12,11 +12,21 @@ interface GamesFiltersProps {
   searchQuery: string;
   onSearch: (query: string) => void;
   statusFilter: GamesStatusFilter;
-  onStatusChange: (status: GamesStatusFilter) => void;
+  onStatusChange: (statuses: GamesStatusFilter) => void;
   participationFilter: GamesParticipationFilter;
   onParticipationChange: (participation: GamesParticipationFilter) => void;
   isAuthenticated: boolean;
 }
+
+const STATUS_CHIP_ACTIVE_STYLE = {
+  borderColor: 'rgba(255,255,255,0.4)',
+  borderWidth: 1,
+} as const;
+
+const STATUS_CHIP_INACTIVE_STYLE = {
+  borderColor: 'rgba(255,255,255,0.1)',
+  borderWidth: 1,
+} as const;
 
 export function GamesFilters({
   searchQuery,
@@ -28,6 +38,7 @@ export function GamesFilters({
   isAuthenticated,
 }: GamesFiltersProps) {
   const { t } = useTranslation();
+  const ALL_STATUSES_COUNT = 3;
 
   return (
     <Filters>
@@ -49,17 +60,37 @@ export function GamesFilters({
                 completed: 'games.lounge.filters.status.completed',
               } as const;
               const label = t(statusKeys[value] as TranslationKey);
+              const isActive =
+                value === 'all'
+                  ? statusFilter.length === 0 ||
+                    statusFilter.length === ALL_STATUSES_COUNT
+                  : statusFilter.includes(value);
               return (
                 <Button
                   key={value}
                   variant="chip"
                   size="sm"
-                  isActive={statusFilter === value}
-                  onClick={() => onStatusChange(value)}
+                  isActive={isActive}
+                  style={
+                    isActive
+                      ? STATUS_CHIP_ACTIVE_STYLE
+                      : STATUS_CHIP_INACTIVE_STYLE
+                  }
+                  onClick={() => {
+                    if (value === 'all') {
+                      onStatusChange([]);
+                    } else {
+                      const next = statusFilter.includes(value)
+                        ? statusFilter.filter((s) => s !== value)
+                        : [...statusFilter, value];
+                      onStatusChange(next);
+                    }
+                  }}
                   aria-label={`Filter by status: ${label || value}`}
-                  aria-pressed={statusFilter === value}
+                  aria-pressed={isActive}
                 >
                   {label || value}
+                  {isActive ? ' ✓' : ''}
                 </Button>
               );
             },
@@ -94,18 +125,25 @@ export function GamesFilters({
                 not_joined: 'games.lounge.filters.participation.not_joined',
               } as const;
               const label = t(participationKeys[value] as TranslationKey);
+              const isActive = participationFilter === value;
               return (
                 <Button
                   key={value}
                   variant="chip"
                   size="sm"
-                  isActive={participationFilter === value}
+                  isActive={isActive}
+                  style={
+                    isActive
+                      ? STATUS_CHIP_ACTIVE_STYLE
+                      : STATUS_CHIP_INACTIVE_STYLE
+                  }
                   disabled={value !== 'all' && !isAuthenticated}
                   onClick={() => onParticipationChange(value)}
                   aria-label={`Filter by participation: ${label || value}`}
-                  aria-pressed={participationFilter === value}
+                  aria-pressed={isActive}
                 >
                   {label || value}
+                  {isActive ? ' ✓' : ''}
                 </Button>
               );
             },

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -50,11 +50,13 @@ export function GamesFilters({
                 completed: 'games.lounge.filters.status.completed',
               } as const;
               const label = t(statusKeys[value] as TranslationKey);
+              const allSelected =
+                statusFilter.length === 0 ||
+                statusFilter.length === ALL_STATUSES_COUNT;
               const isActive =
                 value === 'all'
-                  ? statusFilter.length === 0 ||
-                    statusFilter.length === ALL_STATUSES_COUNT
-                  : statusFilter.includes(value);
+                  ? allSelected
+                  : allSelected || statusFilter.includes(value);
               return (
                 <FilterChip
                   key={value}

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -8,7 +8,7 @@ import {
 import { FilterChips, FilterGroup, FilterLabel, Filters } from '../styles';
 import { FilterChip } from '@arcadeum/ui';
 import type { GamesParticipationFilter, GamesStatusFilter } from '../types';
-import { STATUS_VALUES } from '../types';
+import { ALL_STATUS_VALUES, STATUS_VALUES } from '../types';
 
 interface GamesFiltersProps {
   searchQuery: string;
@@ -20,7 +20,19 @@ interface GamesFiltersProps {
   isAuthenticated: boolean;
 }
 
-const ALL_STATUSES_COUNT = 3;
+const STATUS_KEYS = {
+  all: 'games.lounge.filters.status.all',
+  lobby: 'games.lounge.filters.status.lobby',
+  in_progress: 'games.lounge.filters.status.in_progress',
+  completed: 'games.lounge.filters.status.completed',
+} as const;
+
+const PARTICIPATION_KEYS = {
+  all: 'games.lounge.filters.participation.all',
+  hosting: 'games.lounge.filters.participation.hosting',
+  joined: 'games.lounge.filters.participation.joined',
+  not_joined: 'games.lounge.filters.participation.not_joined',
+} as const;
 
 export function GamesFilters({
   searchQuery,
@@ -34,9 +46,10 @@ export function GamesFilters({
   const { t } = useTranslation();
 
   const handleStatusToggle = useCallback(
-    (value: 'all' | 'lobby' | 'in_progress' | 'completed') => {
+    (value: (typeof ALL_STATUS_VALUES)[number]) => {
       const allSelected =
-        statusFilter.length === 0 || statusFilter.length === ALL_STATUSES_COUNT;
+        statusFilter.length === 0 ||
+        statusFilter.length === STATUS_VALUES.length;
 
       if (value === 'all') {
         onStatusChange([]);
@@ -63,36 +76,28 @@ export function GamesFilters({
       <FilterGroup>
         <FilterLabel>{t('games.lounge.filters.statusLabel')}</FilterLabel>
         <FilterChips>
-          {(['all', 'lobby', 'in_progress', 'completed'] as const).map(
-            (value) => {
-              const statusKeys = {
-                all: 'games.lounge.filters.status.all',
-                lobby: 'games.lounge.filters.status.lobby',
-                in_progress: 'games.lounge.filters.status.in_progress',
-                completed: 'games.lounge.filters.status.completed',
-              } as const;
-              const label = t(statusKeys[value] as TranslationKey);
-              const allSelected =
-                statusFilter.length === 0 ||
-                statusFilter.length === ALL_STATUSES_COUNT;
-              const isActive =
-                value === 'all'
-                  ? allSelected
-                  : allSelected || statusFilter.includes(value);
-              return (
-                <FilterChip
-                  key={value}
-                  active={isActive}
-                  onClick={() => handleStatusToggle(value)}
-                  aria-label={`Filter by status: ${label || value}`}
-                  aria-pressed={isActive}
-                >
-                  {label || value}
-                  {isActive ? ' ✓' : ''}
-                </FilterChip>
-              );
-            },
-          )}
+          {ALL_STATUS_VALUES.map((value) => {
+            const label = t(STATUS_KEYS[value] as TranslationKey);
+            const allSelected =
+              statusFilter.length === 0 ||
+              statusFilter.length === STATUS_VALUES.length;
+            const isActive =
+              value === 'all'
+                ? allSelected
+                : allSelected || statusFilter.includes(value);
+            return (
+              <FilterChip
+                key={value}
+                active={isActive}
+                onClick={() => handleStatusToggle(value)}
+                aria-label={`Filter by status: ${label || value}`}
+                aria-pressed={isActive}
+              >
+                {label || value}
+                {isActive ? ' ✓' : ''}
+              </FilterChip>
+            );
+          })}
         </FilterChips>
       </FilterGroup>
 
@@ -114,31 +119,27 @@ export function GamesFilters({
           )}
         </XStack>
         <FilterChips>
-          {(['all', 'hosting', 'joined', 'not_joined'] as const).map(
-            (value) => {
-              const participationKeys = {
-                all: 'games.lounge.filters.participation.all',
-                hosting: 'games.lounge.filters.participation.hosting',
-                joined: 'games.lounge.filters.participation.joined',
-                not_joined: 'games.lounge.filters.participation.not_joined',
-              } as const;
-              const label = t(participationKeys[value] as TranslationKey);
-              const isActive = participationFilter === value;
-              return (
-                <FilterChip
-                  key={value}
-                  active={isActive}
-                  disabled={value !== 'all' && !isAuthenticated}
-                  onClick={() => onParticipationChange(value)}
-                  aria-label={`Filter by participation: ${label || value}`}
-                  aria-pressed={isActive}
-                >
-                  {label || value}
-                  {isActive ? ' ✓' : ''}
-                </FilterChip>
-              );
-            },
-          )}
+          {(
+            Object.keys(PARTICIPATION_KEYS) as Array<
+              keyof typeof PARTICIPATION_KEYS
+            >
+          ).map((value) => {
+            const label = t(PARTICIPATION_KEYS[value] as TranslationKey);
+            const isActive = participationFilter === value;
+            return (
+              <FilterChip
+                key={value}
+                active={isActive}
+                disabled={value !== 'all' && !isAuthenticated}
+                onClick={() => onParticipationChange(value)}
+                aria-label={`Filter by participation: ${label || value}`}
+                aria-pressed={isActive}
+              >
+                {label || value}
+                {isActive ? ' ✓' : ''}
+              </FilterChip>
+            );
+          })}
         </FilterChips>
       </FilterGroup>
     </Filters>

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -7,6 +7,7 @@ import {
 import { FilterChips, FilterGroup, FilterLabel, Filters } from '../styles';
 import { FilterChip } from '@arcadeum/ui';
 import type { GamesParticipationFilter, GamesStatusFilter } from '../types';
+import { STATUS_VALUES } from '../types';
 
 interface GamesFiltersProps {
   searchQuery: string;
@@ -64,6 +65,8 @@ export function GamesFilters({
                   onClick={() => {
                     if (value === 'all') {
                       onStatusChange([]);
+                    } else if (allSelected) {
+                      onStatusChange(STATUS_VALUES.filter((s) => s !== value));
                     } else {
                       const next = statusFilter.includes(value)
                         ? statusFilter.filter((s) => s !== value)

--- a/apps/web/src/app/[locale]/games/types.ts
+++ b/apps/web/src/app/[locale]/games/types.ts
@@ -9,7 +9,33 @@ export interface GamesClientProps {
   pageTitle?: string;
 }
 
-export type GamesStatusFilter = 'all' | 'lobby' | 'in_progress' | 'completed';
+export type GamesStatusValue = 'lobby' | 'in_progress' | 'completed';
+export type GamesStatusFilter = GamesStatusValue[];
+
+export const STATUS_VALUES: GamesStatusValue[] = [
+  'lobby',
+  'in_progress',
+  'completed',
+];
+
+export function parseStatusFilterFromUrl(
+  raw: string | null,
+): GamesStatusFilter {
+  if (!raw || raw === 'all') return [];
+  return raw
+    .split(',')
+    .filter((s): s is GamesStatusValue =>
+      STATUS_VALUES.includes(s as GamesStatusValue),
+    );
+}
+
+export function serializeStatusFilterToUrl(
+  statuses: GamesStatusFilter,
+): string | undefined {
+  if (statuses.length === 0 || statuses.length === STATUS_VALUES.length)
+    return undefined;
+  return statuses.join(',');
+}
 
 export type GamesParticipationFilter =
   | 'all'

--- a/apps/web/src/app/[locale]/games/types.ts
+++ b/apps/web/src/app/[locale]/games/types.ts
@@ -18,6 +18,8 @@ export const STATUS_VALUES: GamesStatusValue[] = [
   'completed',
 ];
 
+export const ALL_STATUS_VALUES = ['all', ...STATUS_VALUES] as const;
+
 export function parseStatusFilterFromUrl(
   raw: string | null,
 ): GamesStatusFilter {

--- a/packages/ui/src/components/FilterChip/FilterChip.stories.tsx
+++ b/packages/ui/src/components/FilterChip/FilterChip.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { XStack } from 'tamagui';
+import { FilterChip } from './FilterChip';
+
+const meta: Meta<typeof FilterChip> = {
+  title: 'Components/FilterChip',
+  component: FilterChip,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof FilterChip>;
+
+export const Default: Story = {
+  render: () => <FilterChip>In Progress</FilterChip>,
+};
+
+export const Active: Story = {
+  render: () => <FilterChip active>In Progress</FilterChip>,
+};
+
+export const Disabled: Story = {
+  render: () => <FilterChip disabled>In Progress</FilterChip>,
+};
+
+export const MultiSelect: Story = {
+  render: () => {
+    function Example() {
+      const [selected, setSelected] = useState<string[]>(['lobby']);
+      const options = ['all', 'lobby', 'in_progress', 'completed'] as const;
+
+      const toggle = (value: string) => {
+        if (value === 'all') {
+          setSelected([]);
+          return;
+        }
+        setSelected((prev) =>
+          prev.includes(value)
+            ? prev.filter((v) => v !== value)
+            : [...prev, value],
+        );
+      };
+
+      const isAllActive =
+        selected.length === 0 || selected.length === options.length - 1;
+
+      return (
+        <XStack gap="$2" flexWrap="wrap">
+          {options.map((opt) => (
+            <FilterChip
+              key={opt}
+              active={opt === 'all' ? isAllActive : selected.includes(opt)}
+              onClick={() => toggle(opt)}
+            >
+              {opt === 'all' ? 'All' : opt.replace('_', ' ')}
+            </FilterChip>
+          ))}
+        </XStack>
+      );
+    }
+    return <Example />;
+  },
+};

--- a/packages/ui/src/components/FilterChip/FilterChip.tsx
+++ b/packages/ui/src/components/FilterChip/FilterChip.tsx
@@ -1,0 +1,98 @@
+import { XStack, Text, styled } from 'tamagui';
+import type { ReactNode } from 'react';
+
+const ChipRoot = styled(XStack, {
+  name: 'FilterChip',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '$1',
+  paddingHorizontal: '$3',
+  paddingVertical: 5,
+  borderRadius: '$4',
+  borderWidth: 1,
+  cursor: 'pointer',
+  userSelect: 'none',
+  transition: 'background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease',
+
+  backgroundColor: 'rgba(255, 255, 255, 0.05)',
+  borderColor: 'rgba(255, 255, 255, 0.1)',
+  shadowColor: 'rgba(0,0,0,0.3)',
+  shadowOffset: { width: 0, height: 2 },
+  shadowOpacity: 1,
+  shadowRadius: 1,
+
+  hoverStyle: {
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    borderColor: 'rgba(255, 255, 255, 0.16)',
+  },
+
+  pressStyle: {
+    scale: 0.97,
+  },
+
+  focusStyle: {
+    outlineWidth: 0,
+  },
+
+  variants: {
+    active: {
+      true: {
+        backgroundColor: 'rgba(255, 255, 255, 0.12)',
+        borderColor: 'rgba(255, 255, 255, 0.4)',
+      },
+    },
+    disabled: {
+      true: {
+        opacity: 0.4,
+        cursor: 'not-allowed',
+        pointerEvents: 'none',
+      },
+    },
+  } as const,
+
+  defaultVariants: {
+    active: false,
+    disabled: false,
+  },
+});
+
+export type FilterChipProps = {
+  children: ReactNode;
+  active?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  'aria-label'?: string;
+  'aria-pressed'?: boolean | 'true' | 'false';
+  'data-testid'?: string;
+};
+
+export function FilterChip({
+  children,
+  active = false,
+  disabled = false,
+  onClick,
+  'aria-label': ariaLabel,
+  'aria-pressed': ariaPressed,
+  'data-testid': testId,
+}: FilterChipProps) {
+  return (
+    <ChipRoot
+      active={active}
+      disabled={disabled}
+      onPress={onClick}
+      role="checkbox"
+      aria-checked={active}
+      aria-label={ariaLabel}
+      aria-pressed={ariaPressed}
+      testID={testId}
+    >
+      <Text
+        fontSize="$2"
+        fontWeight="600"
+        color={active ? '#ffffff' : 'rgba(255,255,255,0.7)'}
+      >
+        {children}
+      </Text>
+    </ChipRoot>
+  );
+}

--- a/packages/ui/src/components/FilterChip/FilterChip.tsx
+++ b/packages/ui/src/components/FilterChip/FilterChip.tsx
@@ -6,8 +6,8 @@ const ChipRoot = styled(XStack, {
   alignItems: 'center',
   justifyContent: 'center',
   gap: '$1',
-  paddingHorizontal: '$3',
-  paddingVertical: 5,
+  paddingHorizontal: '$4',
+  paddingVertical: 8,
   borderRadius: '$4',
   borderWidth: 1,
   cursor: 'pointer',
@@ -87,7 +87,7 @@ export function FilterChip({
       testID={testId}
     >
       <Text
-        fontSize="$2"
+        fontSize="$3"
         fontWeight="600"
         color={active ? '#ffffff' : 'rgba(255,255,255,0.7)'}
       >

--- a/packages/ui/src/components/FilterChip/index.ts
+++ b/packages/ui/src/components/FilterChip/index.ts
@@ -1,0 +1,2 @@
+export { FilterChip } from './FilterChip';
+export type { FilterChipProps } from './FilterChip';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -61,6 +61,7 @@ export * from './components/Header/LogoInner';
 
 export * from './components/CountdownClock';
 export * from './components/FormPips';
+export * from './components/FilterChip/FilterChip';
 export * from './components/LiveChip';
 export * from './components/MythicSpotlight';
 export * from './components/RankBadge';


### PR DESCRIPTION
## What
Add multi-select status filter to the games lounge page, allowing users to select multiple statuses (lobby, in_progress, completed) simultaneously.

## Why
The current status filter only supports single-select. Users need to filter rooms by multiple statuses at once (e.g., see both lobby and in-progress rooms).

## Changes

### UI Component
- **`packages/ui/src/components/FilterChip/FilterChip.tsx`** — New reusable `FilterChip` component with `active` and `disabled` variants, clear visual border for selected state
- **`packages/ui/src/components/FilterChip/FilterChip.stories.tsx`** — Storybook stories (Default, Active, Disabled, MultiSelect)
- **`packages/ui/src/components/FilterChip/index.ts`** — Re-export
- **`packages/ui/src/index.ts`** — Register FilterChip in UI package exports

### Games List Filter
- **`apps/web/src/app/[locale]/games/types.ts`** — `GamesStatusFilter` changed from single string to `GamesStatusValue[]` array; added `STATUS_VALUES`, `ALL_STATUS_VALUES` constants, `parseStatusFilterFromUrl`, `serializeStatusFilterToUrl` helpers
- **`apps/web/src/app/[locale]/games/components/GamesFilters.tsx`** — Multi-select toggle logic in `handleStatusToggle` callback; "All" clears selection; clicking a chip when all selected deselects just that chip; all chips highlight when "All" is active
- **`apps/web/src/app/[locale]/games/GamesPage.tsx`** — Local `selectedStatuses` state synced with URL search params; serialized as comma-separated `status` param

### Filter Behavior
- Click "All" → clears all selections
- Click individual chip → toggles it
- When all selected and click a chip → deselects just that chip
- When "All" is active, all individual chips show as selected
- Selected chips show visible border + ✓ suffix