### PR TITLE
fix(web,be): rename middleware to proxy and remove duplicate mongoose index

### DIFF
--- a/apps/be/src/achievements/schemas/user-achievement.schema.ts
+++ b/apps/be/src/achievements/schemas/user-achievement.schema.ts
@@ -5,7 +5,7 @@ import { Document, Types } from 'mongoose';
 export class UserAchievement extends Document {
   declare _id: Types.ObjectId;
 
-  @Prop({ type: Types.ObjectId, ref: 'User', required: true, index: true })
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
   userId!: Types.ObjectId;
 
   @Prop({

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Slug keys whose pages we never want indexed (per-user dashboards,
  * payment flows, the OAuth callback, admin). Mirrors `PRIVATE_SLUG_KEYS`
- * in `src/middleware.ts` so robots.txt, the `x-robots-tag` header, and
+ * in `src/proxy.ts` so robots.txt, the `x-robots-tag` header, and
  * the sitemap give Google the same signal in three places. Belt and
  * braces — but cheap, and search-console reports get cleaner.
  */

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -83,7 +83,7 @@ const PAGE_LAST_MODIFIED: Record<RouteKey, string> = {
  * URLs it will refuse to index, and surfaces a "submitted URL marked
  * noindex" warning in Search Console.
  *
- * Keep this set in sync with `PRIVATE_SLUG_KEYS` in `src/middleware.ts`.
+ * Keep this set in sync with `PRIVATE_SLUG_KEYS` in `src/proxy.ts`.
  */
 const NOINDEX_KEYS: ReadonlySet<RouteKey> = new Set<RouteKey>([
   'auth',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -81,7 +81,7 @@ function isPrivatePath(locale: Locale, segmentsAfterLocale: string[]): boolean {
   return false;
 }
 
-export function middleware(req: NextRequest) {
+export function proxy(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
   if (SKIP_PREFIXES.some((p) => pathname.startsWith(p))) {

--- a/apps/web/src/shared/config/locale-slugs.ts
+++ b/apps/web/src/shared/config/locale-slugs.ts
@@ -4,7 +4,7 @@
 // `rewrites()` in next.config (URL → filesystem) and `redirects()`
 // (English-slug-in-locale → localized canonical).
 //
-// Imported by routes.ts, middleware.ts, and next.config.ts. Keep this
+// Imported by routes.ts, proxy.ts, and next.config.ts. Keep this
 // file dependency-free — routes.ts is imported transitively by
 // app-config.ts, which would create a cycle if we pulled in the i18n
 // message bundles here.


### PR DESCRIPTION
## Summary
- Rename `middleware.ts` → `proxy.ts` to follow Next.js 16 proxy file convention and remove the deprecation warning
- Remove duplicate `userId` index in `user-achievement.schema.ts` (had both `index: true` on `@Prop` and `schema.index({ userId: 1 }, { unique: true })`)

## Changes
- `apps/web/src/middleware.ts` → `apps/web/src/proxy.ts` — renamed file and exported function `middleware` → `proxy`
- `apps/be/src/achievements/schemas/user-achievement.schema.ts` — removed `index: true` from `userId` `@Prop` since `schema.index({ userId: 1 }, { unique: true })` already covers it
- Updated comment references in `robots.ts`, `sitemap.ts`, `locale-slugs.ts`