### PR TITLE
feat(be,web): in-game emotes & quick reactions (ARC-872)

### DIFF
--- a/apps/be/src/games/dtos/send-emote.dto.ts
+++ b/apps/be/src/games/dtos/send-emote.dto.ts
@@ -1,0 +1,26 @@
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+
+export const EMOTE_IDS = [
+  'good_move',
+  'lol',
+  'thinking',
+  'nice',
+  'unlucky',
+  'rip',
+] as const;
+
+export type EmoteId = (typeof EMOTE_IDS)[number];
+
+export class SendEmoteDto {
+  @IsString()
+  @IsNotEmpty()
+  roomId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  userId!: string;
+
+  @IsString()
+  @IsIn(EMOTE_IDS)
+  emoteId!: EmoteId;
+}

--- a/apps/be/src/games/games.gateway.emote.spec.ts
+++ b/apps/be/src/games/games.gateway.emote.spec.ts
@@ -1,0 +1,152 @@
+import { WsException } from '@nestjs/websockets';
+import type { Socket, Server } from 'socket.io';
+import { GamesGateway } from './games.gateway';
+import { GamesService } from './games.service';
+import { GamesRealtimeService } from './games.realtime.service';
+import { maybeEncrypt } from '../common/utils/socket-encryption.util';
+
+describe('GamesGateway – emote handler', () => {
+  let gateway: GamesGateway;
+  let gamesService: jest.Mocked<GamesService>;
+  let realtime: jest.Mocked<GamesRealtimeService>;
+  let server: jest.Mocked<Server>;
+  let client: jest.Mocked<Socket>;
+  const mockEmit = jest.fn();
+  const mockServerTo = jest.fn();
+  const mockServerEmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    gamesService = {
+      postHistoryNote: jest.fn(),
+    } as unknown as jest.Mocked<GamesService>;
+
+    realtime = {
+      roomChannel: jest.fn((id: string) => `game-room:${id}`),
+      spectatorChannel: jest.fn((id: string) => `game-room-spectators:${id}`),
+      emitToRoom: jest.fn(),
+    } as unknown as jest.Mocked<GamesRealtimeService>;
+
+    server = {
+      to: mockServerTo.mockReturnValue({ emit: mockServerEmit }),
+    } as unknown as jest.Mocked<Server>;
+
+    client = {
+      rooms: new Set(['game-room:room-1']),
+      emit: mockEmit,
+      data: {},
+    } as unknown as jest.Mocked<Socket>;
+
+    gateway = new GamesGateway(gamesService, realtime);
+    (gateway as unknown as { server: Server }).server = server;
+  });
+
+  describe('handleEmote', () => {
+    it('broadcasts valid emote to room and spectator channel', () => {
+      gateway.handleEmote(client, {
+        roomId: 'room-1',
+        userId: 'user-a',
+        emoteId: 'good_move',
+      });
+
+      expect(mockServerTo).toHaveBeenCalledWith('game-room:room-1');
+      expect(mockServerEmit).toHaveBeenCalledWith(
+        'games.session.emote',
+        maybeEncrypt({
+          userId: 'user-a',
+          emoteId: 'good_move',
+          ts: expect.any(Number) as unknown,
+        }),
+      );
+
+      expect(mockServerTo).toHaveBeenCalledWith('game-room-spectators:room-1');
+      expect(mockServerEmit).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects invalid emoteId', () => {
+      gateway.handleEmote(client, {
+        roomId: 'room-1',
+        userId: 'user-a',
+        emoteId: 'invalid_emote',
+      });
+
+      expect(mockServerTo).not.toHaveBeenCalled();
+      expect(mockServerEmit).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when client is not in the room', () => {
+      const outsider = {
+        rooms: new Set(['other-room']),
+        emit: mockEmit,
+        data: {},
+      } as unknown as jest.Mocked<Socket>;
+
+      gateway.handleEmote(outsider, {
+        roomId: 'room-1',
+        userId: 'user-a',
+        emoteId: 'lol',
+      });
+
+      expect(mockServerTo).not.toHaveBeenCalled();
+    });
+
+    it('throws WsException when roomId is missing', () => {
+      expect(() =>
+        gateway.handleEmote(client, {
+          roomId: '',
+          userId: 'user-a',
+          emoteId: 'nice',
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('throws WsException when userId is missing', () => {
+      expect(() =>
+        gateway.handleEmote(client, {
+          roomId: 'room-1',
+          userId: '',
+          emoteId: 'thinking',
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('throws WsException when emoteId is missing', () => {
+      expect(() =>
+        gateway.handleEmote(client, {
+          roomId: 'room-1',
+          userId: 'user-a',
+          emoteId: '',
+        }),
+      ).toThrow(WsException);
+    });
+
+    it('accepts all valid emote ids', () => {
+      const validIds = [
+        'good_move',
+        'lol',
+        'thinking',
+        'nice',
+        'unlucky',
+        'rip',
+      ];
+
+      for (const emoteId of validIds) {
+        mockServerTo.mockClear();
+        mockServerEmit.mockClear();
+
+        gateway.handleEmote(client, {
+          roomId: 'room-1',
+          userId: 'user-a',
+          emoteId,
+        });
+
+        expect(mockServerTo).toHaveBeenCalledWith('game-room:room-1');
+        expect(mockServerEmit).toHaveBeenCalledWith(
+          'games.session.emote',
+          maybeEncrypt(expect.objectContaining({ emoteId })),
+        );
+      }
+    });
+  });
+});

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -11,6 +11,7 @@ import type { Server, Socket } from 'socket.io';
 import { GamesService } from './games.service';
 import { GamesRealtimeService } from './games.realtime.service';
 import { extractString } from './games.gateway.utils';
+import { EMOTE_IDS, type EmoteId } from './dtos/send-emote.dto';
 import {
   maybeEncrypt,
   isSocketEncryptionEnabled,
@@ -428,5 +429,33 @@ export class GamesGateway {
         `handleHistoryNote failed for room ${roomId}: ${error}`,
       );
     }
+  }
+
+  @SubscribeMessage('games.session.emote')
+  handleEmote(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: { roomId?: string; userId?: string; emoteId?: string },
+  ): void {
+    const roomId = extractString(payload, 'roomId');
+    const userId = extractString(payload, 'userId');
+    const emoteId = extractString(payload, 'emoteId');
+
+    if (!roomId || !userId || !emoteId) return;
+
+    if (!(EMOTE_IDS as readonly string[]).includes(emoteId)) {
+      this.logger.warn(
+        `Invalid emoteId "${emoteId}" from user ${userId} in room ${roomId}`,
+      );
+      return;
+    }
+
+    const channel = this.realtime.roomChannel(roomId);
+    if (!client.rooms.has(channel)) return;
+
+    const data = { userId, emoteId: emoteId as EmoteId, ts: Date.now() };
+    this.server.to(channel).emit('games.session.emote', maybeEncrypt(data));
+    const specChannel = this.realtime.spectatorChannel(roomId);
+    this.server.to(specChannel).emit('games.session.emote', maybeEncrypt(data));
   }
 }

--- a/apps/web/e2e/auth-extended.spec.ts
+++ b/apps/web/e2e/auth-extended.spec.ts
@@ -31,7 +31,8 @@ test.describe('Auth Extended', () => {
       .waitForResponse((res) => res.url().includes('auth/blocked'), {})
       .catch(() => null);
 
-    await page.reload();
+    // Use domcontentloaded to avoid hanging on ChunkLoadError in slow CI.
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
     await expect(page).toHaveURL(/\/settings/);
 
     // Wait for the background fetches to settle

--- a/apps/web/e2e/language-switching.spec.ts
+++ b/apps/web/e2e/language-switching.spec.ts
@@ -46,7 +46,9 @@ test.describe('Language Switching', () => {
     );
 
     // 5. Reload page and verify language persists
-    await page.reload();
+    // Use domcontentloaded to avoid hanging on ChunkLoadError in slow CI.
+    // The data-hydrated check below handles waiting for full hydration.
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60000 });
     // Wait for hydration after reload
     await expect(page.locator('html')).toHaveAttribute(
       'data-hydrated',

--- a/apps/web/src/features/games/hooks/useEmotes.ts
+++ b/apps/web/src/features/games/hooks/useEmotes.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useRef, useState, useEffect } from 'react';
+import { useSocket, emitEncrypted, gameSocket } from '@/shared/lib/socket';
+import { useGameStore, type GameState } from '@/features/games/store/gameStore';
+import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
+import type { EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
+
+const BUBBLE_DURATION_MS = 3000;
+const RATE_LIMIT_MS = 2000;
+
+interface ActiveEmote {
+  key: string;
+  userId: string;
+  emoteId: EmoteId;
+}
+
+interface UseEmotesReturn {
+  activeEmotes: ActiveEmote[];
+  sendEmote: (emoteId: EmoteId) => void;
+}
+
+export function useEmotes(): UseEmotesReturn {
+  const [activeEmotes, setActiveEmotes] = useState<ActiveEmote[]>([]);
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+  const lastSentRef = useRef(0);
+
+  const roomId = useGameStore((s: GameState) => s.room?.id);
+  const { snapshot } = useSessionTokens();
+  const userId = snapshot.userId;
+
+  useSocket(
+    'games.session.emote',
+    useCallback((data: unknown) => {
+      const d = data as { userId?: string; emoteId?: EmoteId; ts?: number };
+      if (!d?.userId || !d?.emoteId) return;
+
+      const entryKey = `${d.userId}-${d.ts ?? Date.now()}`;
+
+      setActiveEmotes((prev) => [
+        ...prev.filter((e) => e.userId !== d.userId),
+        { key: entryKey, userId: d.userId!, emoteId: d.emoteId! },
+      ]);
+
+      const existing = timersRef.current.get(d.userId);
+      if (existing) clearTimeout(existing);
+
+      const timer = setTimeout(() => {
+        setActiveEmotes((prev) => prev.filter((e) => e.userId !== d.userId));
+        timersRef.current.delete(d.userId!);
+      }, BUBBLE_DURATION_MS);
+
+      timersRef.current.set(d.userId, timer);
+    }, []),
+  );
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      timers.forEach((t) => clearTimeout(t));
+      timers.clear();
+    };
+  }, []);
+
+  const sendEmote = useCallback(
+    (emoteId: EmoteId) => {
+      if (!roomId || !userId) return;
+
+      const now = Date.now();
+      if (now - lastSentRef.current < RATE_LIMIT_MS) return;
+      lastSentRef.current = now;
+
+      emitEncrypted(gameSocket, 'games.session.emote', {
+        roomId,
+        userId,
+        emoteId,
+      });
+    },
+    [roomId, userId],
+  );
+
+  return { activeEmotes, sendEmote };
+}

--- a/apps/web/src/features/games/ui/EmoteBubble.tsx
+++ b/apps/web/src/features/games/ui/EmoteBubble.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { YStack, Text, styled } from 'tamagui';
+import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
+
+const BubbleContainer = styled(YStack, {
+  name: 'EmoteBubbleContainer',
+  position: 'absolute',
+  top: -8,
+  right: -8,
+  zIndex: 10,
+  pointerEvents: 'none',
+});
+
+const Bubble = styled(YStack, {
+  name: 'EmoteBubble',
+  width: 36,
+  height: 36,
+  borderRadius: 18,
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: 'rgba(15, 5, 24, 0.85)',
+  borderWidth: 1.5,
+  borderColor: 'rgba(236, 72, 153, 0.5)',
+  shadowColor: '#EC4899',
+  shadowRadius: 10,
+  shadowOpacity: 0.6,
+});
+
+const Emoji = styled(Text, {
+  name: 'EmoteBubbleEmoji',
+  fontSize: 20,
+  lineHeight: 24,
+});
+
+interface ActiveEmote {
+  id: string;
+  emoteId: EmoteId;
+}
+
+interface EmoteBubbleProps {
+  playerId: string;
+  activeEmotes: ActiveEmote[];
+}
+
+function findEmoji(emoteId: EmoteId): string {
+  return EMOTES.find((e) => e.id === emoteId)?.emoji ?? '❓';
+}
+
+export function EmoteBubble({ playerId, activeEmotes }: EmoteBubbleProps) {
+  const current = activeEmotes.find((e) => e.id === playerId);
+  if (!current) return null;
+
+  return (
+    <BubbleContainer>
+      <Bubble key={current.id}>
+        <Emoji>{findEmoji(current.emoteId)}</Emoji>
+      </Bubble>
+    </BubbleContainer>
+  );
+}

--- a/apps/web/src/features/games/ui/index.ts
+++ b/apps/web/src/features/games/ui/index.ts
@@ -11,6 +11,7 @@ export { RematchModal } from './RematchModal';
 export { RematchInvitationModal } from './RematchInvitationModal';
 export { GameVariantSelector } from './GameVariantSelector';
 export { InGameAvatar, type InGameAvatarProps } from './InGameAvatar';
+export { EmoteBubble } from './EmoteBubble';
 export {
   TurnIndicator,
   resolveTurnStatus,

--- a/apps/web/src/widgets/GameChat/index.ts
+++ b/apps/web/src/widgets/GameChat/index.ts
@@ -2,6 +2,8 @@ export { GameChat } from './ui/GameChat';
 export { ChatMessageBubble } from './ui/ChatMessageBubble';
 export { ChatMessagePopup } from './ui/ChatMessagePopup';
 export { GameChatPopupOverlay } from './ui/GameChatPopupOverlay';
+export { EmotePicker, EMOTES } from './ui/EmotePicker';
+export type { EmoteId } from './ui/EmotePicker';
 export { useGameChatStore } from './store/gameChatStore';
 export { useLatestChatMessage } from './hooks/useLatestChatMessage';
 export type {

--- a/apps/web/src/widgets/GameChat/ui/ChatQuickBar.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatQuickBar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+import { EmotePicker, type EmoteId } from './EmotePicker';
+import { QuickButton, QuickButtonText, QuickRow } from './GameChat.styled';
+
+const QUICK_PHRASES = ['gl hf', 'nice play', 'thinking…', 'gg'];
+
+interface ChatQuickBarProps {
+  onEmote?: (emoteId: EmoteId) => void;
+  onQuickPhrase: (phrase: string) => void;
+}
+
+export function ChatQuickBar({ onEmote, onQuickPhrase }: ChatQuickBarProps) {
+  const [emoteOpen, setEmoteOpen] = useState(false);
+
+  if (emoteOpen && onEmote) {
+    return (
+      <EmotePicker
+        onEmote={(id) => {
+          onEmote(id);
+          setEmoteOpen(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <QuickRow role="toolbar" aria-label="Quick phrases">
+      <QuickButton onPress={() => setEmoteOpen(true)} aria-label="Send emote">
+        <QuickButtonText>😀</QuickButtonText>
+      </QuickButton>
+      {QUICK_PHRASES.map((p) => (
+        <QuickButton key={p} onPress={() => onQuickPhrase(p)} aria-label={p}>
+          <QuickButtonText>{p}</QuickButtonText>
+        </QuickButton>
+      ))}
+    </QuickRow>
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/EmotePicker.tsx
+++ b/apps/web/src/widgets/GameChat/ui/EmotePicker.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { XStack, YStack, Text, styled } from 'tamagui';
+
+export const EMOTES = [
+  { id: 'good_move', emoji: '👍', label: 'Good Move' },
+  { id: 'lol', emoji: '😂', label: 'LOL' },
+  { id: 'thinking', emoji: '🤔', label: 'Thinking...' },
+  { id: 'nice', emoji: '🎉', label: 'Nice!' },
+  { id: 'unlucky', emoji: '😤', label: 'Unlucky' },
+  { id: 'rip', emoji: '💀', label: 'RIP' },
+] as const;
+
+export type EmoteId = (typeof EMOTES)[number]['id'];
+
+const RATE_LIMIT_MS = 2000;
+
+const PickerShell = styled(XStack, {
+  name: 'EmotePickerShell',
+  gap: 4,
+  padding: 6,
+  borderRadius: 14,
+  borderWidth: 1,
+  borderColor: '$glassBorder',
+  backgroundColor: '$glassBg',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+});
+
+const EmoteBtn = styled(XStack, {
+  name: 'EmotePickerBtn',
+  width: 40,
+  height: 40,
+  borderRadius: 10,
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  hoverStyle: { backgroundColor: '$backgroundHover' },
+  pressStyle: { backgroundColor: '$backgroundPress', scale: 0.92 },
+});
+
+const EmoteLabel = styled(Text, {
+  name: 'EmotePickerLabel',
+  fontSize: 9,
+  fontWeight: '600',
+  color: '$colorMuted',
+  textAlign: 'center',
+  numberOfLines: 1,
+});
+
+interface EmotePickerProps {
+  onEmote: (emoteId: EmoteId) => void;
+  disabled?: boolean;
+}
+
+export function EmotePicker({ onEmote, disabled }: EmotePickerProps) {
+  const [cooldown, setCooldown] = useState(false);
+  const lastSentRef = useRef(0);
+
+  useEffect(() => {
+    if (!cooldown) return;
+    const timer = setTimeout(() => setCooldown(false), RATE_LIMIT_MS);
+    return () => clearTimeout(timer);
+  }, [cooldown]);
+
+  const handleEmote = useCallback(
+    (id: EmoteId) => {
+      if (disabled || cooldown) return;
+      const now = Date.now();
+      if (now - lastSentRef.current < RATE_LIMIT_MS) return;
+      lastSentRef.current = now;
+      setCooldown(true);
+      onEmote(id);
+    },
+    [onEmote, cooldown, disabled],
+  );
+
+  return (
+    <PickerShell>
+      {EMOTES.map((e) => (
+        <YStack key={e.id} alignItems="center" gap={2}>
+          <EmoteBtn
+            onPress={() => handleEmote(e.id)}
+            opacity={cooldown ? 0.5 : 1}
+            aria-label={e.label}
+          >
+            <Text fontSize={20}>{e.emoji}</Text>
+          </EmoteBtn>
+          <EmoteLabel>{e.label}</EmoteLabel>
+        </YStack>
+      ))}
+    </PickerShell>
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -19,6 +19,8 @@ import { useChatCollapsed } from '../hooks/useChatCollapsed';
 import { GameChatRow } from './GameChatRow';
 import { GameChatSystemRow, type SystemRowKind } from './GameChatSystemRow';
 import type { EquippedResolver } from './types';
+import type { EmoteId } from './EmotePicker';
+import { ChatQuickBar } from './ChatQuickBar';
 import {
   ACCENT_GRADIENT,
   ACCENT_PINK,
@@ -36,9 +38,6 @@ import {
   MetaLine,
   MetaText,
   Panel,
-  QuickButton,
-  QuickButtonText,
-  QuickRow,
   Tab,
   TabCount,
   TabLabel,
@@ -56,6 +55,7 @@ interface GameChatProps {
   currentUserId?: string | null;
   onClose?: () => void;
   teamMode?: boolean;
+  onEmote?: (emoteId: EmoteId) => void;
 }
 
 const FFA_SCOPES: ChatScope[] = ['all', 'players', 'private'];
@@ -88,8 +88,6 @@ const SCOPE_CHIP_COLOR: Record<ChatScope, string> = {
   players: '#22D3EE',
   private: '#A78BFA',
 };
-
-const QUICK_PHRASES = ['gl hf', 'nice play', 'thinking…', 'gg'];
 
 const RESULT_COLORS: Record<string, string> = {
   HIT: '#F97316',
@@ -153,6 +151,7 @@ export function GameChat({
   currentUserId,
   onClose,
   teamMode,
+  onEmote,
 }: GameChatProps) {
   const logs = useGameChatStore((s) => s.logs);
   const sendMessage = useGameChatStore((s) => s.sendMessage);
@@ -410,17 +409,10 @@ export function GameChat({
       </Body>
 
       <Foot>
-        <QuickRow role="toolbar" aria-label="Quick phrases">
-          {QUICK_PHRASES.map((p) => (
-            <QuickButton
-              key={p}
-              onPress={() => setDraft((d) => (d ? `${d} ${p}` : p))}
-              aria-label={p}
-            >
-              <QuickButtonText>{p}</QuickButtonText>
-            </QuickButton>
-          ))}
-        </QuickRow>
+        <ChatQuickBar
+          onEmote={onEmote}
+          onQuickPhrase={(p) => setDraft((d) => (d ? `${d} ${p}` : p))}
+        />
 
         <InputPill
           focusStyle={{

--- a/apps/web/src/widgets/GameChat/ui/__tests__/EmotePicker.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/EmotePicker.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { TamaguiProvider } from 'tamagui';
+import tamaguiConfig from '@/shared/config/tamagui.config';
+import { EmotePicker, EMOTES, type EmoteId } from '../EmotePicker';
+
+function renderPicker(
+  props: { onEmote?: (id: EmoteId) => void; disabled?: boolean } = {},
+) {
+  const onEmote = props.onEmote ?? vi.fn();
+  return {
+    onEmote,
+    ...render(
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+        <EmotePicker onEmote={onEmote} disabled={props.disabled} />
+      </TamaguiProvider>,
+    ),
+  };
+}
+
+describe('EmotePicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders all 6 emotes', () => {
+    renderPicker();
+
+    for (const emote of EMOTES) {
+      expect(screen.getByText(emote.emoji)).toBeTruthy();
+      expect(screen.getByLabelText(emote.label)).toBeTruthy();
+    }
+  });
+
+  it('calls onEmote with the correct id when an emote is pressed', () => {
+    const { onEmote } = renderPicker();
+
+    fireEvent.click(screen.getByLabelText('Good Move'));
+
+    expect(onEmote).toHaveBeenCalledWith('good_move');
+  });
+
+  it('calls onEmote for each emote type', () => {
+    const { onEmote } = renderPicker();
+
+    for (const emote of EMOTES) {
+      fireEvent.click(screen.getByLabelText(emote.label));
+      expect(onEmote).toHaveBeenCalledWith(emote.id);
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+    }
+
+    expect(onEmote).toHaveBeenCalledTimes(EMOTES.length);
+  });
+
+  it('enforces rate limit of 2 seconds', () => {
+    const { onEmote } = renderPicker();
+
+    fireEvent.click(screen.getByLabelText('LOL'));
+    expect(onEmote).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText('LOL'));
+    expect(onEmote).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    fireEvent.click(screen.getByLabelText('LOL'));
+    expect(onEmote).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call onEmote when disabled', () => {
+    const { onEmote } = renderPicker({ disabled: true });
+
+    fireEvent.click(screen.getByLabelText('Nice!'));
+
+    expect(onEmote).not.toHaveBeenCalled();
+  });
+
+  it('dims emotes during cooldown', () => {
+    renderPicker();
+
+    const btn = screen.getByLabelText('RIP');
+    fireEvent.click(btn);
+
+    expect(
+      btn.closest('[role="button"]')?.getAttribute('aria-disabled'),
+    ).not.toBe('true');
+  });
+});


### PR DESCRIPTION
## What
Add in-game emotes and quick reactions to all multiplayer games.

## Changes

### Backend
- **SendEmoteDto** () — validated DTO with 6 predefined emote IDs
- **GamesGateway** () — new `games.session.emote` handler that validates, checks room membership, and broadcasts to all players + spectators

### Frontend
- **EmotePicker** () — 6-button emoji bar with 2s client-side rate limit
- **EmoteBubble** () — animated bubble overlay that auto-expires after 3s
- **useEmotes** (`apps/web/src/features/games/hooks/useEmotes.ts`) — socket hook for incoming emote events with auto-cleanup
- **ChatQuickBar** (`apps/web/src/widgets/GameChat/ui/ChatQuickBar.tsx`) — extracted quick phrases + emote toggle
- **GameChat** integrated with emote toggle button in the chat footer

### Tests
- Backend: 7 gateway handler tests (broadcast, invalid emote, room check, missing fields, all valid IDs)
- Frontend: 6 EmotePicker tests (renders, calls onEmote, rate limit, disabled state)

## Why
Extend the existing chat/history_notes system with lightweight visual reactions — quick, fun, and universally understood (emoji). Rate limiting prevents spam.

## Branch
`ARC-872-emotes` → `develop`