### PR TITLE
feat(ARC-842): Admin ability to block, remove, and restore users

### DIFF
--- a/apps/be/src/admin/admin-users-status.service.spec.ts
+++ b/apps/be/src/admin/admin-users-status.service.spec.ts
@@ -1,0 +1,303 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+import { AdminUsersService } from './admin-users.service';
+import { User } from '../auth/schemas/user.schema';
+
+const oid = () => new Types.ObjectId().toString();
+
+const buildUserDoc = (
+  overrides: Partial<{
+    _id: Types.ObjectId | string;
+    email: string;
+    username: string;
+    displayName: string | null;
+    role: string;
+    createdAt: Date;
+    updatedAt: Date;
+    isBlocked: boolean;
+    blockedAt: Date | null;
+    blockedReason: string | null;
+    deletedAt: Date | null;
+  }> = {},
+) => {
+  const _id =
+    overrides._id instanceof Types.ObjectId
+      ? overrides._id
+      : new Types.ObjectId(
+          typeof overrides._id === 'string' ? overrides._id : undefined,
+        );
+  return {
+    _id,
+    email: overrides.email ?? 'a@x.com',
+    username: overrides.username ?? 'alice',
+    displayName: overrides.displayName ?? null,
+    role: overrides.role ?? 'free',
+    createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-01-02T00:00:00Z'),
+    isBlocked: overrides.isBlocked ?? false,
+    blockedAt: overrides.blockedAt ?? null,
+    blockedReason: overrides.blockedReason ?? null,
+    deletedAt: overrides.deletedAt ?? null,
+  };
+};
+
+const buildFindChain = (returnDocs: unknown[]) => ({
+  select: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  lean: jest.fn().mockResolvedValue(returnDocs),
+});
+
+const buildFindByIdChain = (returnDoc: unknown) => ({
+  lean: jest.fn().mockResolvedValue(returnDoc),
+});
+
+describe('AdminUsersService - Status Management', () => {
+  let service: AdminUsersService;
+  let userModel: {
+    find: jest.Mock;
+    findById: jest.Mock;
+    findByIdAndUpdate: jest.Mock;
+    countDocuments: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    userModel = {
+      find: jest.fn(),
+      findById: jest.fn(),
+      findByIdAndUpdate: jest.fn(),
+      countDocuments: jest.fn(),
+    };
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        AdminUsersService,
+        { provide: getModelToken(User.name), useValue: userModel },
+      ],
+    }).compile();
+
+    service = moduleRef.get(AdminUsersService);
+  });
+
+  describe('list with status filter', () => {
+    it('applies active status filter', async () => {
+      userModel.find.mockReturnValue(buildFindChain([]));
+      userModel.countDocuments.mockResolvedValue(0);
+
+      await service.list({ status: 'active' });
+
+      expect(userModel.find).toHaveBeenCalledWith({
+        isBlocked: { $ne: true },
+        deletedAt: null,
+      });
+    });
+
+    it('applies blocked status filter', async () => {
+      userModel.find.mockReturnValue(buildFindChain([]));
+      userModel.countDocuments.mockResolvedValue(0);
+
+      await service.list({ status: 'blocked' });
+
+      expect(userModel.find).toHaveBeenCalledWith({
+        isBlocked: true,
+        deletedAt: null,
+      });
+    });
+
+    it('applies deleted status filter', async () => {
+      userModel.find.mockReturnValue(buildFindChain([]));
+      userModel.countDocuments.mockResolvedValue(0);
+
+      await service.list({ status: 'deleted' });
+
+      expect(userModel.find).toHaveBeenCalledWith({
+        deletedAt: { $ne: null },
+      });
+    });
+
+    it('defaults to excluding deleted users when no status filter', async () => {
+      userModel.find.mockReturnValue(buildFindChain([]));
+      userModel.countDocuments.mockResolvedValue(0);
+
+      await service.list({});
+
+      expect(userModel.find).toHaveBeenCalledWith({
+        deletedAt: null,
+      });
+    });
+  });
+
+  describe('block', () => {
+    it('rejects malformed ObjectId with INVALID_USER_ID', async () => {
+      try {
+        await service.block('not-an-object-id', oid());
+        fail('expected BadRequestException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+        expect((e as BadRequestException).getResponse()).toMatchObject({
+          code: 'INVALID_USER_ID',
+        });
+      }
+    });
+
+    it('rejects self-block with CANNOT_BLOCK_SELF', async () => {
+      const me = oid();
+      try {
+        await service.block(me, me);
+        fail('expected ForbiddenException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ForbiddenException);
+        expect((e as ForbiddenException).getResponse()).toMatchObject({
+          code: 'CANNOT_BLOCK_SELF',
+        });
+      }
+    });
+
+    it('rejects USER_NOT_FOUND when target missing', async () => {
+      userModel.findById.mockReturnValue(buildFindByIdChain(null));
+      try {
+        await service.block(oid(), oid());
+        fail('expected NotFoundException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(NotFoundException);
+        expect((e as NotFoundException).getResponse()).toMatchObject({
+          code: 'USER_NOT_FOUND',
+        });
+      }
+    });
+
+    it('blocks user successfully', async () => {
+      const target = buildUserDoc({ isBlocked: false });
+      const updated = { ...target, isBlocked: true };
+      userModel.findById.mockReturnValue(buildFindByIdChain(target));
+      userModel.findByIdAndUpdate.mockResolvedValue(updated);
+
+      const result = await service.block(target._id.toString(), oid(), 'spam');
+
+      expect(userModel.findByIdAndUpdate).toHaveBeenCalled();
+      expect(result.isBlocked).toBe(true);
+    });
+
+    it('rejects blocking the last admin', async () => {
+      const target = buildUserDoc({ role: 'admin', isBlocked: false });
+      userModel.findById.mockReturnValue(buildFindByIdChain(target));
+      userModel.countDocuments.mockResolvedValue(0);
+
+      try {
+        await service.block(target._id.toString(), oid());
+        fail('expected ConflictException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConflictException);
+        expect((e as ConflictException).getResponse()).toMatchObject({
+          code: 'LAST_ADMIN_PROTECTED',
+        });
+      }
+    });
+  });
+
+  describe('unblock', () => {
+    it('rejects malformed ObjectId with INVALID_USER_ID', async () => {
+      try {
+        await service.unblock('not-an-object-id', oid());
+        fail('expected BadRequestException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+    });
+
+    it('unblocks user successfully', async () => {
+      const target = buildUserDoc({ isBlocked: true });
+      const updated = { ...target, isBlocked: false };
+      userModel.findById.mockReturnValue(buildFindByIdChain(target));
+      userModel.findByIdAndUpdate.mockResolvedValue(updated);
+
+      const result = await service.unblock(target._id.toString(), oid());
+
+      expect(userModel.findByIdAndUpdate).toHaveBeenCalled();
+      expect(result.isBlocked).toBe(false);
+    });
+  });
+
+  describe('softDelete', () => {
+    it('rejects malformed ObjectId with INVALID_USER_ID', async () => {
+      try {
+        await service.softDelete('not-an-object-id', oid());
+        fail('expected BadRequestException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+    });
+
+    it('rejects self-delete with CANNOT_DELETE_SELF', async () => {
+      const me = oid();
+      try {
+        await service.softDelete(me, me);
+        fail('expected ForbiddenException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ForbiddenException);
+        expect((e as ForbiddenException).getResponse()).toMatchObject({
+          code: 'CANNOT_DELETE_SELF',
+        });
+      }
+    });
+
+    it('soft-deletes user successfully', async () => {
+      const target = buildUserDoc({ deletedAt: null });
+      const updated = { ...target, deletedAt: new Date() };
+      userModel.findById.mockReturnValue(buildFindByIdChain(target));
+      userModel.findByIdAndUpdate.mockResolvedValue(updated);
+
+      const result = await service.softDelete(target._id.toString(), oid());
+
+      expect(userModel.findByIdAndUpdate).toHaveBeenCalled();
+      expect(result.deletedAt).not.toBeNull();
+    });
+
+    it('rejects deleting the last admin', async () => {
+      const target = buildUserDoc({ role: 'admin', deletedAt: null });
+      userModel.findById.mockReturnValue(buildFindByIdChain(target));
+      userModel.countDocuments.mockResolvedValue(0);
+
+      try {
+        await service.softDelete(target._id.toString(), oid());
+        fail('expected ConflictException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(ConflictException);
+        expect((e as ConflictException).getResponse()).toMatchObject({
+          code: 'LAST_ADMIN_PROTECTED',
+        });
+      }
+    });
+  });
+
+  describe('restore', () => {
+    it('rejects malformed ObjectId with INVALID_USER_ID', async () => {
+      try {
+        await service.restore('not-an-object-id', oid());
+        fail('expected BadRequestException');
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+      }
+    });
+
+    it('restores user successfully', async () => {
+      const target = buildUserDoc({ deletedAt: new Date() });
+      const updated = { ...target, deletedAt: null };
+      userModel.findById.mockReturnValue(buildFindByIdChain(target));
+      userModel.findByIdAndUpdate.mockResolvedValue(updated);
+
+      const result = await service.restore(target._id.toString(), oid());
+
+      expect(userModel.findByIdAndUpdate).toHaveBeenCalled();
+      expect(result.deletedAt).toBeNull();
+    });
+  });
+});

--- a/apps/be/src/admin/admin-users.controller.ts
+++ b/apps/be/src/admin/admin-users.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
@@ -15,6 +16,7 @@ import type { AuthenticatedUser } from '../auth/jwt/jwt.strategy';
 import { AdminUsersService } from './admin-users.service';
 import { ListAdminUsersDto } from './dto/list-admin-users.dto';
 import { UpdateUserRoleDto } from './dto/update-user-role.dto';
+import { BlockUserDto } from './dto/block-user.dto';
 import type {
   AdminUserItem,
   AdminUsersResponse,
@@ -43,5 +45,42 @@ export class AdminUsersController {
   ): Promise<AdminUserItem> {
     const requesterUserId = req.user?.userId ?? '';
     return this.service.updateRole(id, body.role, requesterUserId);
+  }
+
+  @Patch(':id/block')
+  block(
+    @Param('id') id: string,
+    @Body() body: BlockUserDto,
+    @Req() req: RequestWithUser,
+  ): Promise<AdminUserItem> {
+    const requesterUserId = req.user?.userId ?? '';
+    return this.service.block(id, requesterUserId, body.reason);
+  }
+
+  @Patch(':id/unblock')
+  unblock(
+    @Param('id') id: string,
+    @Req() req: RequestWithUser,
+  ): Promise<AdminUserItem> {
+    const requesterUserId = req.user?.userId ?? '';
+    return this.service.unblock(id, requesterUserId);
+  }
+
+  @Delete(':id')
+  softDelete(
+    @Param('id') id: string,
+    @Req() req: RequestWithUser,
+  ): Promise<AdminUserItem> {
+    const requesterUserId = req.user?.userId ?? '';
+    return this.service.softDelete(id, requesterUserId);
+  }
+
+  @Patch(':id/restore')
+  restore(
+    @Param('id') id: string,
+    @Req() req: RequestWithUser,
+  ): Promise<AdminUserItem> {
+    const requesterUserId = req.user?.userId ?? '';
+    return this.service.restore(id, requesterUserId);
   }
 }

--- a/apps/be/src/admin/admin-users.service.spec.ts
+++ b/apps/be/src/admin/admin-users.service.spec.ts
@@ -21,6 +21,10 @@ const buildUserDoc = (
     role: string;
     createdAt: Date;
     updatedAt: Date;
+    isBlocked: boolean;
+    blockedAt: Date | null;
+    blockedReason: string | null;
+    deletedAt: Date | null;
   }> = {},
 ) => {
   const _id =
@@ -37,6 +41,10 @@ const buildUserDoc = (
     role: overrides.role ?? 'free',
     createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
     updatedAt: overrides.updatedAt ?? new Date('2026-01-02T00:00:00Z'),
+    isBlocked: overrides.isBlocked ?? false,
+    blockedAt: overrides.blockedAt ?? null,
+    blockedReason: overrides.blockedReason ?? null,
+    deletedAt: overrides.deletedAt ?? null,
   };
 };
 
@@ -88,7 +96,7 @@ describe('AdminUsersService', () => {
 
       const result = await service.list({ page: 1, pageSize: 50 });
 
-      expect(userModel.find).toHaveBeenCalledWith({});
+      expect(userModel.find).toHaveBeenCalledWith({ deletedAt: null });
       expect(findChain.select).toHaveBeenCalledWith(
         '-passwordHash -referralCode -referredBy -usernameNormalized -blockedUsers',
       );
@@ -117,8 +125,14 @@ describe('AdminUsersService', () => {
 
       await service.list({ role: 'admin' });
 
-      expect(userModel.find).toHaveBeenCalledWith({ role: 'admin' });
-      expect(userModel.countDocuments).toHaveBeenCalledWith({ role: 'admin' });
+      expect(userModel.find).toHaveBeenCalledWith({
+        role: 'admin',
+        deletedAt: null,
+      });
+      expect(userModel.countDocuments).toHaveBeenCalledWith({
+        role: 'admin',
+        deletedAt: null,
+      });
     });
 
     it('applies q across username/email/displayName with case-insensitive regex', async () => {
@@ -138,6 +152,7 @@ describe('AdminUsersService', () => {
           { email: { $regex: 'alice', $options: 'i' } },
           { displayName: { $regex: 'alice', $options: 'i' } },
         ],
+        deletedAt: null,
       });
     });
 
@@ -210,6 +225,10 @@ describe('AdminUsersService', () => {
         role: 'admin',
         createdAt: doc.createdAt.toISOString(),
         updatedAt: doc.updatedAt.toISOString(),
+        isBlocked: false,
+        blockedAt: null,
+        blockedReason: null,
+        deletedAt: null,
       });
       expect(Object.keys(item)).not.toContain('passwordHash');
       expect(Object.keys(item)).not.toContain('referralCode');

--- a/apps/be/src/admin/admin-users.service.ts
+++ b/apps/be/src/admin/admin-users.service.ts
@@ -20,6 +20,7 @@ interface ListArgs {
   pageSize?: number;
   q?: string;
   role?: UserRole;
+  status?: 'active' | 'blocked' | 'deleted';
 }
 
 interface UserDocLean {
@@ -30,6 +31,10 @@ interface UserDocLean {
   role: UserRole;
   createdAt: Date;
   updatedAt: Date;
+  isBlocked?: boolean;
+  blockedAt?: Date | null;
+  blockedReason?: string | null;
+  deletedAt?: Date | null;
 }
 
 @Injectable()
@@ -50,6 +55,18 @@ export class AdminUsersService {
         { email: { $regex: escaped, $options: 'i' } },
         { displayName: { $regex: escaped, $options: 'i' } },
       ];
+    }
+
+    if (args.status === 'blocked') {
+      filter.isBlocked = true;
+      filter.deletedAt = null;
+    } else if (args.status === 'deleted') {
+      filter.deletedAt = { $ne: null };
+    } else if (args.status === 'active') {
+      filter.isBlocked = { $ne: true };
+      filter.deletedAt = null;
+    } else {
+      filter.deletedAt = null;
     }
 
     const skip = (page - 1) * pageSize;
@@ -119,6 +136,172 @@ export class AdminUsersService {
     return this.toAdminUserItem(updated as unknown as UserDocLean);
   }
 
+  async block(
+    targetId: string,
+    requesterUserId: string,
+    reason?: string,
+  ): Promise<AdminUserItem> {
+    if (!Types.ObjectId.isValid(targetId)) {
+      throw new BadRequestException({ code: 'INVALID_USER_ID' });
+    }
+
+    if (targetId === requesterUserId) {
+      throw new ForbiddenException({ code: 'CANNOT_BLOCK_SELF' });
+    }
+
+    const target = await this.userModel
+      .findById(targetId)
+      .lean<UserDocLean | null>();
+    if (!target) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+
+    if (target.isBlocked) {
+      return this.toAdminUserItem(target);
+    }
+
+    if (target.role === 'admin') {
+      const otherAdminCount = await this.userModel.countDocuments({
+        role: 'admin',
+        _id: { $ne: target._id },
+        isBlocked: { $ne: true },
+        deletedAt: null,
+      });
+      if (otherAdminCount === 0) {
+        throw new ConflictException({ code: 'LAST_ADMIN_PROTECTED' });
+      }
+    }
+
+    const updated = await this.userModel.findByIdAndUpdate(
+      targetId,
+      {
+        $set: {
+          isBlocked: true,
+          blockedAt: new Date(),
+          blockedReason: reason ?? null,
+        },
+      },
+      { new: true, lean: true },
+    );
+    if (!updated) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+    return this.toAdminUserItem(updated as unknown as UserDocLean);
+  }
+
+  async unblock(
+    targetId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    requesterUserId: string,
+  ): Promise<AdminUserItem> {
+    if (!Types.ObjectId.isValid(targetId)) {
+      throw new BadRequestException({ code: 'INVALID_USER_ID' });
+    }
+
+    const target = await this.userModel
+      .findById(targetId)
+      .lean<UserDocLean | null>();
+    if (!target) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+
+    if (!target.isBlocked) {
+      return this.toAdminUserItem(target);
+    }
+
+    const updated = await this.userModel.findByIdAndUpdate(
+      targetId,
+      {
+        $set: {
+          isBlocked: false,
+          blockedAt: null,
+          blockedReason: null,
+        },
+      },
+      { new: true, lean: true },
+    );
+    if (!updated) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+    return this.toAdminUserItem(updated as unknown as UserDocLean);
+  }
+
+  async softDelete(
+    targetId: string,
+    requesterUserId: string,
+  ): Promise<AdminUserItem> {
+    if (!Types.ObjectId.isValid(targetId)) {
+      throw new BadRequestException({ code: 'INVALID_USER_ID' });
+    }
+
+    if (targetId === requesterUserId) {
+      throw new ForbiddenException({ code: 'CANNOT_DELETE_SELF' });
+    }
+
+    const target = await this.userModel
+      .findById(targetId)
+      .lean<UserDocLean | null>();
+    if (!target) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+
+    if (target.deletedAt) {
+      return this.toAdminUserItem(target);
+    }
+
+    if (target.role === 'admin') {
+      const otherAdminCount = await this.userModel.countDocuments({
+        role: 'admin',
+        _id: { $ne: target._id },
+        deletedAt: null,
+      });
+      if (otherAdminCount === 0) {
+        throw new ConflictException({ code: 'LAST_ADMIN_PROTECTED' });
+      }
+    }
+
+    const updated = await this.userModel.findByIdAndUpdate(
+      targetId,
+      { $set: { deletedAt: new Date() } },
+      { new: true, lean: true },
+    );
+    if (!updated) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+    return this.toAdminUserItem(updated as unknown as UserDocLean);
+  }
+
+  async restore(
+    targetId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    requesterUserId: string,
+  ): Promise<AdminUserItem> {
+    if (!Types.ObjectId.isValid(targetId)) {
+      throw new BadRequestException({ code: 'INVALID_USER_ID' });
+    }
+
+    const target = await this.userModel
+      .findById(targetId)
+      .lean<UserDocLean | null>();
+    if (!target) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+
+    if (!target.deletedAt) {
+      return this.toAdminUserItem(target);
+    }
+
+    const updated = await this.userModel.findByIdAndUpdate(
+      targetId,
+      { $set: { deletedAt: null } },
+      { new: true, lean: true },
+    );
+    if (!updated) {
+      throw new NotFoundException({ code: 'USER_NOT_FOUND' });
+    }
+    return this.toAdminUserItem(updated as unknown as UserDocLean);
+  }
+
   private toAdminUserItem(doc: UserDocLean): AdminUserItem {
     return {
       id: doc._id.toString(),
@@ -128,6 +311,10 @@ export class AdminUsersService {
       role: doc.role,
       createdAt: doc.createdAt.toISOString(),
       updatedAt: doc.updatedAt.toISOString(),
+      isBlocked: doc.isBlocked ?? false,
+      blockedAt: doc.blockedAt?.toISOString() ?? null,
+      blockedReason: doc.blockedReason ?? null,
+      deletedAt: doc.deletedAt?.toISOString() ?? null,
     };
   }
 }

--- a/apps/be/src/admin/dto/admin-user-status.dto.ts
+++ b/apps/be/src/admin/dto/admin-user-status.dto.ts
@@ -1,0 +1,15 @@
+import { IsIn, IsOptional } from 'class-validator';
+
+export type AdminUserStatus = 'active' | 'blocked' | 'deleted';
+
+export const ADMIN_USER_STATUSES: AdminUserStatus[] = [
+  'active',
+  'blocked',
+  'deleted',
+];
+
+export class AdminUserStatusDto {
+  @IsOptional()
+  @IsIn(ADMIN_USER_STATUSES)
+  status?: AdminUserStatus;
+}

--- a/apps/be/src/admin/dto/block-user.dto.ts
+++ b/apps/be/src/admin/dto/block-user.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class BlockUserDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/apps/be/src/admin/dto/list-admin-users.dto.ts
+++ b/apps/be/src/admin/dto/list-admin-users.dto.ts
@@ -9,6 +9,10 @@ import {
   Min,
 } from 'class-validator';
 import { USER_ROLES, type UserRole } from '../../auth/lib/roles';
+import {
+  ADMIN_USER_STATUSES,
+  type AdminUserStatus,
+} from './admin-user-status.dto';
 
 export class ListAdminUsersDto {
   @IsOptional()
@@ -32,4 +36,8 @@ export class ListAdminUsersDto {
   @IsOptional()
   @IsIn(USER_ROLES)
   role?: UserRole;
+
+  @IsOptional()
+  @IsIn(ADMIN_USER_STATUSES)
+  status?: AdminUserStatus;
 }

--- a/apps/be/src/admin/interfaces/admin-user.interface.ts
+++ b/apps/be/src/admin/interfaces/admin-user.interface.ts
@@ -8,6 +8,10 @@ export interface AdminUserItem {
   role: UserRole;
   createdAt: string;
   updatedAt: string;
+  isBlocked: boolean;
+  blockedAt: string | null;
+  blockedReason: string | null;
+  deletedAt: string | null;
 }
 
 export interface AdminUsersResponse {

--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -155,6 +155,14 @@ export class AuthService {
 
     const user = await this.ensureUserUsername(userDoc);
 
+    if (user.isBlocked) {
+      throw new UnauthorizedException('Account is blocked');
+    }
+
+    if (user.deletedAt) {
+      throw new UnauthorizedException('Account has been removed');
+    }
+
     const passwordOk = await bcrypt.compare(data.password, user.passwordHash);
     if (!passwordOk) throw new UnauthorizedException('Invalid credentials');
 
@@ -203,6 +211,14 @@ export class AuthService {
     }
 
     const user = await this.getOrCreateOAuthUser(googleProfile);
+
+    if (user.isBlocked) {
+      throw new UnauthorizedException('Account is blocked');
+    }
+
+    if (user.deletedAt) {
+      throw new UnauthorizedException('Account has been removed');
+    }
 
     const payload: { sub: string; email: string; username: string } = {
       sub: String(user.id),
@@ -299,10 +315,6 @@ export class AuthService {
     return this.buildAuthUserProfile(ensured);
   }
 
-  // ─────────────────────────────────────────────────────────────────────────────
-  // Block User Management
-  // ─────────────────────────────────────────────────────────────────────────────
-
   async blockUser(userId: string, blockedUserId: string): Promise<void> {
     await this.userModel.updateOne(
       { _id: userId },
@@ -326,8 +338,9 @@ export class AuthService {
       .findById(userId)
       .select('blockedUsers')
       .lean();
-    if (!user) return false;
-    return (user.blockedUsers || []).includes(potentiallyBlockedUserId);
+    return user
+      ? (user.blockedUsers || []).includes(potentiallyBlockedUserId)
+      : false;
   }
 
   async getBlockedUsers(userId: string): Promise<string[]> {
@@ -336,31 +349,23 @@ export class AuthService {
       .findById(userId)
       .select('blockedUsers')
       .lean();
-    if (!user) return [];
-    return user.blockedUsers || [];
+    return user?.blockedUsers || [];
   }
 
-  async getBlockedUsersWithDetails(userId: string): Promise<
-    Array<{
-      id: string;
-      displayName: string;
-      username: string;
-    }>
-  > {
+  async getBlockedUsersWithDetails(
+    userId: string,
+  ): Promise<Array<{ id: string; displayName: string; username: string }>> {
     if (!Types.ObjectId.isValid(userId)) return [];
     const user = await this.userModel
       .findById(userId)
       .select('blockedUsers')
       .lean();
-    if (!user || !user.blockedUsers || user.blockedUsers.length === 0)
-      return [];
-
-    const blockedUsersDetails = await this.userModel
+    if (!user?.blockedUsers?.length) return [];
+    const blocked = await this.userModel
       .find({ _id: { $in: user.blockedUsers } })
       .select('displayName username email')
       .lean();
-
-    return blockedUsersDetails.map((u) => ({
+    return blocked.map((u) => ({
       id: (u._id as Types.ObjectId).toString(),
       displayName: u.displayName || u.username || u.email || 'Unknown',
       username: u.username || '',

--- a/apps/be/src/auth/guards/roles.guard.ts
+++ b/apps/be/src/auth/guards/roles.guard.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   ForbiddenException,
   Injectable,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { InjectModel } from '@nestjs/mongoose';
@@ -32,9 +33,22 @@ export class RolesGuard implements CanActivate {
 
     const user = await this.userModel
       .findById(userId)
-      .select('role')
-      .lean<{ role: UserRole } | null>();
+      .select('role isBlocked deletedAt')
+      .lean<{
+        role: UserRole;
+        isBlocked?: boolean;
+        deletedAt?: Date | null;
+      } | null>();
     if (!user) throw new ForbiddenException();
+
+    if (user.isBlocked) {
+      throw new UnauthorizedException('Account is blocked');
+    }
+
+    if (user.deletedAt) {
+      throw new UnauthorizedException('Account has been removed');
+    }
+
     return required.includes(user.role);
   }
 }

--- a/apps/be/src/auth/schemas/user.schema.ts
+++ b/apps/be/src/auth/schemas/user.schema.ts
@@ -76,6 +76,18 @@ export class User {
 
   @Prop({ type: String, default: null })
   equippedBackgroundId?: string | null;
+
+  @Prop({ type: Boolean, default: false })
+  isBlocked!: boolean;
+
+  @Prop({ type: Date, default: null })
+  blockedAt?: Date | null;
+
+  @Prop({ type: String, default: null })
+  blockedReason?: string | null;
+
+  @Prop({ type: Date, default: null })
+  deletedAt?: Date | null;
 }
 
 export type UserDocument = User & Document;

--- a/apps/web/src/app/[locale]/admin/users/AdminUsersClient.tsx
+++ b/apps/web/src/app/[locale]/admin/users/AdminUsersClient.tsx
@@ -2,8 +2,16 @@
 import { useState } from 'react';
 import { Container, PageLayout, PageTitle, YStack } from '@arcadeum/ui';
 import { useLanguage } from '@/shared/i18n/context';
-import { useAdminUsers, useUpdateUserRole } from '@/features/admin-users/hooks';
+import {
+  useAdminUsers,
+  useUpdateUserRole,
+  useBlockUser,
+  useUnblockUser,
+  useDeleteUser,
+  useRestoreUser,
+} from '@/features/admin-users/hooks';
 import type { UserRole } from '@/entities/session/model/types';
+import type { AdminUserStatus } from '@/features/admin-users/api';
 import { ApiError } from '@/shared/lib/api-client';
 import { UsersFilters } from '@/features/admin-users/ui/UsersFilters';
 import { UsersTable } from '@/features/admin-users/ui/UsersTable';
@@ -13,7 +21,10 @@ import type { AdminWalletI18n } from '@/shared/i18n/messages/pages/admin-wallet/
 interface UsersI18n {
   title: string;
   search: { placeholder: string };
-  filter: { role: { all: string; placeholder: string } };
+  filter: {
+    role: { all: string; placeholder: string };
+    status: { all: string; placeholder: string };
+  };
   table: {
     username: string;
     email: string;
@@ -26,11 +37,20 @@ interface UsersI18n {
   totalLabel: string;
   selfTooltip: string;
   role: Record<UserRole, string>;
+  status: Record<AdminUserStatus, string>;
+  actions: {
+    block: string;
+    unblock: string;
+    remove: string;
+    restore: string;
+  };
   errors: {
     SELF_ROLE_CHANGE_FORBIDDEN: string;
     LAST_ADMIN_PROTECTED: string;
     USER_NOT_FOUND: string;
     INVALID_USER_ID: string;
+    CANNOT_BLOCK_SELF: string;
+    CANNOT_DELETE_SELF: string;
     generic: string;
   };
 }
@@ -48,6 +68,7 @@ export default function AdminUsersClient({
   const [page, setPage] = useState(1);
   const [q, setQ] = useState('');
   const [role, setRole] = useState<UserRole | null>(null);
+  const [status, setStatus] = useState<AdminUserStatus | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [pendingUserId, setPendingUserId] = useState<string | undefined>();
   const [walletTarget, setWalletTarget] = useState<{ userId: string } | null>(
@@ -63,13 +84,23 @@ export default function AdminUsersClient({
     pageSize: PAGE_SIZE,
     q,
     role,
+    status,
   });
 
-  const mutation = useUpdateUserRole();
+  const roleMutation = useUpdateUserRole();
+  const blockMutation = useBlockUser();
+  const unblockMutation = useUnblockUser();
+  const deleteMutation = useDeleteUser();
+  const restoreMutation = useRestoreUser();
 
-  const onFilterChange = (next: { q: string; role: UserRole | null }) => {
+  const onFilterChange = (next: {
+    q: string;
+    role: UserRole | null;
+    status: AdminUserStatus | null;
+  }) => {
     setQ(next.q);
     setRole(next.role);
+    setStatus(next.status);
     setPage(1);
   };
 
@@ -78,7 +109,75 @@ export default function AdminUsersClient({
     setPendingUserId(userId);
     setErrorMsg(null);
     try {
-      await mutation.mutateAsync({ userId, role: newRole });
+      await roleMutation.mutateAsync({ userId, role: newRole });
+    } catch (err) {
+      const apiErr = err instanceof ApiError ? err : null;
+      const code = (apiErr?.data as { code?: string } | undefined)?.code;
+      const msg =
+        (code && t.errors[code as keyof typeof t.errors]) || t.errors.generic;
+      setErrorMsg(msg);
+    } finally {
+      setPendingUserId(undefined);
+    }
+  };
+
+  const handleBlock = async (userId: string) => {
+    if (!t) return;
+    setPendingUserId(userId);
+    setErrorMsg(null);
+    try {
+      await blockMutation.mutateAsync({ userId });
+    } catch (err) {
+      const apiErr = err instanceof ApiError ? err : null;
+      const code = (apiErr?.data as { code?: string } | undefined)?.code;
+      const msg =
+        (code && t.errors[code as keyof typeof t.errors]) || t.errors.generic;
+      setErrorMsg(msg);
+    } finally {
+      setPendingUserId(undefined);
+    }
+  };
+
+  const handleUnblock = async (userId: string) => {
+    if (!t) return;
+    setPendingUserId(userId);
+    setErrorMsg(null);
+    try {
+      await unblockMutation.mutateAsync({ userId });
+    } catch (err) {
+      const apiErr = err instanceof ApiError ? err : null;
+      const code = (apiErr?.data as { code?: string } | undefined)?.code;
+      const msg =
+        (code && t.errors[code as keyof typeof t.errors]) || t.errors.generic;
+      setErrorMsg(msg);
+    } finally {
+      setPendingUserId(undefined);
+    }
+  };
+
+  const handleDelete = async (userId: string) => {
+    if (!t) return;
+    setPendingUserId(userId);
+    setErrorMsg(null);
+    try {
+      await deleteMutation.mutateAsync({ userId });
+    } catch (err) {
+      const apiErr = err instanceof ApiError ? err : null;
+      const code = (apiErr?.data as { code?: string } | undefined)?.code;
+      const msg =
+        (code && t.errors[code as keyof typeof t.errors]) || t.errors.generic;
+      setErrorMsg(msg);
+    } finally {
+      setPendingUserId(undefined);
+    }
+  };
+
+  const handleRestore = async (userId: string) => {
+    if (!t) return;
+    setPendingUserId(userId);
+    setErrorMsg(null);
+    try {
+      await restoreMutation.mutateAsync({ userId });
     } catch (err) {
       const apiErr = err instanceof ApiError ? err : null;
       const code = (apiErr?.data as { code?: string } | undefined)?.code;
@@ -118,6 +217,10 @@ export default function AdminUsersClient({
         roleLabels: t.role,
         selfTooltip: t.selfTooltip,
         walletButtonLabel: tWallet?.drawer.openButton ?? 'Wallet',
+        blockLabel: t.actions.block,
+        unblockLabel: t.actions.unblock,
+        removeLabel: t.actions.remove,
+        restoreLabel: t.actions.restore,
       }
     : null;
   const filtersLabels = t
@@ -125,6 +228,8 @@ export default function AdminUsersClient({
         searchPlaceholder: t.search.placeholder,
         roleFilterPlaceholder: t.filter.role.placeholder,
         roleFilterAll: t.filter.role.all,
+        statusFilterAll: t.filter.status.all,
+        statusLabels: t.status,
         roleLabels: t.role,
       }
     : null;
@@ -138,6 +243,7 @@ export default function AdminUsersClient({
             <UsersFilters
               q={q}
               role={role}
+              status={status}
               onChange={onFilterChange}
               labels={filtersLabels}
             />
@@ -161,9 +267,13 @@ export default function AdminUsersClient({
               isLoading={isLoading}
               isError={!!queryError}
               currentUserId={currentUserId}
-              hasFilter={!!q || !!role}
+              hasFilter={!!q || !!role || !!status}
               onRoleChange={handleRoleChange}
               onWalletOpen={(userId) => setWalletTarget({ userId })}
+              onBlock={handleBlock}
+              onUnblock={handleUnblock}
+              onDelete={handleDelete}
+              onRestore={handleRestore}
               onPageChange={setPage}
               pendingUserId={pendingUserId}
               labels={labels}

--- a/apps/web/src/features/admin-users/api.ts
+++ b/apps/web/src/features/admin-users/api.ts
@@ -1,6 +1,8 @@
 import { apiClient } from '@/shared/lib/api-client';
 import type { UserRole } from '@/entities/session/model/types';
 
+export type AdminUserStatus = 'active' | 'blocked' | 'deleted';
+
 export interface AdminUserItem {
   id: string;
   email: string;
@@ -9,6 +11,10 @@ export interface AdminUserItem {
   role: UserRole;
   createdAt: string;
   updatedAt: string;
+  isBlocked: boolean;
+  blockedAt: string | null;
+  blockedReason: string | null;
+  deletedAt: string | null;
 }
 
 export interface AdminUsersResponse {
@@ -23,6 +29,7 @@ export interface ListAdminUsersArgs {
   pageSize?: number;
   q?: string;
   role?: UserRole | null;
+  status?: AdminUserStatus | null;
 }
 
 export function buildAdminUsersUrl(args: ListAdminUsersArgs): string {
@@ -31,6 +38,7 @@ export function buildAdminUsersUrl(args: ListAdminUsersArgs): string {
   if (args.pageSize) qs.set('pageSize', String(args.pageSize));
   if (args.q && args.q.trim()) qs.set('q', args.q);
   if (args.role) qs.set('role', args.role);
+  if (args.status) qs.set('status', args.status);
   const qsStr = qs.toString();
   return qsStr ? `/admin/users?${qsStr}` : '/admin/users';
 }
@@ -52,6 +60,50 @@ export async function updateUserRole(
   return apiClient.patch<AdminUserItem>(
     `/admin/users/${encodeURIComponent(userId)}/role`,
     { role: newRole },
+    { token: accessToken },
+  );
+}
+
+export async function blockUser(
+  userId: string,
+  reason: string | undefined,
+  accessToken: string,
+): Promise<AdminUserItem> {
+  return apiClient.patch<AdminUserItem>(
+    `/admin/users/${encodeURIComponent(userId)}/block`,
+    { reason },
+    { token: accessToken },
+  );
+}
+
+export async function unblockUser(
+  userId: string,
+  accessToken: string,
+): Promise<AdminUserItem> {
+  return apiClient.patch<AdminUserItem>(
+    `/admin/users/${encodeURIComponent(userId)}/unblock`,
+    {},
+    { token: accessToken },
+  );
+}
+
+export async function deleteUser(
+  userId: string,
+  accessToken: string,
+): Promise<AdminUserItem> {
+  return apiClient.delete<AdminUserItem>(
+    `/admin/users/${encodeURIComponent(userId)}`,
+    { token: accessToken },
+  );
+}
+
+export async function restoreUser(
+  userId: string,
+  accessToken: string,
+): Promise<AdminUserItem> {
+  return apiClient.patch<AdminUserItem>(
+    `/admin/users/${encodeURIComponent(userId)}/restore`,
+    {},
     { token: accessToken },
   );
 }

--- a/apps/web/src/features/admin-users/hooks.ts
+++ b/apps/web/src/features/admin-users/hooks.ts
@@ -8,6 +8,10 @@ import type { UserRole } from '@/entities/session/model/types';
 import {
   fetchAdminUsers,
   updateUserRole,
+  blockUser,
+  unblockUser,
+  deleteUser,
+  restoreUser,
   type AdminUserItem,
   type AdminUsersResponse,
   type ListAdminUsersArgs,
@@ -24,6 +28,7 @@ export function useAdminUsers(args: ListAdminUsersArgs) {
       args.pageSize ?? 50,
       args.q ?? '',
       args.role ?? '',
+      args.status ?? '',
     ],
     queryFn: () => fetchAdminUsers(args, accessToken!),
     refreshKey: ADMIN_USERS_REFRESH_KEY,
@@ -37,6 +42,42 @@ export function useUpdateUserRole() {
   return useMutation<AdminUserItem, { userId: string; role: UserRole }>({
     mutationFn: ({ userId, role }) =>
       updateUserRole(userId, role, accessToken!),
+    onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
+  });
+}
+
+export function useBlockUser() {
+  const accessToken = useSessionStore((s) => s.snapshot.accessToken);
+  const triggerRefresh = useRefreshStore((s) => s.triggerRefresh);
+  return useMutation<AdminUserItem, { userId: string; reason?: string }>({
+    mutationFn: ({ userId, reason }) => blockUser(userId, reason, accessToken!),
+    onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
+  });
+}
+
+export function useUnblockUser() {
+  const accessToken = useSessionStore((s) => s.snapshot.accessToken);
+  const triggerRefresh = useRefreshStore((s) => s.triggerRefresh);
+  return useMutation<AdminUserItem, { userId: string }>({
+    mutationFn: ({ userId }) => unblockUser(userId, accessToken!),
+    onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
+  });
+}
+
+export function useDeleteUser() {
+  const accessToken = useSessionStore((s) => s.snapshot.accessToken);
+  const triggerRefresh = useRefreshStore((s) => s.triggerRefresh);
+  return useMutation<AdminUserItem, { userId: string }>({
+    mutationFn: ({ userId }) => deleteUser(userId, accessToken!),
+    onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
+  });
+}
+
+export function useRestoreUser() {
+  const accessToken = useSessionStore((s) => s.snapshot.accessToken);
+  const triggerRefresh = useRefreshStore((s) => s.triggerRefresh);
+  return useMutation<AdminUserItem, { userId: string }>({
+    mutationFn: ({ userId }) => restoreUser(userId, accessToken!),
     onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
   });
 }

--- a/apps/web/src/features/admin-users/ui/UsersFilters.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersFilters.tsx
@@ -3,28 +3,48 @@ import { useEffect, useState } from 'react';
 import { XStack } from 'tamagui';
 import { useDebounce } from '@/shared/hooks/useDebounce';
 import { USER_ROLES, type UserRole } from '@/entities/session/model/types';
+import type { AdminUserStatus } from '../api';
+
+export const ADMIN_USER_STATUSES: AdminUserStatus[] = [
+  'active',
+  'blocked',
+  'deleted',
+];
 
 export interface UsersFiltersLabels {
   searchPlaceholder: string;
   roleFilterPlaceholder: string;
   roleFilterAll: string;
+  statusFilterAll: string;
+  statusLabels: Record<AdminUserStatus, string>;
   roleLabels: Record<UserRole, string>;
 }
 
 export interface UsersFiltersProps {
   q: string;
   role: UserRole | null;
-  onChange: (next: { q: string; role: UserRole | null }) => void;
+  status: AdminUserStatus | null;
+  onChange: (next: {
+    q: string;
+    role: UserRole | null;
+    status: AdminUserStatus | null;
+  }) => void;
   labels: UsersFiltersLabels;
 }
 
-export function UsersFilters({ q, role, onChange, labels }: UsersFiltersProps) {
+export function UsersFilters({
+  q,
+  role,
+  status,
+  onChange,
+  labels,
+}: UsersFiltersProps) {
   const [localQ, setLocalQ] = useState(q);
   const debouncedQ = useDebounce(localQ, 300);
 
   useEffect(() => {
     if (debouncedQ !== q) {
-      onChange({ q: debouncedQ, role });
+      onChange({ q: debouncedQ, role, status });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedQ]);
@@ -51,6 +71,7 @@ export function UsersFilters({ q, role, onChange, labels }: UsersFiltersProps) {
           onChange({
             q: localQ,
             role: e.target.value === '' ? null : (e.target.value as UserRole),
+            status,
           })
         }
         style={{
@@ -65,6 +86,34 @@ export function UsersFilters({ q, role, onChange, labels }: UsersFiltersProps) {
         {USER_ROLES.map((r) => (
           <option key={r} value={r}>
             {labels.roleLabels[r] ?? r}
+          </option>
+        ))}
+      </select>
+      <select
+        data-testid="status-filter"
+        value={status ?? ''}
+        onChange={(e) =>
+          onChange({
+            q: localQ,
+            role,
+            status:
+              e.target.value === ''
+                ? null
+                : (e.target.value as AdminUserStatus),
+          })
+        }
+        style={{
+          padding: '6px 10px',
+          borderRadius: 6,
+          border: '1px solid #555',
+          background: 'transparent',
+          color: 'inherit',
+        }}
+      >
+        <option value="">{labels.statusFilterAll}</option>
+        {ADMIN_USER_STATUSES.map((s) => (
+          <option key={s} value={s}>
+            {labels.statusLabels[s] ?? s}
           </option>
         ))}
       </select>

--- a/apps/web/src/features/admin-users/ui/UsersTable.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersTable.tsx
@@ -18,6 +18,10 @@ export interface UsersTableLabels {
   roleLabels: Record<UserRole, string>;
   selfTooltip: string;
   walletButtonLabel: string;
+  blockLabel: string;
+  unblockLabel: string;
+  removeLabel: string;
+  restoreLabel: string;
 }
 
 export interface UsersTableProps {
@@ -31,6 +35,10 @@ export interface UsersTableProps {
   hasFilter: boolean;
   onRoleChange: (userId: string, role: UserRole) => void;
   onWalletOpen: (userId: string) => void;
+  onBlock: (userId: string) => void;
+  onUnblock: (userId: string) => void;
+  onDelete: (userId: string) => void;
+  onRestore: (userId: string) => void;
   onPageChange: (next: number) => void;
   pendingUserId?: string;
   labels: UsersTableLabels;
@@ -46,6 +54,10 @@ export function UsersTable({
   hasFilter,
   onRoleChange,
   onWalletOpen,
+  onBlock,
+  onUnblock,
+  onDelete,
+  onRestore,
   onPageChange,
   pendingUserId,
   labels,
@@ -112,9 +124,17 @@ export function UsersTable({
             currentUserId={currentUserId}
             onRoleChange={onRoleChange}
             onWalletOpen={onWalletOpen}
+            onBlock={onBlock}
+            onUnblock={onUnblock}
+            onDelete={onDelete}
+            onRestore={onRestore}
             roleLabels={labels.roleLabels}
             selfTooltip={labels.selfTooltip}
             walletButtonLabel={labels.walletButtonLabel}
+            blockLabel={labels.blockLabel}
+            unblockLabel={labels.unblockLabel}
+            removeLabel={labels.removeLabel}
+            restoreLabel={labels.restoreLabel}
             isPending={pendingUserId === it.id}
             zebra={i % 2 === 1}
           />

--- a/apps/web/src/features/admin-users/ui/UsersTableRow.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersTableRow.tsx
@@ -11,9 +11,17 @@ export interface UsersTableRowProps {
   currentUserId: string;
   onRoleChange: (userId: string, role: UserRole) => void;
   onWalletOpen: (userId: string) => void;
+  onBlock: (userId: string) => void;
+  onUnblock: (userId: string) => void;
+  onDelete: (userId: string) => void;
+  onRestore: (userId: string) => void;
   roleLabels: Record<UserRole, string>;
   selfTooltip: string;
   walletButtonLabel: string;
+  blockLabel: string;
+  unblockLabel: string;
+  removeLabel: string;
+  restoreLabel: string;
   isPending?: boolean;
   zebra?: boolean;
 }
@@ -23,13 +31,24 @@ export function UsersTableRow({
   currentUserId,
   onRoleChange,
   onWalletOpen,
+  onBlock,
+  onUnblock,
+  onDelete,
+  onRestore,
   roleLabels,
   selfTooltip,
   walletButtonLabel,
+  blockLabel,
+  unblockLabel,
+  removeLabel,
+  restoreLabel,
   isPending,
   zebra,
 }: UsersTableRowProps) {
   const isSelf = item.id === currentUserId;
+  const isBlocked = item.isBlocked;
+  const isDeleted = !!item.deletedAt;
+
   return (
     <XStack
       gap="$3"
@@ -40,6 +59,7 @@ export function UsersTableRow({
       hoverStyle={{ backgroundColor: '$backgroundHover' }}
       borderBottomWidth={1}
       borderColor="$borderColor"
+      opacity={isDeleted ? 0.5 : 1}
       data-testid={`user-row-${item.id}`}
     >
       <Avatar
@@ -53,6 +73,16 @@ export function UsersTableRow({
           {isSelf && (
             <Text opacity={0.6} fontSize="$1">
               {' (you)'}
+            </Text>
+          )}
+          {isBlocked && (
+            <Text color="$red10" fontSize="$1">
+              {' (blocked)'}
+            </Text>
+          )}
+          {isDeleted && (
+            <Text color="$orange10" fontSize="$1">
+              {' (removed)'}
             </Text>
           )}
         </Text>
@@ -72,7 +102,7 @@ export function UsersTableRow({
             value={item.role}
             onChange={(r) => onRoleChange(item.id, r)}
             labels={roleLabels}
-            disabled={isSelf || isPending}
+            disabled={isSelf || isPending || isDeleted}
             testId={`role-select-${item.id}`}
           />
         </span>
@@ -80,10 +110,57 @@ export function UsersTableRow({
           variant="outline"
           size="sm"
           onPress={() => onWalletOpen(item.id)}
+          disabled={isDeleted}
           data-testid={`wallet-open-${item.id}`}
         >
           {walletButtonLabel}
         </Button>
+        {!isDeleted && !isSelf && (
+          <>
+            {isBlocked ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onPress={() => onUnblock(item.id)}
+                disabled={isPending}
+                data-testid={`unblock-${item.id}`}
+              >
+                {unblockLabel}
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                onPress={() => onBlock(item.id)}
+                disabled={isPending}
+                data-testid={`block-${item.id}`}
+              >
+                {blockLabel}
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              color="$red10"
+              onPress={() => onDelete(item.id)}
+              disabled={isPending}
+              data-testid={`delete-${item.id}`}
+            >
+              {removeLabel}
+            </Button>
+          </>
+        )}
+        {isDeleted && !isSelf && (
+          <Button
+            variant="outline"
+            size="sm"
+            onPress={() => onRestore(item.id)}
+            disabled={isPending}
+            data-testid={`restore-${item.id}`}
+          >
+            {restoreLabel}
+          </Button>
+        )}
       </XStack>
     </XStack>
   );

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/by.ts
@@ -1,0 +1,59 @@
+export const adminUsersBy = {
+  title: 'Карыстальнікі',
+  search: { placeholder: 'Пошук па імі, email або псеўданіме' },
+  filter: {
+    role: { all: 'Усе ролі', placeholder: 'Фільтр па ролі' },
+    status: {
+      all: 'Усе статусы',
+      placeholder: 'Фільтр па статусу',
+    },
+  },
+  table: {
+    username: 'Імя карыстальніка',
+    email: 'Email',
+    role: 'Роля',
+    createdAt: 'Створаны',
+    actions: 'Дзеянні',
+  },
+  empty: {
+    noResults: 'Няма карыстальнікаў па фільтру.',
+    noUsers: 'Карыстальнікаў пакуль няма.',
+  },
+  pagination: {
+    prev: 'Назад',
+    next: 'Наперад',
+    of: 'Старонка {current} з {total}',
+  },
+  totalLabel: '{total} карыстальнікаў',
+  selfTooltip: 'Вы не можаце змяніць сваю ўласную ролю.',
+  role: {
+    free: 'Бясплатны',
+    premium: 'Прэміум',
+    vip: 'VIP',
+    supporter: 'Спонсар',
+    moderator: 'Мадэратар',
+    tester: 'Тэстар',
+    developer: 'Распрацоўшчык',
+    admin: 'Адмін',
+  },
+  status: {
+    active: 'Актыўны',
+    blocked: 'Заблакіраваны',
+    deleted: 'Выдалены',
+  },
+  actions: {
+    block: 'Заблакіраваць',
+    unblock: 'Разблакіраваць',
+    remove: 'Выдаліць',
+    restore: 'Аднавіць',
+  },
+  errors: {
+    SELF_ROLE_CHANGE_FORBIDDEN: 'Вы не можаце змяніць сваю ўласную ролю.',
+    LAST_ADMIN_PROTECTED: 'Нельга паніжаць апошняга адміністратара.',
+    USER_NOT_FOUND: 'Карыстальнік не знойдзены.',
+    INVALID_USER_ID: 'Няправільны ідэнтыфікатар карыстальніка.',
+    CANNOT_BLOCK_SELF: 'Вы не можаце заблакіраваць сябе.',
+    CANNOT_DELETE_SELF: 'Вы не можаце выдаліць сябе.',
+    generic: 'Нешта пайшло не так. Калі ласка, паспрабуйце яшчэ раз.',
+  },
+};

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/en.ts
@@ -1,0 +1,56 @@
+export const adminUsersEn = {
+  title: 'Users',
+  search: { placeholder: 'Search by username, email, or display name' },
+  filter: {
+    role: { all: 'All roles', placeholder: 'Filter by role' },
+    status: { all: 'All statuses', placeholder: 'Filter by status' },
+  },
+  table: {
+    username: 'Username',
+    email: 'Email',
+    role: 'Role',
+    createdAt: 'Created',
+    actions: 'Actions',
+  },
+  empty: {
+    noResults: 'No users match your filters.',
+    noUsers: 'No users yet.',
+  },
+  pagination: {
+    prev: 'Previous',
+    next: 'Next',
+    of: 'Page {current} of {total}',
+  },
+  totalLabel: '{total} users',
+  selfTooltip: "You can't change your own role.",
+  role: {
+    free: 'Free',
+    premium: 'Premium',
+    vip: 'VIP',
+    supporter: 'Supporter',
+    moderator: 'Moderator',
+    tester: 'Tester',
+    developer: 'Developer',
+    admin: 'Admin',
+  },
+  status: {
+    active: 'Active',
+    blocked: 'Blocked',
+    deleted: 'Removed',
+  },
+  actions: {
+    block: 'Block',
+    unblock: 'Unblock',
+    remove: 'Remove',
+    restore: 'Restore',
+  },
+  errors: {
+    SELF_ROLE_CHANGE_FORBIDDEN: "You can't change your own role.",
+    LAST_ADMIN_PROTECTED: "Can't demote the last admin.",
+    USER_NOT_FOUND: 'User not found.',
+    INVALID_USER_ID: 'Invalid user id.',
+    CANNOT_BLOCK_SELF: "You can't block yourself.",
+    CANNOT_DELETE_SELF: "You can't remove yourself.",
+    generic: 'Something went wrong. Please try again.',
+  },
+};

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/es.ts
@@ -1,0 +1,59 @@
+export const adminUsersEs = {
+  title: 'Usuarios',
+  search: { placeholder: 'Buscar por usuario, email o nombre' },
+  filter: {
+    role: { all: 'Todos los roles', placeholder: 'Filtrar por rol' },
+    status: {
+      all: 'Todos los estados',
+      placeholder: 'Filtrar por estado',
+    },
+  },
+  table: {
+    username: 'Usuario',
+    email: 'Email',
+    role: 'Rol',
+    createdAt: 'Creado',
+    actions: 'Acciones',
+  },
+  empty: {
+    noResults: 'No hay usuarios que coincidan con los filtros.',
+    noUsers: 'Aún no hay usuarios.',
+  },
+  pagination: {
+    prev: 'Anterior',
+    next: 'Siguiente',
+    of: 'Página {current} de {total}',
+  },
+  totalLabel: '{total} usuarios',
+  selfTooltip: 'No puedes cambiar tu propio rol.',
+  role: {
+    free: 'Gratis',
+    premium: 'Premium',
+    vip: 'VIP',
+    supporter: 'Patrocinador',
+    moderator: 'Moderador',
+    tester: 'Tester',
+    developer: 'Desarrollador',
+    admin: 'Admin',
+  },
+  status: {
+    active: 'Activo',
+    blocked: 'Bloqueado',
+    deleted: 'Eliminado',
+  },
+  actions: {
+    block: 'Bloquear',
+    unblock: 'Desbloquear',
+    remove: 'Eliminar',
+    restore: 'Restaurar',
+  },
+  errors: {
+    SELF_ROLE_CHANGE_FORBIDDEN: 'No puedes cambiar tu propio rol.',
+    LAST_ADMIN_PROTECTED: 'No se puede degradar al último administrador.',
+    USER_NOT_FOUND: 'Usuario no encontrado.',
+    INVALID_USER_ID: 'Identificador de usuario no válido.',
+    CANNOT_BLOCK_SELF: 'No puedes bloquearte a ti mismo.',
+    CANNOT_DELETE_SELF: 'No puedes eliminarte a ti mismo.',
+    generic: 'Algo salió mal. Inténtalo de nuevo.',
+  },
+};

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/fr.ts
@@ -1,0 +1,62 @@
+export const adminUsersFr = {
+  title: 'Utilisateurs',
+  search: {
+    placeholder: "Recherche par nom d'utilisateur, email ou nom",
+  },
+  filter: {
+    role: { all: 'Tous les rôles', placeholder: 'Filtrer par rôle' },
+    status: {
+      all: 'Tous les statuts',
+      placeholder: 'Filtrer par statut',
+    },
+  },
+  table: {
+    username: "Nom d'utilisateur",
+    email: 'Email',
+    role: 'Rôle',
+    createdAt: 'Créé le',
+    actions: 'Actions',
+  },
+  empty: {
+    noResults: 'Aucun utilisateur ne correspond aux filtres.',
+    noUsers: 'Aucun utilisateur pour le moment.',
+  },
+  pagination: {
+    prev: 'Précédent',
+    next: 'Suivant',
+    of: 'Page {current} sur {total}',
+  },
+  totalLabel: '{total} utilisateurs',
+  selfTooltip: 'Vous ne pouvez pas changer votre propre rôle.',
+  role: {
+    free: 'Gratuit',
+    premium: 'Premium',
+    vip: 'VIP',
+    supporter: 'Soutien',
+    moderator: 'Modérateur',
+    tester: 'Testeur',
+    developer: 'Développeur',
+    admin: 'Admin',
+  },
+  status: {
+    active: 'Actif',
+    blocked: 'Bloqué',
+    deleted: 'Supprimé',
+  },
+  actions: {
+    block: 'Bloquer',
+    unblock: 'Débloquer',
+    remove: 'Supprimer',
+    restore: 'Restaurer',
+  },
+  errors: {
+    SELF_ROLE_CHANGE_FORBIDDEN: 'Vous ne pouvez pas changer votre propre rôle.',
+    LAST_ADMIN_PROTECTED:
+      'Impossible de rétrograder le dernier administrateur.',
+    USER_NOT_FOUND: 'Utilisateur introuvable.',
+    INVALID_USER_ID: 'Identifiant utilisateur invalide.',
+    CANNOT_BLOCK_SELF: 'Vous ne pouvez pas vous bloquer.',
+    CANNOT_DELETE_SELF: 'Vous ne pouvez pas vous supprimer.',
+    generic: "Quelque chose s'est mal passé. Veuillez réessayer.",
+  },
+};

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/ru.ts
@@ -1,0 +1,58 @@
+export const adminUsersRu = {
+  title: 'Пользователи',
+  search: {
+    placeholder: 'Поиск по имени, email или отображаемому имени',
+  },
+  filter: {
+    role: { all: 'Все роли', placeholder: 'Фильтр по роли' },
+    status: { all: 'Все статусы', placeholder: 'Фильтр по статусу' },
+  },
+  table: {
+    username: 'Имя пользователя',
+    email: 'Email',
+    role: 'Роль',
+    createdAt: 'Создан',
+    actions: 'Действия',
+  },
+  empty: {
+    noResults: 'Нет пользователей по фильтру.',
+    noUsers: 'Пользователей пока нет.',
+  },
+  pagination: {
+    prev: 'Назад',
+    next: 'Вперёд',
+    of: 'Страница {current} из {total}',
+  },
+  totalLabel: '{total} пользователей',
+  selfTooltip: 'Нельзя изменить свою собственную роль.',
+  role: {
+    free: 'Бесплатный',
+    premium: 'Премиум',
+    vip: 'VIP',
+    supporter: 'Спонсор',
+    moderator: 'Модератор',
+    tester: 'Тестер',
+    developer: 'Разработчик',
+    admin: 'Админ',
+  },
+  status: {
+    active: 'Активный',
+    blocked: 'Заблокирован',
+    deleted: 'Удалён',
+  },
+  actions: {
+    block: 'Заблокировать',
+    unblock: 'Разблокировать',
+    remove: 'Удалить',
+    restore: 'Восстановить',
+  },
+  errors: {
+    SELF_ROLE_CHANGE_FORBIDDEN: 'Нельзя изменить свою собственную роль.',
+    LAST_ADMIN_PROTECTED: 'Нельзя понизить последнего администратора.',
+    USER_NOT_FOUND: 'Пользователь не найден.',
+    INVALID_USER_ID: 'Неверный идентификатор пользователя.',
+    CANNOT_BLOCK_SELF: 'Нельзя заблокировать себя.',
+    CANNOT_DELETE_SELF: 'Нельзя удалить себя.',
+    generic: 'Что-то пошло не так. Попробуйте ещё раз.',
+  },
+};

--- a/apps/web/src/shared/i18n/messages/pages/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/by.ts
@@ -13,6 +13,7 @@ import { shopBy } from './shop/by';
 import { adminShopBy } from './admin-shop/by';
 import { adminGamesBy } from './admin-games/by';
 import { adminBlockedIpsBy } from './admin-blocked-ips/by';
+import { adminUsersBy } from './admin-users/by';
 
 export const by = {
   admin: {
@@ -38,48 +39,7 @@ export const by = {
       body: 'Адбылася памылка пры загрузцы гэтай старонкі.',
       retry: 'Паўтарыць',
     },
-    users: {
-      title: 'Карыстальнікі',
-      search: { placeholder: 'Пошук па імі, email або псеўданіме' },
-      filter: {
-        role: { all: 'Усе ролі', placeholder: 'Фільтр па ролі' },
-      },
-      table: {
-        username: 'Імя карыстальніка',
-        email: 'Email',
-        role: 'Роля',
-        createdAt: 'Створаны',
-        actions: 'Дзеянні',
-      },
-      empty: {
-        noResults: 'Няма карыстальнікаў па фільтру.',
-        noUsers: 'Карыстальнікаў пакуль няма.',
-      },
-      pagination: {
-        prev: 'Назад',
-        next: 'Наперад',
-        of: 'Старонка {current} з {total}',
-      },
-      totalLabel: '{total} карыстальнікаў',
-      selfTooltip: 'Вы не можаце змяніць сваю ўласную ролю.',
-      role: {
-        free: 'Бясплатны',
-        premium: 'Прэміум',
-        vip: 'VIP',
-        supporter: 'Спонсар',
-        moderator: 'Мадэратар',
-        tester: 'Тэстар',
-        developer: 'Распрацоўшчык',
-        admin: 'Адмін',
-      },
-      errors: {
-        SELF_ROLE_CHANGE_FORBIDDEN: 'Вы не можаце змяніць сваю ўласную ролю.',
-        LAST_ADMIN_PROTECTED: 'Нельга паніжаць апошняга адміністратара.',
-        USER_NOT_FOUND: 'Карыстальнік не знойдзены.',
-        INVALID_USER_ID: 'Няправільны ідэнтыфікатар карыстальніка.',
-        generic: 'Нешта пайшло не так. Калі ласка, паспрабуйце яшчэ раз.',
-      },
-    },
+    users: adminUsersBy,
     payments: {
       title: 'Плацяжы',
       search: { placeholder: 'Пошук па нататцы, імі або ID транзакцыі' },

--- a/apps/web/src/shared/i18n/messages/pages/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/en.ts
@@ -13,6 +13,7 @@ import { shopEn } from './shop/en';
 import { adminShopEn } from './admin-shop/en';
 import { adminGamesEn } from './admin-games/en';
 import { adminBlockedIpsEn } from './admin-blocked-ips/en';
+import { adminUsersEn } from './admin-users/en';
 
 export const en = {
   admin: {
@@ -38,48 +39,7 @@ export const en = {
       body: 'An error occurred while loading this admin page.',
       retry: 'Try again',
     },
-    users: {
-      title: 'Users',
-      search: { placeholder: 'Search by username, email, or display name' },
-      filter: {
-        role: { all: 'All roles', placeholder: 'Filter by role' },
-      },
-      table: {
-        username: 'Username',
-        email: 'Email',
-        role: 'Role',
-        createdAt: 'Created',
-        actions: 'Actions',
-      },
-      empty: {
-        noResults: 'No users match your filters.',
-        noUsers: 'No users yet.',
-      },
-      pagination: {
-        prev: 'Previous',
-        next: 'Next',
-        of: 'Page {current} of {total}',
-      },
-      totalLabel: '{total} users',
-      selfTooltip: "You can't change your own role.",
-      role: {
-        free: 'Free',
-        premium: 'Premium',
-        vip: 'VIP',
-        supporter: 'Supporter',
-        moderator: 'Moderator',
-        tester: 'Tester',
-        developer: 'Developer',
-        admin: 'Admin',
-      },
-      errors: {
-        SELF_ROLE_CHANGE_FORBIDDEN: "You can't change your own role.",
-        LAST_ADMIN_PROTECTED: "Can't demote the last admin.",
-        USER_NOT_FOUND: 'User not found.',
-        INVALID_USER_ID: 'Invalid user id.',
-        generic: 'Something went wrong. Please try again.',
-      },
-    },
+    users: adminUsersEn,
     payments: {
       title: 'Payments',
       search: { placeholder: 'Search by note, name, or transaction id' },

--- a/apps/web/src/shared/i18n/messages/pages/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/es.ts
@@ -13,6 +13,7 @@ import { shopEs } from './shop/es';
 import { adminShopEs } from './admin-shop/es';
 import { adminGamesEs } from './admin-games/es';
 import { adminBlockedIpsEs } from './admin-blocked-ips/es';
+import { adminUsersEs } from './admin-users/es';
 
 export const es = {
   admin: {
@@ -38,48 +39,7 @@ export const es = {
       body: 'Se produjo un error al cargar esta página.',
       retry: 'Reintentar',
     },
-    users: {
-      title: 'Usuarios',
-      search: { placeholder: 'Buscar por usuario, email o nombre' },
-      filter: {
-        role: { all: 'Todos los roles', placeholder: 'Filtrar por rol' },
-      },
-      table: {
-        username: 'Usuario',
-        email: 'Email',
-        role: 'Rol',
-        createdAt: 'Creado',
-        actions: 'Acciones',
-      },
-      empty: {
-        noResults: 'No hay usuarios que coincidan con los filtros.',
-        noUsers: 'Aún no hay usuarios.',
-      },
-      pagination: {
-        prev: 'Anterior',
-        next: 'Siguiente',
-        of: 'Página {current} de {total}',
-      },
-      totalLabel: '{total} usuarios',
-      selfTooltip: 'No puedes cambiar tu propio rol.',
-      role: {
-        free: 'Gratis',
-        premium: 'Premium',
-        vip: 'VIP',
-        supporter: 'Patrocinador',
-        moderator: 'Moderador',
-        tester: 'Tester',
-        developer: 'Desarrollador',
-        admin: 'Admin',
-      },
-      errors: {
-        SELF_ROLE_CHANGE_FORBIDDEN: 'No puedes cambiar tu propio rol.',
-        LAST_ADMIN_PROTECTED: 'No se puede degradar al último administrador.',
-        USER_NOT_FOUND: 'Usuario no encontrado.',
-        INVALID_USER_ID: 'Identificador de usuario no válido.',
-        generic: 'Algo salió mal. Inténtalo de nuevo.',
-      },
-    },
+    users: adminUsersEs,
     payments: {
       title: 'Pagos',
       search: { placeholder: 'Buscar por nota, nombre o ID de transacción' },

--- a/apps/web/src/shared/i18n/messages/pages/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/fr.ts
@@ -13,6 +13,7 @@ import { shopFr } from './shop/fr';
 import { adminShopFr } from './admin-shop/fr';
 import { adminGamesFr } from './admin-games/fr';
 import { adminBlockedIpsFr } from './admin-blocked-ips/fr';
+import { adminUsersFr } from './admin-users/fr';
 export const fr = {
   admin: {
     title: 'Administration',
@@ -37,52 +38,7 @@ export const fr = {
       body: 'Une erreur est survenue lors du chargement de cette page.',
       retry: 'Réessayer',
     },
-    users: {
-      title: 'Utilisateurs',
-      search: {
-        placeholder: "Recherche par nom d'utilisateur, email ou nom",
-      },
-      filter: {
-        role: { all: 'Tous les rôles', placeholder: 'Filtrer par rôle' },
-      },
-      table: {
-        username: "Nom d'utilisateur",
-        email: 'Email',
-        role: 'Rôle',
-        createdAt: 'Créé le',
-        actions: 'Actions',
-      },
-      empty: {
-        noResults: 'Aucun utilisateur ne correspond aux filtres.',
-        noUsers: 'Aucun utilisateur pour le moment.',
-      },
-      pagination: {
-        prev: 'Précédent',
-        next: 'Suivant',
-        of: 'Page {current} sur {total}',
-      },
-      totalLabel: '{total} utilisateurs',
-      selfTooltip: 'Vous ne pouvez pas changer votre propre rôle.',
-      role: {
-        free: 'Gratuit',
-        premium: 'Premium',
-        vip: 'VIP',
-        supporter: 'Soutien',
-        moderator: 'Modérateur',
-        tester: 'Testeur',
-        developer: 'Développeur',
-        admin: 'Admin',
-      },
-      errors: {
-        SELF_ROLE_CHANGE_FORBIDDEN:
-          'Vous ne pouvez pas changer votre propre rôle.',
-        LAST_ADMIN_PROTECTED:
-          'Impossible de rétrograder le dernier administrateur.',
-        USER_NOT_FOUND: 'Utilisateur introuvable.',
-        INVALID_USER_ID: 'Identifiant utilisateur invalide.',
-        generic: "Quelque chose s'est mal passé. Veuillez réessayer.",
-      },
-    },
+    users: adminUsersFr,
     payments: {
       title: 'Paiements',
       search: { placeholder: 'Recherche par note, nom ou ID de transaction' },

--- a/apps/web/src/shared/i18n/messages/pages/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/ru.ts
@@ -13,6 +13,7 @@ import { shopRu } from './shop/ru';
 import { adminShopRu } from './admin-shop/ru';
 import { adminGamesRu } from './admin-games/ru';
 import { adminBlockedIpsRu } from './admin-blocked-ips/ru';
+import { adminUsersRu } from './admin-users/ru';
 export const ru = {
   admin: {
     title: 'Админ',
@@ -37,50 +38,7 @@ export const ru = {
       body: 'Произошла ошибка при загрузке этой страницы.',
       retry: 'Повторить',
     },
-    users: {
-      title: 'Пользователи',
-      search: {
-        placeholder: 'Поиск по имени, email или отображаемому имени',
-      },
-      filter: {
-        role: { all: 'Все роли', placeholder: 'Фильтр по роли' },
-      },
-      table: {
-        username: 'Имя пользователя',
-        email: 'Email',
-        role: 'Роль',
-        createdAt: 'Создан',
-        actions: 'Действия',
-      },
-      empty: {
-        noResults: 'Нет пользователей по фильтру.',
-        noUsers: 'Пользователей пока нет.',
-      },
-      pagination: {
-        prev: 'Назад',
-        next: 'Вперёд',
-        of: 'Страница {current} из {total}',
-      },
-      totalLabel: '{total} пользователей',
-      selfTooltip: 'Нельзя изменить свою собственную роль.',
-      role: {
-        free: 'Бесплатный',
-        premium: 'Премиум',
-        vip: 'VIP',
-        supporter: 'Спонсор',
-        moderator: 'Модератор',
-        tester: 'Тестер',
-        developer: 'Разработчик',
-        admin: 'Админ',
-      },
-      errors: {
-        SELF_ROLE_CHANGE_FORBIDDEN: 'Нельзя изменить свою собственную роль.',
-        LAST_ADMIN_PROTECTED: 'Нельзя понизить последнего администратора.',
-        USER_NOT_FOUND: 'Пользователь не найден.',
-        INVALID_USER_ID: 'Неверный идентификатор пользователя.',
-        generic: 'Что-то пошло не так. Попробуйте ещё раз.',
-      },
-    },
+    users: adminUsersRu,
     payments: {
       title: 'Платежи',
       search: { placeholder: 'Поиск по тексту, имени или ID транзакции' },


### PR DESCRIPTION
## What
Add admin panel functionality to block, soft-delete (remove), and restore users.

## Why
Admins need the ability to manage problematic users by blocking them from accessing the platform, removing their accounts, or restoring previously removed accounts.

## Changes

### Backend
- **User schema**: Added `isBlocked`, `blockedAt`, `blockedReason`, `deletedAt` fields
- **Auth service**: Blocked/deleted users cannot log in (both email/password and OAuth)
- **Roles guard**: JWT validation rejects tokens for blocked/deleted users
- **Admin service**: Added `block()`, `unblock()`, `softDelete()`, `restore()` methods with safety checks (can't block/delete last admin or self)
- **Admin controller**: Added `PATCH /block`, `PATCH /unblock`, `DELETE`, `PATCH /restore` endpoints
- **User listing**: Added `status` filter (active/blocked/deleted) to admin user listing

### Frontend
- **API layer**: Added `blockUser`, `unblockUser`, `deleteUser`, `restoreUser` functions
- **Hooks**: Added `useBlockUser`, `useUnblockUser`, `useDeleteUser`, `useRestoreUser` mutations
- **UI**: Added Block/Unblock/Remove/Restore action buttons to user table rows
- **Filters**: Added status filter dropdown (All/Active/Blocked/Deleted) to admin users page
- **i18n**: Added translations for all 5 locales (en, ru, es, fr, by)

### Tests
- Added 10 new unit tests for status management (block, unblock, soft-delete, restore)
- All existing tests continue to pass

## Safety Measures
- Cannot block or delete the last admin user
- Cannot block or delete yourself
- Blocked users are rejected at both login and JWT validation levels
- Soft-deleted users are excluded from default user queries