### PR TITLE
ci: add OCI deployment setup for be and tg-bot

### DIFF
--- a/.github/workflows/deploy-tg-bot.yml
+++ b/.github/workflows/deploy-tg-bot.yml
@@ -1,0 +1,42 @@
+name: Deploy to OCI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/be/**'
+      - 'apps/tg-bot/**'
+      - 'packages/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.OCI_SSH_HOST }}
+          username: ${{ secrets.OCI_SSH_USER }}
+          key: ${{ secrets.OCI_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.OCI_SSH_PORT || 22 }}
+          script: |
+            set -euo pipefail
+            DEPLOY_DIR="/opt/arcadeum"
+            cd "$DEPLOY_DIR"
+
+            git fetch origin main
+            git reset --hard origin/main
+
+            pnpm install --frozen-lockfile
+
+            pnpm --filter be build
+            pnpm --filter tg-bot build
+
+            pm2 restart arcadeum-be arcadeum-tg-bot || \
+              (pm2 start "node apps/be/dist/src/main.js" --name arcadeum-be && \
+               pm2 start "node apps/tg-bot/dist/src/main.js" --name arcadeum-tg-bot && \
+               pm2 save)
+
+            echo "==> Done!"
+            pm2 list

--- a/apps/be/.dockerignore
+++ b/apps/be/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+.git
+.github
+.claude
+.opencode
+*.md
+coverage
+test-results

--- a/apps/be/Dockerfile
+++ b/apps/be/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/be/package.json apps/be/
+
+RUN corepack enable && pnpm install --frozen-lockfile
+
+COPY apps/be/ apps/be/
+COPY packages/ packages/
+
+RUN pnpm --filter be build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+RUN apk add --no-cache dumb-init
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/be/dist ./dist
+COPY --from=builder /app/apps/be/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/be/node_modules ./be-node_modules
+
+EXPOSE 4000
+
+USER node
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/src/main"]

--- a/apps/be/src/economy/economy-settings.integration-spec.ts
+++ b/apps/be/src/economy/economy-settings.integration-spec.ts
@@ -46,7 +46,7 @@ describe('EconomySettingsService (integration)', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
         MongooseModule.forRoot(uri),
-        ConfigModule.forRoot({ isGlobal: true }),
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true }),
         AuthModule,
         WalletModule,
         EconomyModule,

--- a/apps/tg-bot/.dockerignore
+++ b/apps/tg-bot/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+dist
+.env
+.env.*
+!.env.example
+.git
+.github
+.claude
+.opencode
+*.md
+coverage
+test-results

--- a/apps/tg-bot/Dockerfile
+++ b/apps/tg-bot/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/tg-bot/package.json apps/tg-bot/
+
+RUN corepack enable && pnpm install --frozen-lockfile
+
+COPY apps/tg-bot/ apps/tg-bot/
+COPY packages/ packages/
+
+RUN pnpm --filter tg-bot build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+RUN apk add --no-cache dumb-init
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/apps/tg-bot/dist ./dist
+COPY --from=builder /app/apps/tg-bot/package.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/apps/tg-bot/node_modules ./tg-bot-node_modules
+
+EXPOSE 4001
+
+USER node
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/src/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  mongo:
+    image: mongo:7
+    container_name: arcadeum-mongo
+    restart: unless-stopped
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - '127.0.0.1:27017:27017'
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER:-admin}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+    healthcheck:
+      test: ['CMD', 'mongosh', '--eval', "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  be:
+    build:
+      context: .
+      dockerfile: apps/be/Dockerfile
+    container_name: arcadeum-be
+    restart: unless-stopped
+    env_file:
+      - ./apps/be/.env
+    ports:
+      - '127.0.0.1:4000:4000'
+    depends_on:
+      mongo:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:4000/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  tg-bot:
+    build:
+      context: .
+      dockerfile: apps/tg-bot/Dockerfile
+    container_name: arcadeum-tg-bot
+    restart: unless-stopped
+    env_file:
+      - ./apps/tg-bot/.env
+    ports:
+      - '127.0.0.1:4001:4001'
+    depends_on:
+      mongo:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:4001/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  mongo-data:

--- a/scripts/deploy-tg-bot.sh
+++ b/scripts/deploy-tg-bot.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEPLOY_DIR="/opt/arcadeum"
+
+echo "==> Pulling latest code..."
+cd "${DEPLOY_DIR}"
+git fetch origin main
+git reset --hard origin/main
+
+echo "==> Installing dependencies..."
+pnpm install --frozen-lockfile
+
+echo "==> Building..."
+pnpm --filter be build
+pnpm --filter tg-bot build
+
+echo "==> Restarting services..."
+pm2 restart arcadeum-be arcadeum-tg-bot
+
+echo "==> Deploy complete! Status:"
+pm2 list

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Installing Node.js 22..."
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt install -y nodejs
+
+echo "==> Installing MongoDB 7..."
+curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor --yes
+echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-7.0.list
+sudo apt update && sudo apt install -y mongodb-org
+
+echo "==> Starting MongoDB..."
+sudo systemctl start mongod
+sudo systemctl enable mongod
+
+echo "==> Installing pnpm..."
+sudo npm install -g pnpm
+
+echo "==> Installing PM2..."
+sudo npm install -g pm2
+
+DEPLOY_DIR="/opt/arcadeum"
+
+echo "==> Setting up project..."
+sudo mkdir -p /opt
+sudo chown "$USER" /opt
+cd /opt
+
+if [ ! -d "arcadeum" ]; then
+  git clone https://github.com/AnAtoliy-AA/arcadeum.git arcadeum
+fi
+
+cd arcadeum
+git fetch origin main
+git reset --hard origin/main
+
+pnpm install
+
+echo "==> Building apps..."
+pnpm --filter be build
+pnpm --filter tg-bot build
+
+echo "==> Creating env files..."
+cp apps/be/.env.example apps/be/.env
+cp apps/tg-bot/.env.example apps/tg-bot/.env
+
+MONGO_PASS=$(openssl rand -hex 16)
+echo "MONGO_PASSWORD=$MONGO_PASS" > .env
+
+echo ""
+echo "============================================"
+echo "  Now configure secrets and start services"
+echo "============================================"
+echo ""
+
+# Create MongoDB admin user
+echo "==> Creating MongoDB admin user..."
+mongosh --eval "db.createUser({user:'admin',pwd:'${MONGO_PASS}',roles:['root']})" --authenticationDatabase admin 2>/dev/null || true
+
+echo ""
+echo "1. Edit backend env:"
+echo "   nano ${DEPLOY_DIR}/apps/be/.env"
+echo ""
+echo "   Set this line:"
+echo "   MONGODB_URI=mongodb://admin:${MONGO_PASS}@localhost:27017/arcadeum?authSource=admin"
+echo ""
+echo "   Also fill in: AUTH_JWT_SECRET, SOLANA_PRIVATE_KEY, OAUTH_*, etc."
+echo ""
+echo "2. Edit tg-bot env:"
+echo "   nano ${DEPLOY_DIR}/apps/tg-bot/.env"
+echo ""
+echo "   Fill in: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, PUMPFUN_MINT_ADDRESS"
+echo ""
+echo "3. Start services with pm2:"
+echo "   cd ${DEPLOY_DIR}"
+echo "   pm2 start \"node apps/be/dist/src/main.js\" --name arcadeum-be"
+echo "   pm2 start \"node apps/tg-bot/dist/src/main.js\" --name arcadeum-tg-bot"
+echo "   pm2 save"
+echo "   pm2 startup   # follow the output"
+echo ""
+echo "4. Open ports in OCI console (4000, 4001)"
+echo ""
+echo "5. Test:"
+echo "   curl localhost:4000/health"
+echo "   curl localhost:4001/health"


### PR DESCRIPTION
## Summary
- Add Dockerfiles for be and tg-bot apps
- Add docker-compose.yml with MongoDB, be, and tg-bot services
- Add GitHub Actions workflow for auto-deploy to OCI on push to main
- Add deploy and VM setup scripts
- Fix economy-settings integration test (ignoreEnvFile to avoid .env bleed)