### PR TITLE
feat(admin): add game rules visibility control for lobby

### DIFF
--- a/apps/be/src/admin/admin.module.ts
+++ b/apps/be/src/admin/admin.module.ts
@@ -7,6 +7,7 @@ import { AdminController } from './admin.controller';
 import { AdminUsersController } from './admin-users.controller';
 import { AdminUsersService } from './admin-users.service';
 import { GameVisibilityModule } from './game-visibility/game-visibility.module';
+import { GameRuleVisibilityModule } from './game-visibility/game-rule-visibility.module';
 import { AdminBlockedIpsController } from './admin-blocked-ips.controller';
 import { IpBlockService } from '../common/guards/ip-block.guard';
 
@@ -15,6 +16,7 @@ import { IpBlockService } from '../common/guards/ip-block.guard';
     AuthModule,
     MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]),
     GameVisibilityModule,
+    GameRuleVisibilityModule,
   ],
   controllers: [
     AdminController,

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Put,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { JwtAuthGuard } from '../../auth/jwt/jwt.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/guards/roles.decorator';
+import { GameRuleVisibilityService } from './game-rule-visibility.service';
+import { GAME_CATALOG } from '../../games/games.catalog';
+import { IsBoolean } from 'class-validator';
+
+class SetRuleDto {
+  @IsBoolean()
+  enabled!: boolean;
+}
+
+class BulkSetRulesDto {
+  rules!: Array<{ ruleId: string; enabled: boolean }>;
+}
+
+@Controller('admin/game-rules')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin')
+export class GameRuleVisibilityController {
+  constructor(private readonly ruleVisibility: GameRuleVisibilityService) {}
+
+  @Get()
+  async getAllRules() {
+    const allRules = await this.ruleVisibility.getAllRules();
+    const result: Record<
+      string,
+      Array<{ ruleId: string; label: string; enabled: boolean }>
+    > = {};
+
+    for (const entry of GAME_CATALOG) {
+      if (entry.rules.length === 0) continue;
+      const ruleMap = allRules.get(entry.gameId) ?? new Map<string, boolean>();
+      result[entry.gameId] = entry.rules.map((r) => ({
+        ruleId: r.ruleId,
+        label: r.label,
+        enabled: ruleMap.get(r.ruleId) ?? true,
+      }));
+    }
+
+    return result;
+  }
+
+  @Put(':gameId/:ruleId')
+  async setRule(
+    @Param('gameId') gameId: string,
+    @Param('ruleId') ruleId: string,
+    @Body() dto: SetRuleDto,
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as { userId: string })?.userId;
+    await this.ruleVisibility.setRuleEnabled(
+      gameId,
+      ruleId,
+      dto.enabled,
+      userId,
+    );
+    return { success: true };
+  }
+
+  @Put(':gameId')
+  async bulkSetRules(
+    @Param('gameId') gameId: string,
+    @Body() dto: BulkSetRulesDto,
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as { userId: string })?.userId;
+    await this.ruleVisibility.setAllRulesForGame(gameId, dto.rules, userId);
+    return { success: true };
+  }
+}

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.module.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import {
+  GameRuleVisibility,
+  GameRuleVisibilitySchema,
+} from './game-rule-visibility.schema';
+import { GameRuleVisibilityService } from './game-rule-visibility.service';
+import { GameRuleVisibilityController } from './game-rule-visibility.controller';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      {
+        name: GameRuleVisibility.name,
+        schema: GameRuleVisibilitySchema,
+      },
+    ]),
+  ],
+  controllers: [GameRuleVisibilityController],
+  providers: [GameRuleVisibilityService],
+  exports: [GameRuleVisibilityService],
+})
+export class GameRuleVisibilityModule {}

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.module.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.module.ts
@@ -1,5 +1,8 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import { AuthModule } from '../../auth/auth.module';
+import { User, UserSchema } from '../../auth/schemas/user.schema';
+import { RolesGuard } from '../../auth/guards/roles.guard';
 import {
   GameRuleVisibility,
   GameRuleVisibilitySchema,
@@ -9,15 +12,14 @@ import { GameRuleVisibilityController } from './game-rule-visibility.controller'
 
 @Module({
   imports: [
+    AuthModule,
     MongooseModule.forFeature([
-      {
-        name: GameRuleVisibility.name,
-        schema: GameRuleVisibilitySchema,
-      },
+      { name: GameRuleVisibility.name, schema: GameRuleVisibilitySchema },
+      { name: User.name, schema: UserSchema },
     ]),
   ],
   controllers: [GameRuleVisibilityController],
-  providers: [GameRuleVisibilityService],
+  providers: [GameRuleVisibilityService, RolesGuard],
   exports: [GameRuleVisibilityService],
 })
 export class GameRuleVisibilityModule {}

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.schema.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.schema.ts
@@ -1,0 +1,24 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true, collection: 'game_rule_visibility' })
+export class GameRuleVisibility extends Document {
+  declare _id: Types.ObjectId;
+
+  @Prop({ required: true, trim: true, index: true })
+  gameId!: string;
+
+  @Prop({ required: true, trim: true })
+  ruleId!: string;
+
+  @Prop({ required: true, default: true })
+  enabled!: boolean;
+
+  @Prop({ required: true, trim: true })
+  updatedBy!: string;
+}
+
+export type GameRuleVisibilityDocument = GameRuleVisibility;
+export const GameRuleVisibilitySchema =
+  SchemaFactory.createForClass(GameRuleVisibility);
+GameRuleVisibilitySchema.index({ gameId: 1, ruleId: 1 }, { unique: true });

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.service.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.service.ts
@@ -1,0 +1,77 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import {
+  GameRuleVisibility,
+  type GameRuleVisibilityDocument,
+} from './game-rule-visibility.schema';
+
+export interface RuleAvailability {
+  ruleId: string;
+  enabled: boolean;
+}
+
+@Injectable()
+export class GameRuleVisibilityService {
+  private readonly logger = new Logger(GameRuleVisibilityService.name);
+
+  constructor(
+    @InjectModel(GameRuleVisibility.name)
+    private readonly model: Model<GameRuleVisibilityDocument>,
+  ) {}
+
+  async getRulesForGame(gameId: string): Promise<Map<string, boolean>> {
+    const rows = await this.model.find({ gameId }).exec();
+    const map = new Map<string, boolean>();
+    for (const row of rows) {
+      map.set(row.ruleId, row.enabled);
+    }
+    return map;
+  }
+
+  async getAllRules(): Promise<Map<string, Map<string, boolean>>> {
+    const rows = await this.model.find().exec();
+    const result = new Map<string, Map<string, boolean>>();
+    for (const row of rows) {
+      if (!result.has(row.gameId)) {
+        result.set(row.gameId, new Map());
+      }
+      result.get(row.gameId)!.set(row.ruleId, row.enabled);
+    }
+    return result;
+  }
+
+  async setRuleEnabled(
+    gameId: string,
+    ruleId: string,
+    enabled: boolean,
+    updatedBy: string,
+  ): Promise<void> {
+    await this.model.findOneAndUpdate(
+      { gameId, ruleId },
+      { enabled, updatedBy },
+      { upsert: true },
+    );
+    this.logger.log(
+      `Rule ${ruleId} for ${gameId} set to ${enabled ? 'enabled' : 'disabled'} by ${updatedBy}`,
+    );
+  }
+
+  async setAllRulesForGame(
+    gameId: string,
+    rules: Array<{ ruleId: string; enabled: boolean }>,
+    updatedBy: string,
+  ): Promise<void> {
+    const ops = rules.map((r) =>
+      this.model.findOneAndUpdate(
+        { gameId, ruleId: r.ruleId },
+        { enabled: r.enabled, updatedBy },
+        { upsert: true },
+      ),
+    );
+    await Promise.all(ops);
+    this.logger.log(
+      `Bulk updated ${rules.length} rules for ${gameId} by ${updatedBy}`,
+    );
+  }
+}

--- a/apps/be/src/games/games.catalog-endpoint.spec.ts
+++ b/apps/be/src/games/games.catalog-endpoint.spec.ts
@@ -4,6 +4,7 @@ import { GamesService } from './games.service';
 import { CriticalService } from './critical/critical.service';
 import { TexasHoldemService } from './texas-holdem/texas-holdem.service';
 import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
+import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
 import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
 
 function reqWithUser(userId: string | undefined): Request {
@@ -11,6 +12,10 @@ function reqWithUser(userId: string | undefined): Request {
     ? { user: { userId } }
     : { user: undefined }) as unknown as Request;
 }
+
+const ruleVis = {
+  getAllRules: jest.fn().mockResolvedValue(new Map()),
+} as unknown as GameRuleVisibilityService;
 
 function buildController(
   visibility: GameVisibilityService,
@@ -21,6 +26,7 @@ function buildController(
     {} as unknown as CriticalService,
     {} as unknown as TexasHoldemService,
     visibility,
+    ruleVis,
     resolver,
   );
 }
@@ -96,6 +102,10 @@ describe('GamesController.getCatalog', () => {
       gameId: 'glimworm_v1',
       comingSoon: true,
       variants: [],
+      rules: [
+        { ruleId: 'idle', comingSoon: true },
+        { ruleId: 'spectators', comingSoon: true },
+      ],
     });
   });
 
@@ -235,6 +245,11 @@ describe('getCatalog (comingSoon + new tiers)', () => {
         gameId: 'critical_v1',
         comingSoon: true,
         variants: [],
+        rules: [
+          { ruleId: 'combos', comingSoon: true },
+          { ruleId: 'idle', comingSoon: true },
+          { ruleId: 'spectators', comingSoon: true },
+        ],
       });
     }
   });

--- a/apps/be/src/games/games.catalog.ts
+++ b/apps/be/src/games/games.catalog.ts
@@ -1,6 +1,12 @@
+export interface GameCatalogRule {
+  ruleId: string;
+  label: string;
+}
+
 export interface GameCatalogEntry {
   gameId: string;
   variants: ReadonlyArray<string>;
+  rules: ReadonlyArray<GameCatalogRule>;
 }
 
 export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
@@ -21,6 +27,11 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       'zen',
       'random',
     ],
+    rules: [
+      { ruleId: 'combos', label: 'Action card combos' },
+      { ruleId: 'idle', label: 'Idle timer autoplay' },
+      { ruleId: 'spectators', label: 'Allow spectators' },
+    ],
   },
   {
     gameId: 'sea_battle_v1',
@@ -39,15 +50,32 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       'battle_royale',
       'team_2v2',
     ],
+    rules: [
+      { ruleId: 'idle', label: 'Idle timer autoplay' },
+      { ruleId: 'teams', label: 'Team mode' },
+      { ruleId: 'spectators', label: 'Allow spectators' },
+    ],
   },
-  { gameId: 'texas_holdem_v1', variants: [] },
+  {
+    gameId: 'texas_holdem_v1',
+    variants: [],
+    rules: [],
+  },
   {
     gameId: 'glimworm_v1',
     variants: ['battle_royale', 'time_attack', 'lives_heats'],
+    rules: [
+      { ruleId: 'idle', label: 'Idle timer autoplay' },
+      { ruleId: 'spectators', label: 'Allow spectators' },
+    ],
   },
   {
     gameId: 'tic_tac_toe_v1',
     variants: ['classic', 'neon', 'paper', 'pixel', 'chalkboard', 'retro'],
+    rules: [
+      { ruleId: 'teams', label: 'Team mode' },
+      { ruleId: 'spectators', label: 'Allow spectators' },
+    ],
   },
   {
     // Cascade's `variants` list is the union of visual themes AND gameplay
@@ -67,6 +95,10 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       'steampunk',
       'pure',
       'speed',
+    ],
+    rules: [
+      { ruleId: 'idle', label: 'Idle timer autoplay' },
+      { ruleId: 'spectators', label: 'Allow spectators' },
     ],
   },
 ];

--- a/apps/be/src/games/games.controller.ts
+++ b/apps/be/src/games/games.controller.ts
@@ -37,6 +37,7 @@ import {
 import { CriticalService } from './critical/critical.service';
 import { TexasHoldemService } from './texas-holdem/texas-holdem.service';
 import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
+import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
 import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
 import { GAME_CATALOG } from './games.catalog';
 import { extractVariantFromOptions } from './game-options';
@@ -48,6 +49,7 @@ export class GamesController {
     private readonly criticalService: CriticalService,
     private readonly texasHoldemService: TexasHoldemService,
     private readonly visibility: GameVisibilityService,
+    private readonly ruleVisibility: GameRuleVisibilityService,
     private readonly roleResolver: UserRoleResolver,
   ) {}
 
@@ -56,15 +58,19 @@ export class GamesController {
   async getCatalog(@Req() req: Request): Promise<CatalogResponse> {
     const user = req.user as AuthenticatedUser | undefined | null;
     const role = await this.roleResolver.resolveRole(user?.userId);
+    const allRuleMaps = await this.ruleVisibility.getAllRules();
     const games: CatalogGame[] = [];
     for (const entry of GAME_CATALOG) {
       const visible = await this.visibility.canSee(role, entry.gameId);
       if (!visible) {
-        // Game restricted for this caller — include as coming-soon, no variants surfaced
         games.push({
           gameId: entry.gameId,
           comingSoon: true,
           variants: [],
+          rules: entry.rules.map((r) => ({
+            ruleId: r.ruleId,
+            comingSoon: true,
+          })),
         });
         continue;
       }
@@ -75,10 +81,17 @@ export class GamesController {
         variants.push({ id: v, comingSoon: !visible });
       }
 
+      const ruleMap = allRuleMaps.get(entry.gameId);
+      const rules = entry.rules.map((r) => ({
+        ruleId: r.ruleId,
+        comingSoon: ruleMap ? !ruleMap.get(r.ruleId) : false,
+      }));
+
       games.push({
         gameId: entry.gameId,
         comingSoon: false,
         variants,
+        rules,
       });
     }
     return { games };

--- a/apps/be/src/games/games.controller.visibility.spec.ts
+++ b/apps/be/src/games/games.controller.visibility.spec.ts
@@ -4,9 +4,14 @@ import { GamesService } from './games.service';
 import { CriticalService } from './critical/critical.service';
 import { TexasHoldemService } from './texas-holdem/texas-holdem.service';
 import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
+import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
 import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
 import { CreateGameRoomDto } from './dtos/create-game-room.dto';
 import { QuickplayGameDto } from './dtos/quickplay-game.dto';
+
+const ruleVis = {
+  getAllRules: jest.fn().mockResolvedValue(new Map()),
+} as unknown as GameRuleVisibilityService;
 
 function buildController(
   games: GamesService,
@@ -18,6 +23,7 @@ function buildController(
     {} as unknown as CriticalService,
     {} as unknown as TexasHoldemService,
     vis,
+    ruleVis,
     resolver,
   );
 }

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -21,7 +21,6 @@ import {
 import { corsOriginMatcher } from '../common/utils/cors.util';
 import { verifySocketJwt } from '../common/utils/socket-jwt.util';
 import { handleEmote } from './games.gateway.emote';
-
 @WebSocketGateway({
   namespace: 'games',
   cors: { origin: corsOriginMatcher },
@@ -55,7 +54,7 @@ export class GamesGateway {
 
   async handleConnection(client: Socket): Promise<void> {
     this.logger.verbose(`Client connected ${client.id}`);
-  // Verify JWT if present (optional — guest mode allowed without token)
+    // Verify JWT if present (optional — guest mode allowed without token)
     const authUserId = await verifySocketJwt(
       client,
       this.jwt,

--- a/apps/be/src/games/games.module.ts
+++ b/apps/be/src/games/games.module.ts
@@ -57,6 +57,7 @@ import { LeaderboardsModule } from '../leaderboards/leaderboards.module';
 import { WalletModule } from '../wallet/wallet.module';
 import { EconomyModule } from '../economy/economy.module';
 import { GameVisibilityModule } from '../admin/game-visibility/game-visibility.module';
+import { GameRuleVisibilityModule } from '../admin/game-visibility/game-rule-visibility.module';
 import { resolveJwtSecret } from '../common/utils/jwt-secret.util';
 // Note: GamesModule ↔ LeaderboardsModule is a circular dep
 // (LeaderboardsService.markInMatch is called from GamesService when matches
@@ -84,6 +85,7 @@ import { resolveJwtSecret } from '../common/utils/jwt-secret.util';
     WalletModule,
     EconomyModule,
     GameVisibilityModule,
+    GameRuleVisibilityModule,
     DailyChallengesModule,
     AchievementsModule,
   ],

--- a/apps/be/src/games/games.types.ts
+++ b/apps/be/src/games/games.types.ts
@@ -68,10 +68,16 @@ export interface CatalogVariant {
   comingSoon: boolean;
 }
 
+export interface CatalogRule {
+  ruleId: string;
+  comingSoon: boolean;
+}
+
 export interface CatalogGame {
   gameId: string;
   comingSoon: boolean;
   variants: CatalogVariant[];
+  rules: CatalogRule[];
 }
 
 export interface CatalogResponse {

--- a/apps/web/src/app/[locale]/admin/AdminLayoutShell.tsx
+++ b/apps/web/src/app/[locale]/admin/AdminLayoutShell.tsx
@@ -18,6 +18,7 @@ interface AdminNavTranslations {
   economy?: string;
   shop?: string;
   games?: string;
+  gameRules?: string;
   blockedIps?: string;
   comingSoon?: string;
 }
@@ -50,6 +51,7 @@ export default async function AdminLayoutShell({
       economy: navT?.economy,
       shop: navT?.shop,
       games: navT?.games,
+      gameRules: navT?.gameRules,
       blockedIps: navT?.blockedIps,
     },
     comingSoon: navT?.comingSoon ?? 'Coming soon',

--- a/apps/web/src/app/[locale]/admin/_components/sidebarItems.ts
+++ b/apps/web/src/app/[locale]/admin/_components/sidebarItems.ts
@@ -8,6 +8,7 @@ export interface AdminSidebarItem {
     | 'economy'
     | 'shop'
     | 'games'
+    | 'gameRules'
     | 'bulkRewards'
     | 'blockedIps';
   href: string | null;
@@ -23,6 +24,7 @@ export const ADMIN_SIDEBAR_ITEMS: readonly AdminSidebarItem[] = [
   { id: 'economy', href: '/admin/economy', enabled: true },
   { id: 'shop', href: '/admin/shop', enabled: true },
   { id: 'games', href: '/admin/games', enabled: true },
+  { id: 'gameRules', href: '/admin/game-rules', enabled: true },
   { id: 'bulkRewards', href: '/admin/bulk-rewards', enabled: true },
   { id: 'blockedIps', href: '/admin/blocked-ips', enabled: true },
 ];

--- a/apps/web/src/app/[locale]/admin/game-rules/page.tsx
+++ b/apps/web/src/app/[locale]/admin/game-rules/page.tsx
@@ -1,0 +1,52 @@
+import { Suspense } from 'react';
+import { requireAdmin } from '@/entities/session/api/requireAdmin';
+import { AdminGameRulesTable } from '@/features/admin-games/ui/AdminGameRulesTable';
+
+export default async function AdminGameRulesPage() {
+  await requireAdmin();
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        maxWidth: '1200px',
+        minWidth: 0,
+        margin: '0 auto',
+        padding: '32px 16px',
+      }}
+    >
+      <div style={{ marginBottom: '24px' }}>
+        <h1
+          style={{
+            fontSize: '24px',
+            fontWeight: 700,
+            color: 'var(--color-text, #e4e4e7)',
+            marginBottom: '4px',
+          }}
+        >
+          Game Rules Visibility
+        </h1>
+        <p style={{ fontSize: '14px', color: '#71717a' }}>
+          Include or exclude house rules per game. Excluded rules show
+          &quot;Coming Soon&quot; in the lobby.
+        </p>
+      </div>
+
+      <Suspense
+        fallback={
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '48px 16px',
+              color: '#71717a',
+            }}
+          >
+            Loading...
+          </div>
+        }
+      >
+        <AdminGameRulesTable />
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/features/admin-games/ui/AdminGameRulesTable.tsx
+++ b/apps/web/src/features/admin-games/ui/AdminGameRulesTable.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiClient } from '@/shared/lib/api-client';
+
+interface RuleItem {
+  ruleId: string;
+  label: string;
+  enabled: boolean;
+}
+
+type RulesByGame = Record<string, RuleItem[]>;
+
+export function AdminGameRulesTable() {
+  const [rules, setRules] = useState<RulesByGame | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiClient
+      .get<RulesByGame>('/admin/game-rules')
+      .then((data) => {
+        setRules(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  const toggleRule = useCallback(
+    async (gameId: string, ruleId: string, enabled: boolean) => {
+      setSaving(`${gameId}::${ruleId}`);
+      try {
+        await apiClient.put(`/admin/game-rules/${gameId}/${ruleId}`, {
+          enabled,
+        });
+        setRules((prev) => {
+          if (!prev) return prev;
+          const updated = { ...prev };
+          updated[gameId] = updated[gameId].map((r) =>
+            r.ruleId === ruleId ? { ...r, enabled } : r,
+          );
+          return updated;
+        });
+      } catch {
+        // revert on error
+      } finally {
+        setSaving(null);
+      }
+    },
+    [],
+  );
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: '48px', color: '#71717a' }}>
+        Loading...
+      </div>
+    );
+  }
+
+  if (!rules || Object.keys(rules).length === 0) {
+    return (
+      <div style={{ textAlign: 'center', padding: '48px', color: '#71717a' }}>
+        No games with configurable rules found.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+        marginTop: '16px',
+      }}
+    >
+      {Object.entries(rules).map(([gameId, gameRules]) => (
+        <div
+          key={gameId}
+          style={{
+            background: 'var(--color-card, #1c1c1e)',
+            borderRadius: '12px',
+            border: '1px solid rgba(255,255,255,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              padding: '16px 20px',
+              borderBottom: '1px solid rgba(255,255,255,0.08)',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <h3
+              style={{
+                fontSize: '16px',
+                fontWeight: 600,
+                color: 'var(--color-text, #e4e4e7)',
+                margin: 0,
+              }}
+            >
+              {gameId.replace('_v1', '').replace(/_/g, ' ')}
+            </h3>
+            <span
+              style={{
+                fontSize: '12px',
+                color: '#71717a',
+              }}
+            >
+              {gameRules.filter((r) => r.enabled).length}/{gameRules.length}{' '}
+              enabled
+            </span>
+          </div>
+          <div style={{ padding: '8px 0' }}>
+            {gameRules.map((rule) => {
+              const isSaving = saving === `${gameId}::${rule.ruleId}`;
+              return (
+                <div
+                  key={rule.ruleId}
+                  style={{
+                    padding: '12px 20px',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    borderBottom: '1px solid rgba(255,255,255,0.04)',
+                  }}
+                >
+                  <div>
+                    <div
+                      style={{
+                        fontSize: '14px',
+                        fontWeight: 500,
+                        color: rule.enabled
+                          ? 'var(--color-text, #e4e4e7)'
+                          : '#71717a',
+                      }}
+                    >
+                      {rule.label}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: '12px',
+                        color: '#52525b',
+                        marginTop: '2px',
+                      }}
+                    >
+                      {rule.ruleId}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={isSaving}
+                    onClick={() =>
+                      toggleRule(gameId, rule.ruleId, !rule.enabled)
+                    }
+                    style={{
+                      padding: '6px 16px',
+                      borderRadius: '8px',
+                      fontSize: '13px',
+                      fontWeight: 600,
+                      cursor: isSaving ? 'not-allowed' : 'pointer',
+                      opacity: isSaving ? 0.6 : 1,
+                      border: '1px solid',
+                      borderColor: rule.enabled
+                        ? 'rgba(239,68,68,0.4)'
+                        : 'rgba(34,197,94,0.4)',
+                      background: rule.enabled
+                        ? 'rgba(239,68,68,0.1)'
+                        : 'rgba(34,197,94,0.1)',
+                      color: rule.enabled ? '#f87171' : '#4ade80',
+                      transition: 'all 0.15s ease',
+                    }}
+                  >
+                    {rule.enabled ? 'Exclude' : 'Include'}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/features/games/api.ts
+++ b/apps/web/src/features/games/api.ts
@@ -11,10 +11,16 @@ export interface CatalogVariant {
   comingSoon: boolean;
 }
 
+export interface CatalogRule {
+  ruleId: string;
+  comingSoon: boolean;
+}
+
 export interface CatalogGame {
   gameId: string;
   comingSoon: boolean;
   variants: CatalogVariant[];
+  rules: CatalogRule[];
 }
 
 export interface CatalogResponse {

--- a/apps/web/src/features/games/ui/create/createPageState.ts
+++ b/apps/web/src/features/games/ui/create/createPageState.ts
@@ -1,21 +1,24 @@
 import type { CatalogResponse } from '@/features/games/api';
 
 /**
- * Builds two look-up maps from a catalog response:
+ * Builds look-up maps from a catalog response:
  * - gameComingSoon: gameId → boolean
  * - variantComingSoon: "gameId::variantId" → boolean
+ * - ruleComingSoon: "gameId::ruleId" → boolean
  *
  * Returns empty maps when catalog is null (fetch not yet complete or failed).
  */
 export function buildComingSoonMaps(catalog: CatalogResponse | null): {
   gameComingSoon: Map<string, boolean>;
   variantComingSoon: Map<string, boolean>;
+  ruleComingSoon: Map<string, boolean>;
 } {
   const gameComingSoon = new Map<string, boolean>();
   const variantComingSoon = new Map<string, boolean>();
+  const ruleComingSoon = new Map<string, boolean>();
 
   if (!catalog || !Array.isArray(catalog.games)) {
-    return { gameComingSoon, variantComingSoon };
+    return { gameComingSoon, variantComingSoon, ruleComingSoon };
   }
 
   for (const g of catalog.games) {
@@ -25,9 +28,14 @@ export function buildComingSoonMaps(catalog: CatalogResponse | null): {
         variantComingSoon.set(`${g.gameId}::${v.id}`, v.comingSoon);
       }
     }
+    if (Array.isArray(g.rules)) {
+      for (const r of g.rules) {
+        ruleComingSoon.set(`${g.gameId}::${r.ruleId}`, r.comingSoon);
+      }
+    }
   }
 
-  return { gameComingSoon, variantComingSoon };
+  return { gameComingSoon, variantComingSoon, ruleComingSoon };
 }
 
 /**

--- a/apps/web/src/features/games/ui/create/redesign/GameCreateView.module.scss
+++ b/apps/web/src/features/games/ui/create/redesign/GameCreateView.module.scss
@@ -816,6 +816,39 @@
   line-height: 1.45;
 }
 
+.ruleComingSoon {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.comingSoonBadge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+.comingSoonTag {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
 .toggle {
   width: 40px;
   height: 22px;

--- a/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
@@ -22,6 +22,7 @@ import { QuickPresets } from './QuickPresets';
 import { GamePicker } from './GamePicker';
 import { ExpansionPacks } from './ExpansionPacks';
 import { RoomDetails } from './RoomDetails';
+import { HouseRules } from './HouseRules';
 import { PreviewRail } from './PreviewRail';
 import { GAMES, VISIBLE_GAMES, themesFor, type GameId } from './data/themes';
 import { applyPreset } from './data/presets';
@@ -209,7 +210,7 @@ export function GameCreateView() {
       cancelled = true;
     };
   }, []);
-  const { gameComingSoon, variantComingSoon } = useMemo(
+  const { gameComingSoon, variantComingSoon, ruleComingSoon } = useMemo(
     () => buildComingSoonMaps(catalog),
     [catalog],
   );
@@ -278,6 +279,7 @@ export function GameCreateView() {
   let n = 1;
   const numGame = String(n++).padStart(2, '0');
   const numExpansion = game.hasExpansion ? String(n++).padStart(2, '0') : null;
+  const numRules = String(n++).padStart(2, '0');
   const numDetails = String(n++).padStart(2, '0');
 
   return (
@@ -334,6 +336,18 @@ export function GameCreateView() {
                     />
                   </SectionGroup>
                 ) : null}
+
+                <SectionGroup num={numRules} title={L.sectionRules}>
+                  <HouseRules
+                    gameId={form.gameId}
+                    value={form.rules}
+                    labels={L.rules}
+                    ruleComingSoon={ruleComingSoon}
+                    onChange={(rules) =>
+                      setForm((prev) => ({ ...prev, rules }))
+                    }
+                  />
+                </SectionGroup>
 
                 <SectionGroup num={numDetails} title={L.sectionDetails}>
                   <RoomDetails

--- a/apps/web/src/features/games/ui/create/redesign/HouseRules.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/HouseRules.tsx
@@ -14,11 +14,17 @@ interface Props {
   value: CreateRoomForm['rules'];
   labels: Record<RuleKey, RuleLabels>;
   onChange: (rules: CreateRoomForm['rules']) => void;
+  ruleComingSoon?: Map<string, boolean>;
 }
 
-export function HouseRules({ gameId, value, labels, onChange }: Props) {
+export function HouseRules({
+  gameId,
+  value,
+  labels,
+  onChange,
+  ruleComingSoon,
+}: Props) {
   const game = GAMES[gameId];
-  // Compose ordered list of visible rule keys for this game.
   const ruleIds: RuleKey[] = [];
   if (game.rules.includes('combos')) ruleIds.push('combos');
   ruleIds.push('idle');
@@ -33,24 +39,38 @@ export function HouseRules({ gameId, value, labels, onChange }: Props) {
     <div className={s.rules} data-testid="house-rules">
       {ruleIds.map((key) => {
         const on = value[key];
+        const isComingSoon = ruleComingSoon?.get(`${gameId}::${key}`) ?? false;
         return (
-          <div key={key} className={s.rule}>
+          <div
+            key={key}
+            className={`${s.rule} ${isComingSoon ? s.ruleComingSoon : ''}`}
+            data-testid={`rule-${key}`}
+          >
             <div className={s.ruleHead}>
               <div>
-                <h3 className={s.ruleTitle}>{labels[key].title}</h3>
+                <h3 className={s.ruleTitle}>
+                  {labels[key].title}
+                  {isComingSoon && (
+                    <span className={s.comingSoonBadge}>Coming Soon</span>
+                  )}
+                </h3>
                 <p className={s.ruleDesc}>{labels[key].desc}</p>
               </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={on}
-                aria-label={labels[key].title}
-                data-testid={`rule-toggle-${key}`}
-                className={`${s.toggle} ${on ? s.toggleOn : ''}`}
-                onClick={() => toggle(key)}
-              >
-                <span className={s.toggleHandle} />
-              </button>
+              {isComingSoon ? (
+                <span className={s.comingSoonTag}>Coming Soon</span>
+              ) : (
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={on}
+                  aria-label={labels[key].title}
+                  data-testid={`rule-toggle-${key}`}
+                  className={`${s.toggle} ${on ? s.toggleOn : ''}`}
+                  onClick={() => toggle(key)}
+                >
+                  <span className={s.toggleHandle} />
+                </button>
+              )}
             </div>
           </div>
         );

--- a/apps/web/src/shared/i18n/messages/pages/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/by.ts
@@ -33,6 +33,7 @@ export const by = {
       economy: 'Эканоміка',
       shop: 'Крама',
       games: 'Гульні',
+      gameRules: 'Правы гульняў',
       bulkRewards: 'Масавыя Ўзнагароды',
       blockedIps: 'Заблакіраваныя IP',
       comingSoon: 'Хутка',

--- a/apps/web/src/shared/i18n/messages/pages/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/en.ts
@@ -33,6 +33,7 @@ export const en = {
       economy: 'Economy',
       shop: 'Shop',
       games: 'Games',
+      gameRules: 'Game Rules',
       bulkRewards: 'Bulk Rewards',
       blockedIps: 'Blocked IPs',
       comingSoon: 'Coming soon',

--- a/apps/web/src/shared/i18n/messages/pages/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/es.ts
@@ -33,6 +33,7 @@ export const es = {
       economy: 'Economía',
       shop: 'Tienda',
       games: 'Juegos',
+      gameRules: 'Reglas del Juego',
       bulkRewards: 'Recompensas Masivas',
       blockedIps: 'IPs Bloqueados',
       comingSoon: 'Próximamente',

--- a/apps/web/src/shared/i18n/messages/pages/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/fr.ts
@@ -32,6 +32,7 @@ export const fr = {
       economy: 'Économie',
       shop: 'Boutique',
       games: 'Jeux',
+      gameRules: 'Règles du Jeu',
       bulkRewards: 'Récompenses en Masse',
       blockedIps: 'IPs Bloqués',
       comingSoon: 'Bientôt',

--- a/apps/web/src/shared/i18n/messages/pages/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/ru.ts
@@ -32,6 +32,7 @@ export const ru = {
       economy: 'Экономика',
       shop: 'Магазин',
       games: 'Игры',
+      gameRules: 'Правила игр',
       bulkRewards: 'Массовые Награды',
       blockedIps: 'Заблокированные IP',
       comingSoon: 'Скоро',


### PR DESCRIPTION
## What
Add admin ability to include/exclude house rules and settings per game, showing "Coming Soon" for excluded rules in the lobby.

## Why
Admins need granular control over which rules are available in the room creation flow. Excluded rules should show as "Coming Soon" rather than being hidden entirely.

## Changes
- **Backend**: New `GameRuleVisibility` schema, service, and admin controller (`/admin/game-rules`)
- **Backend**: Extended `GameCatalogEntry` with `rules` per game, catalog endpoint returns `ruleComingSoon` flags
- **Frontend**: `HouseRules` component now accepts `ruleComingSoon` map, shows "Coming Soon" badge for disabled rules
- **Frontend**: New admin page at `/admin/game-rules` with toggle UI for each rule per game
- **Frontend**: Added sidebar nav item and i18n keys in all 5 locales

## Test plan
- [ ] Admin can toggle rules at `/admin/game-rules`
- [ ] Disabled rules show "Coming Soon" in lobby creation flow
- [ ] Enabled rules work normally with toggle switches
- [ ] Catalog endpoint returns correct `ruleComingSoon` flags