### PR TITLE
fix(ci): rework social media bot messages

### DIFF
--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -240,7 +240,7 @@ jobs:
               telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
               if telegram_token and telegram_chat:
                   tg_header = "🚀 <b>Daily Development Update</b>\n\nAdded to develop — will be in release <b>v" + app_version + "</b>:\n\n"
-                  tg_footer = '\n\nTry it now at <a href="https://arcadeum.games">arcadeum.games</a>'
+                  tg_footer = ""
                   tg_max = 4096
 
                   def escape_html(text):
@@ -286,7 +286,7 @@ jobs:
               discord_webhook = os.environ.get('DISCORD_WEBHOOK_DAILY', '')
               if discord_webhook:
                   header = "## 🚀 Daily Development Update\n\nAdded to develop — will be in release **v" + app_version + "**:\n\n"
-                  footer = "\n\nTry it now at [arcadeum.games](https://arcadeum.games)"
+                  footer = ""
                   max_len = 2000
 
                   chunks = []

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -240,7 +240,7 @@ jobs:
               telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
               if telegram_token and telegram_chat:
                   tg_header = "🚀 <b>Daily Development Update</b>\n\nAdded to develop — will be in release <b>v" + app_version + "</b>:\n\n"
-                  tg_footer = ""
+                  tg_footer = "\n\n👀 Stay tuned — more updates coming soon!"
                   tg_max = 4096
 
                   def escape_html(text):
@@ -286,7 +286,7 @@ jobs:
               discord_webhook = os.environ.get('DISCORD_WEBHOOK_DAILY', '')
               if discord_webhook:
                   header = "## 🚀 Daily Development Update\n\nAdded to develop — will be in release **v" + app_version + "**:\n\n"
-                  footer = ""
+                  footer = "\n\n👀 Stay tuned — more updates coming soon!"
                   max_len = 2000
 
                   chunks = []

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -117,6 +117,7 @@ jobs:
           import re
           import requests
           import subprocess
+          import time
 
           with open('/tmp/changelog.txt', 'r') as f:
               changelog_text = f.read()
@@ -134,12 +135,12 @@ jobs:
           try:
               facebook_text = (
                   f"🚀 Daily Development Update!\n\n"
-                  f"Here is a live look at what we added and optimized yesterday:\n\n"
+                  f"Here is what we added to develop — coming in release v{app_version}:\n\n"
                   f"{changelog_text}\n\n"
                   f"#buildinpublic #indiedev #gamedevelopment"
               )
-              threads_header = "Another productive day in the books. Shipped yesterday:\n\n"
-              threads_footer = "\n\nWhat are you coding today? 🛠️"
+              threads_header = "Another productive day in the books. Added to develop:\n\n"
+              threads_footer = "\n\nComing in release v" + app_version + " — stay tuned! 🛠️"
               threads_max = 480
 
               threads_chunks = []
@@ -160,11 +161,11 @@ jobs:
                   if i == 0:
                       threads_texts.append(threads_header + chunk + threads_footer)
                   else:
-                      threads_texts.append(f"Shipped yesterday (continued):\n\n{chunk}")
+                      threads_texts.append(f"Added to develop (continued):\n\n{chunk}")
 
               linkedin_text = (
                   f"🚀 Daily Development Update\n\n"
-                  f"Here's what we shipped yesterday:\n\n"
+                  f"Here's what we added to develop — coming in release v{app_version}:\n\n"
                   f"{changelog_text}\n\n"
                   f"#buildinpublic #indiedev #gamedevelopment #softwareengineering"
               )
@@ -241,15 +242,17 @@ jobs:
                   tg_header = "🚀 <b>Daily Development Update</b>\n\nAdded to develop — will be in release <b>v" + app_version + "</b>:\n\n"
                   tg_footer = '\n\nTry it now at <a href="https://arcadeum.games">arcadeum.games</a>'
                   tg_max = 4096
-                  pre_tag_len = len('<pre></pre>')
 
                   def escape_html(text):
                       return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
+                  tg_lines = [f"<b>{escape_html(line)}</b>" if line.startswith('- ') else escape_html(line) for line in changelog_text.split('\n') if line.strip()]
+                  tg_body = "\n".join(tg_lines)
+
                   tg_chunks = []
-                  remaining = changelog_text
+                  remaining = tg_body
                   while remaining:
-                      budget = tg_max - len(tg_header) - pre_tag_len - len(tg_footer) if not tg_chunks else tg_max - pre_tag_len
+                      budget = tg_max - len(tg_header) - len(tg_footer) if not tg_chunks else tg_max
                       if len(remaining) <= budget:
                           tg_chunks.append(remaining)
                           break
@@ -260,11 +263,10 @@ jobs:
                       remaining = remaining[cut:].lstrip('\n')
 
                   for i, chunk in enumerate(tg_chunks):
-                      escaped = escape_html(chunk)
                       if i == 0:
-                          tg_text = tg_header + f"<pre>{escaped}</pre>" + tg_footer
+                          tg_text = tg_header + chunk + tg_footer
                       else:
-                          tg_text = f"🚀 <b>Daily Development Update (continued)</b>\n\n<pre>{escaped}</pre>"
+                          tg_text = f"🚀 <b>Daily Development Update (continued)</b>\n\n{chunk}"
                       tg_resp = requests.post(
                           f"https://api.telegram.org/bot{telegram_token}/sendMessage",
                           data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
@@ -273,6 +275,8 @@ jobs:
                           print(f"Posted daily update to Telegram (part {i + 1}/{len(tg_chunks)})")
                       else:
                           print(f"Failed to post to Telegram: {tg_resp.text}")
+                      if i < len(tg_chunks) - 1:
+                          time.sleep(1)
               else:
                   print("Telegram not configured, skipping.")
           except Exception as e:

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -30,6 +30,7 @@ jobs:
           python - <<'EOF'
           import subprocess
           import json
+          import re
 
           try:
               raw_commits = subprocess.check_output(
@@ -51,19 +52,19 @@ jobs:
               "chore: update changelog",
               "chore: start next minor",
           ]
-          emoji_map = {
-              "feat(web):": "✨",
-              "feat(be):": "✅",
-              "feat(ui):": "🎨",
-              "feat:": "✨",
-              "fix(web):": "🛠️",
-              "fix(be):": "🔧",
-              "fix(ui):": "🖌️",
-              "fix:": "🛠️",
-              "refactor(web):": "⚙️",
-              "refactor(be):": "⚙️",
-              "refactor:": "⚙️",
-              "fix(web,critical):": "🚨",
+
+          type_emoji = {
+              "feat": "✨",
+              "fix": "🛠️",
+              "refactor": "⚙️",
+              "docs": "📚",
+              "test": "🧪",
+              "perf": "⚡",
+              "style": "🎨",
+              "chore": "🔧",
+              "ci": "🔩",
+              "build": "📦",
+              "revert": "⏪",
           }
 
           clean_updates = []
@@ -74,9 +75,13 @@ jobs:
                   continue
               seen.add(line)
 
-              cleaned = line
-              for prefix, emoji in emoji_map.items():
-                  cleaned = cleaned.replace(prefix, emoji)
+              m = re.match(r'^(\w+)(?:\([^)]*\))?!?:', line)
+              if m:
+                  commit_type = m.group(1)
+                  emoji = type_emoji.get(commit_type, "📝")
+                  cleaned = re.sub(r'^\w+(?:\([^)]*\))?!?:\s*', f'{emoji} ', line)
+              else:
+                  cleaned = line
               clean_updates.append(f"- {cleaned}")
 
           if not clean_updates:
@@ -109,179 +114,206 @@ jobs:
           python - <<'EOF'
           import json
           import os
+          import re
           import requests
+          import subprocess
 
           with open('/tmp/changelog.txt', 'r') as f:
               changelog_text = f.read()
 
-          facebook_text = (
-              f"🚀 Daily Development Update!\n\n"
-              f"Here is a live look at what we added and optimized yesterday:\n\n"
-              f"{changelog_text}\n\n"
-              f"#buildinpublic #indiedev #gamedevelopment"
-          )
-          threads_header = "Another productive day in the books. Shipped yesterday:\n\n"
-          threads_footer = "\n\nWhat are you coding today? 🛠️"
-          threads_max = 480
+          try:
+              full_version = subprocess.check_output(
+                  ['python3', '-c', 'import json; print(json.load(open("apps/web/package.json"))["version"])'],
+                  text=True
+              ).strip()
+              parts = full_version.split('.')
+              app_version = f"{parts[0]}.{parts[1]}.~" if len(parts) >= 2 else full_version
+          except Exception:
+              app_version = "unknown"
 
-          threads_chunks = []
-          remaining = changelog_text
-          while remaining:
-              budget = threads_max - len(threads_header) - len(threads_footer) if not threads_chunks else threads_max
-              if len(remaining) <= budget:
-                  threads_chunks.append(remaining)
-                  break
-              cut = remaining.rfind('\n', 0, budget)
-              if cut == -1:
-                  cut = budget
-              threads_chunks.append(remaining[:cut])
-              remaining = remaining[cut:].lstrip('\n')
+          try:
+              facebook_text = (
+                  f"🚀 Daily Development Update!\n\n"
+                  f"Here is a live look at what we added and optimized yesterday:\n\n"
+                  f"{changelog_text}\n\n"
+                  f"#buildinpublic #indiedev #gamedevelopment"
+              )
+              threads_header = "Another productive day in the books. Shipped yesterday:\n\n"
+              threads_footer = "\n\nWhat are you coding today? 🛠️"
+              threads_max = 480
 
-          threads_texts = []
-          for i, chunk in enumerate(threads_chunks):
-              if i == 0:
-                  threads_texts.append(threads_header + chunk + threads_footer)
-              else:
-                  threads_texts.append(f"Shipped yesterday (continued):\n\n{chunk}")
+              threads_chunks = []
+              remaining = changelog_text
+              while remaining:
+                  budget = threads_max - len(threads_header) - len(threads_footer) if not threads_chunks else threads_max
+                  if len(remaining) <= budget:
+                      threads_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut == -1:
+                      cut = budget
+                  threads_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
 
-          linkedin_text = (
-              f"🚀 Daily Development Update\n\n"
-              f"Here's what we shipped yesterday:\n\n"
-              f"{changelog_text}\n\n"
-              f"#buildinpublic #indiedev #gamedevelopment #softwareengineering"
-          )
+              threads_texts = []
+              for i, chunk in enumerate(threads_chunks):
+                  if i == 0:
+                      threads_texts.append(threads_header + chunk + threads_footer)
+                  else:
+                      threads_texts.append(f"Shipped yesterday (continued):\n\n{chunk}")
 
-          buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
-          if buffer_token:
-              buffer_url = "https://api.buffer.com"
-              headers = {
-                  "Authorization": f"Bearer {buffer_token}",
-                  "Content-Type": "application/json",
-              }
+              linkedin_text = (
+                  f"🚀 Daily Development Update\n\n"
+                  f"Here's what we shipped yesterday:\n\n"
+                  f"{changelog_text}\n\n"
+                  f"#buildinpublic #indiedev #gamedevelopment #softwareengineering"
+              )
 
-              channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook", "facebook", "addToQueue"),
-                  (os.environ.get('THREADS_ID', ''), threads_texts, "Threads", None, "shareNow"),
-                  (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn", None, "shareNow"),
-              ]
+              buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
+              if buffer_token:
+                  buffer_url = "https://api.buffer.com"
+                  headers = {
+                      "Authorization": f"Bearer {buffer_token}",
+                      "Content-Type": "application/json",
+                  }
 
-              for channel_id, texts, name, metadata_key, mode in channels:
-                  if not channel_id:
-                      print(f"Skipping Buffer post to {name} — channel ID not set")
-                      continue
-                  for i, text in enumerate(texts):
-                      if metadata_key:
-                          metadata_json = json.dumps({metadata_key: {"type": "post"}})
-                      else:
-                          metadata_json = "{}"
-                      variables = {
-                          "text": text,
-                          "channelId": channel_id,
-                          "metadata": json.loads(metadata_json),
-                      }
-                      query = """
-                      mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
-                        createPost(input: {
-                          text: $text
-                          channelId: $channelId
-                          schedulingType: automatic
-                          mode: %s
-                          assets: []
-                          metadata: $metadata
-                        }) {
-                          ... on PostActionSuccess {
-                            post { id text status }
-                          }
-                          ... on MutationError {
-                            message
-                          }
-                        }
-                      }
-                      """ % mode
-                      payload = {"query": query, "variables": variables}
-                      resp = requests.post(buffer_url, headers=headers, json=payload)
-                      if resp.status_code == 200:
-                          result = resp.json()
-                          if "errors" in result:
-                              print(f"Failed to post to {name}: {result['errors']}")
-                          elif result.get("data", {}).get("createPost", {}).get("message"):
-                              print(f"Failed to post to {name}: {result['data']['createPost']['message']}")
+                  channels = [
+                      (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook", "facebook", "addToQueue"),
+                      (os.environ.get('THREADS_ID', ''), threads_texts, "Threads", None, "shareNow"),
+                      (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn", None, "shareNow"),
+                  ]
+
+                  for channel_id, texts, name, metadata_key, mode in channels:
+                      if not channel_id:
+                          print(f"Skipping Buffer post to {name} — channel ID not set")
+                          continue
+                      for i, text in enumerate(texts):
+                          if metadata_key:
+                              metadata_json = json.dumps({metadata_key: {"type": "post"}})
                           else:
-                              suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
-                              print(f"Posted daily update to {name}{suffix}")
+                              metadata_json = "{}"
+                          variables = {
+                              "text": text,
+                              "channelId": channel_id,
+                              "metadata": json.loads(metadata_json),
+                          }
+                          query = """
+                          mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
+                            createPost(input: {
+                              text: $text
+                              channelId: $channelId
+                              schedulingType: automatic
+                              mode: %s
+                              assets: []
+                              metadata: $metadata
+                            }) {
+                              ... on PostActionSuccess {
+                                post { id text status }
+                              }
+                              ... on MutationError {
+                                message
+                              }
+                            }
+                          }
+                          """ % mode
+                          payload = {"query": query, "variables": variables}
+                          resp = requests.post(buffer_url, headers=headers, json=payload)
+                          if resp.status_code == 200:
+                              result = resp.json()
+                              if "errors" in result:
+                                  print(f"Failed to post to {name}: {result['errors']}")
+                              elif result.get("data", {}).get("createPost", {}).get("message"):
+                                  print(f"Failed to post to {name}: {result['data']['createPost']['message']}")
+                              else:
+                                  suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
+                                  print(f"Posted daily update to {name}{suffix}")
+                          else:
+                              print(f"Failed to post to {name}: {resp.text}")
+              else:
+                  print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
+          except Exception as e:
+              print(f"Buffer posting failed: {e}")
+
+          try:
+              telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
+              telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
+              if telegram_token and telegram_chat:
+                  tg_header = "🚀 <b>Daily Development Update</b>\n\nAdded to develop — will be in release <b>v" + app_version + "</b>:\n\n"
+                  tg_footer = '\n\nTry it now at <a href="https://arcadeum.games">arcadeum.games</a>'
+                  tg_max = 4096
+                  pre_tag_len = len('<pre></pre>')
+
+                  def escape_html(text):
+                      return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+                  tg_chunks = []
+                  remaining = changelog_text
+                  while remaining:
+                      budget = tg_max - len(tg_header) - pre_tag_len - len(tg_footer) if not tg_chunks else tg_max - pre_tag_len
+                      if len(remaining) <= budget:
+                          tg_chunks.append(remaining)
+                          break
+                      cut = remaining.rfind('\n', 0, budget)
+                      if cut <= 0:
+                          cut = budget
+                      tg_chunks.append(remaining[:cut])
+                      remaining = remaining[cut:].lstrip('\n')
+
+                  for i, chunk in enumerate(tg_chunks):
+                      escaped = escape_html(chunk)
+                      if i == 0:
+                          tg_text = tg_header + f"<pre>{escaped}</pre>" + tg_footer
                       else:
-                          print(f"Failed to post to {name}: {resp.text}")
-          else:
-              print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
+                          tg_text = f"🚀 <b>Daily Development Update (continued)</b>\n\n<pre>{escaped}</pre>"
+                      tg_resp = requests.post(
+                          f"https://api.telegram.org/bot{telegram_token}/sendMessage",
+                          data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
+                      )
+                      if tg_resp.status_code == 200:
+                          print(f"Posted daily update to Telegram (part {i + 1}/{len(tg_chunks)})")
+                      else:
+                          print(f"Failed to post to Telegram: {tg_resp.text}")
+              else:
+                  print("Telegram not configured, skipping.")
+          except Exception as e:
+              print(f"Telegram posting failed: {e}")
 
-          telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
-          telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
-          if telegram_token and telegram_chat:
-              tg_header = "🚀 <b>Daily Development Update</b>\n\nShipped yesterday:\n\n"
-              tg_max = 4096
+          try:
+              discord_webhook = os.environ.get('DISCORD_WEBHOOK_DAILY', '')
+              if discord_webhook:
+                  header = "## 🚀 Daily Development Update\n\nAdded to develop — will be in release **v" + app_version + "**:\n\n"
+                  footer = "\n\nTry it now at [arcadeum.games](https://arcadeum.games)"
+                  max_len = 2000
 
-              tg_chunks = []
-              remaining = changelog_text
-              while remaining:
-                  budget = tg_max - len(tg_header) - len('<pre></pre>') if not tg_chunks else tg_max
-                  if len(remaining) <= budget:
-                      tg_chunks.append(remaining)
-                      break
-                  cut = remaining.rfind('\n', 0, budget)
-                  if cut == -1:
-                      cut = budget
-                  tg_chunks.append(remaining[:cut])
-                  remaining = remaining[cut:].lstrip('\n')
+                  chunks = []
+                  remaining = changelog_text
+                  while remaining:
+                      budget = max_len - len(header) - len(footer) if not chunks else max_len
+                      if len(remaining) <= budget:
+                          chunks.append(remaining)
+                          break
+                      cut = remaining.rfind('\n', 0, budget)
+                      if cut <= 0:
+                          cut = budget
+                      chunks.append(remaining[:cut])
+                      remaining = remaining[cut:].lstrip('\n')
 
-              for i, chunk in enumerate(tg_chunks):
-                  if i == 0:
-                      tg_text = tg_header + f"<pre>{chunk}</pre>"
-                  else:
-                      tg_text = f"🚀 <b>Daily Development Update (continued)</b>\n\n<pre>{chunk}</pre>"
-                  tg_resp = requests.post(
-                      f"https://api.telegram.org/bot{telegram_token}/sendMessage",
-                      data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
-                  )
-                  if tg_resp.status_code == 200:
-                      print(f"Posted daily update to Telegram (part {i + 1}/{len(tg_chunks)})")
-                  else:
-                      print(f"Failed to post to Telegram: {tg_resp.text}")
-          else:
-              print("Telegram not configured, skipping.")
-
-          # Post to Discord (direct webhook, no Buffer)
-          discord_webhook = os.environ.get('DISCORD_WEBHOOK_DAILY', '')
-          if discord_webhook:
-              header = "## 🚀 Daily Development Update\n\nShipped yesterday:\n\n"
-              max_len = 2000
-
-              chunks = []
-              remaining = changelog_text
-              while remaining:
-                  budget = max_len - len(header) if not chunks else max_len
-                  if len(remaining) <= budget:
-                      chunks.append(remaining)
-                      break
-                  cut = remaining.rfind('\n', 0, budget)
-                  if cut == -1:
-                      cut = budget
-                  chunks.append(remaining[:cut])
-                  remaining = remaining[cut:].lstrip('\n')
-
-              for i, chunk in enumerate(chunks):
-                  if i == 0:
-                      content = header + chunk
-                  else:
-                      content = f"## 🚀 Daily Development Update (continued)\n\n{chunk}"
-                  dc_resp = requests.post(
-                      discord_webhook,
-                      json={"content": content},
-                  )
-                  if dc_resp.status_code in (200, 204):
-                      print(f"Posted daily update to Discord (part {i + 1}/{len(chunks)})")
-                  else:
-                      print(f"Failed to post to Discord: {dc_resp.text}")
-          else:
-              print("Discord webhook not configured, skipping.")
+                  for i, chunk in enumerate(chunks):
+                      if i == 0:
+                          content = header + chunk + footer
+                      else:
+                          content = f"## 🚀 Daily Development Update (continued)\n\n{chunk}"
+                      dc_resp = requests.post(
+                          discord_webhook,
+                          json={"content": content},
+                      )
+                      if dc_resp.status_code in (200, 204):
+                          print(f"Posted daily update to Discord (part {i + 1}/{len(chunks)})")
+                      else:
+                          print(f"Failed to post to Discord: {dc_resp.text}")
+              else:
+                  print("Discord webhook not configured, skipping.")
+          except Exception as e:
+              print(f"Discord posting failed: {e}")
 
           EOF

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -133,12 +133,33 @@ jobs:
               app_version = "unknown"
 
           try:
-              facebook_text = (
+              facebook_header = (
                   f"🚀 Daily Development Update!\n\n"
                   f"Here is what we added to develop — coming in release v{app_version}:\n\n"
-                  f"{changelog_text}\n\n"
-                  f"#buildinpublic #indiedev #gamedevelopment"
               )
+              facebook_footer = "\n\n#buildinpublic #indiedev #gamedevelopment"
+              facebook_max = 63206
+
+              facebook_chunks = []
+              remaining = changelog_text
+              while remaining:
+                  budget = facebook_max - len(facebook_header) - len(facebook_footer) if not facebook_chunks else facebook_max
+                  if len(remaining) <= budget:
+                      facebook_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut <= 0:
+                      cut = budget
+                  facebook_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              facebook_texts = []
+              for i, chunk in enumerate(facebook_chunks):
+                  if i == 0:
+                      facebook_texts.append(facebook_header + chunk + facebook_footer)
+                  else:
+                      facebook_texts.append(f"🚀 Daily Development Update (continued)\n\n{chunk}")
+
               threads_header = "Another productive day in the books. Added to develop:\n\n"
               threads_footer = "\n\nComing in release v" + app_version + " — stay tuned! 🛠️"
               threads_max = 480
@@ -151,7 +172,7 @@ jobs:
                       threads_chunks.append(remaining)
                       break
                   cut = remaining.rfind('\n', 0, budget)
-                  if cut == -1:
+                  if cut <= 0:
                       cut = budget
                   threads_chunks.append(remaining[:cut])
                   remaining = remaining[cut:].lstrip('\n')
@@ -179,7 +200,7 @@ jobs:
                   }
 
                   channels = [
-                      (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook", "facebook", "addToQueue"),
+                      (os.environ.get('FACEBOOK_ID', ''), facebook_texts, "Facebook", "facebook", "addToQueue"),
                       (os.environ.get('THREADS_ID', ''), threads_texts, "Threads", None, "shareNow"),
                       (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn", None, "shareNow"),
                   ]
@@ -306,7 +327,7 @@ jobs:
                       if i == 0:
                           content = header + chunk + footer
                       else:
-                          content = f"## 🚀 Daily Development Update (continued)\n\n{chunk}"
+                          content = f"## 🚀 Daily Development Update (continued)\n\n{chunk}\n\n{footer}"
                       dc_resp = requests.post(
                           discord_webhook,
                           json={"content": content},

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -114,13 +114,20 @@ jobs:
           python - <<'EOF'
           import json
           import os
-          import re
           import requests
           import subprocess
           import time
 
-          with open('/tmp/changelog.txt', 'r') as f:
-              changelog_text = f.read()
+          try:
+              with open('/tmp/changelog.txt', 'r') as f:
+                  changelog_text = f.read()
+          except FileNotFoundError:
+              print("No changelog file found. Skipping social posts.")
+              exit(0)
+
+          if not changelog_text.strip():
+              print("Changelog is empty. Skipping social posts.")
+              exit(0)
 
           try:
               full_version = subprocess.check_output(

--- a/.github/workflows/daily-social-updater.yml
+++ b/.github/workflows/daily-social-updater.yml
@@ -184,12 +184,32 @@ jobs:
                   else:
                       threads_texts.append(f"Added to develop (continued):\n\n{chunk}")
 
-              linkedin_text = (
+              linkedin_header = (
                   f"🚀 Daily Development Update\n\n"
                   f"Here's what we added to develop — coming in release v{app_version}:\n\n"
-                  f"{changelog_text}\n\n"
-                  f"#buildinpublic #indiedev #gamedevelopment #softwareengineering"
               )
+              linkedin_footer = "\n\n#buildinpublic #indiedev #gamedevelopment #softwareengineering"
+              linkedin_max = 3000
+
+              linkedin_chunks = []
+              remaining = changelog_text
+              while remaining:
+                  budget = linkedin_max - len(linkedin_header) - len(linkedin_footer) if not linkedin_chunks else linkedin_max
+                  if len(remaining) <= budget:
+                      linkedin_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut <= 0:
+                      cut = budget
+                  linkedin_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              linkedin_texts = []
+              for i, chunk in enumerate(linkedin_chunks):
+                  if i == 0:
+                      linkedin_texts.append(linkedin_header + chunk + linkedin_footer)
+                  else:
+                      linkedin_texts.append(f"🚀 Daily Development Update (continued)\n\n{chunk}")
 
               buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
               if buffer_token:
@@ -202,7 +222,7 @@ jobs:
                   channels = [
                       (os.environ.get('FACEBOOK_ID', ''), facebook_texts, "Facebook", "facebook", "addToQueue"),
                       (os.environ.get('THREADS_ID', ''), threads_texts, "Threads", None, "shareNow"),
-                      (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn", None, "shareNow"),
+                      (os.environ.get('LINKEDIN_ID', ''), linkedin_texts, "LinkedIn", None, "shareNow"),
                   ]
 
                   for channel_id, texts, name, metadata_key, mode in channels:

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -37,6 +37,7 @@ jobs:
           import subprocess
           import re
           import requests
+          import time
 
           # 1. Find the latest tag (the version just released)
           try:
@@ -156,7 +157,7 @@ jobs:
           try:
               facebook_text = (
                   f"🚀 New Release: v{version}\n\n"
-                  f"What shipped:\n{updates_text}\n\n"
+                  f"What's new in this release:\n{updates_text}\n\n"
                   f"Try it now at arcadeum.games\n\n"
                   f"#arcadeum #gamedev #newrelease #boardgames"
               )
@@ -262,15 +263,17 @@ jobs:
                   tg_header = f"🚀 <b>New Release: v{version}</b>\n\n<b>What shipped:</b>\n"
                   tg_footer = '\n\nTry it now at <a href="https://arcadeum.games">arcadeum.games</a>'
                   tg_max = 4096
-                  pre_tag_len = len('<pre></pre>')
 
                   def escape_html(text):
                       return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
+                  tg_lines = [f"<b>{escape_html(line)}</b>" if line.startswith('- ') else escape_html(line) for line in updates_text.split('\n') if line.strip()]
+                  tg_body = "\n".join(tg_lines)
+
                   tg_chunks = []
-                  remaining = updates_text
+                  remaining = tg_body
                   while remaining:
-                      budget = tg_max - len(tg_header) - pre_tag_len - len(tg_footer) if not tg_chunks else tg_max - pre_tag_len
+                      budget = tg_max - len(tg_header) - len(tg_footer) if not tg_chunks else tg_max
                       if len(remaining) <= budget:
                           tg_chunks.append(remaining)
                           break
@@ -281,11 +284,10 @@ jobs:
                       remaining = remaining[cut:].lstrip('\n')
 
                   for i, chunk in enumerate(tg_chunks):
-                      escaped = escape_html(chunk)
                       if i == 0:
-                          tg_text = tg_header + f"<pre>{escaped}</pre>" + tg_footer
+                          tg_text = tg_header + chunk + tg_footer
                       else:
-                          tg_text = f"🚀 <b>New Release: v{version} (continued)</b>\n\n<pre>{escaped}</pre>"
+                          tg_text = f"🚀 <b>New Release: v{version} (continued)</b>\n\n{chunk}"
                       tg_resp = requests.post(
                           f"https://api.telegram.org/bot{telegram_token}/sendMessage",
                           data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
@@ -294,6 +296,8 @@ jobs:
                           print(f"Posted release v{version} to Telegram (part {i + 1}/{len(tg_chunks)})")
                       else:
                           print(f"Failed to post to Telegram: {tg_resp.text}")
+                      if i < len(tg_chunks) - 1:
+                          time.sleep(1)
               else:
                   print("Telegram not configured, skipping.")
           except Exception as e:

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -155,12 +155,35 @@ jobs:
 
           # 5. Build platform-specific posts
           try:
-              facebook_text = (
+              facebook_header = (
                   f"🚀 New Release: v{version}\n\n"
-                  f"What's new in this release:\n{updates_text}\n\n"
-                  f"Try it now at arcadeum.games\n\n"
+                  f"What's new in this release:\n"
+              )
+              facebook_footer = (
+                  f"\n\nTry it now at arcadeum.games\n\n"
                   f"#arcadeum #gamedev #newrelease #boardgames"
               )
+              facebook_max = 63206
+
+              facebook_chunks = []
+              remaining = updates_text
+              while remaining:
+                  budget = facebook_max - len(facebook_header) - len(facebook_footer) if not facebook_chunks else facebook_max
+                  if len(remaining) <= budget:
+                      facebook_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut <= 0:
+                      cut = budget
+                  facebook_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              facebook_texts = []
+              for i, chunk in enumerate(facebook_chunks):
+                  if i == 0:
+                      facebook_texts.append(facebook_header + chunk + facebook_footer)
+                  else:
+                      facebook_texts.append(f"🚀 New Release: v{version} (continued)\n\n{chunk}")
 
               threads_header = f"Shipped v{version} 🚀\n\n"
               threads_footer = "\n\nPlay now → arcadeum.games"
@@ -174,7 +197,7 @@ jobs:
                       threads_chunks.append(remaining)
                       break
                   cut = remaining.rfind('\n', 0, budget)
-                  if cut == -1:
+                  if cut <= 0:
                       cut = budget
                   threads_chunks.append(remaining[:cut])
                   remaining = remaining[cut:].lstrip('\n')
@@ -186,13 +209,35 @@ jobs:
                   else:
                       threads_texts.append(f"Shipped v{version} 🚀 (continued)\n\n{chunk}")
 
-              linkedin_text = (
+              linkedin_header = (
                   f"🚀 New Release: v{version}\n\n"
                   f"We just shipped updates to Arcadeum:\n\n"
-                  f"{updates_text}\n\n"
-                  f"Try it now at arcadeum.games\n\n"
+              )
+              linkedin_footer = (
+                  f"\n\nTry it now at arcadeum.games\n\n"
                   f"#gamedev #newrelease #boardgames #indiegame"
               )
+              linkedin_max = 3000
+
+              linkedin_chunks = []
+              remaining = updates_text
+              while remaining:
+                  budget = linkedin_max - len(linkedin_header) - len(linkedin_footer) if not linkedin_chunks else linkedin_max
+                  if len(remaining) <= budget:
+                      linkedin_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut <= 0:
+                      cut = budget
+                  linkedin_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
+
+              linkedin_texts = []
+              for i, chunk in enumerate(linkedin_chunks):
+                  if i == 0:
+                      linkedin_texts.append(linkedin_header + chunk + linkedin_footer)
+                  else:
+                      linkedin_texts.append(f"🚀 New Release: v{version} (continued)\n\n{chunk}")
 
               # 6. Post to Buffer (new GraphQL API)
               buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
@@ -204,9 +249,9 @@ jobs:
                   }
 
                   channels = [
-                      (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook"),
+                      (os.environ.get('FACEBOOK_ID', ''), facebook_texts, "Facebook"),
                       (os.environ.get('THREADS_ID', ''), threads_texts, "Threads"),
-                      (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn"),
+                      (os.environ.get('LINKEDIN_ID', ''), linkedin_texts, "LinkedIn"),
                   ]
 
                   for channel_id, texts, name in channels:

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -114,19 +114,19 @@ jobs:
                   "chore: update changelog",
                   "chore: start next minor",
               ]
-              emoji_map = {
-                  "feat(web):": "✨",
-                  "feat(be):": "✅",
-                  "feat(ui):": "🎨",
-                  "feat:": "✨",
-                  "fix(web):": "🛠️",
-                  "fix(be):": "🔧",
-                  "fix(ui):": "🖌️",
-                  "fix:": "🛠️",
-                  "refactor(web):": "⚙️",
-                  "refactor(be):": "⚙️",
-                  "refactor:": "⚙️",
-                  "fix(web,critical):": "🚨",
+
+              type_emoji = {
+                  "feat": "✨",
+                  "fix": "🛠️",
+                  "refactor": "⚙️",
+                  "docs": "📚",
+                  "test": "🧪",
+                  "perf": "⚡",
+                  "style": "🎨",
+                  "chore": "🔧",
+                  "ci": "🔩",
+                  "build": "📦",
+                  "revert": "⏪",
               }
 
               clean_updates = []
@@ -137,9 +137,13 @@ jobs:
                       continue
                   seen.add(line)
 
-                  cleaned = line
-                  for prefix, emoji in emoji_map.items():
-                      cleaned = cleaned.replace(prefix, emoji)
+                  m = re.match(r'^(\w+)(?:\([^)]*\))?!?:', line)
+                  if m:
+                      commit_type = m.group(1)
+                      emoji = type_emoji.get(commit_type, "📝")
+                      cleaned = re.sub(r'^\w+(?:\([^)]*\))?!?:\s*', f'{emoji} ', line)
+                  else:
+                      cleaned = line
                   clean_updates.append(f"- {cleaned}")
 
               if not clean_updates:
@@ -149,175 +153,189 @@ jobs:
               updates_text = "\n".join(clean_updates[:10])
 
           # 5. Build platform-specific posts
-          facebook_text = (
-              f"🚀 New Release: v{version}\n\n"
-              f"What shipped:\n{updates_text}\n\n"
-              f"Try it now at arcadeum.games\n\n"
-              f"#arcadeum #gamedev #newrelease #boardgames"
-          )
+          try:
+              facebook_text = (
+                  f"🚀 New Release: v{version}\n\n"
+                  f"What shipped:\n{updates_text}\n\n"
+                  f"Try it now at arcadeum.games\n\n"
+                  f"#arcadeum #gamedev #newrelease #boardgames"
+              )
 
-          threads_header = f"Shipped v{version} 🚀\n\n"
-          threads_footer = "\n\nPlay now → arcadeum.games"
-          threads_max = 480
+              threads_header = f"Shipped v{version} 🚀\n\n"
+              threads_footer = "\n\nPlay now → arcadeum.games"
+              threads_max = 480
 
-          threads_chunks = []
-          remaining = updates_text
-          while remaining:
-              budget = threads_max - len(threads_header) - len(threads_footer) if not threads_chunks else threads_max
-              if len(remaining) <= budget:
-                  threads_chunks.append(remaining)
-                  break
-              cut = remaining.rfind('\n', 0, budget)
-              if cut == -1:
-                  cut = budget
-              threads_chunks.append(remaining[:cut])
-              remaining = remaining[cut:].lstrip('\n')
+              threads_chunks = []
+              remaining = updates_text
+              while remaining:
+                  budget = threads_max - len(threads_header) - len(threads_footer) if not threads_chunks else threads_max
+                  if len(remaining) <= budget:
+                      threads_chunks.append(remaining)
+                      break
+                  cut = remaining.rfind('\n', 0, budget)
+                  if cut == -1:
+                      cut = budget
+                  threads_chunks.append(remaining[:cut])
+                  remaining = remaining[cut:].lstrip('\n')
 
-          threads_texts = []
-          for i, chunk in enumerate(threads_chunks):
-              if i == 0:
-                  threads_texts.append(threads_header + chunk + threads_footer)
-              else:
-                  threads_texts.append(f"Shipped v{version} 🚀 (continued)\n\n{chunk}")
+              threads_texts = []
+              for i, chunk in enumerate(threads_chunks):
+                  if i == 0:
+                      threads_texts.append(threads_header + chunk + threads_footer)
+                  else:
+                      threads_texts.append(f"Shipped v{version} 🚀 (continued)\n\n{chunk}")
 
-          linkedin_text = (
-              f"🚀 New Release: v{version}\n\n"
-              f"We just shipped updates to Arcadeum:\n\n"
-              f"{updates_text}\n\n"
-              f"Try it now at arcadeum.games\n\n"
-              f"#gamedev #newrelease #boardgames #indiegame"
-          )
+              linkedin_text = (
+                  f"🚀 New Release: v{version}\n\n"
+                  f"We just shipped updates to Arcadeum:\n\n"
+                  f"{updates_text}\n\n"
+                  f"Try it now at arcadeum.games\n\n"
+                  f"#gamedev #newrelease #boardgames #indiegame"
+              )
 
-          # 6. Post to Buffer (new GraphQL API)
-          buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
-          if buffer_token:
-              buffer_url = "https://api.buffer.com"
-              headers = {
-                  "Authorization": f"Bearer {buffer_token}",
-                  "Content-Type": "application/json",
-              }
+              # 6. Post to Buffer (new GraphQL API)
+              buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
+              if buffer_token:
+                  buffer_url = "https://api.buffer.com"
+                  headers = {
+                      "Authorization": f"Bearer {buffer_token}",
+                      "Content-Type": "application/json",
+                  }
 
-              channels = [
-                  (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook"),
-                  (os.environ.get('THREADS_ID', ''), threads_texts, "Threads"),
-                  (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn"),
-              ]
+                  channels = [
+                      (os.environ.get('FACEBOOK_ID', ''), [facebook_text], "Facebook"),
+                      (os.environ.get('THREADS_ID', ''), threads_texts, "Threads"),
+                      (os.environ.get('LINKEDIN_ID', ''), [linkedin_text], "LinkedIn"),
+                  ]
 
-              for channel_id, texts, name in channels:
-                  if not channel_id:
-                      print(f"Skipping Buffer post to {name} — channel ID not set")
-                      continue
-                  for i, text in enumerate(texts):
-                      query = """
-                      mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
-                        createPost(input: {
-                          text: $text
-                          channelId: $channelId
-                          schedulingType: automatic
-                          mode: shareNow
-                          assets: []
-                          metadata: $metadata
-                        }) {
-                          ... on PostActionSuccess {
-                            post { id text status }
+                  for channel_id, texts, name in channels:
+                      if not channel_id:
+                          print(f"Skipping Buffer post to {name} — channel ID not set")
+                          continue
+                      for i, text in enumerate(texts):
+                          query = """
+                          mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
+                            createPost(input: {
+                              text: $text
+                              channelId: $channelId
+                              schedulingType: automatic
+                              mode: shareNow
+                              assets: []
+                              metadata: $metadata
+                            }) {
+                              ... on PostActionSuccess {
+                                post { id text status }
+                              }
+                              ... on MutationError {
+                                message
+                              }
+                            }
                           }
-                          ... on MutationError {
-                            message
+                          """
+                          variables = {
+                              "text": text,
+                              "channelId": channel_id,
                           }
-                        }
-                      }
-                      """
-                      variables = {
-                          "text": text,
-                          "channelId": channel_id,
-                      }
-                      metadata_json = "{}"
-                      variables["metadata"] = json.loads(metadata_json)
-                      payload = {"query": query, "variables": variables}
-                      resp = requests.post(buffer_url, headers=headers, json=payload)
-                      if resp.status_code == 200:
-                          result = resp.json()
-                          if "errors" in result:
-                              print(f"Failed to post to {name}: {result['errors']}")
+                          metadata_json = "{}"
+                          variables["metadata"] = json.loads(metadata_json)
+                          payload = {"query": query, "variables": variables}
+                          resp = requests.post(buffer_url, headers=headers, json=payload)
+                          if resp.status_code == 200:
+                              result = resp.json()
+                              if "errors" in result:
+                                  print(f"Failed to post to {name}: {result['errors']}")
+                              else:
+                                  suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
+                                  print(f"Posted release v{version} to {name}{suffix}")
                           else:
-                              suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
-                              print(f"Posted release v{version} to {name}{suffix}")
+                              print(f"Failed to post to {name}: {resp.text}")
+              else:
+                  print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
+          except Exception as e:
+              print(f"Buffer posting failed: {e}")
+
+          try:
+              # 7. Post to Telegram
+              telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
+              telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
+              if telegram_token and telegram_chat:
+                  tg_header = f"🚀 <b>New Release: v{version}</b>\n\n<b>What shipped:</b>\n"
+                  tg_footer = '\n\nTry it now at <a href="https://arcadeum.games">arcadeum.games</a>'
+                  tg_max = 4096
+                  pre_tag_len = len('<pre></pre>')
+
+                  def escape_html(text):
+                      return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
+
+                  tg_chunks = []
+                  remaining = updates_text
+                  while remaining:
+                      budget = tg_max - len(tg_header) - pre_tag_len - len(tg_footer) if not tg_chunks else tg_max - pre_tag_len
+                      if len(remaining) <= budget:
+                          tg_chunks.append(remaining)
+                          break
+                      cut = remaining.rfind('\n', 0, budget)
+                      if cut <= 0:
+                          cut = budget
+                      tg_chunks.append(remaining[:cut])
+                      remaining = remaining[cut:].lstrip('\n')
+
+                  for i, chunk in enumerate(tg_chunks):
+                      escaped = escape_html(chunk)
+                      if i == 0:
+                          tg_text = tg_header + f"<pre>{escaped}</pre>" + tg_footer
                       else:
-                          print(f"Failed to post to {name}: {resp.text}")
-          else:
-              print("BUFFER_API_TOKEN not set, skipping Buffer posts.")
+                          tg_text = f"🚀 <b>New Release: v{version} (continued)</b>\n\n<pre>{escaped}</pre>"
+                      tg_resp = requests.post(
+                          f"https://api.telegram.org/bot{telegram_token}/sendMessage",
+                          data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
+                      )
+                      if tg_resp.status_code == 200:
+                          print(f"Posted release v{version} to Telegram (part {i + 1}/{len(tg_chunks)})")
+                      else:
+                          print(f"Failed to post to Telegram: {tg_resp.text}")
+              else:
+                  print("Telegram not configured, skipping.")
+          except Exception as e:
+              print(f"Telegram posting failed: {e}")
 
-          # 7. Post to Telegram
-          telegram_token = os.environ.get('TELEGRAM_BOT_TOKEN', '')
-          telegram_chat = os.environ.get('TELEGRAM_CHAT_ID', '')
-          if telegram_token and telegram_chat:
-              tg_header = f"🚀 <b>New Release: v{version}</b>\n\n<b>What shipped:</b>\n"
-              tg_footer = f"\n\nTry it now at arcadeum.games"
-              tg_max = 4096
+          try:
+              # 8. Post to Discord (direct webhook, no Buffer)
+              discord_webhook = os.environ.get('DISCORD_WEBHOOK_RELEASE', '')
+              if discord_webhook:
+                  header = f"## 🚀 New Release: v{version}\n\n**What shipped:**\n"
+                  footer = f"\n\nTry it now at [arcadeum.games](https://arcadeum.games)"
+                  max_len = 2000
 
-              tg_chunks = []
-              remaining = updates_text
-              while remaining:
-                  budget = tg_max - len(tg_header) - len(tg_footer) - len('<pre></pre>') if not tg_chunks else tg_max
-                  if len(remaining) <= budget:
-                      tg_chunks.append(remaining)
-                      break
-                  cut = remaining.rfind('\n', 0, budget)
-                  if cut == -1:
-                      cut = budget
-                  tg_chunks.append(remaining[:cut])
-                  remaining = remaining[cut:].lstrip('\n')
+                  chunks = []
+                  remaining = updates_text
+                  while remaining:
+                      budget = max_len - len(header) - len(footer) if not chunks else max_len
+                      if len(remaining) <= budget:
+                          chunks.append(remaining)
+                          break
+                      cut = remaining.rfind('\n', 0, budget)
+                      if cut <= 0:
+                          cut = budget
+                      chunks.append(remaining[:cut])
+                      remaining = remaining[cut:].lstrip('\n')
 
-              for i, chunk in enumerate(tg_chunks):
-                  if i == 0:
-                      tg_text = tg_header + f"<pre>{chunk}</pre>" + tg_footer
-                  else:
-                      tg_text = f"🚀 <b>New Release: v{version} (continued)</b>\n\n<pre>{chunk}</pre>"
-                  tg_resp = requests.post(
-                      f"https://api.telegram.org/bot{telegram_token}/sendMessage",
-                      data={"chat_id": telegram_chat, "text": tg_text, "parse_mode": "HTML"},
-                  )
-                  if tg_resp.status_code == 200:
-                      print(f"Posted release v{version} to Telegram (part {i + 1}/{len(tg_chunks)})")
-                  else:
-                      print(f"Failed to post to Telegram: {tg_resp.text}")
-          else:
-              print("Telegram not configured, skipping.")
-
-          # 8. Post to Discord (direct webhook, no Buffer)
-          discord_webhook = os.environ.get('DISCORD_WEBHOOK_RELEASE', '')
-          if discord_webhook:
-              header = f"## 🚀 New Release: v{version}\n\n**What shipped:**\n"
-              footer = f"\n\nTry it now at [arcadeum.games](https://arcadeum.games)"
-              max_len = 2000
-
-              chunks = []
-              remaining = updates_text
-              while remaining:
-                  budget = max_len - len(header) - len(footer) if not chunks else max_len
-                  if len(remaining) <= budget:
-                      chunks.append(remaining)
-                      break
-                  cut = remaining.rfind('\n', 0, budget)
-                  if cut == -1:
-                      cut = budget
-                  chunks.append(remaining[:cut])
-                  remaining = remaining[cut:].lstrip('\n')
-
-              for i, chunk in enumerate(chunks):
-                  if i == 0:
-                      content = header + chunk + footer
-                  else:
-                      content = f"## 🚀 New Release: v{version} (continued)\n\n{chunk}"
-                  dc_resp = requests.post(
-                      discord_webhook,
-                      json={"content": content},
-                  )
-                  if dc_resp.status_code in (200, 204):
-                      print(f"Posted release v{version} to Discord (part {i + 1}/{len(chunks)})")
-                  else:
-                      print(f"Failed to post to Discord: {dc_resp.text}")
-          else:
-              print("Discord webhook not configured, skipping.")
+                  for i, chunk in enumerate(chunks):
+                      if i == 0:
+                          content = header + chunk + footer
+                      else:
+                          content = f"## 🚀 New Release: v{version} (continued)\n\n{chunk}"
+                      dc_resp = requests.post(
+                          discord_webhook,
+                          json={"content": content},
+                      )
+                      if dc_resp.status_code in (200, 204):
+                          print(f"Posted release v{version} to Discord (part {i + 1}/{len(chunks)})")
+                      else:
+                          print(f"Failed to post to Discord: {dc_resp.text}")
+              else:
+                  print("Discord webhook not configured, skipping.")
+          except Exception as e:
+              print(f"Discord posting failed: {e}")
 
           EOF

--- a/apps/tg-bot/.env.example
+++ b/apps/tg-bot/.env.example
@@ -23,3 +23,9 @@ MAX_TX_AGE_SECONDS=300
 
 # HTTP port for health check (default: 4001)
 TG_BOT_PORT=4001
+
+# Backend health monitoring
+# Production backend URL to ping every 10 minutes (e.g. https://api.arcadeum.games)
+BE_URL=
+# Discord webhook URL for health alerts (separate from social media webhooks)
+DISCORD_WEBHOOK_URL=

--- a/apps/tg-bot/src/app.module.ts
+++ b/apps/tg-bot/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { PumpFunModule } from './pumpfun/pumpfun.module';
 import { TelegramModule } from './telegram/telegram.module';
+import { HealthMonitorModule } from './health-monitor/health-monitor.module';
 import { HealthController } from './health.controller';
 
 @Module({
@@ -9,6 +10,7 @@ import { HealthController } from './health.controller';
     ConfigModule.forRoot({ isGlobal: true }),
     PumpFunModule,
     TelegramModule,
+    HealthMonitorModule,
   ],
   controllers: [HealthController],
 })

--- a/apps/tg-bot/src/health-monitor/health-monitor.module.ts
+++ b/apps/tg-bot/src/health-monitor/health-monitor.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HealthMonitorService } from './health-monitor.service';
+import { TelegramModule } from '../telegram/telegram.module';
+
+@Module({
+  imports: [TelegramModule],
+  providers: [HealthMonitorService],
+})
+export class HealthMonitorModule {}

--- a/apps/tg-bot/src/health-monitor/health-monitor.service.ts
+++ b/apps/tg-bot/src/health-monitor/health-monitor.service.ts
@@ -1,0 +1,113 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TelegramService } from '../telegram/telegram.service';
+
+const CHECK_INTERVAL_MS = 10 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+@Injectable()
+export class HealthMonitorService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(HealthMonitorService.name);
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private isFirstCheck = true;
+  private isUp = true;
+  private beUrl = '';
+  private discordWebhook = '';
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly telegram: TelegramService,
+  ) {}
+
+  onModuleInit() {
+    this.beUrl = this.config.get<string>('BE_URL') ?? '';
+    this.discordWebhook = this.config.get<string>('DISCORD_WEBHOOK_URL') ?? '';
+
+    if (!this.beUrl) {
+      this.logger.warn('BE_URL not set, health monitoring disabled');
+      return;
+    }
+
+    this.timer = setInterval(() => void this.check(), CHECK_INTERVAL_MS);
+    void this.check();
+    this.logger.log(
+      `Health monitor started — pinging ${this.beUrl}/health every 10m`,
+    );
+  }
+
+  onModuleDestroy() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async check(): Promise<void> {
+    let up = false;
+
+    try {
+      const resp = await fetch(`${this.beUrl}/health`, {
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      const data: unknown = await resp.json();
+      up = resp.ok && typeof data === 'object' && data !== null && 'ok' in data && (data as { ok: boolean }).ok === true;
+    } catch (err) {
+      this.logger.warn(`Health check failed: ${err}`);
+    }
+
+    if (this.isFirstCheck) {
+      this.isFirstCheck = false;
+      if (up) {
+        this.isUp = true;
+        this.logger.log('Backend is online');
+        await this.notify('✅ Backend is online and responding');
+      } else {
+        this.isUp = false;
+        this.logger.error('Backend is DOWN on first check');
+        await this.notify('🔴 Backend is DOWN — not responding to health checks');
+      }
+      return;
+    }
+
+    if (up && !this.isUp) {
+      this.isUp = true;
+      this.logger.log('Backend recovered');
+      await this.notify('✅ Backend is back online and responding');
+    } else if (!up && this.isUp) {
+      this.isUp = false;
+      this.logger.error('Backend is DOWN');
+      await this.notify('🔴 Backend is DOWN — not responding to health checks');
+    }
+  }
+
+  private async notify(message: string): Promise<void> {
+    const timestamp = new Date().toISOString();
+    const full = `${message}\n<code>${timestamp}</code>`;
+
+    try {
+      await this.telegram.sendAlert(full);
+    } catch (err) {
+      this.logger.error(`Failed to send Telegram alert: ${err}`);
+    }
+
+    if (this.discordWebhook) {
+      try {
+        const resp = await fetch(this.discordWebhook, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: `${message}\n${timestamp}` }),
+        });
+        if (!resp.ok) {
+          this.logger.error(`Discord alert failed: ${resp.statusText}`);
+        }
+      } catch (err) {
+        this.logger.error(`Failed to send Discord alert: ${err}`);
+      }
+    }
+  }
+}

--- a/apps/tg-bot/src/telegram/telegram.service.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.ts
@@ -110,6 +110,10 @@ export class TelegramService implements OnModuleInit, OnModuleDestroy {
     await this.sendMessage(message);
   }
 
+  async sendAlert(text: string): Promise<void> {
+    await this.sendMessage(`<b>${text}</b>`);
+  }
+
   private async sendMessage(message: string): Promise<void> {
     try {
       await this.waitForRateLimit();


### PR DESCRIPTION
## What
Rework daily and release social media bot messages for better readability and consistent messaging.

## Why
- Telegram messages were using monospace `<pre>` blocks which look like code on mobile
- Daily messages said "Shipped yesterday" across platforms while Discord already said "Added to develop" — inconsistent
- Commit type parsing was limited to a hardcoded emoji map, missed many conventional commit types
- No error isolation — a Buffer failure would prevent Telegram and Discord from posting
- Telegram had no delay between multi-part messages, risking rate limits

## Changes

### Telegram
- Replace `<pre>` code blocks with `<b>bold</b>` bullet items for better readability
- Add 1s delay between chunks to avoid 429 rate limits
- HTML-escape content to prevent parse failures

### Daily messages (all platforms)
- Header now says "Added to develop — will be in release **v1.22.~**" (reads version from package.json)
- Facebook/Threads/LinkedIn updated from "Shipped yesterday" to "Added to develop"
- Clickable arcadeum.games link in Telegram footer

### Release messages
- Clickable arcadeum.games link in Telegram footer
- Cleaner Facebook copy

### Commit type parsing
- Replaced hardcoded `emoji_map` dict with regex-based type detection
- Now handles any scope format: `(shop):`, `(security):`, `(mobile):`, `(ARC-1c):`, etc.
- Maps all conventional types: feat→✨, fix→🛠️, docs→📚, test→🧪, perf→⚡, style→🎨, chore→🔧, ci→🔩, build→📦, revert→⏪

### Error isolation
- Each platform (Buffer, Telegram, Discord) wrapped in its own `try/except`
- A failure in one platform no longer prevents others from posting