### PR TITLE
feat(ARC-871): persistent account-less stat tracking

### DIFF
--- a/.claude/skills/implement-roadmap-feature/SKILL.md
+++ b/.claude/skills/implement-roadmap-feature/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: implement-roadmap-feature
+description: Implement a feature from docs/ROADMAP.md end-to-end: branch, code, test, commit, push, open PR, fix CI. Use when user says "implement feature X from roadmap" or "start with feature X".
+---
+
+This skill turns a roadmap item into a shippable PR. Follow every step — skipping steps causes rework.
+
+## Reference
+
+- Roadmap: `docs/ROADMAP.md` — has ARC ticket reference table with branch names and statuses
+- Commit convention: `/commit` skill
+- PR descriptions: `/pr-description` skill
+- Tests: Vitest for web (`pnpm --filter web test`), Jest for BE (`pnpm --filter be test`)
+
+## Step-by-step workflow
+
+### 1. Identify the feature
+
+Read `docs/ROADMAP.md` to find the feature. Note:
+- ARC ticket number (e.g. `ARC-872`)
+- Branch name (e.g. `ARC-872-emotes`)
+- Implementation status (Not started / Partial / Implemented)
+- Effort estimate
+- Files to create/modify listed in the roadmap
+
+### 2. Create the branch
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b ARC-XXX-feature-name
+```
+
+Branch naming: `ARC-<number>-<short-kebab-description>`
+
+### 3. Explore the codebase
+
+Before writing code, understand existing patterns:
+- Use `explore` subagent or grep/glob to find related code
+- Read existing implementations of similar features
+- Check `packages/ui` for reusable components (`/check-ui-components`)
+- Identify integration points (socket events, hooks, stores, pages)
+
+### 4. Implement the feature
+
+Follow existing code conventions:
+- **TypeScript**: never use `any`, define proper types
+- **React**: Server Components by default, `'use client'` only when needed
+- **State**: Zustand stores with `persist` middleware for localStorage
+- **Styling**: Tamagui components from `@arcadeum/ui`, use `styled()` for custom styles
+- **i18n**: all user-facing strings through `useTranslation()`, add keys to all 5 locales (en, es, fr, ru, by)
+- **Backend**: validate DTOs with `class-validator`, protect routes with `JwtAuthGuard`
+
+### 5. Write tests
+
+**Every feature MUST have tests.** Create test files alongside source files.
+
+For web (Vitest):
+- Unit tests for pure functions, stores, hooks
+- Component tests with `@testing-library/react`
+- Test file naming: `*.test.ts` or `*.test.tsx`
+
+For backend (Jest):
+- Unit tests for services, validators, utils
+- Integration tests for controllers with mocked dependencies
+- Test file naming: `*.spec.ts`
+
+Test coverage requirements:
+- Happy path
+- Edge cases (empty state, null values, boundary conditions)
+- Error states
+
+Run tests before committing:
+```bash
+pnpm --filter web test        # web unit tests
+pnpm --filter be test         # backend unit tests
+pnpm test                     # all tests via turborepo
+```
+
+### 6. Verify code quality
+
+Run all checks before committing:
+```bash
+# Type check
+cd apps/web && npx tsc --noEmit
+cd apps/be && npx tsc --noEmit
+
+# Lint
+pnpm --filter web lint
+pnpm --filter be lint
+
+# i18n completeness
+pnpm --filter web test -- --run src/shared/i18n/messages/completeness.test.ts
+
+# File length check (max 500 lines)
+pnpm check-file-length
+```
+
+### 7. Commit
+
+Follow Conventional Commits with ARC scope:
+
+```bash
+git add <specific files>
+git commit -m "<type>(ARC-XXX): <short description>"
+```
+
+Rules:
+- Stage specific files, never `git add -A` or `git add .`
+- Type: `feat`, `fix`, `docs`, `test`, `refactor`, etc.
+- Scope: `ARC-XXX` from the branch name
+- Subject: lowercase, imperative mood, no period, under 72 chars
+- Body: explain **why**, not **what** (if needed)
+- Pre-commit hooks will run lint, tests, type check — they must pass
+
+Make **multiple atomic commits** for large features:
+1. `feat(ARC-XXX): add store and types` — core logic
+2. `feat(ARC-XXX): add UI components` — frontend
+3. `feat(ARC-XXX): integrate with game widgets` — wiring
+4. `feat(ARC-XXX): add i18n keys` — translations
+5. `test(ARC-XXX): add unit tests` — tests (if committed separately)
+
+### 8. Push and open PR
+
+```bash
+git push --no-verify -u origin ARC-XXX-feature-name
+```
+
+Open PR:
+```bash
+gh pr create --base develop --title "<type>(ARC-XXX): <description>" --body "$(cat <<'EOF'
+## What
+<one sentence>
+
+## Why
+<context>
+
+## Changes
+- <bullet points>
+
+## Test plan
+- [x] Unit tests pass
+- [x] Type check passes
+- [x] Lint passes
+- [x] i18n completeness passes
+EOF
+)"
+```
+
+### 9. Monitor CI/CD
+
+After PR is created, check CI status:
+
+```bash
+gh pr checks <PR_NUMBER>
+# or
+gh pr view <PR_NUMBER> --json statusCheckRollup
+```
+
+If CI fails:
+1. Read the failure logs: `gh run view <run-id> --log-failed`
+2. Fix the issue
+3. Commit the fix: `git commit -m "fix(ARC-XXX): <description>"`
+4. Push: `git push --no-verify`
+5. Re-check CI
+
+Common CI failures:
+- **Lint errors**: run `eslint --fix` on affected files
+- **Type errors**: run `tsc --noEmit` and fix
+- **Test failures**: run tests locally, fix, re-run
+- **i18n missing keys**: add keys to all 5 locale files
+- **File too long**: split into smaller modules
+
+### 10. Update roadmap status
+
+After PR is merged, update `docs/ROADMAP.md`:
+- Change status from "Not started" to "**Implemented**"
+- Remove the branch name from the reference table (or mark as merged)
+
+## Gotchas
+
+- **Never push to `main`, `staging`, or `develop`** — always use feature branches
+- **Never use `git commit --amend`** — create new commits instead
+- **Never use `git push --force`** — CI blocks force pushes on branches with open PRs
+- **Always pull develop before opening PR** — `git fetch origin && git merge origin/develop`
+- **Pre-commit hooks run full test suites** — they take ~2 minutes, be patient
+- **localStorage keys must be versioned** — use `arcadeum_<feature>_v1` format
+- **Zustand persist requires `createJSONStorage(() => localStorage)`** — SSR-safe pattern
+- **Tests must pass before commit** — hooks will block the commit otherwise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Branch naming: `ARC-XXX` (Jira tickets). Footer: `(ARC-XXX)` for issue tracking.
 - `/new-mobile-screen` — add an Expo Router screen with i18n and Tamagui UI
 - `/new-ui-component` — add a shared Tamagui component to `packages/ui` (`@arcadeum/ui`)
 - `/check-ui-components` — audit existing `@arcadeum/ui` components before implementing any UI; reuse or add to `packages/ui`
+- `/implement-roadmap-feature` — implement a roadmap feature end-to-end: branch, code, test, commit, push, open PR, fix CI
 
 ### Global superpowers skills
 

--- a/apps/web/src/app/[locale]/stats/StatsPage.tsx
+++ b/apps/web/src/app/[locale]/stats/StatsPage.tsx
@@ -16,6 +16,7 @@ import {
   useTranslation,
   type TranslationKey,
 } from '@/shared/lib/useTranslation';
+import { useLocalStatsStore } from '@/features/stats/store/statsStore';
 import { useStats } from './hooks/useStats';
 import { useLeaderboard } from './hooks/useLeaderboard';
 import {
@@ -60,6 +61,10 @@ export default function StatsPage({
     accessToken: snapshot.accessToken,
     initialData: initialStats,
   });
+
+  const localStats = useLocalStatsStore((s) => s.getOverview());
+  const localBreakdown = useLocalStatsStore((s) => s.getByGameType());
+  const hasLocalStats = localStats.totalGames > 0;
 
   const {
     leaderboard,
@@ -144,15 +149,52 @@ export default function StatsPage({
               <StatsOverview stats={stats} loading={loading} />
               <GameBreakdown stats={stats} loading={loading} />
             </>
+          ) : hasLocalStats ? (
+            <>
+              <LocalStatsBanner>
+                <Text fontSize="$2" color="rgba(236,239,238,0.6)">
+                  {t('stats.localStatsNotice')}
+                </Text>
+              </LocalStatsBanner>
+              <StatsOverview
+                stats={{
+                  totalGames: localStats.totalGames,
+                  wins: localStats.wins,
+                  losses: localStats.losses,
+                  winRate: localStats.winRate,
+                  byGameType: localBreakdown,
+                }}
+                loading={false}
+              />
+              <GameBreakdown
+                stats={{
+                  totalGames: localStats.totalGames,
+                  wins: localStats.wins,
+                  losses: localStats.losses,
+                  winRate: localStats.winRate,
+                  byGameType: localBreakdown,
+                }}
+                loading={false}
+              />
+              <YStack ai="center" gap="$3" mt="$4">
+                <Button
+                  variant="primary"
+                  size="md"
+                  onClick={() => router.push('/auth')}
+                >
+                  {t('stats.syncToAccount')}
+                </Button>
+              </YStack>
+            </>
           ) : (
             <YStack ai="center" gap="$5" p="$10">
-              <EmptyState icon="🔒" message={t('stats.loginRequired')} />
+              <EmptyState icon="📊" message={t('stats.noLocalStats')} />
               <Button
                 variant="primary"
                 size="lg"
                 onClick={() => router.push('/auth')}
               >
-                Log In
+                {t('stats.logInToTrack')}
               </Button>
             </YStack>
           )
@@ -235,4 +277,15 @@ const FilterLabel = styled(Text, {
   color: '$color',
   letterSpacing: 0.5,
   userSelect: 'none',
+} as unknown as Record<string, unknown>);
+
+const LocalStatsBanner = styled(XStack, {
+  name: 'LocalStatsBanner',
+  padding: '$4',
+  paddingHorizontal: '$5',
+  backgroundColor: 'rgba(255,200,50,0.08)',
+  borderWidth: 1,
+  borderColor: 'rgba(255,200,50,0.2)',
+  borderRadius: 12,
+  alignItems: 'center',
 } as unknown as Record<string, unknown>);

--- a/apps/web/src/app/[locale]/stats/StatsPage.tsx
+++ b/apps/web/src/app/[locale]/stats/StatsPage.tsx
@@ -62,8 +62,50 @@ export default function StatsPage({
     initialData: initialStats,
   });
 
-  const localStats = useLocalStatsStore((s) => s.getOverview());
-  const localBreakdown = useLocalStatsStore((s) => s.getByGameType());
+  const records = useLocalStatsStore((s) => s.records);
+  const localBreakdown = useMemo(() => {
+    const byGame = new Map<
+      string,
+      { totalGames: number; wins: number; losses: number; draws: number }
+    >();
+    for (const record of records) {
+      const existing = byGame.get(record.gameId) ?? {
+        totalGames: 0,
+        wins: 0,
+        losses: 0,
+        draws: 0,
+      };
+      existing.totalGames++;
+      if (record.result === 'won') existing.wins++;
+      else if (record.result === 'lost') existing.losses++;
+      else existing.draws++;
+      byGame.set(record.gameId, existing);
+    }
+    return Array.from(byGame.entries())
+      .map(([gameId, stats]) => ({
+        gameId,
+        ...stats,
+        winRate:
+          stats.totalGames > 0
+            ? Math.round((stats.wins / stats.totalGames) * 100)
+            : 0,
+      }))
+      .sort((a, b) => b.totalGames - a.totalGames);
+  }, [records]);
+  const localStats = useMemo(() => {
+    const wins = records.filter((r) => r.result === 'won').length;
+    const losses = records.filter((r) => r.result === 'lost').length;
+    const draws = records.filter((r) => r.result === 'draw').length;
+    const totalGames = records.length;
+    return {
+      totalGames,
+      wins,
+      losses,
+      draws,
+      winRate: totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0,
+      byGameType: localBreakdown,
+    };
+  }, [records, localBreakdown]);
   const hasLocalStats = localStats.totalGames > 0;
 
   const {

--- a/apps/web/src/features/stats/hooks/useRecordGameResult.test.ts
+++ b/apps/web/src/features/stats/hooks/useRecordGameResult.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useRecordGameResult } from './useRecordGameResult';
+import { useLocalStatsStore } from '../store/statsStore';
+
+describe('useRecordGameResult', () => {
+  beforeEach(() => {
+    useLocalStatsStore.getState().resetStats();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('records a won result', () => {
+    renderHook(() => useRecordGameResult('won', 'tic_tac_toe_v1', 'session-1'));
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+    expect(overview.wins).toBe(1);
+  });
+
+  it('records a lost result', () => {
+    renderHook(() => useRecordGameResult('lost', 'cascade_v1', 'session-1'));
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+    expect(overview.losses).toBe(1);
+  });
+
+  it('records a draw result', () => {
+    renderHook(() =>
+      useRecordGameResult('draw', 'tic_tac_toe_v1', 'session-1'),
+    );
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+    expect(overview.draws).toBe(1);
+  });
+
+  it('does not record when result is null', () => {
+    renderHook(() => useRecordGameResult(null, 'tic_tac_toe_v1', 'session-1'));
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(0);
+  });
+
+  it('does not record when sessionId is null', () => {
+    renderHook(() => useRecordGameResult('won', 'tic_tac_toe_v1', null));
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(0);
+  });
+
+  it('deduplicates by sessionId', () => {
+    const { rerender } = renderHook(
+      ({ result, sessionId }) =>
+        useRecordGameResult(result, 'tic_tac_toe_v1', sessionId),
+      { initialProps: { result: 'won' as const, sessionId: 'session-1' } },
+    );
+
+    // Re-render with same session — should NOT record again
+    rerender({ result: 'won', sessionId: 'session-1' });
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+  });
+
+  it('records separately for different sessionIds', () => {
+    const { rerender } = renderHook(
+      ({ result, sessionId }) =>
+        useRecordGameResult(result, 'tic_tac_toe_v1', sessionId),
+      { initialProps: { result: 'won' as const, sessionId: 'session-1' } },
+    );
+
+    rerender({ result: 'lost', sessionId: 'session-2' });
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(2);
+    expect(overview.wins).toBe(1);
+    expect(overview.losses).toBe(1);
+  });
+});

--- a/apps/web/src/features/stats/hooks/useRecordGameResult.ts
+++ b/apps/web/src/features/stats/hooks/useRecordGameResult.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { useLocalStatsStore } from '../store/statsStore';
+import type { GameResult } from '@/features/games/hooks/useGameResultModal';
+
+/**
+ * Automatically records game results to the local stats store.
+ * Deduplicates by sessionId to prevent double-recording.
+ */
+export function useRecordGameResult(
+  result: GameResult,
+  gameId: string,
+  sessionId?: string | null,
+) {
+  const recordGameResult = useLocalStatsStore((s) => s.recordGameResult);
+  const recordedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!result || !sessionId) return;
+    if (recordedRef.current === sessionId) return;
+
+    recordedRef.current = sessionId;
+    recordGameResult({
+      gameId,
+      result,
+      timestamp: Date.now(),
+      sessionId,
+    });
+  }, [result, gameId, sessionId, recordGameResult]);
+}

--- a/apps/web/src/features/stats/store/statsStore.test.ts
+++ b/apps/web/src/features/stats/store/statsStore.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLocalStatsStore } from './statsStore';
+
+describe('useLocalStatsStore', () => {
+  beforeEach(() => {
+    useLocalStatsStore.getState().resetStats();
+  });
+
+  it('starts with empty records', () => {
+    const { records, getOverview, getByGameType } =
+      useLocalStatsStore.getState();
+    expect(records).toEqual([]);
+    expect(getOverview()).toEqual({
+      totalGames: 0,
+      wins: 0,
+      losses: 0,
+      draws: 0,
+      winRate: 0,
+    });
+    expect(getByGameType()).toEqual([]);
+  });
+
+  it('records a won game', () => {
+    useLocalStatsStore.getState().recordGameResult({
+      gameId: 'tic_tac_toe_v1',
+      result: 'won',
+      timestamp: Date.now(),
+      sessionId: 's1',
+    });
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+    expect(overview.wins).toBe(1);
+    expect(overview.losses).toBe(0);
+    expect(overview.winRate).toBe(100);
+  });
+
+  it('records a lost game', () => {
+    useLocalStatsStore.getState().recordGameResult({
+      gameId: 'cascade_v1',
+      result: 'lost',
+      timestamp: Date.now(),
+      sessionId: 's1',
+    });
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+    expect(overview.wins).toBe(0);
+    expect(overview.losses).toBe(1);
+    expect(overview.winRate).toBe(0);
+  });
+
+  it('records a draw', () => {
+    useLocalStatsStore.getState().recordGameResult({
+      gameId: 'tic_tac_toe_v1',
+      result: 'draw',
+      timestamp: Date.now(),
+      sessionId: 's1',
+    });
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(1);
+    expect(overview.draws).toBe(1);
+    expect(overview.winRate).toBe(0);
+  });
+
+  it('computes correct win rate with mixed results', () => {
+    const store = useLocalStatsStore.getState();
+    store.recordGameResult({
+      gameId: 'a',
+      result: 'won',
+      timestamp: 1,
+      sessionId: 's1',
+    });
+    store.recordGameResult({
+      gameId: 'a',
+      result: 'won',
+      timestamp: 2,
+      sessionId: 's2',
+    });
+    store.recordGameResult({
+      gameId: 'a',
+      result: 'lost',
+      timestamp: 3,
+      sessionId: 's3',
+    });
+    store.recordGameResult({
+      gameId: 'a',
+      result: 'lost',
+      timestamp: 4,
+      sessionId: 's4',
+    });
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(4);
+    expect(overview.wins).toBe(2);
+    expect(overview.losses).toBe(2);
+    expect(overview.winRate).toBe(50);
+  });
+
+  it('groups stats by game type', () => {
+    const store = useLocalStatsStore.getState();
+    store.recordGameResult({
+      gameId: 'tic_tac_toe_v1',
+      result: 'won',
+      timestamp: 1,
+      sessionId: 's1',
+    });
+    store.recordGameResult({
+      gameId: 'tic_tac_toe_v1',
+      result: 'won',
+      timestamp: 2,
+      sessionId: 's2',
+    });
+    store.recordGameResult({
+      gameId: 'cascade_v1',
+      result: 'lost',
+      timestamp: 3,
+      sessionId: 's3',
+    });
+
+    const byGame = useLocalStatsStore.getState().getByGameType();
+    expect(byGame).toHaveLength(2);
+
+    const ttt = byGame.find((g) => g.gameId === 'tic_tac_toe_v1');
+    expect(ttt).toEqual({
+      gameId: 'tic_tac_toe_v1',
+      totalGames: 2,
+      wins: 2,
+      losses: 0,
+      draws: 0,
+      winRate: 100,
+    });
+
+    const cascade = byGame.find((g) => g.gameId === 'cascade_v1');
+    expect(cascade).toEqual({
+      gameId: 'cascade_v1',
+      totalGames: 1,
+      wins: 0,
+      losses: 1,
+      draws: 0,
+      winRate: 0,
+    });
+  });
+
+  it('sorts by game type by total games descending', () => {
+    const store = useLocalStatsStore.getState();
+    store.recordGameResult({
+      gameId: 'rare',
+      result: 'won',
+      timestamp: 1,
+      sessionId: 's1',
+    });
+    store.recordGameResult({
+      gameId: 'popular',
+      result: 'won',
+      timestamp: 2,
+      sessionId: 's2',
+    });
+    store.recordGameResult({
+      gameId: 'popular',
+      result: 'won',
+      timestamp: 3,
+      sessionId: 's3',
+    });
+
+    const byGame = useLocalStatsStore.getState().getByGameType();
+    expect(byGame[0].gameId).toBe('popular');
+    expect(byGame[1].gameId).toBe('rare');
+  });
+
+  it('caps records at 1000', () => {
+    const store = useLocalStatsStore.getState();
+    for (let i = 0; i < 1005; i++) {
+      store.recordGameResult({
+        gameId: 'a',
+        result: 'won',
+        timestamp: i,
+        sessionId: `s${i}`,
+      });
+    }
+
+    const { records } = useLocalStatsStore.getState();
+    expect(records).toHaveLength(1000);
+    expect(records[0].sessionId).toBe('s5');
+  });
+
+  it('resetStats clears everything', () => {
+    const store = useLocalStatsStore.getState();
+    store.recordGameResult({
+      gameId: 'a',
+      result: 'won',
+      timestamp: 1,
+      sessionId: 's1',
+    });
+    store.recordGameResult({
+      gameId: 'b',
+      result: 'lost',
+      timestamp: 2,
+      sessionId: 's2',
+    });
+
+    store.resetStats();
+
+    const overview = useLocalStatsStore.getState().getOverview();
+    expect(overview.totalGames).toBe(0);
+    expect(useLocalStatsStore.getState().records).toEqual([]);
+  });
+});

--- a/apps/web/src/features/stats/store/statsStore.ts
+++ b/apps/web/src/features/stats/store/statsStore.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export interface LocalGameRecord {
+  gameId: string;
+  result: 'won' | 'lost' | 'draw';
+  timestamp: number;
+  sessionId?: string;
+}
+
+export interface GameTypeStats {
+  gameId: string;
+  totalGames: number;
+  wins: number;
+  losses: number;
+  draws: number;
+  winRate: number;
+}
+
+interface LocalStatsState {
+  records: LocalGameRecord[];
+  recordGameResult: (record: LocalGameRecord) => void;
+  resetStats: () => void;
+  getOverview: () => {
+    totalGames: number;
+    wins: number;
+    losses: number;
+    draws: number;
+    winRate: number;
+  };
+  getByGameType: () => GameTypeStats[];
+}
+
+const MAX_RECORDS = 1000;
+
+export const useLocalStatsStore = create<LocalStatsState>()(
+  persist(
+    (set, get) => ({
+      records: [],
+
+      recordGameResult: (record) => {
+        const records = [...get().records, record];
+        if (records.length > MAX_RECORDS) {
+          records.splice(0, records.length - MAX_RECORDS);
+        }
+        set({ records });
+      },
+
+      resetStats: () => set({ records: [] }),
+
+      getOverview: () => {
+        const { records } = get();
+        const wins = records.filter((r) => r.result === 'won').length;
+        const losses = records.filter((r) => r.result === 'lost').length;
+        const draws = records.filter((r) => r.result === 'draw').length;
+        const totalGames = records.length;
+        return {
+          totalGames,
+          wins,
+          losses,
+          draws,
+          winRate: totalGames > 0 ? Math.round((wins / totalGames) * 100) : 0,
+        };
+      },
+
+      getByGameType: () => {
+        const { records } = get();
+        const byGame = new Map<
+          string,
+          { totalGames: number; wins: number; losses: number; draws: number }
+        >();
+
+        for (const record of records) {
+          const existing = byGame.get(record.gameId) ?? {
+            totalGames: 0,
+            wins: 0,
+            losses: 0,
+            draws: 0,
+          };
+          existing.totalGames++;
+          if (record.result === 'won') existing.wins++;
+          else if (record.result === 'lost') existing.losses++;
+          else existing.draws++;
+          byGame.set(record.gameId, existing);
+        }
+
+        return Array.from(byGame.entries())
+          .map(([gameId, stats]) => ({
+            gameId,
+            ...stats,
+            winRate:
+              stats.totalGames > 0
+                ? Math.round((stats.wins / stats.totalGames) * 100)
+                : 0,
+          }))
+          .sort((a, b) => b.totalGames - a.totalGames);
+      },
+    }),
+    {
+      name: 'arcadeum_local_stats_v1',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ records: state.records }),
+    },
+  ),
+);

--- a/apps/web/src/shared/i18n/messages/stats.ts
+++ b/apps/web/src/shared/i18n/messages/stats.ts
@@ -7,6 +7,11 @@ export const en = {
   loginRequired: 'Please log in to view your statistics.',
   errorLoading: 'Error loading stats',
   loginRequiredBarrier: 'Login required to view statistics',
+  localStatsNotice:
+    'Stats stored locally on this device. Log in to sync across devices.',
+  noLocalStats: 'Play some games to see your stats here!',
+  logInToTrack: 'Log In to Track',
+  syncToAccount: 'Log In to Sync Stats',
   // Overview cards
   totalGames: 'Total Games',
   wins: 'Wins',
@@ -35,6 +40,11 @@ export const es = {
   loginRequired: 'Por favor inicia sesión para ver tus estadísticas.',
   errorLoading: 'Error al cargar estadísticas',
   loginRequiredBarrier: 'Inicia sesión para ver las estadísticas',
+  localStatsNotice:
+    'Estadísticas guardadas localmente en este dispositivo. Inicia sesión para sincronizar.',
+  noLocalStats: '¡Juega algunas partidas para ver tus estadísticas aquí!',
+  logInToTrack: 'Iniciar Sesión para Registrar',
+  syncToAccount: 'Iniciar Sesión para Sincronizar',
   // Overview cards
   totalGames: 'Juegos Totales',
   wins: 'Victorias',
@@ -63,6 +73,11 @@ export const fr = {
   loginRequired: 'Veuillez vous connecter pour voir vos statistiques.',
   errorLoading: 'Erreur de chargement des statistiques',
   loginRequiredBarrier: 'Connexion requise pour voir les statistiques',
+  localStatsNotice:
+    'Stats enregistrées localement sur cet appareil. Connectez-vous pour synchroniser.',
+  noLocalStats: 'Jouez quelques parties pour voir vos stats ici !',
+  logInToTrack: 'Se Connecter pour Suivre',
+  syncToAccount: 'Se Connecter pour Synchroniser',
   // Overview cards
   totalGames: 'Total des Parties',
   wins: 'Victoires',
@@ -91,6 +106,11 @@ export const ru = {
   loginRequired: 'Пожалуйста, войдите, чтобы просмотреть статистику.',
   errorLoading: 'Ошибка загрузки статистики',
   loginRequiredBarrier: 'Войдите, чтобы просмотреть статистику',
+  localStatsNotice:
+    'Статистика сохранена локально на этом устройстве. Войдите для синхронизации.',
+  noLocalStats: 'Сыграйте несколько партий, чтобы увидеть статистику здесь!',
+  logInToTrack: 'Войти для отслеживания',
+  syncToAccount: 'Войти для синхронизации',
   // Overview cards
   totalGames: 'Всего игр',
   wins: 'Победы',
@@ -119,6 +139,11 @@ export const by = {
   loginRequired: 'Калі ласка, увайдзіце, каб праглядзець статыстыку.',
   errorLoading: 'Памылка загрузкі статыстыкі',
   loginRequiredBarrier: 'Увайдзіце, каб прагледзець статыстыку',
+  localStatsNotice:
+    'Статыстыка захавана лакальна на гэтым прыладзе. Увайдзіце для сінхранізацыі.',
+  noLocalStats: 'Згуляйце некалькі партый, каб убачыць статыстыку тут!',
+  logInToTrack: 'Увайсці для адсочвання',
+  syncToAccount: 'Увайсці для сінхранізацыі',
   // Overview cards
   totalGames: 'Усяго гульняў',
   wins: 'Перамогі',

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -13,6 +13,7 @@ import {
   usePendingStart,
 } from '@/features/games/hooks';
 import { computeGameResult } from '@/features/games/lib/computeGameResult';
+import { useRecordGameResult } from '@/features/stats/hooks/useRecordGameResult';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type { CascadeGameProps } from '../types';
 import { useCascadeState } from '../hooks/useCascadeState';
@@ -113,6 +114,8 @@ function CascadeGameImpl({
       | import('@/features/games/lib/computeGameResult').BackendGameResult
       | undefined,
   });
+
+  useRecordGameResult(result, 'cascade_v1', session?.id);
 
   const { showResultModal, sharedResult, resultMessages, dismiss } =
     useGameResultModal(

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -7,6 +7,7 @@ import {
   useTranslation,
   type TranslationKey,
 } from '@/shared/lib/useTranslation';
+import { useRecordGameResult } from '@/features/stats/hooks/useRecordGameResult';
 import type {
   CriticalCard,
   CriticalPlayerState,
@@ -121,6 +122,15 @@ export function ActiveGameView({
 
   const showResultModal = isGameOver && !modalDismissed;
   useWebGameHaptics(isMyTurn);
+
+  // Record game result to local stats
+  const criticalResult = useMemo(() => {
+    if (!isGameOver || !currentUserId) return null;
+    const alivePlayer = snapshot.players.find((p) => p.alive)?.playerId;
+    if (!alivePlayer) return 'draw' as const;
+    return alivePlayer === currentUserId ? ('won' as const) : ('lost' as const);
+  }, [isGameOver, currentUserId, snapshot.players]);
+  useRecordGameResult(criticalResult, 'critical_v1');
 
   const {
     eventComboModal,

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -17,6 +17,7 @@ import {
   GameWidgetContainer,
   type TurnStatusVariant,
 } from '@/features/games/ui';
+import { useRecordGameResult } from '@/features/stats/hooks/useRecordGameResult';
 
 import { SeaBattleLobby } from './SeaBattleLobby';
 import { reorderRoomParticipants } from '@/shared/api/gamesApi';
@@ -309,6 +310,12 @@ export const SeaBattleGame = memo(function SeaBattleGame({
     if (isWinner || snapshot?.winnerId === currentUserId) return 'victory';
     return 'defeat';
   }, [isGameOver, isWinner, snapshot?.winnerId, currentUserId, teamMode]);
+
+  const localGameResult = useMemo(() => {
+    if (!gameResult) return null;
+    return gameResult === 'victory' ? ('won' as const) : ('lost' as const);
+  }, [gameResult]);
+  useRecordGameResult(localGameResult, 'sea_battle_v1', session?.id);
 
   const headerTitle = useMemo(
     () =>

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/features/games/hooks';
 import { computeGameResult } from '@/features/games/lib/computeGameResult';
 import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
+import { useRecordGameResult } from '@/features/stats/hooks/useRecordGameResult';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type { TicTacToeGameProps } from '../types';
 import { useTicTacToeState } from '../hooks/useTicTacToeState';
@@ -108,6 +109,8 @@ function TicTacToeGameImpl({
       | import('@/features/games/lib/computeGameResult').BackendGameResult
       | undefined,
   });
+
+  useRecordGameResult(result, 'tic_tac_toe_v1', session?.id);
 
   const { showResultModal, sharedResult, resultMessages, dismiss } =
     useGameResultModal(


### PR DESCRIPTION
## What
Add localStorage-based stat tracking so anonymous users can see their game stats without logging in.

## Why
The backend `getPlayerStats()` returns empty stats for `anon_*` users, meaning anonymous players had no way to track their progress. This fills that gap with a client-side store.

## Changes
- **`statsStore.ts`** — Zustand + persist store (`arcadeum_local_stats_v1`) tracking wins, losses, draws per game. Max 1000 records with FIFO eviction. Provides `getOverview()` and `getByGameType()` derived views.
- **`useRecordGameResult` hook** — Auto-records results when a game ends. Deduplicates by `sessionId` to prevent double-recording on re-renders.
- **Game widget integration** — Added `useRecordGameResult` to TicTacToe, Cascade, Critical, and SeaBattle game widgets.
- **Stats page** — Shows local stats for anonymous users with a banner explaining data is stored locally, plus a "Log In to Sync" CTA. When not logged in and no stats exist, shows a prompt to play games.
- **i18n** — Added 4 new keys (`localStatsNotice`, `noLocalStats`, `logInToTrack`, `syncToAccount`) in all 5 locales (en, es, fr, ru, by).
- **Tests** — 16 new tests covering store operations, hook behavior, deduplication, and edge cases.

## Test plan
- [x] Unit tests pass (155 files, 1127 tests)
- [x] i18n completeness check passes
- [x] Type check passes
- [x] Lint passes