### PR TITLE
ci: add discord posting to release and daily social workflows

### DIFF
--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -104,6 +104,7 @@ jobs:
           LINKEDIN_ID: ${{ secrets.BUFFER_LINKEDIN_ID }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          DISCORD_WEBHOOK_DAILY: ${{ secrets.DISCORD_WEBHOOK_DAILY }}
         run: |
           python - <<'EOF'
           import json
@@ -119,14 +120,29 @@ jobs:
               f"{changelog_text}\n\n"
               f"#buildinpublic #indiedev #gamedevelopment"
           )
-          threads_text = (
-              f"Another productive day in the books. Shipped yesterday:\n\n"
-              f"{changelog_text}\n\n"
-              f"What are you coding today? 🛠️"
-          )
+          threads_header = "Another productive day in the books. Shipped yesterday:\n\n"
+          threads_footer = "\n\nWhat are you coding today? 🛠️"
+          threads_max = 480
 
-          if len(threads_text) > 480:
-              threads_text = threads_text[:475] + "..."
+          threads_chunks = []
+          remaining = changelog_text
+          while remaining:
+              budget = threads_max - len(threads_header) - len(threads_footer) if not threads_chunks else threads_max
+              if len(remaining) <= budget:
+                  threads_chunks.append(remaining)
+                  break
+              cut = remaining.rfind('\n', 0, budget)
+              if cut == -1:
+                  cut = budget
+              threads_chunks.append(remaining[:cut])
+              remaining = remaining[cut:].lstrip('\n')
+
+          threads_texts = []
+          for i, chunk in enumerate(threads_chunks):
+              if i == 0:
+                  threads_texts.append(threads_header + chunk + threads_footer)
+              else:
+                  threads_texts.append(f"Shipped yesterday (continued):\n\n{chunk}")
 
           linkedin_text = (
               f"🚀 Daily Development Update\n\n"
@@ -144,75 +160,128 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook", "facebook", "addToQueue"),
-                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads", None, "shareNow"),
-                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn", None, "shareNow"),
+                  (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook", "facebook", "addToQueue"),
+                  (os.environ.get('THREADS_ID', ''), threads_texts, "Threads", None, "shareNow"),
+                  (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn", None, "shareNow"),
               ]
 
-              for channel_id, text, name, metadata_key, mode in channels:
+              for channel_id, texts, name, metadata_key, mode in channels:
                   if not channel_id:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
-                  if metadata_key:
-                      metadata_json = json.dumps({metadata_key: {"type": "post"}})
-                  else:
-                      metadata_json = "{}"
-                  variables = {
-                      "text": text,
-                      "channelId": channel_id,
-                      "metadata": json.loads(metadata_json),
-                  }
-                  query = """
-                  mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
-                    createPost(input: {
-                      text: $text
-                      channelId: $channelId
-                      schedulingType: automatic
-                      mode: %s
-                      assets: []
-                      metadata: $metadata
-                    }) {
-                      ... on PostActionSuccess {
-                        post { id text status }
-                      }
-                      ... on MutationError {
-                        message
-                      }
-                    }
-                  }
-                  """ % mode
-                  payload = {"query": query, "variables": variables}
-                  resp = requests.post(buffer_url, headers=headers, json=payload)
-                  if resp.status_code == 200:
-                      result = resp.json()
-                      if "errors" in result:
-                          print(f"Failed to post to {name}: {result['errors']}")
-                      elif result.get("data", {}).get("createPost", {}).get("message"):
-                          print(f"Failed to post to {name}: {result['data']['createPost']['message']}")
+                  for i, text in enumerate(texts):
+                      if metadata_key:
+                          metadata_json = json.dumps({metadata_key: {"type": "post"}})
                       else:
-                          print(f"Posted daily update to {name}")
-                  else:
-                      print(f"Failed to post to {name}: {resp.text}")
+                          metadata_json = "{}"
+                      variables = {
+                          "text": text,
+                          "channelId": channel_id,
+                          "metadata": json.loads(metadata_json),
+                      }
+                      query = """
+                      mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
+                        createPost(input: {
+                          text: $text
+                          channelId: $channelId
+                          schedulingType: automatic
+                          mode: %s
+                          assets: []
+                          metadata: $metadata
+                        }) {
+                          ... on PostActionSuccess {
+                            post { id text status }
+                          }
+                          ... on MutationError {
+                            message
+                          }
+                        }
+                      }
+                      """ % mode
+                      payload = {"query": query, "variables": variables}
+                      resp = requests.post(buffer_url, headers=headers, json=payload)
+                      if resp.status_code == 200:
+                          result = resp.json()
+                          if "errors" in result:
+                              print(f"Failed to post to {name}: {result['errors']}")
+                          elif result.get("data", {}).get("createPost", {}).get("message"):
+                              print(f"Failed to post to {name}: {result['data']['createPost']['message']}")
+                          else:
+                              suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
+                              print(f"Posted daily update to {name}{suffix}")
+                      else:
+                          print(f"Failed to post to {name}: {resp.text}")
           else:
               print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 
           telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
           telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
           if telegram_token and telegram_chat:
-              telegram_text = (
-                  f"🚀 <b>Daily Development Update</b>\n\n"
-                  f"Shipped yesterday:\n\n"
-                  f"<pre>{changelog_text}</pre>"
-              )
-              tg_resp = requests.post(
-                  f"https://api.telegram.org/bot{telegram_token}/sendMessage",
-                  data={"chat_id": telegram_chat, "text": telegram_text, "parse_mode": "HTML"},
-              )
-              if tg_resp.status_code == 200:
-                  print("Posted daily update to Telegram")
-              else:
-                  print(f"Failed to post to Telegram: {tg_resp.text}")
+              tg_header = "🚀 <b>Daily Development Update</b>\n\nShipped yesterday:\n\n"
+              tg_max = 4096
+
+              tg_chunks = []
+              remaining = changelog_text
+              while remaining:
+                  budget = tg_max - len(tg_header) - len('<pre></pre>') if not tg_chunks else tg_max
+                  if len(remaining) <= budget:
+                      tg_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut == -1:
+                      cut = budget
+                  tg_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              for i, chunk in enumerate(tg_chunks):
+                  if i == 0:
+                      tg_text = tg_header + f"<pre>{chunk}</pre>"
+                  else:
+                      tg_text = f"🚀 <b>Daily Development Update (continued)</b>\n\n<pre>{chunk}</pre>"
+                  tg_resp = requests.post(
+                      f"https://api.telegram.org/bot{telegram_token}/sendMessage",
+                      data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
+                  )
+                  if tg_resp.status_code == 200:
+                      print(f"Posted daily update to Telegram (part {i + 1}/{len(tg_chunks)})")
+                  else:
+                      print(f"Failed to post to Telegram: {tg_resp.text}")
           else:
               print("Telegram not configured, skipping.")
+
+          # Post to Discord (direct webhook, no Buffer)
+          discord_webhook = os.environ.get('DISCORD_WEBHOOK_DAILY', '')
+          if discord_webhook:
+              header = "## 🚀 Daily Development Update\n\nShipped yesterday:\n\n"
+              max_len = 2000
+
+              chunks = []
+              remaining = changelog_text
+              while remaining:
+                  budget = max_len - len(header) if not chunks else max_len
+                  if len(remaining) <= budget:
+                      chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut == -1:
+                      cut = budget
+                  chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              for i, chunk in enumerate(chunks):
+                  if i == 0:
+                      content = header + chunk
+                  else:
+                      content = f"## 🚀 Daily Development Update (continued)\n\n{chunk}"
+                  dc_resp = requests.post(
+                      discord_webhook,
+                      json={"content": content},
+                  )
+                  if dc_resp.status_code in (200, 204):
+                      print(f"Posted daily update to Discord (part {i + 1}/{len(chunks)})")
+                  else:
+                      print(f"Failed to post to Discord: {dc_resp.text}")
+          else:
+              print("Discord webhook not configured, skipping.")
 
           EOF

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -29,6 +29,7 @@ jobs:
           LINKEDIN_ID: ${{ secrets.BUFFER_LINKEDIN_ID }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          DISCORD_WEBHOOK_RELEASE: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
         run: |
           python - <<EOF
           import json
@@ -155,14 +156,29 @@ jobs:
               f"#arcadeum #gamedev #newrelease #boardgames"
           )
 
-          threads_text = (
-              f"Shipped v{version} 🚀\n\n"
-              f"{updates_text}\n\n"
-              f"Play now → arcadeum.games"
-          )
+          threads_header = f"Shipped v{version} 🚀\n\n"
+          threads_footer = "\n\nPlay now → arcadeum.games"
+          threads_max = 480
 
-          if len(threads_text) > 480:
-              threads_text = threads_text[:475] + "..."
+          threads_chunks = []
+          remaining = updates_text
+          while remaining:
+              budget = threads_max - len(threads_header) - len(threads_footer) if not threads_chunks else threads_max
+              if len(remaining) <= budget:
+                  threads_chunks.append(remaining)
+                  break
+              cut = remaining.rfind('\n', 0, budget)
+              if cut == -1:
+                  cut = budget
+              threads_chunks.append(remaining[:cut])
+              remaining = remaining[cut:].lstrip('\n')
+
+          threads_texts = []
+          for i, chunk in enumerate(threads_chunks):
+              if i == 0:
+                  threads_texts.append(threads_header + chunk + threads_footer)
+              else:
+                  threads_texts.append(f"Shipped v{version} 🚀 (continued)\n\n{chunk}")
 
           linkedin_text = (
               f"🚀 New Release: v{version}\n\n"
@@ -182,50 +198,52 @@ jobs:
               }
 
               channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), facebook_text, "Facebook"),
-                  (os.environ.get('THREADS_ID', ''), threads_text, "Threads"),
-                  (os.environ.get('LINKEDIN_ID', ''), linkedin_text, "LinkedIn"),
+                  (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook"),
+                  (os.environ.get('THREADS_ID', ''), threads_texts, "Threads"),
+                  (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn"),
               ]
 
-              for channel_id, text, name in channels:
+              for channel_id, texts, name in channels:
                   if not channel_id:
                       print(f"Skipping Buffer post to {name} — channel ID not set")
                       continue
-                  query = """
-                  mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
-                    createPost(input: {
-                      text: $text
-                      channelId: $channelId
-                      schedulingType: automatic
-                      mode: shareNow
-                      assets: []
-                      metadata: $metadata
-                    }) {
-                      ... on PostActionSuccess {
-                        post { id text status }
+                  for i, text in enumerate(texts):
+                      query = """
+                      mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
+                        createPost(input: {
+                          text: $text
+                          channelId: $channelId
+                          schedulingType: automatic
+                          mode: shareNow
+                          assets: []
+                          metadata: $metadata
+                        }) {
+                          ... on PostActionSuccess {
+                            post { id text status }
+                          }
+                          ... on MutationError {
+                            message
+                          }
+                        }
                       }
-                      ... on MutationError {
-                        message
+                      """
+                      variables = {
+                          "text": text,
+                          "channelId": channel_id,
                       }
-                    }
-                  }
-                  """
-                  variables = {
-                      "text": text,
-                      "channelId": channel_id,
-                  }
-                  metadata_json = "{}"
-                  variables["metadata"] = json.loads(metadata_json)
-                  payload = {"query": query, "variables": variables}
-                  resp = requests.post(buffer_url, headers=headers, json=payload)
-                  if resp.status_code == 200:
-                      result = resp.json()
-                      if "errors" in result:
-                          print(f"Failed to post to {name}: {result['errors']}")
+                      metadata_json = "{}"
+                      variables["metadata"] = json.loads(metadata_json)
+                      payload = {"query": query, "variables": variables}
+                      resp = requests.post(buffer_url, headers=headers, json=payload)
+                      if resp.status_code == 200:
+                          result = resp.json()
+                          if "errors" in result:
+                              print(f"Failed to post to {name}: {result['errors']}")
+                          else:
+                              suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
+                              print(f"Posted release v{version} to {name}{suffix}")
                       else:
-                          print(f"Posted release v{version} to {name}")
-                  else:
-                      print(f"Failed to post to {name}: {resp.text}")
+                          print(f"Failed to post to {name}: {resp.text}")
           else:
               print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
 
@@ -233,20 +251,73 @@ jobs:
           telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
           telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
           if telegram_token and telegram_chat:
-              telegram_text = (
-                  f"🚀 <b>New Release: v{version}</b>\n\n"
-                  f"<b>What shipped:</b>\n<pre>{updates_text}</pre>\n\n"
-                  f"Try it now at arcadeum.games"
-              )
-              tg_resp = requests.post(
-                  f"https://api.telegram.org/bot{telegram_token}/sendMessage",
-                  data={"chat_id": telegram_chat, "text": telegram_text, "parse_mode": "HTML"},
-              )
-              if tg_resp.status_code == 200:
-                  print(f"Posted release v{version} to Telegram")
-              else:
-                  print(f"Failed to post to Telegram: {tg_resp.text}")
+              tg_header = f"🚀 <b>New Release: v{version}</b>\n\n<b>What shipped:</b>\n"
+              tg_footer = f"\n\nTry it now at arcadeum.games"
+              tg_max = 4096
+
+              tg_chunks = []
+              remaining = updates_text
+              while remaining:
+                  budget = tg_max - len(tg_header) - len(tg_footer) - len('<pre></pre>') if not tg_chunks else tg_max
+                  if len(remaining) <= budget:
+                      tg_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut == -1:
+                      cut = budget
+                  tg_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              for i, chunk in enumerate(tg_chunks):
+                  if i == 0:
+                      tg_text = tg_header + f"<pre>{chunk}</pre>" + tg_footer
+                  else:
+                      tg_text = f"🚀 <b>New Release: v{version} (continued)</b>\n\n<pre>{chunk}</pre>"
+                  tg_resp = requests.post(
+                      f"https://api.telegram.org/bot{telegram_token}/sendMessage",
+                      data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
+                  )
+                  if tg_resp.status_code == 200:
+                      print(f"Posted release v{version} to Telegram (part {i + 1}/{len(tg_chunks)})")
+                  else:
+                      print(f"Failed to post to Telegram: {tg_resp.text}")
           else:
               print("Telegram not configured, skipping.")
+
+          # 8. Post to Discord (direct webhook, no Buffer)
+          discord_webhook = os.environ.get('DISCORD_WEBHOOK_RELEASE', '')
+          if discord_webhook:
+              header = f"## 🚀 New Release: v{version}\n\n**What shipped:**\n"
+              footer = f"\n\nTry it now at [arcadeum.games](https://arcadeum.games)"
+              max_len = 2000
+
+              chunks = []
+              remaining = updates_text
+              while remaining:
+                  budget = max_len - len(header) - len(footer) if not chunks else max_len
+                  if len(remaining) <= budget:
+                      chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut == -1:
+                      cut = budget
+                  chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              for i, chunk in enumerate(chunks):
+                  if i == 0:
+                      content = header + chunk + footer
+                  else:
+                      content = f"## 🚀 New Release: v{version} (continued)\n\n{chunk}"
+                  dc_resp = requests.post(
+                      discord_webhook,
+                      json={"content": content},
+                  )
+                  if dc_resp.status_code in (200, 204):
+                      print(f"Posted release v{version} to Discord (part {i + 1}/{len(chunks)})")
+                  else:
+                      print(f"Failed to post to Discord: {dc_resp.text}")
+          else:
+              print("Discord webhook not configured, skipping.")
 
           EOF


### PR DESCRIPTION
## Summary
- Add Discord webhook posting to `release-social-poster.yml` and `daily-social-updater.yml`
- Release posts go to `#announcements` via `DISCORD_WEBHOOK_RELEASE` secret
- Daily posts go to `#general` via `DISCORD_WEBHOOK_DAILY` secret
- Discord uses direct webhook posting (no Buffer)
- Split long messages into multiple parts instead of truncating (Threads 480, Telegram 4096, Discord 2000 chars)