### PR TITLE
ci: fix release social poster and e2e test CSP issues

### DIFF
--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -192,13 +192,14 @@ jobs:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
                   query = """
-                  mutation CreatePost($text: String!, $channelId: ChannelId!) {
+                  mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
                     createPost(input: {
                       text: $text
                       channelId: $channelId
                       schedulingType: automatic
                       mode: shareNow
                       assets: []
+                      metadata: $metadata
                     }) {
                       ... on PostActionSuccess {
                         post { id text status }
@@ -213,6 +214,8 @@ jobs:
                       "text": text,
                       "channelId": channel_id,
                   }
+                  metadata_json = "{}"
+                  variables["metadata"] = json.loads(metadata_json)
                   payload = {"query": query, "variables": variables}
                   resp = requests.post(buffer_url, headers=headers, json=payload)
                   if resp.status_code == 200:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
     tags: [ "v*.*.*" ]
 
+env:
+  NEXT_PUBLIC_E2E: 'true'
+  E2E_PROD: 'true'
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -41,5 +45,4 @@ jobs:
         env:
           MONGODB_URI: mongodb://localhost:27017/arcadeum_test
           AUTH_JWT_SECRET: ${{ secrets.AUTH_JWT_SECRET || 'test_jwt_secret_key_for_e2e_only' }}
-          NEXT_PUBLIC_E2E: 'true'
         run: pnpm --filter web test:e2e


### PR DESCRIPTION
## What
Fixes two CI issues: release posts not reaching Facebook/Threads/LinkedIn, and e2e tests failing due to CSP blocking localhost connections.

## Why
- Release updates were only appearing in Telegram because the Buffer GraphQL mutation was missing the `metadata` parameter
- E2e tests in `release.yml` were failing with CSP violations because `NEXT_PUBLIC_E2E` wasn't available at build time (only set during test step)

## Changes
- **release-social-poster.yml**: Added `$metadata: PostInputMetaData` variable and `metadata` field to Buffer GraphQL mutation, matching the daily updater's pattern
- **release.yml**: Moved `NEXT_PUBLIC_E2E` to workflow-level `env` and added `E2E_PROD: 'true'` to match the working `ci.yml` configuration