### PR TITLE
fix(web): room join/watch button visibility based on lobby status and participation

### DIFF
--- a/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   useTranslation,
   type TranslationKey,
 } from '@/shared/lib/useTranslation';
 import { GAME_ROOM_STATUS, type GameRoomSummary } from '@/shared/types/games';
+import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import { resolveGameDisplayInfo } from '@/features/games/lib/variantRegistry';
 import cardStyles from './RoomCardComponent.module.scss';
 import {
@@ -42,6 +43,15 @@ interface RoomCardComponentProps {
 export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
   const { t } = useTranslation();
   const routes = useRoutes();
+  const { snapshot } = useSessionTokens();
+
+  const isParticipant = useMemo(() => {
+    if (!snapshot.userId) return false;
+    return (
+      room.hostId === snapshot.userId ||
+      room.members?.some((m) => m.id === snapshot.userId) === true
+    );
+  }, [snapshot.userId, room.hostId, room.members]);
 
   const {
     displayName: rawDisplayName,
@@ -238,7 +248,7 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
       )}
 
       <StyledRoomActions viewMode={viewMode}>
-        {room.status === GAME_ROOM_STATUS.LOBBY && (
+        {(room.status === GAME_ROOM_STATUS.LOBBY || isParticipant) && (
           <LinkButton
             href={routes.gameRoom(room.id)}
             variant="primary"
@@ -248,14 +258,16 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
             {t('games.common.joinRoom')}
           </LinkButton>
         )}
-        <LinkButton
-          href={`${routes.gameRoom(room.id)}?mode=watch`}
-          variant="secondary"
-          size="md"
-          flex={viewMode === 'grid' ? 1 : 0}
-        >
-          {t('games.common.watchRoom')}
-        </LinkButton>
+        {room.status === GAME_ROOM_STATUS.LOBBY || !isParticipant ? (
+          <LinkButton
+            href={`${routes.gameRoom(room.id)}?mode=watch`}
+            variant="secondary"
+            size="md"
+            flex={viewMode === 'grid' ? 1 : 0}
+          >
+            {t('games.common.watchRoom')}
+          </LinkButton>
+        ) : null}
       </StyledRoomActions>
     </StyledRoomCard>
   );


### PR DESCRIPTION
## What

Fix room card join/watch button visibility logic:

- **Lobby status**: Both Join and Watch buttons visible
- **Participant**: Only Join button visible (regardless of status)
- **Not lobby + not participant**: Only Watch button visible

## Why

The previous implementation only checked lobby status for the Join button and always showed the Watch button. This didn't account for participant state, leading to incorrect button combinations.

## Changes

- Added  to get current user ID
- Computed  by checking if user is host or in 
- Updated button visibility logic in 