### PR TITLE
feat(be): add configurable signup reward for coins and gems

### DIFF
--- a/apps/be/src/auth/auth.module.ts
+++ b/apps/be/src/auth/auth.module.ts
@@ -22,6 +22,7 @@ import {
   RefreshTokenService,
   GoogleOAuthService,
   PasswordResetService,
+  SignupRewardService,
 } from './services';
 import { UserRoleResolver } from './lib/user-role-resolver.service';
 import { AuthThrottlerGuard } from './lib/auth-throttler.guard';
@@ -63,6 +64,7 @@ import { MailerModule } from '../support/mailer.module';
     RefreshTokenService,
     GoogleOAuthService,
     PasswordResetService,
+    SignupRewardService,
     UserRoleResolver,
     AuthThrottlerGuard,
   ],

--- a/apps/be/src/auth/auth.service.ts
+++ b/apps/be/src/auth/auth.service.ts
@@ -29,6 +29,7 @@ import type {
 } from './lib/types';
 import { ReferralService } from '../referrals/referral.service';
 import { InventoryService } from '../shop/services/inventory.service';
+import { SignupRewardService } from './services';
 import { ModuleRef } from '@nestjs/core';
 
 export type {
@@ -47,6 +48,7 @@ export class AuthService {
     private readonly googleOAuth: GoogleOAuthService,
     @Inject(forwardRef(() => ReferralService))
     private readonly referralService: ReferralService,
+    private readonly signupReward: SignupRewardService,
     private readonly moduleRef: ModuleRef,
   ) {}
 
@@ -118,6 +120,7 @@ export class AuthService {
     // recovered by `ShopInventoryBootstrap` on next boot. Failure is
     // non-critical to registration itself.
     await this.grantStarterItems((created as UserDocument).id as string);
+    await this.signupReward.grant((created as UserDocument).id as string);
 
     return this.buildAuthUserProfile(created);
   }
@@ -446,6 +449,7 @@ export class AuthService {
     // Grant starter shop items on first OAuth sign-up. Same un-sessioned
     // approach as `register()`; bootstrap is the safety net.
     await this.grantStarterItems((created as UserDocument).id as string);
+    await this.signupReward.grant((created as UserDocument).id as string);
 
     return created;
   }

--- a/apps/be/src/auth/services/index.ts
+++ b/apps/be/src/auth/services/index.ts
@@ -5,3 +5,4 @@ export { OAuthClientService } from './oauth-client.service';
 export { RefreshTokenService } from './refresh-token.service';
 export { GoogleOAuthService } from './google-oauth.service';
 export { PasswordResetService } from './password-reset.service';
+export { SignupRewardService } from './signup-reward.service';

--- a/apps/be/src/auth/services/signup-reward.service.ts
+++ b/apps/be/src/auth/services/signup-reward.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+import { EconomySettingsService } from '../../economy/economy-settings.service';
+import { WalletService } from '../../wallet/wallet.service';
+
+@Injectable()
+export class SignupRewardService {
+  private readonly logger = new Logger(SignupRewardService.name);
+
+  constructor(private readonly moduleRef: ModuleRef) {}
+
+  async grant(userId: string): Promise<void> {
+    try {
+      const economy = this.moduleRef.get(EconomySettingsService, {
+        strict: false,
+      });
+      const wallet = this.moduleRef.get(WalletService, { strict: false });
+
+      const [coins, gems] = await Promise.all([
+        economy.getNumber('signup_reward_coins'),
+        economy.getNumber('signup_reward_gems'),
+      ]);
+
+      if (coins > 0) {
+        await wallet.credit(
+          userId,
+          'coins',
+          coins,
+          'signup_reward',
+          `signup:${userId}:coins`,
+        );
+      }
+      if (gems > 0) {
+        await wallet.credit(
+          userId,
+          'gems',
+          gems,
+          'signup_reward',
+          `signup:${userId}:gems`,
+        );
+      }
+    } catch (err) {
+      this.logger.error('Failed to grant signup reward', err);
+    }
+  }
+}

--- a/apps/be/src/economy/economy-keys.ts
+++ b/apps/be/src/economy/economy-keys.ts
@@ -37,6 +37,8 @@ export const ECONOMY_KEYS_CONFIG = {
   },
   shop_allow_gems: { env: 'SHOP_ALLOW_GEMS', default: 1 },
   shop_allow_arcadeum: { env: 'SHOP_ALLOW_ARCADEUM', default: 1 },
+  signup_reward_coins: { env: 'SIGNUP_REWARD_COINS', default: 0 },
+  signup_reward_gems: { env: 'SIGNUP_REWARD_GEMS', default: 0 },
 } as const;
 
 export type EconomyKey = keyof typeof ECONOMY_KEYS_CONFIG;

--- a/apps/be/src/economy/economy-settings.integration-spec.ts
+++ b/apps/be/src/economy/economy-settings.integration-spec.ts
@@ -157,7 +157,6 @@ describe('EconomySettingsService (integration)', () => {
   it('listAll returns all economy keys including those with no DB rows', async () => {
     const all = await service.listAll();
     expect(all).toHaveLength(ECONOMY_KEYS.length);
-    expect(all).toHaveLength(16);
 
     // Each entry has the required shape
     for (const entry of all) {

--- a/apps/be/src/wallet/interfaces/wallet-types.ts
+++ b/apps/be/src/wallet/interfaces/wallet-types.ts
@@ -25,5 +25,6 @@ export const WALLET_REASONS = [
   'wager_entry',
   'wager_prize',
   'wager_fee',
+  'signup_reward',
 ] as const;
 export type WalletReason = (typeof WALLET_REASONS)[number];


### PR DESCRIPTION
## What
Add admin-configurable signup rewards (coins and gems) for new users.

## Why
Allow admins to incentivize new signups by configuring reward amounts through the admin economy settings panel.

## Changes
- Added `signup_reward_coins` and `signup_reward_gems` economy keys with env var fallbacks (`SIGNUP_REWARD_COINS`, `SIGNUP_REWARD_GEMS`, default: 0)
- Created `SignupRewardService` to handle reward granting via `ModuleRef` (avoids circular dependencies)
- Added `signup_reward` wallet transaction reason
- Integrated reward granting into both email registration and OAuth sign-up flows
- Fixed hardcoded economy keys count in integration test

## Admin Configuration
- `PUT /admin/economy/signup_reward_coins` with `{ "value": 100 }` — set coins per signup
- `PUT /admin/economy/signup_reward_gems` with `{ "value": 5 }` — set gems per signup
- Or set `SIGNUP_REWARD_COINS=100` / `SIGNUP_REWARD_GEMS=5` env vars
- Default is `0` (disabled) — rewards are only granted when value > 0