### PR TITLE
feat(ARC-870): add bulk rewards for all registered users

### DIFF
--- a/apps/be/src/app.module.ts
+++ b/apps/be/src/app.module.ts
@@ -24,6 +24,7 @@ import { BattlePassModule } from './battle-pass/battle-pass.module';
 import { SupportModule } from './support/support.module';
 import { SolanaModule } from './solana/solana.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { BulkRewardsModule } from './bulk-rewards/bulk-rewards.module';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import {
@@ -66,6 +67,7 @@ import { GlobalThrottlerGuard } from './common/guards/global-throttler.guard';
     ]),
     SupportModule,
     SolanaModule,
+    BulkRewardsModule,
     MongooseModule.forRoot(resolveMongoUri(), resolveMongoOptions()),
   ],
   controllers: [AppController],

--- a/apps/be/src/bulk-rewards/bulk-rewards.controller.ts
+++ b/apps/be/src/bulk-rewards/bulk-rewards.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/guards/roles.decorator';
+import type { AuthenticatedUser } from '../auth/jwt/jwt.strategy';
+import {
+  BulkRewardsService,
+  type BulkRewardResult,
+} from './bulk-rewards.service';
+import { BulkRewardDto } from './dto/bulk-reward.dto';
+
+interface RequestWithUser {
+  user: AuthenticatedUser;
+}
+
+@Controller('admin/bulk-rewards')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+export class BulkRewardsController {
+  constructor(private readonly service: BulkRewardsService) {}
+
+  @Post()
+  rewardAllUsers(
+    @Req() req: RequestWithUser,
+    @Body() dto: BulkRewardDto,
+  ): Promise<BulkRewardResult> {
+    return this.service.rewardAllUsers(dto, req.user.userId);
+  }
+}

--- a/apps/be/src/bulk-rewards/bulk-rewards.module.ts
+++ b/apps/be/src/bulk-rewards/bulk-rewards.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { User, UserSchema } from '../auth/schemas/user.schema';
+import { WalletModule } from '../wallet/wallet.module';
+import { ShopModule } from '../shop/shop.module';
+import { BulkRewardsService } from './bulk-rewards.service';
+import { BulkRewardsController } from './bulk-rewards.controller';
+import { RolesGuard } from '../auth/guards/roles.guard';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
+    WalletModule,
+    ShopModule,
+  ],
+  controllers: [BulkRewardsController],
+  providers: [BulkRewardsService, RolesGuard],
+})
+export class BulkRewardsModule {}

--- a/apps/be/src/bulk-rewards/bulk-rewards.service.ts
+++ b/apps/be/src/bulk-rewards/bulk-rewards.service.ts
@@ -1,0 +1,108 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User, type UserDocument } from '../auth/schemas/user.schema';
+import { WalletService } from '../wallet/wallet.service';
+import { InventoryService } from '../shop/services/inventory.service';
+import { BulkRewardDto, BulkRewardType } from './dto/bulk-reward.dto';
+
+export interface BulkRewardResult {
+  totalUsers: number;
+  successfulRewards: number;
+  failedRewards: number;
+  errors: string[];
+}
+
+@Injectable()
+export class BulkRewardsService {
+  private readonly logger = new Logger(BulkRewardsService.name);
+
+  constructor(
+    @InjectModel(User.name) private readonly userModel: Model<UserDocument>,
+    private readonly walletService: WalletService,
+    private readonly inventoryService: InventoryService,
+  ) {}
+
+  async rewardAllUsers(
+    dto: BulkRewardDto,
+    adminUserId: string,
+  ): Promise<BulkRewardResult> {
+    if (dto.type === BulkRewardType.ITEM && !dto.itemId) {
+      throw new BadRequestException('bulkRewards.itemIdRequired');
+    }
+
+    const users = await this.userModel
+      .find({ deletedAt: null })
+      .select('_id')
+      .lean<{ _id: { toString(): string } }[]>();
+
+    const result: BulkRewardResult = {
+      totalUsers: users.length,
+      successfulRewards: 0,
+      failedRewards: 0,
+      errors: [],
+    };
+
+    const BATCH_SIZE = 100;
+    for (let i = 0; i < users.length; i += BATCH_SIZE) {
+      const batch = users.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.allSettled(
+        batch.map((user) =>
+          this.rewardUser(user._id.toString(), dto, adminUserId),
+        ),
+      );
+
+      for (const outcome of batchResults) {
+        if (outcome.status === 'fulfilled') {
+          result.successfulRewards++;
+        } else {
+          result.failedRewards++;
+          const errorMsg =
+            outcome.reason instanceof Error
+              ? outcome.reason.message
+              : 'Unknown error';
+          result.errors.push(errorMsg);
+        }
+      }
+    }
+
+    this.logger.log(
+      `Bulk reward completed: ${result.successfulRewards}/${result.totalUsers} successful`,
+    );
+
+    return result;
+  }
+
+  private async rewardUser(
+    userId: string,
+    dto: BulkRewardDto,
+    adminUserId: string,
+  ): Promise<void> {
+    const idempotencyKey = `bulk-reward-${dto.type}-${dto.amount}-${dto.itemId || 'none'}-${userId}-${Date.now()}`;
+
+    switch (dto.type) {
+      case BulkRewardType.COINS:
+      case BulkRewardType.GEMS:
+      case BulkRewardType.ARCADEUM:
+        await this.walletService.credit(
+          userId,
+          dto.type,
+          dto.amount,
+          'admin_grant',
+          idempotencyKey,
+          { adminUserId, reason: dto.reason },
+        );
+        break;
+
+      case BulkRewardType.ITEM:
+        if (!dto.itemId) {
+          throw new BadRequestException('bulkRewards.itemIdRequired');
+        }
+        await this.inventoryService.grant(userId, dto.itemId, idempotencyKey);
+        break;
+
+      default:
+        throw new BadRequestException('bulkRewards.invalidType');
+    }
+  }
+}

--- a/apps/be/src/bulk-rewards/dto/bulk-reward.dto.ts
+++ b/apps/be/src/bulk-rewards/dto/bulk-reward.dto.ts
@@ -1,0 +1,36 @@
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export enum BulkRewardType {
+  COINS = 'coins',
+  GEMS = 'gems',
+  ARCADEUM = 'arcadeum',
+  ITEM = 'item',
+}
+
+export class BulkRewardDto {
+  @IsEnum(BulkRewardType)
+  @IsNotEmpty()
+  type!: BulkRewardType;
+
+  @IsInt()
+  @Min(1)
+  @Max(1_000_000)
+  @IsNotEmpty()
+  amount!: number;
+
+  @IsString()
+  @IsOptional()
+  itemId?: string;
+
+  @IsString()
+  @IsOptional()
+  reason?: string;
+}

--- a/apps/web/src/app/[locale]/admin/_components/sidebarItems.ts
+++ b/apps/web/src/app/[locale]/admin/_components/sidebarItems.ts
@@ -8,6 +8,7 @@ export interface AdminSidebarItem {
     | 'economy'
     | 'shop'
     | 'games'
+    | 'bulkRewards'
     | 'blockedIps';
   href: string | null;
   enabled: boolean;
@@ -22,5 +23,6 @@ export const ADMIN_SIDEBAR_ITEMS: readonly AdminSidebarItem[] = [
   { id: 'economy', href: '/admin/economy', enabled: true },
   { id: 'shop', href: '/admin/shop', enabled: true },
   { id: 'games', href: '/admin/games', enabled: true },
+  { id: 'bulkRewards', href: '/admin/bulk-rewards', enabled: true },
   { id: 'blockedIps', href: '/admin/blocked-ips', enabled: true },
 ];

--- a/apps/web/src/app/[locale]/admin/bulk-rewards/AdminBulkRewardsClient.tsx
+++ b/apps/web/src/app/[locale]/admin/bulk-rewards/AdminBulkRewardsClient.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { GlassCard, YStack } from '@arcadeum/ui';
+import { Text } from 'tamagui';
+import type { adminBulkRewardsEn } from '@/shared/i18n/messages/pages/admin-bulk-rewards/en';
+
+type Labels = typeof adminBulkRewardsEn;
+
+interface Props {
+  labels: Labels;
+}
+
+const LoadingSkeleton = (
+  <YStack gap="$4" padding="$4">
+    <Text>Loading...</Text>
+  </YStack>
+);
+
+const AdminBulkRewardsView = dynamic(
+  () =>
+    import('./AdminBulkRewardsView').then((mod) => mod.AdminBulkRewardsView),
+  { ssr: false, loading: () => LoadingSkeleton },
+);
+
+export function AdminBulkRewardsClient({ labels }: Props) {
+  return (
+    <GlassCard padding="$4">
+      <AdminBulkRewardsView labels={labels} />
+    </GlassCard>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/bulk-rewards/AdminBulkRewardsView.tsx
+++ b/apps/web/src/app/[locale]/admin/bulk-rewards/AdminBulkRewardsView.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Button, GlassCard, Input, YStack, XStack } from '@arcadeum/ui';
+import { Text } from 'tamagui';
+import { sendBulkRewardsAction } from '@/features/admin-bulk-rewards/server/admin-bulk-rewards.actions';
+import type { BulkRewardResult } from '@/features/admin-bulk-rewards/server/admin-bulk-rewards.actions';
+import type { adminBulkRewardsEn } from '@/shared/i18n/messages/pages/admin-bulk-rewards/en';
+
+type Labels = typeof adminBulkRewardsEn;
+
+interface Props {
+  labels: Labels;
+}
+
+type RewardType = 'coins' | 'gems' | 'arcadeum' | 'item';
+
+export function AdminBulkRewardsView({ labels }: Props) {
+  const [rewardType, setRewardType] = useState<RewardType>('coins');
+  const [amount, setAmount] = useState('');
+  const [itemId, setItemId] = useState('');
+  const [reason, setReason] = useState('');
+  const [result, setResult] = useState<BulkRewardResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const validate = (): boolean => {
+    const numAmount = parseInt(amount, 10);
+    if (!amount || isNaN(numAmount) || numAmount < 1 || numAmount > 1_000_000) {
+      setError(labels.validation.invalidAmount);
+      return false;
+    }
+    if (rewardType === 'item' && !itemId.trim()) {
+      setError(labels.validation.itemIdRequired);
+      return false;
+    }
+    setError(null);
+    return true;
+  };
+
+  const handleSubmit = () => {
+    if (!validate()) return;
+    setConfirmOpen(true);
+  };
+
+  const confirmSubmit = () => {
+    setConfirmOpen(false);
+    setError(null);
+    setResult(null);
+
+    startTransition(async () => {
+      const response = await sendBulkRewardsAction({
+        type: rewardType,
+        amount: parseInt(amount, 10),
+        itemId: rewardType === 'item' ? itemId.trim() : undefined,
+        reason: reason.trim() || undefined,
+      });
+
+      if (response.ok) {
+        setResult(response.data);
+      } else {
+        setError(labels.result.failed);
+      }
+    });
+  };
+
+  return (
+    <YStack gap="$4">
+      {confirmOpen && (
+        <GlassCard
+          padding="$4"
+          borderWidth={1}
+          borderColor="$warning"
+          backgroundColor="$warningBg"
+        >
+          <Text fontWeight="600" marginBottom="$2">
+            {labels.confirm.title}
+          </Text>
+          <Text marginBottom="$4">
+            {labels.confirm.message
+              .replace('{amount}', amount)
+              .replace('{type}', rewardType)}
+          </Text>
+          <XStack gap="$2">
+            <Button onPress={confirmSubmit} theme="primary">
+              {labels.confirm.confirm}
+            </Button>
+            <Button onPress={() => setConfirmOpen(false)} variant="outline">
+              {labels.confirm.cancel}
+            </Button>
+          </XStack>
+        </GlassCard>
+      )}
+
+      <YStack gap="$3">
+        <YStack gap="$1">
+          <Text fontWeight="600">{labels.form.type.label}</Text>
+          <select
+            value={rewardType}
+            onChange={(e) => setRewardType(e.target.value as RewardType)}
+            style={{
+              padding: '8px 10px',
+              background: 'var(--backgroundFocus)',
+              border: '1px solid var(--borderColor)',
+              borderRadius: 6,
+              color: 'inherit',
+              fontSize: 14,
+            }}
+          >
+            <option value="coins">{labels.form.type.coinsLabel}</option>
+            <option value="gems">{labels.form.type.gemsLabel}</option>
+            <option value="arcadeum">{labels.form.type.arcadeumLabel}</option>
+            <option value="item">{labels.form.type.itemLabel}</option>
+          </select>
+        </YStack>
+
+        <YStack gap="$1">
+          <Text fontWeight="600">{labels.form.amount.label}</Text>
+          <Input
+            type="number"
+            value={amount}
+            onChangeText={setAmount}
+            placeholder={labels.form.amount.placeholder}
+            min={1}
+            max={1000000}
+          />
+        </YStack>
+
+        {rewardType === 'item' && (
+          <YStack gap="$1">
+            <Text fontWeight="600">{labels.form.itemId.label}</Text>
+            <Input
+              value={itemId}
+              onChangeText={setItemId}
+              placeholder={labels.form.itemId.placeholder}
+            />
+          </YStack>
+        )}
+
+        <YStack gap="$1">
+          <Text fontWeight="600">{labels.form.reason.label}</Text>
+          <Input
+            value={reason}
+            onChangeText={setReason}
+            placeholder={labels.form.reason.placeholder}
+          />
+        </YStack>
+
+        {error && (
+          <Text color="$error" fontSize="$2">
+            {error}
+          </Text>
+        )}
+
+        <Button
+          onPress={handleSubmit}
+          disabled={isPending}
+          theme="primary"
+          width="100%"
+        >
+          {isPending ? labels.form.submitting : labels.form.submit}
+        </Button>
+      </YStack>
+
+      {result && (
+        <GlassCard
+          padding="$4"
+          borderWidth={1}
+          borderColor={result.failedRewards > 0 ? '$warning' : '$success'}
+          backgroundColor={
+            result.failedRewards > 0 ? '$warningBg' : '$successBg'
+          }
+        >
+          <Text fontWeight="600" marginBottom="$2">
+            {result.failedRewards > 0
+              ? labels.result.partial
+              : labels.result.success}
+          </Text>
+          <YStack gap="$1">
+            <Text>
+              {labels.result.total}: {result.totalUsers}
+            </Text>
+            <Text color="$success">
+              {labels.result.successful}: {result.successfulRewards}
+            </Text>
+            {result.failedRewards > 0 && (
+              <Text color="$warning">
+                {labels.result.failed}: {result.failedRewards}
+              </Text>
+            )}
+            {result.errors.length > 0 && (
+              <YStack gap="$1" marginTop="$2">
+                <Text fontWeight="600">{labels.result.errors}:</Text>
+                {result.errors.slice(0, 5).map((err, i) => (
+                  <Text key={i} fontSize="$2" color="$gray11">
+                    {err}
+                  </Text>
+                ))}
+                {result.errors.length > 5 && (
+                  <Text fontSize="$2" color="$gray11">
+                    ...and {result.errors.length - 5} more
+                  </Text>
+                )}
+              </YStack>
+            )}
+          </YStack>
+        </GlassCard>
+      )}
+    </YStack>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/bulk-rewards/page.tsx
+++ b/apps/web/src/app/[locale]/admin/bulk-rewards/page.tsx
@@ -1,0 +1,48 @@
+import { requireAdmin } from '@/entities/session/api/requireAdmin';
+import { getTranslations } from '@/shared/i18n/server';
+import { adminBulkRewardsEn } from '@/shared/i18n/messages/pages/admin-bulk-rewards/en';
+import { AdminBulkRewardsClient } from './AdminBulkRewardsClient';
+
+interface AdminBulkRewardsPageMessages {
+  pages?: {
+    adminBulkRewards?: Partial<typeof adminBulkRewardsEn>;
+  };
+}
+
+export default async function AdminBulkRewardsPage() {
+  await requireAdmin();
+
+  const messages = (await getTranslations()) as AdminBulkRewardsPageMessages;
+  const t = messages.pages?.adminBulkRewards ?? {};
+  const labels = { ...adminBulkRewardsEn, ...t } as typeof adminBulkRewardsEn;
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        maxWidth: 800,
+        minWidth: 0,
+        margin: '0 auto',
+        padding: '32px 16px',
+      }}
+    >
+      <div style={{ marginBottom: 24 }}>
+        <h1
+          style={{
+            fontSize: 24,
+            fontWeight: 700,
+            color: 'var(--color, #e4e4e7)',
+            marginBottom: 4,
+          }}
+        >
+          {labels.title}
+        </h1>
+        <p style={{ fontSize: 14, color: 'var(--colorPress, #71717a)' }}>
+          {labels.subtitle}
+        </p>
+      </div>
+
+      <AdminBulkRewardsClient labels={labels} />
+    </div>
+  );
+}

--- a/apps/web/src/features/admin-bulk-rewards/server/admin-bulk-rewards.actions.ts
+++ b/apps/web/src/features/admin-bulk-rewards/server/admin-bulk-rewards.actions.ts
@@ -1,0 +1,67 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { resolveApiUrl } from '@/shared/lib/api-base';
+
+export type BulkRewardType = 'coins' | 'gems' | 'arcadeum' | 'item';
+
+export interface BulkRewardResult {
+  totalUsers: number;
+  successfulRewards: number;
+  failedRewards: number;
+  errors: string[];
+}
+
+export type AdminBulkRewardsActionError =
+  | 'validation'
+  | 'forbidden'
+  | 'generic';
+
+export type AdminBulkRewardsActionResult =
+  | { ok: true; data: BulkRewardResult }
+  | { ok: false; error: AdminBulkRewardsActionError };
+
+async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
+  const cookieJar = await cookies();
+  const token = cookieJar.get('web_access_token')?.value;
+  const url = resolveApiUrl(path);
+  return fetch(url, {
+    ...init,
+    cache: 'no-store',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+}
+
+function classify(status: number): AdminBulkRewardsActionError {
+  if (status === 400) return 'validation';
+  if (status === 403) return 'forbidden';
+  return 'generic';
+}
+
+export async function sendBulkRewardsAction(input: {
+  type: BulkRewardType;
+  amount: number;
+  itemId?: string;
+  reason?: string;
+}): Promise<AdminBulkRewardsActionResult> {
+  if (!input.type || (input.type === 'item' && !input.itemId?.trim())) {
+    return { ok: false, error: 'validation' };
+  }
+
+  if (!input.amount || input.amount < 1 || input.amount > 1_000_000) {
+    return { ok: false, error: 'validation' };
+  }
+
+  const res = await adminFetch('/admin/bulk-rewards', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+
+  if (!res.ok) return { ok: false, error: classify(res.status) };
+
+  return { ok: true, data: (await res.json()) as BulkRewardResult };
+}

--- a/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/by.ts
@@ -1,0 +1,51 @@
+export const adminBulkRewardsBy = {
+  title: 'Масавыя Ўзнагароды',
+  subtitle:
+    'Адправіць узнагароды (манеты, гемы, arcadeum ці прадметы) усім зарэгістраваным карыстальнікам.',
+  form: {
+    type: {
+      label: 'Тып Узнагароды',
+      coinsLabel: 'Манеты',
+      gemsLabel: 'Гемы',
+      arcadeumLabel: 'Arcadeum',
+      itemLabel: 'Прадмет',
+    },
+    amount: {
+      label: 'Колькасць',
+      placeholder: 'Увядзіце колькасць',
+    },
+    itemId: {
+      label: 'ID Прадмета',
+      placeholder: 'Увядзіце ID прадмета з каталога',
+    },
+    reason: {
+      label: 'Прычына (неабавязкова)',
+      placeholder: 'напр. Святочны бонус, Кампенсацыя',
+    },
+    submit: 'Адправіць Усім Карыстальнікам',
+    submitting: 'Адпраўка...',
+  },
+  result: {
+    success: 'Узнагароды паспяхова адпраўлены!',
+    partial: 'Узнагароды часткова адпраўлены.',
+    statusFailed: 'Не ўдалося адправіць узнагароды.',
+    total: 'Усяго карыстальнікаў',
+    successful: 'Паспяховыя',
+    failed: 'Няўдалыя',
+    errors: 'Памылкі',
+  },
+  confirm: {
+    title: 'Пацвердзіць Масавую Ўзнагароду',
+    message:
+      'Гэта адправіць {amount} {type} усім зарэгістраваным карыстальнікам. Вы ўпэўнены?',
+    confirm: 'Пацвердзіць',
+    cancel: 'Скасаваць',
+  },
+  validation: {
+    amountRequired: 'Колькасць абавязкова',
+    itemIdRequired: 'ID прадмета абавязковы для узнагарод у выглядзе прадметаў',
+    invalidAmount: 'Колькасць павінна быць ад 1 да 1 000 000',
+  },
+};
+
+export type AdminBulkRewardsI18n = typeof adminBulkRewardsBy;

--- a/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/en.ts
@@ -1,0 +1,51 @@
+export const adminBulkRewardsEn = {
+  title: 'Bulk Rewards',
+  subtitle:
+    'Send rewards (coins, gems, arcadeum, or items) to all registered users.',
+  form: {
+    type: {
+      label: 'Reward Type',
+      coinsLabel: 'Coins',
+      gemsLabel: 'Gems',
+      arcadeumLabel: 'Arcadeum',
+      itemLabel: 'Item',
+    },
+    amount: {
+      label: 'Amount',
+      placeholder: 'Enter amount',
+    },
+    itemId: {
+      label: 'Item ID',
+      placeholder: 'Enter catalog item ID',
+    },
+    reason: {
+      label: 'Reason (optional)',
+      placeholder: 'e.g. Holiday bonus, Compensation',
+    },
+    submit: 'Send to All Users',
+    submitting: 'Sending...',
+  },
+  result: {
+    success: 'Rewards sent successfully!',
+    partial: 'Rewards partially sent.',
+    statusFailed: 'Failed to send rewards.',
+    total: 'Total users',
+    successful: 'Successful',
+    failed: 'Failed',
+    errors: 'Errors',
+  },
+  confirm: {
+    title: 'Confirm Bulk Reward',
+    message:
+      'This will send {amount} {type} to all registered users. Are you sure?',
+    confirm: 'Confirm',
+    cancel: 'Cancel',
+  },
+  validation: {
+    amountRequired: 'Amount is required',
+    itemIdRequired: 'Item ID is required for item rewards',
+    invalidAmount: 'Amount must be between 1 and 1,000,000',
+  },
+};
+
+export type AdminBulkRewardsI18n = typeof adminBulkRewardsEn;

--- a/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/es.ts
@@ -1,0 +1,52 @@
+export const adminBulkRewardsEs = {
+  title: 'Recompensas Masivas',
+  subtitle:
+    'Enviar recompensas (monedas, gemas, arcadeum o artículos) a todos los usuarios registrados.',
+  form: {
+    type: {
+      label: 'Tipo de Recompensa',
+      coinsLabel: 'Monedas',
+      gemsLabel: 'Gemas',
+      arcadeumLabel: 'Arcadeum',
+      itemLabel: 'Artículo',
+    },
+    amount: {
+      label: 'Cantidad',
+      placeholder: 'Ingresar cantidad',
+    },
+    itemId: {
+      label: 'ID del Artículo',
+      placeholder: 'Ingresar ID del artículo del catálogo',
+    },
+    reason: {
+      label: 'Razón (opcional)',
+      placeholder: 'ej. Bono de vacaciones, Compensación',
+    },
+    submit: 'Enviar a Todos los Usuarios',
+    submitting: 'Enviando...',
+  },
+  result: {
+    success: '¡Recompensas enviadas exitosamente!',
+    partial: 'Recompensas parcialmente enviadas.',
+    statusFailed: 'Error al enviar recompensas.',
+    total: 'Total de usuarios',
+    successful: 'Exitosas',
+    failed: 'Fallidas',
+    errors: 'Errores',
+  },
+  confirm: {
+    title: 'Confirmar Recompensa Masiva',
+    message:
+      'Esto enviará {amount} {type} a todos los usuarios registrados. ¿Estás seguro?',
+    confirm: 'Confirmar',
+    cancel: 'Cancelar',
+  },
+  validation: {
+    amountRequired: 'La cantidad es requerida',
+    itemIdRequired:
+      'El ID del artículo es requerido para recompensas de artículos',
+    invalidAmount: 'La cantidad debe estar entre 1 y 1,000,000',
+  },
+};
+
+export type AdminBulkRewardsI18n = typeof adminBulkRewardsEs;

--- a/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/fr.ts
@@ -1,0 +1,51 @@
+export const adminBulkRewardsFr = {
+  title: 'Récompenses en Masse',
+  subtitle:
+    'Envoyer des récompenses (pièces, gemmes, arcadeum ou objets) à tous les utilisateurs enregistrés.',
+  form: {
+    type: {
+      label: 'Type de Récompense',
+      coinsLabel: 'Pièces',
+      gemsLabel: 'Gemmes',
+      arcadeumLabel: 'Arcadeum',
+      itemLabel: 'Objet',
+    },
+    amount: {
+      label: 'Montant',
+      placeholder: 'Entrer le montant',
+    },
+    itemId: {
+      label: "ID de l'Objet",
+      placeholder: "Entrer l'ID de l'objet du catalogue",
+    },
+    reason: {
+      label: 'Raison (optionnel)',
+      placeholder: 'ex. Bonus de vacances, Compensation',
+    },
+    submit: 'Envoyer à Tous les Utilisateurs',
+    submitting: 'Envoi en cours...',
+  },
+  result: {
+    success: 'Récompenses envoyées avec succès !',
+    partial: 'Récompenses partiellement envoyées.',
+    statusFailed: "Échec de l'envoi des récompenses.",
+    total: 'Total des utilisateurs',
+    successful: 'Réussies',
+    failed: 'Échouées',
+    errors: 'Erreurs',
+  },
+  confirm: {
+    title: 'Confirmer la Récompense en Masse',
+    message:
+      'Cela enverra {amount} {type} à tous les utilisateurs enregistrés. Êtes-vous sûr ?',
+    confirm: 'Confirmer',
+    cancel: 'Annuler',
+  },
+  validation: {
+    amountRequired: 'Le montant est requis',
+    itemIdRequired: "L'ID de l'objet est requis pour les récompenses d'objets",
+    invalidAmount: 'Le montant doit être entre 1 et 1 000 000',
+  },
+};
+
+export type AdminBulkRewardsI18n = typeof adminBulkRewardsFr;

--- a/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-bulk-rewards/ru.ts
@@ -1,0 +1,51 @@
+export const adminBulkRewardsRu = {
+  title: 'Массовые Награды',
+  subtitle:
+    'Отправить награды (монеты, гемы, arcadeum или предметы) всем зарегистрированным пользователям.',
+  form: {
+    type: {
+      label: 'Тип Награды',
+      coinsLabel: 'Монеты',
+      gemsLabel: 'Гемы',
+      arcadeumLabel: 'Arcadeum',
+      itemLabel: 'Предмет',
+    },
+    amount: {
+      label: 'Количество',
+      placeholder: 'Введите количество',
+    },
+    itemId: {
+      label: 'ID Предмета',
+      placeholder: 'Введите ID предмета из каталога',
+    },
+    reason: {
+      label: 'Причина (необязательно)',
+      placeholder: 'напр. Праздничный бонус, Компенсация',
+    },
+    submit: 'Отправить Всем Пользователям',
+    submitting: 'Отправка...',
+  },
+  result: {
+    success: 'Награды успешно отправлены!',
+    partial: 'Награды частично отправлены.',
+    statusFailed: 'Не удалось отправить награды.',
+    total: 'Всего пользователей',
+    successful: 'Успешные',
+    failed: 'Неудачные',
+    errors: 'Ошибки',
+  },
+  confirm: {
+    title: 'Подтвердить Массовую Награду',
+    message:
+      'Это отправит {amount} {type} всем зарегистрированным пользователям. Вы уверены?',
+    confirm: 'Подтвердить',
+    cancel: 'Отмена',
+  },
+  validation: {
+    amountRequired: 'Количество обязательно',
+    itemIdRequired: 'ID предмета обязателен для наград в виде предметов',
+    invalidAmount: 'Количество должно быть от 1 до 1 000 000',
+  },
+};
+
+export type AdminBulkRewardsI18n = typeof adminBulkRewardsRu;

--- a/apps/web/src/shared/i18n/messages/pages/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/by.ts
@@ -14,6 +14,7 @@ import { adminShopBy } from './admin-shop/by';
 import { adminGamesBy } from './admin-games/by';
 import { adminBlockedIpsBy } from './admin-blocked-ips/by';
 import { adminUsersBy } from './admin-users/by';
+import { adminBulkRewardsBy } from './admin-bulk-rewards/by';
 
 export const by = {
   admin: {
@@ -31,6 +32,7 @@ export const by = {
       economy: 'Эканоміка',
       shop: 'Крама',
       games: 'Гульні',
+      bulkRewards: 'Масавыя Ўзнагароды',
       blockedIps: 'Заблакіраваныя IP',
       comingSoon: 'Хутка',
     },
@@ -79,6 +81,7 @@ export const by = {
     tournaments: adminTournamentsBy,
     wallet: adminWalletBy,
     blockedIps: adminBlockedIpsBy,
+    bulkRewards: adminBulkRewardsBy,
   },
   tournaments: {
     title: 'Турніры',

--- a/apps/web/src/shared/i18n/messages/pages/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/en.ts
@@ -14,6 +14,7 @@ import { adminShopEn } from './admin-shop/en';
 import { adminGamesEn } from './admin-games/en';
 import { adminBlockedIpsEn } from './admin-blocked-ips/en';
 import { adminUsersEn } from './admin-users/en';
+import { adminBulkRewardsEn } from './admin-bulk-rewards/en';
 
 export const en = {
   admin: {
@@ -31,6 +32,7 @@ export const en = {
       economy: 'Economy',
       shop: 'Shop',
       games: 'Games',
+      bulkRewards: 'Bulk Rewards',
       blockedIps: 'Blocked IPs',
       comingSoon: 'Coming soon',
     },
@@ -79,6 +81,7 @@ export const en = {
     tournaments: adminTournamentsEn,
     wallet: adminWalletEn,
     blockedIps: adminBlockedIpsEn,
+    bulkRewards: adminBulkRewardsEn,
   },
   tournaments: {
     title: 'Tournaments',

--- a/apps/web/src/shared/i18n/messages/pages/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/es.ts
@@ -14,6 +14,7 @@ import { adminShopEs } from './admin-shop/es';
 import { adminGamesEs } from './admin-games/es';
 import { adminBlockedIpsEs } from './admin-blocked-ips/es';
 import { adminUsersEs } from './admin-users/es';
+import { adminBulkRewardsEs } from './admin-bulk-rewards/es';
 
 export const es = {
   admin: {
@@ -31,6 +32,7 @@ export const es = {
       economy: 'Economía',
       shop: 'Tienda',
       games: 'Juegos',
+      bulkRewards: 'Recompensas Masivas',
       blockedIps: 'IPs Bloqueados',
       comingSoon: 'Próximamente',
     },
@@ -75,6 +77,7 @@ export const es = {
     tournaments: adminTournamentsEs,
     wallet: adminWalletEs,
     blockedIps: adminBlockedIpsEs,
+    bulkRewards: adminBulkRewardsEs,
   },
   tournaments: {
     title: 'Torneos',

--- a/apps/web/src/shared/i18n/messages/pages/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/fr.ts
@@ -14,6 +14,7 @@ import { adminShopFr } from './admin-shop/fr';
 import { adminGamesFr } from './admin-games/fr';
 import { adminBlockedIpsFr } from './admin-blocked-ips/fr';
 import { adminUsersFr } from './admin-users/fr';
+import { adminBulkRewardsFr } from './admin-bulk-rewards/fr';
 export const fr = {
   admin: {
     title: 'Administration',
@@ -30,6 +31,7 @@ export const fr = {
       economy: 'Économie',
       shop: 'Boutique',
       games: 'Jeux',
+      bulkRewards: 'Récompenses en Masse',
       blockedIps: 'IPs Bloqués',
       comingSoon: 'Bientôt',
     },
@@ -74,6 +76,7 @@ export const fr = {
     tournaments: adminTournamentsFr,
     wallet: adminWalletFr,
     blockedIps: adminBlockedIpsFr,
+    bulkRewards: adminBulkRewardsFr,
   },
   tournaments: {
     title: 'Tournois',

--- a/apps/web/src/shared/i18n/messages/pages/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/ru.ts
@@ -14,6 +14,7 @@ import { adminShopRu } from './admin-shop/ru';
 import { adminGamesRu } from './admin-games/ru';
 import { adminBlockedIpsRu } from './admin-blocked-ips/ru';
 import { adminUsersRu } from './admin-users/ru';
+import { adminBulkRewardsRu } from './admin-bulk-rewards/ru';
 export const ru = {
   admin: {
     title: 'Админ',
@@ -30,6 +31,7 @@ export const ru = {
       economy: 'Экономика',
       shop: 'Магазин',
       games: 'Игры',
+      bulkRewards: 'Массовые Награды',
       blockedIps: 'Заблокированные IP',
       comingSoon: 'Скоро',
     },
@@ -78,6 +80,7 @@ export const ru = {
     tournaments: adminTournamentsRu,
     wallet: adminWalletRu,
     blockedIps: adminBlockedIpsRu,
+    bulkRewards: adminBulkRewardsRu,
   },
   tournaments: {
     title: 'Турниры',


### PR DESCRIPTION
## What
Add admin endpoint and UI to send rewards (coins, gems, arcadeum, or items) to all registered users.

## Why
Admins need a way to distribute rewards to all users at once for promotions, compensations, or events.

## Changes
- **Backend**: New `bulk-rewards` module with `POST /admin/bulk-rewards` endpoint
  - Supports coins, gems, arcadeum, and item rewards
  - Processes users in batches of 100 for performance
  - Returns success/failure counts with error details
- **Frontend**: New admin page at `/admin/bulk-rewards`
  - Form with reward type selector, amount, optional item ID, and reason
  - Confirmation dialog before sending
  - Results display with success/failure counts
  - Added to admin sidebar navigation
- **i18n**: Translations added for all locales (en, es, fr, ru, by)