### PR TITLE
feat(web): update music player to use 160-track R2 catalog

### DIFF
--- a/apps/web/src/features/games/ui/GameMusic.tsx
+++ b/apps/web/src/features/games/ui/GameMusic.tsx
@@ -54,7 +54,7 @@ export function GameMusic({ gameId }: { gameId?: string | null }) {
         testID="game-music-player"
         position="fixed"
         zIndex={1000}
-        width={player.miniMode ? 160 : 320}
+        width={player.miniMode ? 200 : 320}
         gap={0}
         paddingVertical="$3"
         paddingHorizontal="$3"

--- a/apps/web/src/features/games/ui/GameMusicPlaylist.tsx
+++ b/apps/web/src/features/games/ui/GameMusicPlaylist.tsx
@@ -67,6 +67,7 @@ function SortableTrackItem({
         alignItems="center"
         gap="$2"
         opacity={isEnabled ? 1 : 0.35}
+        onDoubleClick={() => onPlay(index)}
       >
         <div
           className="game-music-drag-handle"

--- a/apps/web/src/features/games/ui/GameMusicPlaylist.tsx
+++ b/apps/web/src/features/games/ui/GameMusicPlaylist.tsx
@@ -112,6 +112,7 @@ function SortableTrackItem({
           onChange={() => onToggleTrack(index)}
           aria-label={`Toggle ${track.title}`}
           data-testid={`game-music-track-toggle-${index}`}
+          onClick={(e) => e.stopPropagation()}
         />
         <Text
           fontSize={10}

--- a/apps/web/src/features/games/ui/GameMusicPlaylist.tsx
+++ b/apps/web/src/features/games/ui/GameMusicPlaylist.tsx
@@ -67,8 +67,6 @@ function SortableTrackItem({
         alignItems="center"
         gap="$2"
         opacity={isEnabled ? 1 : 0.35}
-        cursor="pointer"
-        onClick={() => onPlay(index)}
       >
         <div
           className="game-music-drag-handle"
@@ -112,7 +110,6 @@ function SortableTrackItem({
           onChange={() => onToggleTrack(index)}
           aria-label={`Toggle ${track.title}`}
           data-testid={`game-music-track-toggle-${index}`}
-          onClick={(e) => e.stopPropagation()}
         />
         <Text
           fontSize={10}

--- a/apps/web/src/features/games/ui/GameMusicUtils.ts
+++ b/apps/web/src/features/games/ui/GameMusicUtils.ts
@@ -10,46 +10,18 @@ export const TRACKS_JSON_URL = `${MUSIC_CDN_URL}/tracks.json`;
 
 export const FALLBACK_TRACKS: MusicTrack[] = [
   { src: `${MUSIC_CDN_URL}/battleship-grid.mp3`, title: 'Battleship Grid' },
-  {
-    src: `${MUSIC_CDN_URL}/battleship-grid-v2.mp3`,
-    title: 'Battleship Grid v2',
-  },
-  { src: `${MUSIC_CDN_URL}/clockwork-horizon.mp3`, title: 'Clockwork Horizon' },
-  {
-    src: `${MUSIC_CDN_URL}/clockwork-horizon-v2.mp3`,
-    title: 'Clockwork Horizon v2',
-  },
+  { src: `${MUSIC_CDN_URL}/clockwork-thesis.mp3`, title: 'Clockwork Thesis' },
   { src: `${MUSIC_CDN_URL}/glass-grid.mp3`, title: 'Glass Grid' },
-  { src: `${MUSIC_CDN_URL}/glass-grid-v2.mp3`, title: 'Glass Grid v2' },
   { src: `${MUSIC_CDN_URL}/grid-of-torpedoes.mp3`, title: 'Grid of Torpedoes' },
-  {
-    src: `${MUSIC_CDN_URL}/grid-of-torpedoes-v2.mp3`,
-    title: 'Grid of Torpedoes v2',
-  },
   { src: `${MUSIC_CDN_URL}/gridline-armada.mp3`, title: 'Gridline Armada' },
-  {
-    src: `${MUSIC_CDN_URL}/gridline-armada-v2.mp3`,
-    title: 'Gridline Armada v2',
-  },
-  { src: `${MUSIC_CDN_URL}/gridwater-clash.mp3`, title: 'Gridwater Clash' },
-  {
-    src: `${MUSIC_CDN_URL}/gridwater-clash-v2.mp3`,
-    title: 'Gridwater Clash v2',
-  },
   { src: `${MUSIC_CDN_URL}/iron-tide.mp3`, title: 'Iron Tide' },
-  { src: `${MUSIC_CDN_URL}/iron-tide-v2.mp3`, title: 'Iron Tide v2' },
   { src: `${MUSIC_CDN_URL}/iron-wake.mp3`, title: 'Iron Wake' },
-  { src: `${MUSIC_CDN_URL}/iron-wake-v2.mp3`, title: 'Iron Wake v2' },
-  { src: `${MUSIC_CDN_URL}/iron-wake-v3.mp3`, title: 'Iron Wake v3' },
-  { src: `${MUSIC_CDN_URL}/iron-wake-v4.mp3`, title: 'Iron Wake v4' },
   {
     src: `${MUSIC_CDN_URL}/saltwater-coordinates.mp3`,
     title: 'Saltwater Coordinates',
   },
-  {
-    src: `${MUSIC_CDN_URL}/saltwater-coordinates-v2.mp3`,
-    title: 'Saltwater Coordinates v2',
-  },
+  { src: `${MUSIC_CDN_URL}/lobby-glow.mp3`, title: 'Lobby Glow' },
+  { src: `${MUSIC_CDN_URL}/victory-bloom.mp3`, title: 'Victory Bloom' },
 ];
 
 if (process.env.NODE_ENV !== 'production') {
@@ -62,16 +34,28 @@ if (process.env.NODE_ENV !== 'production') {
 
 let cachedTracks: readonly MusicTrack[] | null = null;
 
+async function loadTracksJson(): Promise<MusicTrack[] | null> {
+  const res = await fetch(TRACKS_JSON_URL);
+  if (!res.ok) throw new Error(`Failed to fetch tracks: ${res.status}`);
+  const data: MusicTrack[] = await res.json();
+  return Array.isArray(data) && data.length > 0 ? data : null;
+}
+
 export async function fetchTracks(): Promise<readonly MusicTrack[]> {
   if (cachedTracks) return cachedTracks;
-  if (!CDN_BASE) return FALLBACK_TRACKS;
   try {
-    const res = await fetch(TRACKS_JSON_URL);
-    if (!res.ok) throw new Error(`Failed to fetch tracks: ${res.status}`);
-    const data: MusicTrack[] = await res.json();
-    if (Array.isArray(data) && data.length > 0) {
-      cachedTracks = data;
-      return data;
+    const data = await loadTracksJson();
+    if (data) {
+      const resolved = data.map((t) => ({
+        ...t,
+        src: t.src.startsWith('http')
+          ? t.src
+          : CDN_BASE
+            ? `${CDN_BASE}/${t.src}`
+            : t.src,
+      }));
+      cachedTracks = resolved;
+      return resolved;
     }
   } catch {
     // Fall through to fallback

--- a/apps/web/src/features/games/ui/useAudioPlayer.ts
+++ b/apps/web/src/features/games/ui/useAudioPlayer.ts
@@ -119,8 +119,9 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
         setTracks(d);
         setIndex(trackIndexForGame(gameId, d.length));
         const saved = loadStoredSettings().musicEnabledTracks;
+        const savedLength = loadStoredSettings().musicTrackOrder?.length;
         setEnabledTracks(
-          saved?.length
+          saved?.length && savedLength === d.length
             ? new Set(saved.filter((i) => i < d.length))
             : new Set(d.map((_, i) => i)),
         );

--- a/apps/web/src/features/games/ui/useAudioPlayer.ts
+++ b/apps/web/src/features/games/ui/useAudioPlayer.ts
@@ -145,6 +145,7 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
   const shuffleRef = useRef(shuffle);
   const shuffleOrderRef = useRef(shuffleOrder);
   const tracksLengthRef = useRef(tracks.length);
+  const indexRef = useRef(index);
   const track = tracks[index];
 
   useEffect(() => {
@@ -153,6 +154,7 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
     shuffleRef.current = shuffle;
     shuffleOrderRef.current = shuffleOrder;
     tracksLengthRef.current = tracks.length;
+    indexRef.current = index;
   });
 
   const crossfadeTo = useCallback((newSrc: string, newVolume: number) => {
@@ -361,18 +363,33 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
     setRepeat((r) => (r === 'off' ? 'all' : r === 'all' ? 'one' : 'off'));
   }, []);
 
-  const toggleTrack = useCallback((trackIndex: number) => {
-    setEnabledTracks((prev) => {
-      const next = new Set(prev);
-      if (next.has(trackIndex)) {
-        if (next.size > 1) next.delete(trackIndex);
-      } else {
-        next.add(trackIndex);
-      }
-      saveStoredSettings({ musicEnabledTracks: Array.from(next) });
-      return next;
-    });
-  }, []);
+  const toggleTrack = useCallback(
+    (trackIndex: number) => {
+      setEnabledTracks((prev) => {
+        const next = new Set(prev);
+        if (next.has(trackIndex)) {
+          if (next.size > 1) next.delete(trackIndex);
+        } else {
+          next.add(trackIndex);
+        }
+        saveStoredSettings({ musicEnabledTracks: Array.from(next) });
+        if (next.has(trackIndex) === false && trackIndex === indexRef.current) {
+          const dir = (i: number) => (i + 1) % tracksLengthRef.current;
+          let idx = dir(trackIndex);
+          let safety = tracksLengthRef.current;
+          while (!next.has(idx) && safety-- > 0) idx = dir(idx);
+          if (next.has(idx)) setIndex(idx);
+          else {
+            audioRef.current?.pause();
+            audioRef.current.currentTime = 0;
+            setIsPlaying(false);
+          }
+        }
+        return next;
+      });
+    },
+    [],
+  );
   const reorderTracks = useCallback(
     (newTracks: readonly MusicTrack[]) => {
       const currentSrc = tracks[index].src;

--- a/apps/web/src/features/games/ui/useAudioPlayer.ts
+++ b/apps/web/src/features/games/ui/useAudioPlayer.ts
@@ -146,6 +146,7 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
   const shuffleOrderRef = useRef(shuffleOrder);
   const tracksLengthRef = useRef(tracks.length);
   const indexRef = useRef(index);
+  const skipNextCrossfadeRef = useRef(false);
   const track = tracks[index];
 
   useEffect(() => {
@@ -247,10 +248,17 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
 
     const seekPos = audioRef.current?.currentTime ?? 0;
     const isReorder = audioRef.current?.src === track.src;
-    crossfadeTo(track.src, volumeRef.current);
-    if (isReorder && seekPos > 0) {
-      const a = audioRef.current;
-      if (a) a.currentTime = seekPos;
+    if (skipNextCrossfadeRef.current) {
+      skipNextCrossfadeRef.current = false;
+      audioRef.current?.pause();
+      audioRef.current.currentTime = 0;
+      setIsPlaying(false);
+    } else {
+      crossfadeTo(track.src, volumeRef.current);
+      if (isReorder && seekPos > 0) {
+        const a = audioRef.current;
+        if (a) a.currentTime = seekPos;
+      }
     }
 
     return () => {
@@ -378,8 +386,10 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
           let idx = dir(trackIndex);
           let safety = tracksLengthRef.current;
           while (!next.has(idx) && safety-- > 0) idx = dir(idx);
-          if (next.has(idx)) setIndex(idx);
-          else {
+          if (next.has(idx)) {
+            skipNextCrossfadeRef.current = true;
+            setIndex(idx);
+          } else {
             audioRef.current?.pause();
             audioRef.current.currentTime = 0;
             setIsPlaying(false);

--- a/apps/web/src/features/games/ui/useAudioPlayer.ts
+++ b/apps/web/src/features/games/ui/useAudioPlayer.ts
@@ -146,7 +146,6 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
   const shuffleOrderRef = useRef(shuffleOrder);
   const tracksLengthRef = useRef(tracks.length);
   const indexRef = useRef(index);
-  const skipNextCrossfadeRef = useRef(false);
   const track = tracks[index];
 
   useEffect(() => {
@@ -248,17 +247,10 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
 
     const seekPos = audioRef.current?.currentTime ?? 0;
     const isReorder = audioRef.current?.src === track.src;
-    if (skipNextCrossfadeRef.current) {
-      skipNextCrossfadeRef.current = false;
-      audioRef.current?.pause();
-      audioRef.current.currentTime = 0;
-      setIsPlaying(false);
-    } else {
-      crossfadeTo(track.src, volumeRef.current);
-      if (isReorder && seekPos > 0) {
-        const a = audioRef.current;
-        if (a) a.currentTime = seekPos;
-      }
+    crossfadeTo(track.src, volumeRef.current);
+    if (isReorder && seekPos > 0) {
+      const a = audioRef.current;
+      if (a) a.currentTime = seekPos;
     }
 
     return () => {
@@ -381,20 +373,6 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
           next.add(trackIndex);
         }
         saveStoredSettings({ musicEnabledTracks: Array.from(next) });
-        if (next.has(trackIndex) === false && trackIndex === indexRef.current) {
-          const dir = (i: number) => (i + 1) % tracksLengthRef.current;
-          let idx = dir(trackIndex);
-          let safety = tracksLengthRef.current;
-          while (!next.has(idx) && safety-- > 0) idx = dir(idx);
-          if (next.has(idx)) {
-            skipNextCrossfadeRef.current = true;
-            setIndex(idx);
-          } else {
-            audioRef.current?.pause();
-            audioRef.current.currentTime = 0;
-            setIsPlaying(false);
-          }
-        }
         return next;
       });
     },


### PR DESCRIPTION
## Summary
- Update music player to load tracks from R2 CDN (tracks.json + 160 mp3s)
- Trim fallback tracks to 10-track representative subset
- Reset enabledTracks when track count changes (fixes stale localStorage)
- Widen mini mode player from 160px to 200px to prevent button overflow