### PR TITLE
fix(web): normalize VideoObject uploadDate to include time zone

### DIFF
--- a/apps/web/src/shared/config/app-config.ts
+++ b/apps/web/src/shared/config/app-config.ts
@@ -93,6 +93,18 @@ export function parseYouTubeVideoId(input?: string): string | undefined {
   return trimmed; // Return as-is if fallback
 }
 
+/**
+ * Ensure the upload date includes a time zone offset so Google's
+ * Structured Data validator doesn't flag it as missing/invalid.
+ * Accepts "YYYY-MM-DD" or full ISO 8601; always returns with time + tz.
+ */
+function normalizeUploadDate(value: string): string {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return `${value}T00:00:00+00:00`;
+  }
+  return value;
+}
+
 function readAppConfig(): WebAppConfig {
   const appName = trim(process.env.NEXT_PUBLIC_APP_NAME) ?? 'Arcadeum';
   const appVersion = trim(process.env.NEXT_PUBLIC_APP_VERSION) ?? '0.0.0';
@@ -100,8 +112,9 @@ function readAppConfig(): WebAppConfig {
     process.env.NEXT_PUBLIC_PRESENTATION_VIDEO_ID,
   );
 
-  const videoUploadDate =
-    trim(process.env.NEXT_PUBLIC_VIDEO_UPLOAD_DATE) ?? '2025-01-01';
+  const videoUploadDate = normalizeUploadDate(
+    trim(process.env.NEXT_PUBLIC_VIDEO_UPLOAD_DATE) ?? '2025-01-01',
+  );
 
   const primaryCtaHref =
     trim(process.env.NEXT_PUBLIC_WEB_PRIMARY_CTA_HREF) ?? routes.auth;

--- a/apps/web/src/shared/seo/videoObjectJsonLd.ts
+++ b/apps/web/src/shared/seo/videoObjectJsonLd.ts
@@ -29,6 +29,10 @@ export function buildVideoObjectJsonLd({
   const embedUrl = `https://www.youtube-nocookie.com/embed/${youtubeId}`;
   const thumbnail = `https://i.ytimg.com/vi/${youtubeId}/maxresdefault.jpg`;
 
+  const normalizedDate = /^\d{4}-\d{2}-\d{2}$/.test(uploadDate)
+    ? `${uploadDate}T00:00:00+00:00`
+    : uploadDate;
+
   const node: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'VideoObject',
@@ -38,7 +42,7 @@ export function buildVideoObjectJsonLd({
     thumbnailUrl: [thumbnail],
     contentUrl: watchUrl,
     embedUrl,
-    uploadDate,
+    uploadDate: normalizedDate,
   };
   return node;
 }


### PR DESCRIPTION
## What
Normalize VideoObject `uploadDate` to full ISO 8601 with time zone offset for Google Structured Data compliance.

## Why
Google Search Console flagged the `VideoObject` rich results as invalid:
- **Missing field 'uploadDate'** — date-only values weren't recognized as valid datetimes
- **'uploadDate' missing a time zone** — bare `YYYY-MM-DD` format lacks required tz offset
- **Invalid datetime value** — same root cause

The default config value `'2025-01-01'` and any env var set to date-only format were missing the time component and `+00:00` offset that Google requires.

## Changes
- Added `normalizeUploadDate()` helper in `app-config.ts` that appends `T00:00:00+00:00` to bare `YYYY-MM-DD` strings
- Added same normalization as a safety net in `videoObjectJsonLd.ts` builder function
- Default fallback `'2025-01-01'` now produces `'2025-01-01T00:00:00+00:00'` in the rendered JSON-LD