### PR TITLE
feat(be,web): fix emote encryption and expand emote system

### DIFF
--- a/apps/be/src/games/dtos/send-emote.dto.ts
+++ b/apps/be/src/games/dtos/send-emote.dto.ts
@@ -7,6 +7,16 @@ export const EMOTE_IDS = [
   'nice',
   'unlucky',
   'rip',
+  'fire',
+  'clap',
+  'cry',
+  'angry',
+  'rocket',
+  'heart',
+  'brain',
+  'skull',
+  'sweat',
+  'clown',
 ] as const;
 
 export type EmoteId = (typeof EMOTE_IDS)[number];

--- a/apps/be/src/games/games.gateway.emote.spec.ts
+++ b/apps/be/src/games/games.gateway.emote.spec.ts
@@ -148,5 +148,25 @@ describe('GamesGateway – emote handler', () => {
         );
       }
     });
+
+    it('decrypts encrypted payload when encryption is enabled', () => {
+      const encrypted = maybeEncrypt({
+        roomId: 'room-1',
+        userId: 'user-a',
+        emoteId: 'good_move',
+      });
+
+      gateway.handleEmote(client, encrypted);
+
+      expect(mockServerTo).toHaveBeenCalledWith('game-room:room-1');
+      expect(mockServerEmit).toHaveBeenCalledWith(
+        'games.session.emote',
+        maybeEncrypt({
+          userId: 'user-a',
+          emoteId: 'good_move',
+          ts: expect.any(Number) as unknown,
+        }),
+      );
+    });
   });
 });

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -14,6 +14,7 @@ import { extractString } from './games.gateway.utils';
 import { EMOTE_IDS, type EmoteId } from './dtos/send-emote.dto';
 import {
   maybeEncrypt,
+  maybeDecrypt,
   isSocketEncryptionEnabled,
   getEncryptionKeyHex,
 } from '../common/utils/socket-encryption.util';
@@ -435,11 +436,16 @@ export class GamesGateway {
   handleEmote(
     @ConnectedSocket() client: Socket,
     @MessageBody()
-    payload: { roomId?: string; userId?: string; emoteId?: string },
+    payload: unknown,
   ): void {
-    const roomId = extractString(payload, 'roomId');
-    const userId = extractString(payload, 'userId');
-    const emoteId = extractString(payload, 'emoteId');
+    const decrypted = maybeDecrypt<{
+      roomId?: string;
+      userId?: string;
+      emoteId?: string;
+    }>(payload);
+    const roomId = extractString(decrypted, 'roomId');
+    const userId = extractString(decrypted, 'userId');
+    const emoteId = extractString(decrypted, 'emoteId');
 
     if (!roomId || !userId || !emoteId) return;
 

--- a/apps/be/src/solana/solana.service.ts
+++ b/apps/be/src/solana/solana.service.ts
@@ -26,10 +26,17 @@ export class SolanaService {
       'https://api.mainnet-beta.solana.com';
     this.connection = new Connection(rpcUrl, 'confirmed');
 
-    const mintAddress =
-      this.config.get<string>('ARCADEUM_MINT_ADDRESS') ??
-      '11111111111111111111111111111111';
-    this.arcadeumMint = getArcadeumMint(mintAddress);
+    const mintAddress = this.config.get<string>('ARCADEUM_MINT_ADDRESS') ?? '';
+    const isValidMint =
+      mintAddress && /^[1-9A-HJ-NP-Za-km-z]+$/.test(mintAddress);
+    if (!isValidMint && mintAddress) {
+      this.logger.warn(
+        `ARCADEUM_MINT_ADDRESS "${mintAddress}" is not valid base58 — using System Program fallback`,
+      );
+    }
+    this.arcadeumMint = isValidMint
+      ? getArcadeumMint(mintAddress)
+      : new PublicKey('11111111111111111111111111111111');
   }
 
   private getKeypair() {

--- a/apps/web/e2e/sea-battle-6-players.spec.ts
+++ b/apps/web/e2e/sea-battle-6-players.spec.ts
@@ -226,16 +226,12 @@ test.describe('Sea Battle 6 Players Layout', () => {
     await navigateTo(page, `/games/rooms/${roomId}`);
     await waitForRoomReady(page);
 
-    // Verify 2 boards are visible in the same row.
-    // The container starts with display:flex on first render (containerWidth=0
-    // before ResizeObserver fires), then switches to display:grid once the
-    // observer measures the real width. Poll until the grid layout appears.
+    // Verify 2 boards are visible in the same row
     const container = page.getByTestId('sea-battle-grids-container');
-    await expect.poll(
-      async () =>
-        container.evaluate((el) => window.getComputedStyle(el).display),
-      { timeout: 5000 },
-    ).toBe('grid');
+    const display = await container.evaluate(
+      (el) => window.getComputedStyle(el).display,
+    );
+    expect(display).toBe('grid');
 
     const gridTemplateColumns = await container.evaluate(
       (el) => window.getComputedStyle(el).gridTemplateColumns,

--- a/apps/web/e2e/sea-battle-6-players.spec.ts
+++ b/apps/web/e2e/sea-battle-6-players.spec.ts
@@ -226,12 +226,16 @@ test.describe('Sea Battle 6 Players Layout', () => {
     await navigateTo(page, `/games/rooms/${roomId}`);
     await waitForRoomReady(page);
 
-    // Verify 2 boards are visible in the same row
+    // Verify 2 boards are visible in the same row.
+    // The container starts with display:flex on first render (containerWidth=0
+    // before ResizeObserver fires), then switches to display:grid once the
+    // observer measures the real width. Poll until the grid layout appears.
     const container = page.getByTestId('sea-battle-grids-container');
-    const display = await container.evaluate(
-      (el) => window.getComputedStyle(el).display,
-    );
-    expect(display).toBe('grid');
+    await expect.poll(
+      async () =>
+        container.evaluate((el) => window.getComputedStyle(el).display),
+      { timeout: 5000 },
+    ).toBe('grid');
 
     const gridTemplateColumns = await container.evaluate(
       (el) => window.getComputedStyle(el).gridTemplateColumns,

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -8,6 +8,8 @@ import { useFullscreen } from '@/features/games/hooks/useFullscreen';
 import { ConnectionOverlay } from '@arcadeum/ui/components/ConnectionOverlay/ConnectionOverlay';
 import { GamesControlPanel } from '@/widgets/GamesControlPanel';
 import { GameChat, useGameChatStore } from '@/widgets/GameChat';
+import { useEmotes } from '@/features/games/hooks/useEmotes';
+import { EmoteBubble } from '@/features/games/ui/EmoteBubble';
 import type { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
 import { AutoExitFullscreenOnFinish } from './AutoExitFullscreenOnFinish';
@@ -72,6 +74,8 @@ export function GamePageLayout(props: GamePageLayoutProps) {
   // Chat visibility — wide screens default visible, narrow hidden
   const [showChat, setShowChat] = useState(false);
   const handleToggleChat = useCallback(() => setShowChat((v) => !v), []);
+
+  const { activeEmotes, sendEmote } = useEmotes();
 
   useEffect(() => {
     queueMicrotask(() => {
@@ -183,7 +187,34 @@ export function GamePageLayout(props: GamePageLayoutProps) {
         />
 
         <GameRow flexDirection={roomFlexDirection}>
-          {children({ isFullscreen, toggleFullscreen })}
+          <div style={{ position: 'relative', flex: 1, display: 'flex' }}>
+            {children({ isFullscreen, toggleFullscreen })}
+
+            {activeEmotes.length > 0 && (
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 12,
+                  right: 12,
+                  zIndex: 20,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 8,
+                  pointerEvents: 'none',
+                }}
+              >
+                {activeEmotes.map((emote) => (
+                  <EmoteBubble
+                    key={emote.key}
+                    playerId={emote.userId}
+                    activeEmotes={[
+                      { id: emote.userId, emoteId: emote.emoteId },
+                    ]}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
 
           <ChatPanel visible={showChat} data-testid="game-chat-area">
             <GameChat
@@ -192,6 +223,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
               resolveDisplayName={resolveDisplayNameForList}
               resolveEquipped={resolveEquipped}
               currentUserId={userId}
+              onEmote={sendEmote}
             />
           </ChatPanel>
         </GameRow>

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/layoutStyles.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/layoutStyles.tsx
@@ -10,6 +10,7 @@ export const GameRow = styled(YStack, {
   minHeight: 0,
   gap: '$4',
   alignItems: 'stretch',
+  position: 'relative',
 
   // Switch to horizontal layout only on wide screens (> 1150px)
   $md: {

--- a/apps/web/src/features/games/hooks/useEmotes.ts
+++ b/apps/web/src/features/games/hooks/useEmotes.ts
@@ -4,7 +4,8 @@ import { useCallback, useRef, useState, useEffect } from 'react';
 import { useSocket, emitEncrypted, gameSocket } from '@/shared/lib/socket';
 import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
-import type { EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
+import { useGameChatStore } from '@/widgets/GameChat/store/gameChatStore';
+import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
 
 const BUBBLE_DURATION_MS = 3000;
 const RATE_LIMIT_MS = 2000;
@@ -18,6 +19,10 @@ interface ActiveEmote {
 interface UseEmotesReturn {
   activeEmotes: ActiveEmote[];
   sendEmote: (emoteId: EmoteId) => void;
+}
+
+function findEmoji(emoteId: EmoteId): string {
+  return EMOTES.find((e) => e.id === emoteId)?.emoji ?? '❓';
 }
 
 export function useEmotes(): UseEmotesReturn {
@@ -53,6 +58,19 @@ export function useEmotes(): UseEmotesReturn {
       }, BUBBLE_DURATION_MS);
 
       timersRef.current.set(d.userId, timer);
+
+      // Add emote to chat log
+      const addLog = useGameChatStore.getState().addLog;
+      if (addLog) {
+        addLog({
+          id: `emote-${d.userId}-${d.ts ?? Date.now()}`,
+          type: 'action',
+          kind: 'system',
+          message: `${findEmoji(d.emoteId)} ${d.emoteId.replace(/_/g, ' ')}`,
+          createdAt: new Date(d.ts ?? Date.now()).toISOString(),
+          senderId: d.userId,
+        });
+      }
     }, []),
   );
 

--- a/apps/web/src/features/games/ui/EmoteBubble.tsx
+++ b/apps/web/src/features/games/ui/EmoteBubble.tsx
@@ -1,37 +1,75 @@
 'use client';
 
-import { YStack, Text, styled } from 'tamagui';
+import { useRef, useEffect } from 'react';
 import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
 
-const BubbleContainer = styled(YStack, {
-  name: 'EmoteBubbleContainer',
-  position: 'absolute',
-  top: -8,
-  right: -8,
-  zIndex: 10,
-  pointerEvents: 'none',
-});
+const EMOTE_LABELS: Record<EmoteId, string> = {
+  good_move: 'Nice!',
+  lol: 'LOL',
+  thinking: 'Hmm...',
+  nice: 'GG!',
+  unlucky: 'Oof!',
+  rip: 'RIP',
+  fire: 'Fire!',
+  clap: 'Bravo!',
+  cry: 'Sad',
+  angry: 'Mad',
+  rocket: "Let's go!",
+  heart: 'Love',
+  brain: 'Galaxy Brain',
+  skull: 'Dead',
+  sweat: 'Close!',
+  clown: 'Clown',
+};
 
-const Bubble = styled(YStack, {
-  name: 'EmoteBubble',
-  width: 36,
-  height: 36,
-  borderRadius: 18,
-  alignItems: 'center',
-  justifyContent: 'center',
-  backgroundColor: 'rgba(15, 5, 24, 0.85)',
-  borderWidth: 1.5,
-  borderColor: 'rgba(236, 72, 153, 0.5)',
-  shadowColor: '#EC4899',
-  shadowRadius: 10,
-  shadowOpacity: 0.6,
-});
+const KEYFRAMES_CSS = `
+@keyframes emoteFloat {
+  0% {
+    opacity: 0;
+    transform: translateY(140px) translateX(10px) scale(0.4) rotate(-8deg);
+  }
+  10% {
+    opacity: 1;
+    transform: translateY(70px) translateX(-15px) scale(1.2) rotate(5deg);
+  }
+  20% {
+    transform: translateY(20px) translateX(8px) scale(0.95) rotate(-3deg);
+  }
+  30% {
+    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
+  }
+  65% {
+    opacity: 1;
+    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-140px) translateX(-5px) scale(0.6) rotate(4deg);
+  }
+}
 
-const Emoji = styled(Text, {
-  name: 'EmoteBubbleEmoji',
-  fontSize: 20,
-  lineHeight: 24,
-});
+@keyframes labelPop {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) scale(0.5);
+  }
+  15% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.15);
+  }
+  30% {
+    transform: translateY(0) scale(1);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.8);
+  }
+}
+`;
 
 interface ActiveEmote {
   id: string;
@@ -47,15 +85,89 @@ function findEmoji(emoteId: EmoteId): string {
   return EMOTES.find((e) => e.id === emoteId)?.emoji ?? '❓';
 }
 
+let stylesInjected = false;
+
 export function EmoteBubble({ playerId, activeEmotes }: EmoteBubbleProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!stylesInjected) {
+      const style = document.createElement('style');
+      style.textContent = KEYFRAMES_CSS;
+      document.head.appendChild(style);
+      stylesInjected = true;
+    }
+    const el = ref.current;
+    if (el) {
+      el.style.animation = 'emoteFloat 2.4s ease-out forwards';
+      const label = el.querySelector('[data-emote-label]');
+      if (label) {
+        (label as HTMLElement).style.animation =
+          'labelPop 2.4s ease-out forwards';
+      }
+    }
+  }, []);
+
   const current = activeEmotes.find((e) => e.id === playerId);
   if (!current) return null;
 
+  const label = EMOTE_LABELS[current.emoteId] ?? '';
+
   return (
-    <BubbleContainer>
-      <Bubble key={current.id}>
-        <Emoji>{findEmoji(current.emoteId)}</Emoji>
-      </Bubble>
-    </BubbleContainer>
+    <div
+      ref={ref}
+      style={{
+        position: 'absolute',
+        top: '50%',
+        right: 24,
+        zIndex: 10,
+        pointerEvents: 'none',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 6,
+        opacity: 0,
+      }}
+    >
+      <div
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 36,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'rgba(15, 5, 24, 0.88)',
+          borderWidth: 1.5,
+          borderStyle: 'solid',
+          borderColor: 'rgba(236, 72, 153, 0.5)',
+          boxShadow: '0 0 18px 2px rgba(236, 72, 153, 0.45)',
+          fontSize: 42,
+          lineHeight: '48px',
+        }}
+      >
+        {findEmoji(current.emoteId)}
+      </div>
+      {label && (
+        <div
+          data-emote-label=""
+          style={{
+            color: '#fff',
+            fontSize: 16,
+            fontWeight: 800,
+            textShadow:
+              '0 0 8px rgba(236,72,153,0.9), 0 2px 10px rgba(0,0,0,0.8)',
+            letterSpacing: 1,
+            padding: '3px 10px',
+            borderRadius: 8,
+            backgroundColor: 'rgba(236, 72, 153, 0.35)',
+            whiteSpace: 'nowrap',
+            opacity: 0,
+          }}
+        >
+          {label}
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/widgets/GameChat/store/gameChatStore.ts
+++ b/apps/web/src/widgets/GameChat/store/gameChatStore.ts
@@ -37,6 +37,7 @@ interface GameChatStore {
   currentUserId: string | null;
   chatPanelOpen: boolean;
   setLogs: (logs: ChatLogEntry[]) => void;
+  addLog: (entry: ChatLogEntry) => void;
   registerSendMessage: (
     fn: (message: string, scope: ChatScope) => void,
   ) => void;
@@ -61,6 +62,7 @@ export const useGameChatStore = create<GameChatStore>((set) => ({
   currentUserId: null,
   chatPanelOpen: false,
   setLogs: (logs) => set({ logs }),
+  addLog: (entry) => set((s) => ({ logs: [...s.logs, entry] })),
   registerSendMessage: (fn) => set({ sendMessage: fn }),
   registerResolveDisplayName: (fn) => set({ resolveDisplayName: fn }),
   registerFallbackResolveDisplayName: (fn) =>

--- a/apps/web/src/widgets/GameChat/ui/EmotePicker.tsx
+++ b/apps/web/src/widgets/GameChat/ui/EmotePicker.tsx
@@ -10,6 +10,16 @@ export const EMOTES = [
   { id: 'nice', emoji: '🎉', label: 'Nice!' },
   { id: 'unlucky', emoji: '😤', label: 'Unlucky' },
   { id: 'rip', emoji: '💀', label: 'RIP' },
+  { id: 'fire', emoji: '🔥', label: 'Fire!' },
+  { id: 'clap', emoji: '👏', label: 'Clap!' },
+  { id: 'cry', emoji: '😢', label: 'Sad' },
+  { id: 'angry', emoji: '😡', label: 'Angry' },
+  { id: 'rocket', emoji: '🚀', label: 'Rocket!' },
+  { id: 'heart', emoji: '❤️', label: 'Love' },
+  { id: 'brain', emoji: '🧠', label: 'Big Brain' },
+  { id: 'skull', emoji: '☠️', label: 'Dead' },
+  { id: 'sweat', emoji: '😅', label: 'Close One' },
+  { id: 'clown', emoji: '🤡', label: 'Clown' },
 ] as const;
 
 export type EmoteId = (typeof EMOTES)[number]['id'];

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -168,6 +168,14 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = 2;
   }
 
+  // Floor: when containerWidth is 0 (before ResizeObserver fires), the
+  // fits-based calculation may produce cols=1 even for multi-player
+  // landscape views. Force at least 2 cols so the grid layout renders
+  // immediately instead of falling back to single-column flex.
+  if (containerWidth === 0 && count > 1 && isLandscape && cols < 2) {
+    cols = 2;
+  }
+
   if (cols === 1) {
     return (
       <div

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { Children, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  Children,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useMedia } from 'tamagui';
 
 interface SeaBattleGridsProps {
@@ -42,7 +48,16 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [containerHeight, setContainerHeight] = useState(0);
-  const [isLandscape, setIsLandscape] = useState(false);
+
+  // Compute landscape synchronously from window dimensions. Tamagui's
+  // useMedia() may hydrate with SSR defaults (all false) and stay stale
+  // if no matchMedia events fire (e.g. viewport set before page load in
+  // CI). Reading window directly avoids the async useEffect + useState
+  // pattern that can leave isLandscape stuck at false.
+  const [isLandscape, setIsLandscape] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.innerWidth > window.innerHeight;
+  });
   // Widget-level fullscreen: ancestor matches `.game-widget-container.is-fullscreen`
   // (the expand button on the widget header). This is the "fit every
   // board on one screen" state and is the only state where the grid is
@@ -74,7 +89,6 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
 
   useEffect(() => {
     const update = () => setIsLandscape(window.innerWidth > window.innerHeight);
-    update();
     window.addEventListener('resize', update);
     window.addEventListener('orientationchange', update);
     return () => {
@@ -165,16 +179,6 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   // room, not a different column count.
   const wantsTwoColCap = !media.gtMd && (isWidgetFullscreen || isLandscape);
   if (wantsTwoColCap && cols > 2) {
-    cols = 2;
-  }
-
-  // Floor: when containerWidth is 0 (before ResizeObserver fires) and
-  // isLandscape hasn't been set yet by its useEffect, the fits-based
-  // calculation may produce cols=1 even for multi-player non-portrait
-  // views. Force at least 2 cols so the grid layout renders immediately.
-  // Use the synchronous isMobilePortrait check (media queries + isLandscape
-  // default false) to avoid the single-column flex fallback.
-  if (containerWidth === 0 && count > 1 && !isMobilePortrait && cols < 2) {
     cols = 2;
   }
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -1,11 +1,5 @@
 'use client';
-import {
-  Children,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import { Children, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useMedia } from 'tamagui';
 
 interface SeaBattleGridsProps {
@@ -89,6 +83,10 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
 
   useEffect(() => {
     const update = () => setIsLandscape(window.innerWidth > window.innerHeight);
+    // Re-evaluate immediately on mount in case the useState initializer
+    // read stale window dimensions (e.g. WebKit headless where the
+    // Playwright viewport may not be reflected at hydration time).
+    update();
     window.addEventListener('resize', update);
     window.addEventListener('orientationchange', update);
     return () => {

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -129,11 +129,14 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
   } else if (media.short) {
     // Phone-sized landscape (very short viewport): cap at 2 cols so boards
     // stay playable when there are many players.
-    const fits = Math.max(
-      1,
-      Math.floor(containerWidth / MIN_BOARD_WIDTH_MOBILE_LANDSCAPE),
-    );
-    cols = Math.min(2, count, fits || 2);
+    // When containerWidth is 0 (before ResizeObserver fires), default to
+    // 2 cols so the grid layout renders immediately instead of falling
+    // back to the single-column flex layout.
+    const fits =
+      containerWidth > 0
+        ? Math.floor(containerWidth / MIN_BOARD_WIDTH_MOBILE_LANDSCAPE)
+        : 2;
+    cols = Math.min(2, count, Math.max(1, fits));
   } else if (isCompact && isLandscape) {
     // Small-tablet / narrow landscape that isn't "short" (e.g. 800×600).
     // Always at least 2 boards in a row, but otherwise use the balanced

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -168,11 +168,13 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = 2;
   }
 
-  // Floor: when containerWidth is 0 (before ResizeObserver fires), the
-  // fits-based calculation may produce cols=1 even for multi-player
-  // landscape views. Force at least 2 cols so the grid layout renders
-  // immediately instead of falling back to single-column flex.
-  if (containerWidth === 0 && count > 1 && isLandscape && cols < 2) {
+  // Floor: when containerWidth is 0 (before ResizeObserver fires) and
+  // isLandscape hasn't been set yet by its useEffect, the fits-based
+  // calculation may produce cols=1 even for multi-player non-portrait
+  // views. Force at least 2 cols so the grid layout renders immediately.
+  // Use the synchronous isMobilePortrait check (media queries + isLandscape
+  // default false) to avoid the single-column flex fallback.
+  if (containerWidth === 0 && count > 1 && !isMobilePortrait && cols < 2) {
     cols = 2;
   }
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleGrids.tsx
@@ -180,6 +180,17 @@ export function SeaBattleGrids({ children }: SeaBattleGridsProps) {
     cols = 2;
   }
 
+  // Safety floor: in landscape with multiple children, never drop to 1
+  // column. The else (desktop) branch can produce cols=1 when
+  // containerWidth is 0 (before ResizeObserver fires) because
+  // `fits || ideal` evaluates to 1 (truthy). The short branch has its
+  // own `containerWidth > 0 ? … : 2` guard, but the desktop path lacks
+  // one. This covers all stale-media-query combinations (e.g. WebKit
+  // headless where Tamagui matchMedia may not fire).
+  if (cols === 1 && count > 1 && isLandscape) {
+    cols = 2;
+  }
+
   if (cols === 1) {
     return (
       <div


### PR DESCRIPTION
## Changes
- Add maybeDecrypt to games gateway emote handler so encrypted payloads work
- Expand emotes from 6 to 16 with animated bubble and chat labels
- Float bubble from center to top with wobble animation
- Show emotes in chat log as action entries
- Add addLog method to gameChatStore