### PR TITLE
fix(web+be): CSRF header, game rules enforcement, sonar/radar UX

### DIFF
--- a/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
@@ -33,7 +33,7 @@ export class GameRuleVisibilityController {
   @Get()
   async getAllRules() {
     const allRules = await this.ruleVisibility.getAllRules();
-    const result: Record<
+    const rules: Record<
       string,
       Array<{ ruleId: string; label: string; enabled: boolean }>
     > = {};
@@ -41,14 +41,14 @@ export class GameRuleVisibilityController {
     for (const entry of GAME_CATALOG) {
       if (entry.rules.length === 0) continue;
       const ruleMap = allRules.get(entry.gameId) ?? new Map<string, boolean>();
-      result[entry.gameId] = entry.rules.map((r) => ({
+      rules[entry.gameId] = entry.rules.map((r) => ({
         ruleId: r.ruleId,
         label: r.label,
         enabled: ruleMap.get(r.ruleId) ?? true,
       }));
     }
 
-    return result;
+    return { rules };
   }
 
   @Put(':gameId/:ruleId')

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
@@ -35,7 +35,12 @@ export class GameRuleVisibilityController {
     const allRules = await this.ruleVisibility.getAllRules();
     const rules: Record<
       string,
-      Array<{ ruleId: string; label: string; description?: string; enabled: boolean }>
+      Array<{
+        ruleId: string;
+        label: string;
+        description?: string;
+        enabled: boolean;
+      }>
     > = {};
 
     for (const entry of GAME_CATALOG) {

--- a/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
+++ b/apps/be/src/admin/game-visibility/game-rule-visibility.controller.ts
@@ -35,7 +35,7 @@ export class GameRuleVisibilityController {
     const allRules = await this.ruleVisibility.getAllRules();
     const rules: Record<
       string,
-      Array<{ ruleId: string; label: string; enabled: boolean }>
+      Array<{ ruleId: string; label: string; description?: string; enabled: boolean }>
     > = {};
 
     for (const entry of GAME_CATALOG) {
@@ -44,6 +44,7 @@ export class GameRuleVisibilityController {
       rules[entry.gameId] = entry.rules.map((r) => ({
         ruleId: r.ruleId,
         label: r.label,
+        ...(r.description ? { description: r.description } : {}),
         enabled: ruleMap.get(r.ruleId) ?? true,
       }));
     }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
@@ -57,16 +57,20 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       expect(result.state!.lastSonar!.targetId).toBe('b');
       expect(result.state!.lastSonar!.centerRow).toBe(0);
       expect(result.state!.lastSonar!.centerCol).toBe(1);
-      expect(result.state!.lastSonar!.radius).toBe(2);
-      expect(result.state!.lastSonar!.shipPositions).toEqual([
-        { row: 0, col: 0 },
-        { row: 0, col: 1 },
-        { row: 0, col: 2 },
-        { row: 0, col: 3 },
+      expect(result.state!.lastSonar!.radius).toBe(1);
+      // 3×3 area around (0,1): rows 0-1, cols 0-2 (row -1 clamped to 0)
+      const cells = result.state!.lastSonar!.cells;
+      expect(cells).toEqual([
+        { row: 0, col: 0, state: CELL_STATE.SHIP },
+        { row: 0, col: 1, state: CELL_STATE.SHIP },
+        { row: 0, col: 2, state: CELL_STATE.SHIP },
+        { row: 1, col: 0, state: CELL_STATE.EMPTY },
+        { row: 1, col: 1, state: CELL_STATE.EMPTY },
+        { row: 1, col: 2, state: CELL_STATE.EMPTY },
       ]);
     });
 
-    it('only reveals ships within radius', () => {
+    it('only reveals cells within radius', () => {
       const s = battleState({ sonar: true });
       const result = engine.executeAction(s, 'useSonar', ctx('a'), {
         targetPlayerId: 'b',
@@ -75,10 +79,15 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.state!.lastSonar!.shipPositions).toEqual([
-        { row: 0, col: 1 },
-        { row: 0, col: 2 },
-        { row: 0, col: 3 },
+      // 3×3 area around (0,3): rows 0-1, cols 2-4
+      const cells = result.state!.lastSonar!.cells;
+      expect(cells).toEqual([
+        { row: 0, col: 2, state: CELL_STATE.SHIP },
+        { row: 0, col: 3, state: CELL_STATE.SHIP },
+        { row: 0, col: 4, state: CELL_STATE.EMPTY },
+        { row: 1, col: 2, state: CELL_STATE.EMPTY },
+        { row: 1, col: 3, state: CELL_STATE.EMPTY },
+        { row: 1, col: 4, state: CELL_STATE.EMPTY },
       ]);
     });
 
@@ -181,7 +190,11 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
         col: 0,
       });
 
-      expect(result.state!.lastSonar!.shipPositions).toEqual([]);
+      // Cells are still returned (board state unchanged), sunk ships
+      // still show as SHIP on the board — the frontend hides them via
+      // displayState override, not via the sonar data.
+      const cells = result.state!.lastSonar!.cells;
+      expect(cells.length).toBeGreaterThan(0);
     });
 
     it('sanitizes lastSonar for non-attacker', () => {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
@@ -16,7 +16,7 @@ import {
   getActiveShooterId,
 } from './team-rotation.utils';
 
-const SONAR_RADIUS = 2;
+const SONAR_RADIUS = 1;
 
 export function executeSonar(
   state: SeaBattleState,
@@ -38,14 +38,16 @@ export function executeSonar(
   const centerRow = payload.row!;
   const centerCol = payload.col!;
 
-  const shipPositions = target.ships
-    .filter((s) => !s.sunk)
-    .flatMap((s) => s.cells)
-    .filter(
-      (c) =>
-        Math.abs(c.row - centerRow) <= SONAR_RADIUS &&
-        Math.abs(c.col - centerCol) <= SONAR_RADIUS,
-    );
+  const gSize = state.gridSize ?? BOARD_SIZE;
+  const cells: { row: number; col: number; state: CellState }[] = [];
+
+  for (let r = centerRow - SONAR_RADIUS; r <= centerRow + SONAR_RADIUS; r++) {
+    for (let c = centerCol - SONAR_RADIUS; c <= centerCol + SONAR_RADIUS; c++) {
+      if (r >= 0 && r < gSize && c >= 0 && c < gSize) {
+        cells.push({ row: r, col: c, state: target.board[r][c] });
+      }
+    }
+  }
 
   state.lastSonar = {
     attackerId: player.playerId,
@@ -53,7 +55,7 @@ export function executeSonar(
     centerRow,
     centerCol,
     radius: SONAR_RADIUS,
-    shipPositions,
+    cells,
   };
 
   state.logs.push({

--- a/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
@@ -70,7 +70,7 @@ export interface SeaBattleState {
     centerRow: number;
     centerCol: number;
     radius: number;
-    shipPositions: ShipCell[];
+    cells: { row: number; col: number; state: CellState }[];
   };
   lastRadar?: {
     attackerId: string;

--- a/apps/be/src/games/games.catalog.ts
+++ b/apps/be/src/games/games.catalog.ts
@@ -32,17 +32,20 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       {
         ruleId: 'combos',
         label: 'Action card combos',
-        description: 'Players can combine cards for special actions and bonus effects.',
+        description:
+          'Players can combine cards for special actions and bonus effects.',
       },
       {
         ruleId: 'idle',
         label: 'Idle timer autoplay',
-        description: 'Automatically play a random card if the player does not act within the timer.',
+        description:
+          'Automatically play a random card if the player does not act within the timer.',
       },
       {
         ruleId: 'spectators',
         label: 'Allow spectators',
-        description: 'Other users can watch the match in real time without joining.',
+        description:
+          'Other users can watch the match in real time without joining.',
       },
     ],
   },
@@ -67,32 +70,38 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       {
         ruleId: 'idle',
         label: 'Idle timer autoplay',
-        description: 'Automatically fire at a random cell if the player does not act within the timer.',
+        description:
+          'Automatically fire at a random cell if the player does not act within the timer.',
       },
       {
         ruleId: 'teams',
         label: 'Team mode',
-        description: 'Players are divided into teams that share a board and take turns together.',
+        description:
+          'Players are divided into teams that share a board and take turns together.',
       },
       {
         ruleId: 'spectators',
         label: 'Allow spectators',
-        description: 'Other users can watch the match in real time without joining.',
+        description:
+          'Other users can watch the match in real time without joining.',
       },
       {
         ruleId: 'sonar',
         label: 'Sonar scan',
-        description: 'Each player can reveal a 3×3 area on the opponent\'s board once per game to detect ships.',
+        description:
+          "Each player can reveal a 3×3 area on the opponent's board once per game to detect ships.",
       },
       {
         ruleId: 'radar',
         label: 'Radar sweep',
-        description: 'Each player can scan an entire row or column on the opponent\'s board once per game.',
+        description:
+          "Each player can scan an entire row or column on the opponent's board once per game.",
       },
       {
         ruleId: 'gridSize',
         label: 'Board size selection',
-        description: 'Allow players to choose the grid size (10×10, 15×15, or 20×20) before the match starts.',
+        description:
+          'Allow players to choose the grid size (10×10, 15×15, or 20×20) before the match starts.',
       },
     ],
   },
@@ -108,12 +117,14 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       {
         ruleId: 'idle',
         label: 'Idle timer autoplay',
-        description: 'Automatically shoot in a random direction if the player does not act within the timer.',
+        description:
+          'Automatically shoot in a random direction if the player does not act within the timer.',
       },
       {
         ruleId: 'spectators',
         label: 'Allow spectators',
-        description: 'Other users can watch the match in real time without joining.',
+        description:
+          'Other users can watch the match in real time without joining.',
       },
     ],
   },
@@ -124,12 +135,14 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       {
         ruleId: 'teams',
         label: 'Team mode',
-        description: 'Players are divided into teams and take turns on a shared board.',
+        description:
+          'Players are divided into teams and take turns on a shared board.',
       },
       {
         ruleId: 'spectators',
         label: 'Allow spectators',
-        description: 'Other users can watch the match in real time without joining.',
+        description:
+          'Other users can watch the match in real time without joining.',
       },
     ],
   },
@@ -151,12 +164,14 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       {
         ruleId: 'idle',
         label: 'Idle timer autoplay',
-        description: 'Automatically drop a piece if the player does not act within the timer.',
+        description:
+          'Automatically drop a piece if the player does not act within the timer.',
       },
       {
         ruleId: 'spectators',
         label: 'Allow spectators',
-        description: 'Other users can watch the match in real time without joining.',
+        description:
+          'Other users can watch the match in real time without joining.',
       },
     ],
   },

--- a/apps/be/src/games/games.catalog.ts
+++ b/apps/be/src/games/games.catalog.ts
@@ -103,6 +103,11 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
         description:
           'Allow players to choose the grid size (10×10, 15×15, or 20×20) before the match starts.',
       },
+      {
+        ruleId: 'botWeapons',
+        label: 'Bot special weapons',
+        description: 'Allow bots to use sonar and radar during their turn.',
+      },
     ],
   },
   {

--- a/apps/be/src/games/games.catalog.ts
+++ b/apps/be/src/games/games.catalog.ts
@@ -1,6 +1,7 @@
 export interface GameCatalogRule {
   ruleId: string;
   label: string;
+  description?: string;
 }
 
 export interface GameCatalogEntry {
@@ -28,9 +29,21 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       'random',
     ],
     rules: [
-      { ruleId: 'combos', label: 'Action card combos' },
-      { ruleId: 'idle', label: 'Idle timer autoplay' },
-      { ruleId: 'spectators', label: 'Allow spectators' },
+      {
+        ruleId: 'combos',
+        label: 'Action card combos',
+        description: 'Players can combine cards for special actions and bonus effects.',
+      },
+      {
+        ruleId: 'idle',
+        label: 'Idle timer autoplay',
+        description: 'Automatically play a random card if the player does not act within the timer.',
+      },
+      {
+        ruleId: 'spectators',
+        label: 'Allow spectators',
+        description: 'Other users can watch the match in real time without joining.',
+      },
     ],
   },
   {
@@ -51,9 +64,36 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       'team_2v2',
     ],
     rules: [
-      { ruleId: 'idle', label: 'Idle timer autoplay' },
-      { ruleId: 'teams', label: 'Team mode' },
-      { ruleId: 'spectators', label: 'Allow spectators' },
+      {
+        ruleId: 'idle',
+        label: 'Idle timer autoplay',
+        description: 'Automatically fire at a random cell if the player does not act within the timer.',
+      },
+      {
+        ruleId: 'teams',
+        label: 'Team mode',
+        description: 'Players are divided into teams that share a board and take turns together.',
+      },
+      {
+        ruleId: 'spectators',
+        label: 'Allow spectators',
+        description: 'Other users can watch the match in real time without joining.',
+      },
+      {
+        ruleId: 'sonar',
+        label: 'Sonar scan',
+        description: 'Each player can reveal a 3×3 area on the opponent\'s board once per game to detect ships.',
+      },
+      {
+        ruleId: 'radar',
+        label: 'Radar sweep',
+        description: 'Each player can scan an entire row or column on the opponent\'s board once per game.',
+      },
+      {
+        ruleId: 'gridSize',
+        label: 'Board size selection',
+        description: 'Allow players to choose the grid size (10×10, 15×15, or 20×20) before the match starts.',
+      },
     ],
   },
   {
@@ -65,24 +105,35 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
     gameId: 'glimworm_v1',
     variants: ['battle_royale', 'time_attack', 'lives_heats'],
     rules: [
-      { ruleId: 'idle', label: 'Idle timer autoplay' },
-      { ruleId: 'spectators', label: 'Allow spectators' },
+      {
+        ruleId: 'idle',
+        label: 'Idle timer autoplay',
+        description: 'Automatically shoot in a random direction if the player does not act within the timer.',
+      },
+      {
+        ruleId: 'spectators',
+        label: 'Allow spectators',
+        description: 'Other users can watch the match in real time without joining.',
+      },
     ],
   },
   {
     gameId: 'tic_tac_toe_v1',
     variants: ['classic', 'neon', 'paper', 'pixel', 'chalkboard', 'retro'],
     rules: [
-      { ruleId: 'teams', label: 'Team mode' },
-      { ruleId: 'spectators', label: 'Allow spectators' },
+      {
+        ruleId: 'teams',
+        label: 'Team mode',
+        description: 'Players are divided into teams and take turns on a shared board.',
+      },
+      {
+        ruleId: 'spectators',
+        label: 'Allow spectators',
+        description: 'Other users can watch the match in real time without joining.',
+      },
     ],
   },
   {
-    // Cascade's `variants` list is the union of visual themes AND gameplay
-    // modes — the admin/game-visibility surface needs every selectable
-    // option here. The engine reads them as separate axes (`variant` vs
-    // `mode` in CascadeOptions); this catalog entry is the source of truth
-    // for admin filtering only.
     gameId: 'cascade_v1',
     variants: [
       'cosmic',
@@ -97,8 +148,16 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
       'speed',
     ],
     rules: [
-      { ruleId: 'idle', label: 'Idle timer autoplay' },
-      { ruleId: 'spectators', label: 'Allow spectators' },
+      {
+        ruleId: 'idle',
+        label: 'Idle timer autoplay',
+        description: 'Automatically drop a piece if the player does not act within the timer.',
+      },
+      {
+        ruleId: 'spectators',
+        label: 'Allow spectators',
+        description: 'Other users can watch the match in real time without joining.',
+      },
     ],
   },
 ];

--- a/apps/be/src/games/games.controller.ts
+++ b/apps/be/src/games/games.controller.ts
@@ -130,7 +130,7 @@ export class GamesController {
       const ruleMap = allRuleMaps.get(entry.gameId);
       const rules = entry.rules.map((r) => ({
         ruleId: r.ruleId,
-        comingSoon: ruleMap ? !ruleMap.get(r.ruleId) : false,
+        comingSoon: ruleMap ? !(ruleMap.get(r.ruleId) ?? true) : false,
       }));
 
       games.push({

--- a/apps/be/src/games/games.controller.ts
+++ b/apps/be/src/games/games.controller.ts
@@ -53,6 +53,52 @@ export class GamesController {
     private readonly roleResolver: UserRoleResolver,
   ) {}
 
+  /**
+   * Remove disabled rule options from gameOptions so the engine cannot use
+   * features that have been excluded by an admin.
+   */
+  private stripDisabledRules(
+    gameOptions: Record<string, unknown>,
+    ruleMap: Map<string, boolean>,
+  ): void {
+    // gridSize — used by sea_battle_v1
+    if (ruleMap.get('gridSize') === false) {
+      delete gameOptions.gridSize;
+    }
+
+    // specialWeapons (sonar / radar) — used by sea_battle_v1
+    const sw = gameOptions.specialWeapons;
+    if (typeof sw === 'object' && sw !== null) {
+      const weapons = sw as Record<string, unknown>;
+      if (ruleMap.get('sonar') === false) {
+        delete weapons.sonar;
+      }
+      if (ruleMap.get('radar') === false) {
+        delete weapons.radar;
+      }
+      // Remove the whole object if empty
+      if (Object.keys(weapons).length === 0) {
+        delete gameOptions.specialWeapons;
+      }
+    }
+
+    // teams — used by sea_battle_v1, tic_tac_toe_v1
+    if (ruleMap.get('teams') === false) {
+      delete gameOptions.teams;
+      delete gameOptions.teamConfig;
+      if (gameOptions.mode === 'team') {
+        delete gameOptions.mode;
+      }
+    }
+
+    // idle — used by multiple games (timer behavior, not a gameOptions key)
+    // spectators — not a gameOptions key (lobby-level setting)
+    // combos — used by critical_v1
+    if (ruleMap.get('combos') === false) {
+      delete gameOptions.expansions;
+    }
+  }
+
   @UseGuards(JwtOptionalAuthGuard)
   @Get('catalog')
   async getCatalog(@Req() req: Request): Promise<CatalogResponse> {
@@ -111,6 +157,12 @@ export class GamesController {
     const role = await this.roleResolver.resolveRole(user.userId);
     const variant = extractVariantFromOptions(dto.gameOptions);
     await this.visibility.assertVisible(role, dto.gameId, variant);
+
+    // Strip disabled rules from gameOptions so the engine can't use them.
+    if (dto.gameOptions) {
+      const ruleMap = await this.ruleVisibility.getRulesForGame(dto.gameId);
+      this.stripDisabledRules(dto.gameOptions, ruleMap);
+    }
 
     const room = await this.gamesService.createRoom(user.userId, dto);
     return { room };

--- a/apps/be/src/games/games.controller.visibility.spec.ts
+++ b/apps/be/src/games/games.controller.visibility.spec.ts
@@ -11,6 +11,7 @@ import { QuickplayGameDto } from './dtos/quickplay-game.dto';
 
 const ruleVis = {
   getAllRules: jest.fn().mockResolvedValue(new Map()),
+  getRulesForGame: jest.fn().mockResolvedValue(new Map()),
 } as unknown as GameRuleVisibilityService;
 
 function buildController(

--- a/apps/be/src/games/games.gateway.emote.ts
+++ b/apps/be/src/games/games.gateway.emote.ts
@@ -14,7 +14,10 @@ export function handleEmote(
   logger: Logger,
   server: Server,
   client: Socket,
-  realtime: { roomChannel(id: string): string; spectatorChannel(id: string): string },
+  realtime: {
+    roomChannel(id: string): string;
+    spectatorChannel(id: string): string;
+  },
   payload: unknown,
 ): void {
   const decrypted = maybeDecrypt<{

--- a/apps/be/src/games/games.service.spec.ts
+++ b/apps/be/src/games/games.service.spec.ts
@@ -12,6 +12,7 @@ import { SeaBattleService } from './sea-battle/sea-battle.service';
 import { CriticalService } from './critical/critical.service';
 import { GamesLeaderboardSyncService } from './games.leaderboard-sync.service';
 import { GamePostMatchService } from './game-post-match.service';
+import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
 import { CreateGameRoomDto } from './dtos/create-game-room.dto';
 import { GameRoomSummary } from './rooms/game-rooms.types';
 import { GameSessionSummary } from './sessions/game-sessions.service';
@@ -87,6 +88,9 @@ describe('GamesService', () => {
       onGameCompleted: jest.fn().mockResolvedValue(undefined),
       payoutGameWin: jest.fn().mockResolvedValue(undefined),
     };
+    const mockRuleVisibility = {
+      getRulesForGame: jest.fn().mockResolvedValue(new Map()),
+    };
 
     module = await Test.createTestingModule({
       providers: [
@@ -109,6 +113,7 @@ describe('GamesService', () => {
           useValue: mockLeaderboardSync,
         },
         { provide: GamePostMatchService, useValue: mockPostMatchService },
+        { provide: GameRuleVisibilityService, useValue: mockRuleVisibility },
       ],
     }).compile();
 

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -12,6 +12,7 @@ import { GameHistoryService } from './history/game-history.service';
 import { GamesRealtimeService } from './games.realtime.service';
 import { GameUtilitiesService } from './utilities/game-utilities.service';
 import { AuthService } from '../auth/auth.service';
+import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
 import { CreateGameRoomDto } from './dtos/create-game-room.dto';
 import { JoinGameRoomDto } from './dtos/join-game-room.dto';
 import { LeaveGameRoomDto } from './dtos/leave-game-room.dto';
@@ -45,6 +46,7 @@ export class GamesService {
     private readonly criticalService: CriticalService,
     private readonly leaderboardSync: GamesLeaderboardSyncService,
     private readonly postMatch: GamePostMatchService,
+    private readonly ruleVisibility: GameRuleVisibilityService,
   ) {}
 
   // ========== Room Operations ==========
@@ -452,13 +454,55 @@ export class GamesService {
     userId: string,
     options: Record<string, unknown>,
   ) {
-    const room = await this.roomsService.updateRoomOptions(
+    // Strip disabled rules before persisting.
+    try {
+      const room = await this.roomsService.getRoom(roomId);
+      const ruleMap = await this.ruleVisibility.getRulesForGame(room.gameId);
+      this.stripDisabledRules(options, ruleMap);
+    } catch {
+      // Room not found or inaccessible — proceed without stripping.
+    }
+
+    const updated = await this.roomsService.updateRoomOptions(
       roomId,
       userId,
       options,
     );
-    this.realtimeService.emitRoomUpdated(room);
-    return room;
+    this.realtimeService.emitRoomUpdated(updated);
+    return updated;
+  }
+
+  /**
+   * Remove disabled rule options so the engine cannot use features
+   * that have been excluded by an admin.
+   */
+  private stripDisabledRules(
+    options: Record<string, unknown>,
+    ruleMap: Map<string, boolean>,
+  ): void {
+    if (ruleMap.get('gridSize') === false) {
+      delete options.gridSize;
+    }
+
+    const sw = options.specialWeapons;
+    if (typeof sw === 'object' && sw !== null) {
+      const weapons = sw as Record<string, unknown>;
+      if (ruleMap.get('sonar') === false) delete weapons.sonar;
+      if (ruleMap.get('radar') === false) delete weapons.radar;
+      if (Object.keys(weapons).length === 0) {
+        delete options.specialWeapons;
+      }
+    }
+
+    if (ruleMap.get('teams') === false) {
+      delete options.teams;
+      delete options.teamConfig;
+      if (options.mode === 'team') delete options.mode;
+    }
+
+    if (ruleMap.get('combos') === false) {
+      delete options.expansions;
+    }
   }
 
   async reorderParticipants(

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -8,6 +8,7 @@ import {
 import { ChatScope } from './engines/base/game-engine.interface';
 import { GameRoomsService } from './rooms/game-rooms.service';
 import { GameSessionsService } from './sessions/game-sessions.service';
+import type { GameSessionSummary } from './sessions/game-sessions.service';
 import { GameHistoryService } from './history/game-history.service';
 import { GamesRealtimeService } from './games.realtime.service';
 import { GameUtilitiesService } from './utilities/game-utilities.service';
@@ -48,6 +49,20 @@ export class GamesService {
     private readonly postMatch: GamePostMatchService,
     private readonly ruleVisibility: GameRuleVisibilityService,
   ) {}
+
+  private async sanitizeForPlayer(
+    s: GameSessionSummary,
+    pId: string,
+  ): Promise<GameSessionSummary> {
+    const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
+      s.id,
+      pId,
+    );
+    if (sanitized && typeof sanitized === 'object') {
+      return { ...s, state: sanitized as Record<string, unknown> };
+    }
+    return s;
+  }
 
   // ========== Room Operations ==========
 
@@ -96,16 +111,9 @@ export class GamesService {
 
     if (session && userId) {
       try {
-        const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
-          session.id,
-          userId,
-        );
-        if (sanitized && typeof sanitized === 'object') {
-          session = { ...session, state: sanitized as Record<string, unknown> };
-        }
+        session = await this.sanitizeForPlayer(session, userId);
       } catch {
-        // If sanitization fails, return null session or handle appropriately;
-        // safely continue with the unsanitized session state
+        // safely continue with unsanitized session state
       }
     }
 
@@ -226,19 +234,8 @@ export class GamesService {
     await this.leaderboardSync.syncInMatch(playerIds, true);
 
     // Emit real-time event
-    await this.realtimeService.emitGameStarted(
-      room,
-      session,
-      async (s, pId) => {
-        const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
-          s.id,
-          pId,
-        );
-        if (sanitized && typeof sanitized === 'object') {
-          return { ...s, state: sanitized as Record<string, unknown> };
-        }
-        return s;
-      },
+    await this.realtimeService.emitGameStarted(room, session, async (s, pId) =>
+      this.sanitizeForPlayer(s, pId),
     );
 
     return { room, session };
@@ -265,16 +262,7 @@ export class GamesService {
       session,
       action,
       userId,
-      async (s, pId) => {
-        const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
-          s.id,
-          pId,
-        );
-        if (sanitized && typeof sanitized === 'object') {
-          return { ...s, state: sanitized as Record<string, unknown> };
-        }
-        return s;
-      },
+      async (s, pId) => this.sanitizeForPlayer(s, pId),
     );
 
     // Sync room status if game completed
@@ -352,9 +340,6 @@ export class GamesService {
     return this.historyService.getLeaderboard(limit, offset, gameId);
   }
 
-  /**
-   * Create a rematch
-   */
   async createRematchFromHistory(
     userId: string,
     roomId: string,
@@ -391,9 +376,6 @@ export class GamesService {
     return this.rematchService.reinvitePlayers(roomId, hostId, userIds);
   }
 
-  /**
-   * Post a note to game history
-   */
   async postHistoryNote(
     roomId: string,
     userId: string,
@@ -408,14 +390,7 @@ export class GamesService {
       await this.realtimeService.emitSessionSnapshot(
         roomId,
         session,
-        async (s, pId) => {
-          const sanitized =
-            await this.sessionsService.getSanitizedStateForPlayer(s.id, pId);
-          if (sanitized && typeof sanitized === 'object') {
-            return { ...s, state: sanitized as Record<string, unknown> };
-          }
-          return s;
-        },
+        async (s, pId) => this.sanitizeForPlayer(s, pId),
       );
     }
   }
@@ -472,10 +447,6 @@ export class GamesService {
     return updated;
   }
 
-  /**
-   * Remove disabled rule options so the engine cannot use features
-   * that have been excluded by an admin.
-   */
   private stripDisabledRules(
     options: Record<string, unknown>,
     ruleMap: Map<string, boolean>,

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -275,7 +275,13 @@ export class SeaBattleGateway {
   async handleUseSonar(
     @ConnectedSocket() client: Socket,
     @MessageBody()
-    payload: { roomId?: string; userId?: string; targetPlayerId?: string },
+    payload: {
+      roomId?: string;
+      userId?: string;
+      targetPlayerId?: string;
+      row?: number;
+      col?: number;
+    },
   ): Promise<void> {
     const { roomId, userId } = extractRoomAndUser(payload);
     const targetPlayerId = extractString(payload, 'targetPlayerId');
@@ -285,7 +291,7 @@ export class SeaBattleGateway {
         userId,
         roomId,
         'useSonar',
-        { targetPlayerId },
+        { targetPlayerId, row: payload.row, col: payload.col },
       );
       client.emit(
         'seaBattle.session.sonar_result',

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -394,7 +394,12 @@ export class SeaBattleGateway {
     @MessageBody()
     payload: { roomId?: string; userId?: string; enabled?: boolean },
   ): Promise<void> {
-    await handleSetTeamMode(this.runTeamAction, client, payload, this.teamConfigService);
+    await handleSetTeamMode(
+      this.runTeamAction,
+      client,
+      payload,
+      this.teamConfigService,
+    );
   }
 
   @SubscribeMessage('seaBattle.lobby.set_team_config')
@@ -408,7 +413,12 @@ export class SeaBattleGateway {
       hideShipsFromTeammates?: boolean;
     },
   ): Promise<void> {
-    await handleSetTeamConfig(this.runTeamAction, client, payload, this.teamConfigService);
+    await handleSetTeamConfig(
+      this.runTeamAction,
+      client,
+      payload,
+      this.teamConfigService,
+    );
   }
 
   @SubscribeMessage('seaBattle.lobby.assign_team')
@@ -422,7 +432,12 @@ export class SeaBattleGateway {
       teamId?: string | null;
     },
   ): Promise<void> {
-    await handleAssignTeam(this.runTeamAction, client, payload, this.teamConfigService);
+    await handleAssignTeam(
+      this.runTeamAction,
+      client,
+      payload,
+      this.teamConfigService,
+    );
   }
 
   @SubscribeMessage('seaBattle.lobby.add_bot_to_team')
@@ -431,7 +446,12 @@ export class SeaBattleGateway {
     @MessageBody()
     payload: { roomId?: string; userId?: string; teamId?: string },
   ): Promise<void> {
-    await handleAddBotToTeam(this.runTeamAction, client, payload, this.teamConfigService);
+    await handleAddBotToTeam(
+      this.runTeamAction,
+      client,
+      payload,
+      this.teamConfigService,
+    );
   }
 
   @SubscribeMessage('seaBattle.lobby.remove_bot_from_team')
@@ -440,7 +460,12 @@ export class SeaBattleGateway {
     @MessageBody()
     payload: { roomId?: string; userId?: string; targetUserId?: string },
   ): Promise<void> {
-    await handleRemoveBotFromTeam(this.runTeamAction, client, payload, this.teamConfigService);
+    await handleRemoveBotFromTeam(
+      this.runTeamAction,
+      client,
+      payload,
+      this.teamConfigService,
+    );
   }
 
   @SubscribeMessage('seaBattle.lobby.toggle_hide_ships')
@@ -449,6 +474,11 @@ export class SeaBattleGateway {
     @MessageBody()
     payload: { roomId?: string; userId?: string; enabled?: boolean },
   ): Promise<void> {
-    await handleToggleHideShips(this.runTeamAction, client, payload, this.teamConfigService);
+    await handleToggleHideShips(
+      this.runTeamAction,
+      client,
+      payload,
+      this.teamConfigService,
+    );
   }
 }

--- a/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
@@ -264,10 +264,11 @@ export class SeaBattleBotService {
             'useSonar',
             { targetPlayerId: target.playerId, row: centerRow, col: centerCol },
           );
-          currentSession = await this.seaBattleService.findSessionByRoom(
+          const refreshed = await this.seaBattleService.findSessionByRoom(
             currentSession.roomId,
           );
-          if (!currentSession) break;
+          if (!refreshed) break;
+          currentSession = refreshed;
           const postSonar = currentSession.state as unknown as SeaBattleState;
           const nextAfterSonar =
             postSonar.playerOrder[postSonar.currentTurnIndex];
@@ -285,10 +286,11 @@ export class SeaBattleBotService {
             'useRadar',
             { targetPlayerId: target.playerId, row },
           );
-          currentSession = await this.seaBattleService.findSessionByRoom(
+          const refreshedRadar = await this.seaBattleService.findSessionByRoom(
             currentSession.roomId,
           );
-          if (!currentSession) break;
+          if (!refreshedRadar) break;
+          currentSession = refreshedRadar;
           const postRadar = currentSession.state as unknown as SeaBattleState;
           const nextAfterRadar =
             postRadar.playerOrder[postRadar.currentTurnIndex];

--- a/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
@@ -247,6 +247,59 @@ export class SeaBattleBotService {
             Math.floor(Math.random() * eligibleOpponents.length)
           ];
 
+        // --- Special weapons: sonar / radar ---
+        // Weapons are available if state.specialWeapons has them enabled.
+        // Admin exclusion via stripDisabledRules already removes excluded
+        // weapons from gameOptions before engine init, so we just check state.
+        const myUsage = state.specialWeaponUsage?.[botId];
+        const hasSonar = !!state.specialWeapons?.sonar && !myUsage?.sonarUsed;
+        const hasRadar = !!state.specialWeapons?.radar && !myUsage?.radarUsed;
+
+        if (hasSonar) {
+          const centerRow = Math.floor(gridSize / 2);
+          const centerCol = Math.floor(gridSize / 2);
+          await this.seaBattleService.executeActionByRoom(
+            botId,
+            currentSession.roomId,
+            'useSonar',
+            { targetPlayerId: target.playerId, row: centerRow, col: centerCol },
+          );
+          currentSession = await this.seaBattleService.findSessionByRoom(
+            currentSession.roomId,
+          );
+          if (!currentSession) break;
+          const postSonar = currentSession.state as unknown as SeaBattleState;
+          const nextAfterSonar =
+            postSonar.playerOrder[postSonar.currentTurnIndex];
+          if (
+            nextAfterSonar !== botId ||
+            postSonar.phase !== GAME_PHASE.BATTLE
+          ) {
+            break;
+          }
+        } else if (hasRadar) {
+          const row = Math.floor(Math.random() * gridSize);
+          await this.seaBattleService.executeActionByRoom(
+            botId,
+            currentSession.roomId,
+            'useRadar',
+            { targetPlayerId: target.playerId, row },
+          );
+          currentSession = await this.seaBattleService.findSessionByRoom(
+            currentSession.roomId,
+          );
+          if (!currentSession) break;
+          const postRadar = currentSession.state as unknown as SeaBattleState;
+          const nextAfterRadar =
+            postRadar.playerOrder[postRadar.currentTurnIndex];
+          if (
+            nextAfterRadar !== botId ||
+            postRadar.phase !== GAME_PHASE.BATTLE
+          ) {
+            break;
+          }
+        }
+
         // Smart Target Logic: Finish off damaged ships
         let choice: { r: number; c: number } | null = this.getSmartTarget(
           target,

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -147,6 +147,7 @@ export class GameSessionsService {
     }
 
     session.state = state;
+    session.markModified('state');
     if (status) {
       session.status = status;
     }
@@ -184,6 +185,7 @@ export class GameSessionsService {
       session.state = engine.normalizeState(
         session.state as unknown as BaseGameState,
       ) as unknown as Record<string, unknown>;
+      session.markModified('state');
     }
 
     // Create action context
@@ -210,6 +212,7 @@ export class GameSessionsService {
     // Update session with new state
     if (result.state) {
       session.state = result.state as unknown as Record<string, unknown>;
+      session.markModified('state');
     }
 
     // Check if game is over
@@ -240,7 +243,8 @@ export class GameSessionsService {
     if (!history || history.length === 0) return null;
     const previousState = history[history.length - 1];
     state.stateHistory = history.slice(0, -1);
-    session.state = previousState as Record<string, unknown>;
+      session.state = previousState as Record<string, unknown>;
+      session.markModified('state');
     session.updatedAt = new Date();
     await session.save();
     return this.toSessionSummary(session);
@@ -366,6 +370,7 @@ export class GameSessionsService {
 
     if (result.state) {
       session.state = result.state as unknown as Record<string, unknown>;
+      session.markModified('state');
     }
     session.updatedAt = new Date();
 

--- a/apps/web/src/features/admin-bulk-rewards/server/admin-bulk-rewards.actions.ts
+++ b/apps/web/src/features/admin-bulk-rewards/server/admin-bulk-rewards.actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 
 export type BulkRewardType = 'coins' | 'gems' | 'arcadeum' | 'item';
 
@@ -20,21 +19,6 @@ export type AdminBulkRewardsActionError =
 export type AdminBulkRewardsActionResult =
   | { ok: true; data: BulkRewardResult }
   | { ok: false; error: AdminBulkRewardsActionError };
-
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
 
 function classify(status: number): AdminBulkRewardsActionError {
   if (status === 400) return 'validation';
@@ -56,7 +40,7 @@ export async function sendBulkRewardsAction(input: {
     return { ok: false, error: 'validation' };
   }
 
-  const res = await adminFetch('/admin/bulk-rewards', {
+  const res = await serverAuthFetch('/admin/bulk-rewards', {
     method: 'POST',
     body: JSON.stringify(input),
   });

--- a/apps/web/src/features/admin-economy/server/economy.actions.ts
+++ b/apps/web/src/features/admin-economy/server/economy.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type {
   EconomyAuditView,
   EconomyKey,
@@ -20,22 +19,6 @@ export type EconomyActionResult<T> =
 
 // ─── Internal fetch helper ────────────────────────────────────────────────────
 
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
-
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 export async function setEconomyValueAction(input: {
@@ -46,7 +29,7 @@ export async function setEconomyValueAction(input: {
     return { ok: false, error: 'validation' };
   }
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/economy/${encodeURIComponent(input.key)}`,
     {
       method: 'PUT',
@@ -67,7 +50,7 @@ export async function setEconomyValueAction(input: {
 export async function resetEconomyValueAction(input: {
   key: EconomyKey;
 }): Promise<EconomyActionResult<{ reset: true }>> {
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/economy/${encodeURIComponent(input.key)}`,
     { method: 'DELETE' },
   );
@@ -83,7 +66,7 @@ export async function resetEconomyValueAction(input: {
 export async function refreshCacheAction(): Promise<
   EconomyActionResult<{ refreshed: true }>
 > {
-  const res = await adminFetch('/admin/economy/refresh-cache', {
+  const res = await serverAuthFetch('/admin/economy/refresh-cache', {
     method: 'POST',
   });
 
@@ -97,7 +80,7 @@ export async function refreshCacheAction(): Promise<
 export async function loadEconomyHistoryAction(input: {
   key: EconomyKey;
 }): Promise<EconomyActionResult<EconomyAuditView[]>> {
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/economy/${encodeURIComponent(input.key)}/audit`,
   );
 

--- a/apps/web/src/features/admin-games/server/admin-games.actions.ts
+++ b/apps/web/src/features/admin-games/server/admin-games.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type { VisibilityTier } from '../types';
 
 // ─── Discriminated result type ────────────────────────────────────────────────
@@ -13,29 +12,13 @@ export type AdminGamesActionResult =
 
 // ─── Internal fetch helper ────────────────────────────────────────────────────
 
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
-
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 export async function setGameTierAction(input: {
   gameId: string;
   tier: VisibilityTier;
 }): Promise<AdminGamesActionResult> {
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/games/${encodeURIComponent(input.gameId)}/visibility`,
     {
       method: 'PUT',
@@ -56,7 +39,7 @@ export async function setVariantTierAction(input: {
   variantId: string;
   tier: VisibilityTier;
 }): Promise<AdminGamesActionResult> {
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/games/${encodeURIComponent(input.gameId)}/variants/${encodeURIComponent(
       input.variantId,
     )}/visibility`,

--- a/apps/web/src/features/admin-games/ui/AdminGameRulesTable.tsx
+++ b/apps/web/src/features/admin-games/ui/AdminGameRulesTable.tsx
@@ -6,6 +6,7 @@ import { apiClient } from '@/shared/lib/api-client';
 interface RuleItem {
   ruleId: string;
   label: string;
+  description?: string;
   enabled: boolean;
 }
 
@@ -136,7 +137,9 @@ export function AdminGameRulesTable() {
                         color: rule.enabled
                           ? 'var(--color-text, #e4e4e7)'
                           : '#71717a',
+                        cursor: rule.description ? 'help' : 'default',
                       }}
+                      title={rule.description}
                     >
                       {rule.label}
                     </div>

--- a/apps/web/src/features/admin-games/ui/AdminGameRulesTable.tsx
+++ b/apps/web/src/features/admin-games/ui/AdminGameRulesTable.tsx
@@ -18,9 +18,9 @@ export function AdminGameRulesTable() {
 
   useEffect(() => {
     apiClient
-      .get<RulesByGame>('/admin/game-rules')
+      .get<{ rules: RulesByGame }>('/admin/game-rules')
       .then((data) => {
-        setRules(data);
+        setRules(data.rules);
         setLoading(false);
       })
       .catch(() => setLoading(false));

--- a/apps/web/src/features/admin-gem-packages/server/admin-gems.actions.ts
+++ b/apps/web/src/features/admin-gem-packages/server/admin-gems.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type {
   GemPackageAdmin,
   CreateGemPackageInput,
@@ -21,26 +20,10 @@ export type AdminGemActionResult<T> =
 
 // ─── Internal fetch helper ────────────────────────────────────────────────────
 
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
-
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 export async function listAdminPackagesAction(): Promise<GemPackageAdmin[]> {
-  const res = await adminFetch('/admin/gem-packages');
+  const res = await serverAuthFetch('/admin/gem-packages');
   if (!res.ok) return [];
   return (await res.json()) as GemPackageAdmin[];
 }
@@ -53,7 +36,7 @@ export async function createPackageAction(
     return { ok: false, error: 'validation', details: validation.errors };
   }
 
-  const res = await adminFetch('/admin/gem-packages', {
+  const res = await serverAuthFetch('/admin/gem-packages', {
     method: 'POST',
     body: JSON.stringify(input),
   });
@@ -82,7 +65,7 @@ export async function updatePackageAction(
     return { ok: false, error: 'validation', details: ['id is required'] };
   }
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/gem-packages/${encodeURIComponent(id)}`,
     {
       method: 'PATCH',
@@ -112,7 +95,7 @@ export async function deletePackageAction(input: {
     return { ok: false, error: 'validation', details: ['id is required'] };
   }
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/gem-packages/${encodeURIComponent(id)}`,
     {
       method: 'DELETE',

--- a/apps/web/src/features/admin-shop/server/admin-shop.actions.ts
+++ b/apps/web/src/features/admin-shop/server/admin-shop.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { revalidatePath } from 'next/cache';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type {
   EffectiveShopItem,
   InventoryItemView,
@@ -19,21 +18,6 @@ export type AdminShopActionError =
 export type AdminShopActionResult<T> =
   | { ok: true; data: T }
   | { ok: false; error: AdminShopActionError };
-
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
 
 function classify(status: number): AdminShopActionError {
   if (status === 400) return 'validation';
@@ -60,7 +44,7 @@ export async function setShopOverrideAction(input: {
     return { ok: false, error: 'validation' };
   }
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/shop/overrides/${encodeURIComponent(itemId)}`,
     { method: 'PATCH', body: JSON.stringify(patch) },
   );
@@ -84,7 +68,7 @@ export async function grantShopItemAction(input: {
     return { ok: false, error: 'validation' };
   }
 
-  const res = await adminFetch('/admin/shop/grant', {
+  const res = await serverAuthFetch('/admin/shop/grant', {
     method: 'POST',
     body: JSON.stringify(input),
   });
@@ -100,7 +84,7 @@ export async function revokeInventoryAction(input: {
   if (!input.rowId.trim() || !input.reason.trim()) {
     return { ok: false, error: 'validation' };
   }
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/shop/inventory/${encodeURIComponent(input.rowId)}/revoke`,
     { method: 'POST', body: JSON.stringify({ reason: input.reason }) },
   );

--- a/apps/web/src/features/admin-tournaments/server/tournament.actions.ts
+++ b/apps/web/src/features/admin-tournaments/server/tournament.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type { AdminTournamentItem } from '../api';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -20,22 +19,6 @@ export interface MarkCompleteInput {
 }
 
 // ─── Internal fetch helper ─────────────────────────────────────────────────────
-
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
 
 // ─── Action ───────────────────────────────────────────────────────────────────
 
@@ -59,7 +42,7 @@ export async function markCompleteAction(
   const tournamentId = obj.tournamentId as string;
   const winnerUserId = obj.winnerUserId as string;
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/tournaments/${encodeURIComponent(tournamentId)}/complete`,
     {
       method: 'POST',

--- a/apps/web/src/features/admin-users/ui/UsersTable.test.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersTable.test.tsx
@@ -40,6 +40,10 @@ const labels: UsersTableLabels = {
   },
   selfTooltip: 'cant edit',
   walletButtonLabel: 'Wallet',
+  blockLabel: 'Block',
+  unblockLabel: 'Unblock',
+  removeLabel: 'Remove',
+  restoreLabel: 'Restore',
 };
 
 const baseProps = {
@@ -53,6 +57,10 @@ const baseProps = {
   hasFilter: false,
   onRoleChange: () => {},
   onWalletOpen: () => {},
+  onBlock: () => {},
+  onUnblock: () => {},
+  onDelete: () => {},
+  onRestore: () => {},
   onPageChange: () => {},
   labels,
 };
@@ -65,6 +73,10 @@ const sampleItem: AdminUserItem = {
   role: 'free',
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-02T00:00:00Z',
+  isBlocked: false,
+  blockedAt: null,
+  blockedReason: null,
+  deletedAt: null,
 };
 
 describe('UsersTable', () => {

--- a/apps/web/src/features/admin-wallet/server/wallet.actions.ts
+++ b/apps/web/src/features/admin-wallet/server/wallet.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type {
   PaginatedWalletTransactions,
   WalletBalance,
@@ -74,22 +73,6 @@ function validateGrantDeductInput(input: unknown): ValidationResult {
 
 // ─── Shared fetch helper ───────────────────────────────────────────────────────
 
-async function adminFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
-
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 export async function grantWalletAction(
@@ -102,7 +85,7 @@ export async function grantWalletAction(
 
   const { userId, currency, amount, note } = input as WalletGrantDeductInput;
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/wallet/users/${encodeURIComponent(userId)}/grant`,
     {
       method: 'POST',
@@ -127,7 +110,7 @@ export async function deductWalletAction(
 
   const { userId, currency, amount, note } = input as WalletGrantDeductInput;
 
-  const res = await adminFetch(
+  const res = await serverAuthFetch(
     `/admin/wallet/users/${encodeURIComponent(userId)}/deduct`,
     {
       method: 'POST',
@@ -158,8 +141,8 @@ export async function loadAdminWalletAction(userId: string): Promise<
 
   const encoded = encodeURIComponent(userId);
   const [balanceRes, recentRes] = await Promise.all([
-    adminFetch(`/admin/wallet/users/${encoded}/balance`),
-    adminFetch(`/admin/wallet/users/${encoded}/transactions?limit=20`),
+    serverAuthFetch(`/admin/wallet/users/${encoded}/balance`),
+    serverAuthFetch(`/admin/wallet/users/${encoded}/transactions?limit=20`),
   ]);
 
   if (!balanceRes.ok || !recentRes.ok) return { ok: false, error: 'generic' };

--- a/apps/web/src/features/admin-wallet/ui/AdminWalletDrawer.test.tsx
+++ b/apps/web/src/features/admin-wallet/ui/AdminWalletDrawer.test.tsx
@@ -57,7 +57,7 @@ const labels: AdminWalletDrawerLabels = {
   },
 };
 
-const mockBalance = { coins: 500, gems: 10 };
+const mockBalance = { coins: 500, gems: 10, arcadeum: 0 };
 const mockRecent = {
   items: [
     {

--- a/apps/web/src/features/battle-pass/server/battle-pass.server.ts
+++ b/apps/web/src/features/battle-pass/server/battle-pass.server.ts
@@ -1,6 +1,5 @@
 import 'server-only';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type { BattlePassState, ClaimResult } from './battle-pass.types';
 
 export class BattlePassUnauthorizedError extends Error {
@@ -11,19 +10,7 @@ export class BattlePassUnauthorizedError extends Error {
 }
 
 async function fetchWithAuth<T>(path: string, init?: RequestInit): Promise<T> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  const res = await fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      'Content-Type': 'application/json',
-    },
-  });
+  const res = await serverAuthFetch(path, init);
 
   if (!res.ok) {
     if (res.status === 401) {

--- a/apps/web/src/features/daily-rewards/server/daily-rewards.actions.test.ts
+++ b/apps/web/src/features/daily-rewards/server/daily-rewards.actions.test.ts
@@ -5,8 +5,16 @@ vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
 vi.mock('next/headers', () => ({
   cookies: vi.fn().mockResolvedValue({ get: () => ({ value: 'test-token' }) }),
 }));
+
+const TEST_API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 vi.mock('@/shared/lib/api-base', () => ({
-  resolveApiUrl: (path: string) => `http://localhost:4000${path}`,
+  resolveApiUrl: (path: string) => `${TEST_API_BASE}${path}`,
+}));
+vi.mock('@/shared/lib/server-auth-fetch', () => ({
+  serverAuthFetch: vi.fn().mockImplementation(async (path: string, init?: RequestInit) => {
+    return fetchMock(`${TEST_API_BASE}${path}`, init);
+  }),
 }));
 
 // Mock global fetch
@@ -72,9 +80,11 @@ describe('claimDailyRewardAction', () => {
 
     await claimDailyRewardAction();
 
-    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect((opts.headers as Record<string, string>)['Authorization']).toBe(
-      'Bearer test-token',
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:4000/daily-rewards/claim',
+      expect.objectContaining({
+        method: 'POST',
+      }),
     );
   });
 

--- a/apps/web/src/features/daily-rewards/server/daily-rewards.actions.ts
+++ b/apps/web/src/features/daily-rewards/server/daily-rewards.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type { DailyRewardClaimResult } from './daily-rewards.types';
 
 export type ClaimDailyRewardResult =
@@ -16,22 +15,12 @@ export type ClaimDailyRewardResult =
  * chip in real time.
  */
 export async function claimDailyRewardAction(): Promise<ClaimDailyRewardResult> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl('/daily-rewards/claim');
-
   let res: Response;
   try {
-    res = await fetch(url, {
+    res = await serverAuthFetch('/daily-rewards/claim', {
       method: 'POST',
-      cache: 'no-store',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
     });
   } catch {
-    // Network failure, BE unreachable, etc.
     return { ok: false, code: 'unknown' };
   }
 

--- a/apps/web/src/features/daily-rewards/server/daily-rewards.server.ts
+++ b/apps/web/src/features/daily-rewards/server/daily-rewards.server.ts
@@ -1,6 +1,5 @@
 import 'server-only';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type { DailyRewardStatus } from './daily-rewards.types';
 
 /**
@@ -10,20 +9,8 @@ import type { DailyRewardStatus } from './daily-rewards.types';
  * 5xx page — same defensive pattern as `BalanceChip`.
  */
 export async function getDailyRewardStatus(): Promise<DailyRewardStatus | null> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  if (!token) return null;
-
-  const url = resolveApiUrl('/daily-rewards/me');
-
   try {
-    const res = await fetch(url, {
-      cache: 'no-store',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    const res = await serverAuthFetch('/daily-rewards/me');
     if (!res.ok) return null;
     return (await res.json()) as DailyRewardStatus;
   } catch {

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -137,7 +137,7 @@ export function ReusableGameLobby({
         onRuleComingSoonChange?.(map);
       })
       .catch(() => {});
-  }, [room.gameId]);
+  }, [room.gameId, onRuleComingSoonChange]);
 
   const [prevGameOptions, setPrevGameOptions] = useState(room.gameOptions);
   if (prevGameOptions !== room.gameOptions) {
@@ -357,7 +357,9 @@ export function ReusableGameLobby({
                   display: 'flex',
                   alignItems: 'center',
                   gap: 8,
-                  cursor: ruleComingSoon.get('idle') ? 'not-allowed' : 'pointer',
+                  cursor: ruleComingSoon.get('idle')
+                    ? 'not-allowed'
+                    : 'pointer',
                   opacity: ruleComingSoon.get('idle') ? 0.4 : 1,
                 }}
               >

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { YStack, Text } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { useRoomOptions } from '@/features/games/hooks/useRoomOptions';
+import { gamesApi } from '@/features/games/api';
 import {
   LobbyContent,
   CenterSection,
@@ -97,6 +98,7 @@ export function ReusableGameLobby({
   showReorderControls = true,
   showInvitedPlayers = true,
   enableBots = false,
+  onRuleComingSoonChange,
 }: ReusableGameLobbyProps) {
   const {
     waitingLabel = 'Waiting for game to start...',
@@ -116,6 +118,26 @@ export function ReusableGameLobby({
   // Optimistic state for house rules — updates instantly, clears when room syncs
   const [optIdle, setOptIdle] = useState<boolean | null>(null);
   const [optSpectators, setOptSpectators] = useState<boolean | null>(null);
+
+  // Fetch catalog to determine which rules are excluded
+  const [ruleComingSoon, setRuleComingSoon] = useState<Map<string, boolean>>(
+    new Map(),
+  );
+  React.useEffect(() => {
+    gamesApi
+      .getCatalog()
+      .then((catalog) => {
+        const game = catalog.games.find((g) => g.gameId === room.gameId);
+        if (!game) return;
+        const map = new Map<string, boolean>();
+        for (const r of game.rules) {
+          map.set(r.ruleId, r.comingSoon);
+        }
+        setRuleComingSoon(map);
+        onRuleComingSoonChange?.(map);
+      })
+      .catch(() => {});
+  }, [room.gameId]);
 
   const [prevGameOptions, setPrevGameOptions] = useState(room.gameOptions);
   if (prevGameOptions !== room.gameOptions) {
@@ -335,12 +357,14 @@ export function ReusableGameLobby({
                   display: 'flex',
                   alignItems: 'center',
                   gap: 8,
-                  cursor: 'pointer',
+                  cursor: ruleComingSoon.get('idle') ? 'not-allowed' : 'pointer',
+                  opacity: ruleComingSoon.get('idle') ? 0.4 : 1,
                 }}
               >
                 <input
                   type="checkbox"
                   checked={optIdle ?? !!room.gameOptions?.idleTimerAutoplay}
+                  disabled={!!ruleComingSoon.get('idle')}
                   onChange={(e) => {
                     const val = e.target.checked;
                     setOptIdle(val);
@@ -355,13 +379,21 @@ export function ReusableGameLobby({
                 <Text fontSize="$3">
                   {t('games.create.rules.idle.title') || 'Idle timer autoplay'}
                 </Text>
+                {ruleComingSoon.get('idle') && (
+                  <Text fontSize={10} color="#f59e0b" fontWeight="600">
+                    Coming Soon
+                  </Text>
+                )}
               </label>
               <label
                 style={{
                   display: 'flex',
                   alignItems: 'center',
                   gap: 8,
-                  cursor: 'pointer',
+                  cursor: ruleComingSoon.get('spectators')
+                    ? 'not-allowed'
+                    : 'pointer',
+                  opacity: ruleComingSoon.get('spectators') ? 0.4 : 1,
                 }}
               >
                 <input
@@ -369,6 +401,7 @@ export function ReusableGameLobby({
                   checked={
                     optSpectators ?? room.gameOptions?.allowSpectators !== false
                   }
+                  disabled={!!ruleComingSoon.get('spectators')}
                   onChange={(e) => {
                     const val = e.target.checked;
                     setOptSpectators(val);
@@ -384,6 +417,11 @@ export function ReusableGameLobby({
                   {t('games.create.rules.spectators.title') ||
                     'Allow spectators'}
                 </Text>
+                {ruleComingSoon.get('spectators') && (
+                  <Text fontSize={10} color="#f59e0b" fontWeight="600">
+                    Coming Soon
+                  </Text>
+                )}
               </label>
             </YStack>
           )}

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -347,84 +347,79 @@ export function ReusableGameLobby({
 
           {optionsSlot}
 
-          {isHost && room.status === 'lobby' && (
-            <YStack gap="$3" paddingTop="$2">
-              <Text fontSize="$4" fontWeight="600">
-                {t('games.create.sectionHouseRules') || 'House Rules'}
-              </Text>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 8,
-                  cursor: ruleComingSoon.get('idle') ? 'not-allowed' : 'pointer',
-                  opacity: ruleComingSoon.get('idle') ? 0.4 : 1,
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={optIdle ?? !!room.gameOptions?.idleTimerAutoplay}
-                  disabled={!!ruleComingSoon.get('idle')}
-                  onChange={(e) => {
-                    const val = e.target.checked;
-                    setOptIdle(val);
-                    setOption({ idleTimerAutoplay: val });
-                  }}
-                  style={{
-                    width: 16,
-                    height: 16,
-                    accentColor: 'var(--gc-accent, #ffd166)',
-                  }}
-                />
-                <Text fontSize="$3">
-                  {t('games.create.rules.idle.title') || 'Idle timer autoplay'}
+          {isHost &&
+            room.status === 'lobby' &&
+            (!ruleComingSoon.get('idle') ||
+              !ruleComingSoon.get('spectators')) && (
+              <YStack gap="$3" paddingTop="$2">
+                <Text fontSize="$4" fontWeight="600">
+                  {t('games.create.sectionHouseRules') || 'House Rules'}
                 </Text>
-                {ruleComingSoon.get('idle') && (
-                  <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                    {t('games.create.comingSoon') || 'Coming Soon'}
-                  </Text>
+                {!ruleComingSoon.get('idle') && (
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={
+                        optIdle ?? !!room.gameOptions?.idleTimerAutoplay
+                      }
+                      onChange={(e) => {
+                        const val = e.target.checked;
+                        setOptIdle(val);
+                        setOption({ idleTimerAutoplay: val });
+                      }}
+                      style={{
+                        width: 16,
+                        height: 16,
+                        accentColor: 'var(--gc-accent, #ffd166)',
+                      }}
+                    />
+                    <Text fontSize="$3">
+                      {t('games.create.rules.idle.title') ||
+                        'Idle timer autoplay'}
+                    </Text>
+                  </label>
                 )}
-              </label>
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 8,
-                  cursor: ruleComingSoon.get('spectators')
-                    ? 'not-allowed'
-                    : 'pointer',
-                  opacity: ruleComingSoon.get('spectators') ? 0.4 : 1,
-                }}
-              >
-                <input
-                  type="checkbox"
-                  checked={
-                    optSpectators ?? room.gameOptions?.allowSpectators !== false
-                  }
-                  disabled={!!ruleComingSoon.get('spectators')}
-                  onChange={(e) => {
-                    const val = e.target.checked;
-                    setOptSpectators(val);
-                    setOption({ allowSpectators: val });
-                  }}
-                  style={{
-                    width: 16,
-                    height: 16,
-                    accentColor: 'var(--gc-accent, #ffd166)',
-                  }}
-                />
-                <Text fontSize="$3">
-                  {t('games.create.rules.spectators.title') ||
-                    'Allow spectators'}
-                </Text>
-                {ruleComingSoon.get('spectators') && (
-                  <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                    {t('games.create.comingSoon') || 'Coming Soon'}
-                  </Text>
+                {!ruleComingSoon.get('spectators') && (
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 8,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={
+                        optSpectators ??
+                        room.gameOptions?.allowSpectators !== false
+                      }
+                      onChange={(e) => {
+                        const val = e.target.checked;
+                        setOptSpectators(val);
+                        setOption({ allowSpectators: val });
+                      }}
+                      style={{
+                        width: 16,
+                        height: 16,
+                        accentColor: 'var(--gc-accent, #ffd166)',
+                      }}
+                    />
+                    <Text fontSize="$3">
+                      {t('games.create.rules.spectators.title') ||
+                        'Allow spectators'}
+                    </Text>
+                  </label>
                 )}
-              </label>
-            </YStack>
-          )}
+              </YStack>
+            )}
         </CenterSection>
 
         <LobbySidebar

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -381,7 +381,7 @@ export function ReusableGameLobby({
                 </Text>
                 {ruleComingSoon.get('idle') && (
                   <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                    Coming Soon
+                    {t('games.create.comingSoon') || 'Coming Soon'}
                   </Text>
                 )}
               </label>
@@ -419,7 +419,7 @@ export function ReusableGameLobby({
                 </Text>
                 {ruleComingSoon.get('spectators') && (
                   <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                    Coming Soon
+                    {t('games.create.comingSoon') || 'Coming Soon'}
                   </Text>
                 )}
               </label>

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -347,79 +347,84 @@ export function ReusableGameLobby({
 
           {optionsSlot}
 
-          {isHost &&
-            room.status === 'lobby' &&
-            (!ruleComingSoon.get('idle') ||
-              !ruleComingSoon.get('spectators')) && (
-              <YStack gap="$3" paddingTop="$2">
-                <Text fontSize="$4" fontWeight="600">
-                  {t('games.create.sectionHouseRules') || 'House Rules'}
+          {isHost && room.status === 'lobby' && (
+            <YStack gap="$3" paddingTop="$2">
+              <Text fontSize="$4" fontWeight="600">
+                {t('games.create.sectionHouseRules') || 'House Rules'}
+              </Text>
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  cursor: ruleComingSoon.get('idle') ? 'not-allowed' : 'pointer',
+                  opacity: ruleComingSoon.get('idle') ? 0.4 : 1,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={optIdle ?? !!room.gameOptions?.idleTimerAutoplay}
+                  disabled={!!ruleComingSoon.get('idle')}
+                  onChange={(e) => {
+                    const val = e.target.checked;
+                    setOptIdle(val);
+                    setOption({ idleTimerAutoplay: val });
+                  }}
+                  style={{
+                    width: 16,
+                    height: 16,
+                    accentColor: 'var(--gc-accent, #ffd166)',
+                  }}
+                />
+                <Text fontSize="$3">
+                  {t('games.create.rules.idle.title') || 'Idle timer autoplay'}
                 </Text>
-                {!ruleComingSoon.get('idle') && (
-                  <label
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                      cursor: 'pointer',
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={
-                        optIdle ?? !!room.gameOptions?.idleTimerAutoplay
-                      }
-                      onChange={(e) => {
-                        const val = e.target.checked;
-                        setOptIdle(val);
-                        setOption({ idleTimerAutoplay: val });
-                      }}
-                      style={{
-                        width: 16,
-                        height: 16,
-                        accentColor: 'var(--gc-accent, #ffd166)',
-                      }}
-                    />
-                    <Text fontSize="$3">
-                      {t('games.create.rules.idle.title') ||
-                        'Idle timer autoplay'}
-                    </Text>
-                  </label>
+                {ruleComingSoon.get('idle') && (
+                  <Text fontSize={10} color="#f59e0b" fontWeight="600">
+                    {t('games.create.comingSoon') || 'Coming Soon'}
+                  </Text>
                 )}
-                {!ruleComingSoon.get('spectators') && (
-                  <label
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                      cursor: 'pointer',
-                    }}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={
-                        optSpectators ??
-                        room.gameOptions?.allowSpectators !== false
-                      }
-                      onChange={(e) => {
-                        const val = e.target.checked;
-                        setOptSpectators(val);
-                        setOption({ allowSpectators: val });
-                      }}
-                      style={{
-                        width: 16,
-                        height: 16,
-                        accentColor: 'var(--gc-accent, #ffd166)',
-                      }}
-                    />
-                    <Text fontSize="$3">
-                      {t('games.create.rules.spectators.title') ||
-                        'Allow spectators'}
-                    </Text>
-                  </label>
+              </label>
+              <label
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  cursor: ruleComingSoon.get('spectators')
+                    ? 'not-allowed'
+                    : 'pointer',
+                  opacity: ruleComingSoon.get('spectators') ? 0.4 : 1,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={
+                    optSpectators ?? room.gameOptions?.allowSpectators !== false
+                  }
+                  disabled={!!ruleComingSoon.get('spectators')}
+                  onChange={(e) => {
+                    const val = e.target.checked;
+                    setOptSpectators(val);
+                    setOption({ allowSpectators: val });
+                  }}
+                  style={{
+                    width: 16,
+                    height: 16,
+                    accentColor: 'var(--gc-accent, #ffd166)',
+                  }}
+                />
+                <Text fontSize="$3">
+                  {t('games.create.rules.spectators.title') ||
+                    'Allow spectators'}
+                </Text>
+                {ruleComingSoon.get('spectators') && (
+                  <Text fontSize={10} color="#f59e0b" fontWeight="600">
+                    {t('games.create.comingSoon') || 'Coming Soon'}
+                  </Text>
                 )}
-              </YStack>
-            )}
+              </label>
+            </YStack>
+          )}
         </CenterSection>
 
         <LobbySidebar

--- a/apps/web/src/features/games/ui/ReusableGameLobby.types.ts
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.types.ts
@@ -76,4 +76,8 @@ export interface ReusableGameLobbyProps {
   showReorderControls?: boolean;
   showInvitedPlayers?: boolean;
   enableBots?: boolean;
+
+  // Catalog rule visibility — fired once after catalog loads so game-specific
+  // lobbies can disable/exclude options without fetching the catalog themselves.
+  onRuleComingSoonChange?: (map: Map<string, boolean>) => void;
 }

--- a/apps/web/src/features/games/ui/create/createPageState.test.ts
+++ b/apps/web/src/features/games/ui/create/createPageState.test.ts
@@ -36,8 +36,8 @@ describe('buildComingSoonMaps', () => {
   it('maps game comingSoon flags correctly', () => {
     const catalog: CatalogResponse = {
       games: [
-        { gameId: 'critical_v1', comingSoon: true, variants: [] },
-        { gameId: 'sea_battle_v1', comingSoon: false, variants: [] },
+        { gameId: 'critical_v1', comingSoon: true, variants: [], rules: [] },
+        { gameId: 'sea_battle_v1', comingSoon: false, variants: [], rules: [] },
       ],
     };
     const { gameComingSoon } = buildComingSoonMaps(catalog);
@@ -55,6 +55,7 @@ describe('buildComingSoonMaps', () => {
             { id: 'standard', comingSoon: false },
             { id: 'premium', comingSoon: true },
           ],
+          rules: [],
         },
       ],
     };
@@ -70,11 +71,13 @@ describe('buildComingSoonMaps', () => {
           gameId: 'game_a',
           comingSoon: false,
           variants: [{ id: 'v1', comingSoon: true }],
+          rules: [],
         },
         {
           gameId: 'game_b',
           comingSoon: false,
           variants: [{ id: 'v1', comingSoon: false }],
+          rules: [],
         },
       ],
     };

--- a/apps/web/src/features/games/ui/useAudioPlayer.ts
+++ b/apps/web/src/features/games/ui/useAudioPlayer.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMusicSetting } from '@/shared/hooks/useMusicSetting';
+import { usePersistedState } from '@/shared/hooks/usePersistedState';
 import {
   loadStoredSettings,
   saveStoredSettings,
@@ -68,9 +69,9 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
   const [tracks, setTracks] = useState<readonly MusicTrack[]>(FALLBACK_TRACKS);
   const [index, setIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const [volume, setVolume] = useState(DEFAULT_VOLUME);
-  const [shuffle, setShuffle] = useState(false);
-  const [repeat, setRepeat] = useState<RepeatMode>('off');
+  const [volume, setVolume] = usePersistedState('musicVolume', DEFAULT_VOLUME);
+  const [shuffle, setShuffle] = usePersistedState('musicShuffle', false);
+  const [repeat, setRepeat] = usePersistedState('musicRepeat', 'off');
   const [miniMode, setMiniMode] = useState(false);
   const [playlistOpen, setPlaylistOpen] = useState(false);
   const [visible, setVisible] = useState(false);
@@ -148,7 +149,6 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
     tracksLengthRef.current = tracks.length;
     indexRef.current = index;
   });
-
   const crossfadeTo = useCallback((newSrc: string, newVolume: number) => {
     const oldAudio =
       activeSlotRef.current === 'A' ? audioARef.current : audioBRef.current;
@@ -330,15 +330,14 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
       : (index - 1 + tracks.length) % tracks.length;
     playIndex(pi);
   }, [index, shuffle, shuffleOrder, tracks.length, playIndex]);
-
   const onVolumeChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const v = Number(event.target.value) / 100;
       volumeRef.current = v;
-      setVolume(v);
       if (audioRef.current) audioRef.current.volume = v;
+      setVolume(v);
     },
-    [],
+    [setVolume],
   );
   const onSeek = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const time = Number(event.target.value);
@@ -359,15 +358,16 @@ export function useAudioPlayer(gameId?: string | null): AudioPlayerState {
   }, []);
 
   const toggleShuffle = useCallback(() => {
-    setShuffle((s) => {
-      if (!s) setShuffleOrder(shuffleArray(tracks.length));
-      return !s;
-    });
-  }, [tracks.length]);
+    if (!shuffle) setShuffleOrder(shuffleArray(tracks.length));
+    setShuffle(!shuffle);
+  }, [shuffle, tracks.length, setShuffle]);
 
   const cycleRepeat = useCallback(() => {
-    setRepeat((r) => (r === 'off' ? 'all' : r === 'all' ? 'one' : 'off'));
-  }, []);
+    const next = repeat === 'off' ? 'all' : repeat === 'all' ? 'one' : 'off';
+    const a = audioRef.current;
+    if (a) a.loop = next === 'one';
+    setRepeat(next);
+  }, [repeat, setRepeat]);
 
   const toggleTrack = useCallback((trackIndex: number) => {
     setEnabledTracks((prev) => {

--- a/apps/web/src/features/gems/server/gems.actions.test.ts
+++ b/apps/web/src/features/gems/server/gems.actions.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
-vi.mock('next/headers', () => ({
-  cookies: vi.fn().mockResolvedValue({ get: () => ({ value: 'test-token' }) }),
-}));
-vi.mock('@/shared/lib/api-base', () => ({
-  resolveApiUrl: (path: string) => `http://localhost:4000${path}`,
+
+const TEST_API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+vi.mock('@/shared/lib/server-auth-fetch', () => ({
+  serverAuthFetch: vi.fn().mockImplementation(async (path: string, init?: RequestInit) => {
+    return fetchMock(`${TEST_API_BASE}${path}`, init);
+  }),
 }));
 
 const fetchMock = vi.fn();

--- a/apps/web/src/features/gems/server/gems.actions.ts
+++ b/apps/web/src/features/gems/server/gems.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { cookies } from 'next/headers';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type { ConversionResult } from './gems.types';
 
 // ─── Result types ──────────────────────────────────────────────────────────────
@@ -38,24 +37,6 @@ export type CancelGemPurchaseResult =
   | { ok: true }
   | { ok: false; error: 'not_found' | 'generic' };
 
-// ─── Internal fetch helper ────────────────────────────────────────────────────
-
-async function authFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
-
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
 /**
@@ -69,7 +50,7 @@ export async function buyGemsAction(input: {
     return { ok: false, error: 'generic' };
   }
 
-  const res = await authFetch('/payments/gems/orders', {
+  const res = await serverAuthFetch('/payments/gems/orders', {
     method: 'POST',
     body: JSON.stringify({ packageId: input.packageId }),
   });
@@ -118,7 +99,7 @@ export async function finalizeGemPurchase(input: {
     return { ok: false, error: 'generic' };
   }
 
-  const res = await authFetch(
+  const res = await serverAuthFetch(
     `/payments/gems/orders/${encodeURIComponent(input.orderId)}/finalize`,
     { method: 'POST' },
   );
@@ -177,7 +158,7 @@ export async function cancelGemPurchase(input: {
   if (!input.orderId || typeof input.orderId !== 'string') {
     return { ok: false, error: 'generic' };
   }
-  const res = await authFetch(
+  const res = await serverAuthFetch(
     `/payments/gems/orders/${encodeURIComponent(input.orderId)}/cancel`,
     { method: 'POST' },
   );
@@ -219,7 +200,7 @@ export async function convertGemsAction(input: {
     return { ok: false, error: 'invalid' };
   }
 
-  const res = await authFetch('/wallet/convert-gems-to-coins', {
+  const res = await serverAuthFetch('/wallet/convert-gems-to-coins', {
     method: 'POST',
     body: JSON.stringify({
       gems: gemsAmount,

--- a/apps/web/src/features/shop/server/shop.actions.ts
+++ b/apps/web/src/features/shop/server/shop.actions.ts
@@ -1,8 +1,7 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { revalidatePath } from 'next/cache';
-import { resolveApiUrl } from '@/shared/lib/api-base';
+import { serverAuthFetch } from '@/shared/lib/server-auth-fetch';
 import type {
   EquippedView,
   PurchaseResult,
@@ -25,21 +24,6 @@ export type ShopActionError =
   | 'category_mismatch'
   | 'unauthorized'
   | 'generic';
-
-async function authFetch(path: string, init?: RequestInit): Promise<Response> {
-  const cookieJar = await cookies();
-  const token = cookieJar.get('access_token')?.value;
-  const url = resolveApiUrl(path);
-  return fetch(url, {
-    ...init,
-    cache: 'no-store',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-  });
-}
 
 function classifyError(status: number, body: string): ShopActionError {
   if (status === 401) return 'unauthorized';
@@ -71,7 +55,7 @@ export async function purchaseItemAction(
   itemId: string,
   purchaseId: string,
 ): Promise<ShopActionResult<PurchaseResult>> {
-  const res = await authFetch('/shop/purchase', {
+  const res = await serverAuthFetch('/shop/purchase', {
     method: 'POST',
     body: JSON.stringify({ itemId, purchaseId }),
   });
@@ -86,7 +70,7 @@ export async function purchaseItemAction(
 export async function sellItemAction(
   purchaseId: string,
 ): Promise<ShopActionResult<SellResult>> {
-  const res = await authFetch('/shop/sell', {
+  const res = await serverAuthFetch('/shop/sell', {
     method: 'POST',
     body: JSON.stringify({ purchaseId }),
   });
@@ -103,7 +87,7 @@ export async function sellItemAction(
 export async function equipItemAction(
   itemId: string,
 ): Promise<ShopActionResult<EquippedView>> {
-  const res = await authFetch('/shop/equip', {
+  const res = await serverAuthFetch('/shop/equip', {
     method: 'POST',
     body: JSON.stringify({ itemId }),
   });
@@ -118,7 +102,7 @@ export async function equipItemAction(
 export async function unequipItemAction(
   category: ShopCategory,
 ): Promise<ShopActionResult<EquippedView>> {
-  const res = await authFetch('/shop/unequip', {
+  const res = await serverAuthFetch('/shop/unequip', {
     method: 'POST',
     body: JSON.stringify({ category }),
   });

--- a/apps/web/src/features/stats/hooks/useRecordGameResult.test.ts
+++ b/apps/web/src/features/stats/hooks/useRecordGameResult.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useRecordGameResult } from './useRecordGameResult';
 import { useLocalStatsStore } from '../store/statsStore';
+import type { GameResult } from '@/features/games/hooks/useGameResultModal';
 
 describe('useRecordGameResult', () => {
   beforeEach(() => {
@@ -71,7 +72,7 @@ describe('useRecordGameResult', () => {
     const { rerender } = renderHook(
       ({ result, sessionId }) =>
         useRecordGameResult(result, 'tic_tac_toe_v1', sessionId),
-      { initialProps: { result: 'won' as const, sessionId: 'session-1' } },
+      { initialProps: { result: 'won' as GameResult, sessionId: 'session-1' } },
     );
 
     rerender({ result: 'lost', sessionId: 'session-2' });

--- a/apps/web/src/features/wallet/ui/WalletBalanceSummary.test.tsx
+++ b/apps/web/src/features/wallet/ui/WalletBalanceSummary.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@/shared/lib/useTranslation', () => ({
 
 describe('WalletBalanceSummary', () => {
   it('renders coin and gem balances', () => {
-    const balance: WalletBalance = { coins: 1_250, gems: 30 };
+    const balance: WalletBalance = { coins: 1_250, gems: 30, arcadeum: 0 };
     render(<WalletBalanceSummary balance={balance} />);
     expect(screen.getByTestId('balance-coins-value').textContent).toContain(
       '1,250',
@@ -31,7 +31,7 @@ describe('WalletBalanceSummary', () => {
   });
 
   it('renders zero balances for an empty wallet', () => {
-    render(<WalletBalanceSummary balance={{ coins: 0, gems: 0 }} />);
+    render(<WalletBalanceSummary balance={{ coins: 0, gems: 0, arcadeum: 0 }} />);
     expect(screen.getByTestId('balance-coins-value').textContent).toContain(
       '0',
     );

--- a/apps/web/src/shared/api/gamesApi.ts
+++ b/apps/web/src/shared/api/gamesApi.ts
@@ -11,6 +11,7 @@ export async function startGameRoom(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
       Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ engine }),
@@ -34,6 +35,7 @@ export async function reorderRoomParticipants(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
       Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ userIds }),

--- a/apps/web/src/shared/hooks/usePersistedState.ts
+++ b/apps/web/src/shared/hooks/usePersistedState.ts
@@ -1,0 +1,35 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import {
+  loadStoredSettings,
+  saveStoredSettings,
+  subscribeToSettings,
+  type StoredSettings,
+} from '../lib/settings-storage';
+
+type MusicKey = 'musicVolume' | 'musicShuffle' | 'musicRepeat';
+
+export function usePersistedState<K extends MusicKey>(
+  key: K,
+  defaultValue: NonNullable<StoredSettings[K]>,
+): [
+  NonNullable<StoredSettings[K]>,
+  (value: NonNullable<StoredSettings[K]>) => void,
+] {
+  const value = useSyncExternalStore(
+    subscribeToSettings,
+    () =>
+      (loadStoredSettings()[key] ?? defaultValue) as NonNullable<
+        StoredSettings[K]
+      >,
+    () => defaultValue,
+  );
+
+  const setValue = useCallback(
+    (v: NonNullable<StoredSettings[K]>) => {
+      saveStoredSettings({ [key]: v } as Partial<StoredSettings>);
+    },
+    [key],
+  );
+
+  return [value, setValue];
+}

--- a/apps/web/src/shared/lib/server-auth-fetch.ts
+++ b/apps/web/src/shared/lib/server-auth-fetch.ts
@@ -1,0 +1,29 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+import { resolveApiUrl } from './api-base';
+
+/**
+ * Server-side fetch wrapper that automatically resolves the API URL, attaches
+ * the access token from cookies, and includes the `X-Requested-With` header
+ * required by the backend CSRF guard. Returns a raw `Response` so callers
+ * can classify errors by status code as before.
+ */
+export async function serverAuthFetch(
+  path: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const cookieJar = await cookies();
+  const token = cookieJar.get('access_token')?.value;
+  const url = resolveApiUrl(path);
+
+  return fetch(url, {
+    ...init,
+    cache: 'no-store',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+      ...(init?.headers ?? {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+}

--- a/apps/web/src/widgets/CriticalGame/ui/CreationConfig.visibility.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/CreationConfig.visibility.test.tsx
@@ -44,6 +44,7 @@ describe('Critical CreationConfig — variant visibility filter', () => {
             { id: 'cyberpunk', comingSoon: false },
             { id: 'galaxy', comingSoon: false },
           ],
+          rules: [],
         }, // crime hidden
       ],
     });
@@ -84,6 +85,7 @@ describe('Critical CreationConfig — variant visibility filter', () => {
             { id: 'cyberpunk', comingSoon: false },
             { id: 'crime', comingSoon: true },
           ],
+          rules: [],
         },
       ],
     });

--- a/apps/web/src/widgets/CriticalGame/ui/CriticalLobby.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/CriticalLobby.tsx
@@ -80,6 +80,10 @@ export function CriticalLobby({
   const [showRules, setShowRules] = useState(false);
   const { setOption } = useRoomOptions({ roomId: room.id, userId });
 
+  const [ruleComingSoon, setRuleComingSoon] = useState<Map<string, boolean>>(
+    new Map(),
+  );
+
   const cardVariant = room.gameOptions?.cardVariant || GAME_VARIANT.CYBERPUNK;
   const variantInfo = getVariantInfo(cardVariant);
   const theme = getCriticalTheme(cardVariant);
@@ -111,15 +115,24 @@ export function CriticalLobby({
               !!(room.gameOptions as Record<string, unknown>)
                 ?.allowActionCardCombos
             }
+            disabled={!!ruleComingSoon.get('combos')}
             onCheckedChange={(val) => setOption({ allowActionCardCombos: val })}
             size="$2"
           >
             <Switch.Thumb />
           </Switch>
-          <Text fontSize="$3">
+          <Text
+            fontSize="$3"
+            opacity={ruleComingSoon.get('combos') ? 0.4 : 1}
+          >
             {t('games.create.houseRuleActionCardCombos') ||
               'Action Card Combos'}
           </Text>
+          {ruleComingSoon.get('combos') && (
+            <Text fontSize={10} color="#f59e0b" fontWeight="600">
+              Coming Soon
+            </Text>
+          )}
         </XStack>
       </VariantSelectorWrapper>
     ) : null;
@@ -199,6 +212,7 @@ export function CriticalLobby({
       showReorderControls={true}
       showInvitedPlayers={true}
       enableBots={true}
+      onRuleComingSoonChange={setRuleComingSoon}
     />
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/CriticalLobby.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/CriticalLobby.tsx
@@ -130,7 +130,7 @@ export function CriticalLobby({
           </Text>
           {ruleComingSoon.get('combos') && (
             <Text fontSize={10} color="#f59e0b" fontWeight="600">
-              Coming Soon
+              {t('games.create.comingSoon') || 'Coming Soon'}
             </Text>
           )}
         </XStack>

--- a/apps/web/src/widgets/GlimwormGame/ui/GlimwormLobby.visibility.test.tsx
+++ b/apps/web/src/widgets/GlimwormGame/ui/GlimwormLobby.visibility.test.tsx
@@ -70,6 +70,7 @@ describe('GlimwormLobby — variant visibility (coming-soon)', () => {
             { id: 'battle_royale', comingSoon: false },
             { id: 'time_attack', comingSoon: false },
           ],
+          rules: [],
         },
       ],
     });
@@ -100,6 +101,7 @@ describe('GlimwormLobby — variant visibility (coming-soon)', () => {
             { id: 'battle_royale', comingSoon: false },
             { id: 'time_attack', comingSoon: true },
           ],
+          rules: [],
         },
       ],
     });

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -135,7 +135,7 @@ export interface SeaBattleSnapshot {
     centerRow: number;
     centerCol: number;
     radius: number;
-    shipPositions: ShipCell[];
+    cells: { row: number; col: number; state: CellState }[];
   };
   lastRadar?: {
     attackerId: string;

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
@@ -26,6 +26,7 @@ interface AttackBoardCellProps {
 }
 
 export const AttackBoardCell = memo(function AttackBoardCell({
+  cellState,
   displayState,
   isSunk,
   theme,
@@ -44,17 +45,33 @@ export const AttackBoardCell = memo(function AttackBoardCell({
   const icon = getCellIcon(isSunk, displayState);
   const animClass = getCellAnimClass(isSunk, displayState);
 
+  const isShip = cellState === 1; // CellState.SHIP
+
   const highlightStyle: React.CSSProperties =
     highlight === 'sonar'
-      ? {
-          boxShadow: '0 0 8px 2px rgba(6, 182, 212, 0.7)',
-          borderColor: '#06b6d4',
-        }
-      : highlight === 'radar'
+      ? isShip
         ? {
-            boxShadow: '0 0 8px 2px rgba(168, 85, 247, 0.7)',
-            borderColor: '#a855f7',
+            boxShadow: '0 0 10px 3px rgba(6, 182, 212, 0.8)',
+            borderColor: '#06b6d4',
+            backgroundColor: 'rgba(6, 182, 212, 0.2)',
           }
+        : {
+            boxShadow: '0 0 4px 1px rgba(6, 182, 212, 0.3)',
+            borderColor: 'rgba(6, 182, 212, 0.4)',
+            backgroundColor: 'rgba(6, 182, 212, 0.06)',
+          }
+      : highlight === 'radar'
+        ? isShip
+          ? {
+              boxShadow: '0 0 10px 3px rgba(168, 85, 247, 0.8)',
+              borderColor: '#a855f7',
+              backgroundColor: 'rgba(168, 85, 247, 0.2)',
+            }
+          : {
+              boxShadow: '0 0 4px 1px rgba(168, 85, 247, 0.3)',
+              borderColor: 'rgba(168, 85, 247, 0.4)',
+              backgroundColor: 'rgba(168, 85, 247, 0.06)',
+            }
         : {};
 
   const previewStyle: React.CSSProperties =
@@ -170,13 +187,19 @@ export const AttackBoardCell = memo(function AttackBoardCell({
             position: 'absolute',
             top: 1,
             right: 1,
-            fontSize: 8,
+            fontSize: isShip ? 10 : 8,
             lineHeight: 1,
             pointerEvents: 'none',
             opacity: 0.9,
           }}
         >
-          {highlight === 'sonar' ? '🔊' : '📡'}
+          {highlight === 'sonar'
+            ? isShip
+              ? '🚢'
+              : '🔊'
+            : isShip
+              ? '🚢'
+              : '📡'}
         </div>
       )}
     </BoardCell>

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
@@ -27,7 +27,7 @@ interface AttackBoardCellProps {
 }
 
 export const AttackBoardCell = memo(function AttackBoardCell({
-  cellState,
+  cellState: _cellState,
   displayState,
   isSunk,
   theme,

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
@@ -20,6 +20,7 @@ interface AttackBoardCellProps {
   highlight?: 'sonar' | 'radar' | null;
   isWeaponPreview?: boolean;
   weaponPreviewType?: 'sonar' | 'radar' | null;
+  isWeaponClickable?: boolean;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
 }
@@ -36,6 +37,7 @@ export const AttackBoardCell = memo(function AttackBoardCell({
   highlight,
   isWeaponPreview = false,
   weaponPreviewType,
+  isWeaponClickable = false,
   onMouseEnter,
   onMouseLeave,
 }: AttackBoardCellProps) {
@@ -80,7 +82,7 @@ export const AttackBoardCell = memo(function AttackBoardCell({
         ...previewStyle,
         ...(isWeaponPreview ? { cursor: 'crosshair' } : {}),
       }}
-      className={`sb-cell ${isAttackable ? 'sb-attackable' : ''} ${isPending ? 'sb-cell-pending' : ''} ${highlight ? 'sb-highlight' : ''} ${isWeaponPreview ? 'sb-weapon-preview' : ''} ${animClass || ''}`}
+      className={`sb-cell ${isAttackable || isWeaponClickable ? 'sb-attackable' : ''} ${isPending ? 'sb-cell-pending' : ''} ${highlight ? 'sb-highlight' : ''} ${isWeaponPreview ? 'sb-weapon-preview' : ''} ${animClass || ''}`}
       data-row={!isMe ? rIndex : undefined}
       data-col={!isMe ? cIndex : undefined}
       onMouseEnter={onMouseEnter}

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
@@ -18,6 +18,10 @@ interface AttackBoardCellProps {
   isPending?: boolean;
   isMe: boolean;
   highlight?: 'sonar' | 'radar' | null;
+  isWeaponPreview?: boolean;
+  weaponPreviewType?: 'sonar' | 'radar' | null;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
 }
 
 export const AttackBoardCell = memo(function AttackBoardCell({
@@ -30,6 +34,10 @@ export const AttackBoardCell = memo(function AttackBoardCell({
   isPending = false,
   isMe,
   highlight,
+  isWeaponPreview = false,
+  weaponPreviewType,
+  onMouseEnter,
+  onMouseLeave,
 }: AttackBoardCellProps) {
   const icon = getCellIcon(isSunk, displayState);
   const animClass = getCellAnimClass(isSunk, displayState);
@@ -47,6 +55,21 @@ export const AttackBoardCell = memo(function AttackBoardCell({
           }
         : {};
 
+  const previewStyle: React.CSSProperties =
+    isWeaponPreview && weaponPreviewType === 'sonar'
+      ? {
+          boxShadow: '0 0 6px 1px rgba(6, 182, 212, 0.4)',
+          borderColor: 'rgba(6, 182, 212, 0.5)',
+          backgroundColor: 'rgba(6, 182, 212, 0.08)',
+        }
+      : isWeaponPreview && weaponPreviewType === 'radar'
+        ? {
+            boxShadow: '0 0 6px 1px rgba(168, 85, 247, 0.4)',
+            borderColor: 'rgba(168, 85, 247, 0.5)',
+            backgroundColor: 'rgba(168, 85, 247, 0.08)',
+          }
+        : {};
+
   return (
     <BoardCell
       style={{
@@ -54,10 +77,14 @@ export const AttackBoardCell = memo(function AttackBoardCell({
         borderColor: theme.cellBorder,
         borderRadius: parseInt(theme.borderRadius) || 4,
         ...highlightStyle,
+        ...previewStyle,
+        ...(isWeaponPreview ? { cursor: 'crosshair' } : {}),
       }}
-      className={`sb-cell ${isAttackable ? 'sb-attackable' : ''} ${isPending ? 'sb-cell-pending' : ''} ${highlight ? 'sb-highlight' : ''} ${animClass || ''}`}
+      className={`sb-cell ${isAttackable ? 'sb-attackable' : ''} ${isPending ? 'sb-cell-pending' : ''} ${highlight ? 'sb-highlight' : ''} ${isWeaponPreview ? 'sb-weapon-preview' : ''} ${animClass || ''}`}
       data-row={!isMe ? rIndex : undefined}
       data-col={!isMe ? cIndex : undefined}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       {icon && (
         <Text

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
@@ -18,6 +18,7 @@ interface AttackBoardCellProps {
   isPending?: boolean;
   isMe: boolean;
   highlight?: 'sonar' | 'radar' | null;
+  highlightCellState?: number;
   isWeaponPreview?: boolean;
   weaponPreviewType?: 'sonar' | 'radar' | null;
   isWeaponClickable?: boolean;
@@ -36,6 +37,7 @@ export const AttackBoardCell = memo(function AttackBoardCell({
   isPending = false,
   isMe,
   highlight,
+  highlightCellState,
   isWeaponPreview = false,
   weaponPreviewType,
   isWeaponClickable = false,
@@ -45,7 +47,7 @@ export const AttackBoardCell = memo(function AttackBoardCell({
   const icon = getCellIcon(isSunk, displayState);
   const animClass = getCellAnimClass(isSunk, displayState);
 
-  const isShip = cellState === 1; // CellState.SHIP
+  const isShip = highlightCellState === 1; // CellState.SHIP
 
   const highlightStyle: React.CSSProperties =
     highlight === 'sonar'

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -37,7 +37,9 @@ interface AttackPlayerBoardProps {
   team?: SeaBattleTeam;
   sunkCellSet: Set<string>;
   sonarHighlightCells?: Set<string> | null;
+  sonarCellStates?: Map<string, number> | null;
   radarHighlightCells?: Set<string> | null;
+  radarCellStates?: Map<string, number> | null;
   weaponPreviewCells?: Set<string> | null;
   weaponPreviewType?: 'sonar' | 'radar' | null;
   onAttack?: (targetPlayerId: string, row: number, col: number) => void;
@@ -60,7 +62,9 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   team,
   sunkCellSet,
   sonarHighlightCells,
+  sonarCellStates,
   radarHighlightCells,
+  radarCellStates,
   weaponPreviewCells,
   weaponPreviewType,
   onAttack,
@@ -151,12 +155,16 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
             !isPending;
           const isWeaponClickable = !isMe && !isTeammate && !!weaponMode;
           const cellKey = `${player.playerId}-${rIndex}-${cIndex}`;
+          const isSonarCell = !isMe && sonarHighlightCells?.has(cellKey);
+          const isRadarCell = !isMe && radarHighlightCells?.has(cellKey);
           const highlight: 'sonar' | 'radar' | null =
-            !isMe && sonarHighlightCells?.has(cellKey)
-              ? 'sonar'
-              : !isMe && radarHighlightCells?.has(cellKey)
-                ? 'radar'
-                : null;
+            isSonarCell ? 'sonar' : isRadarCell ? 'radar' : null;
+          const highlightCellState =
+            isSonarCell && sonarCellStates
+              ? sonarCellStates.get(cellKey)
+              : isRadarCell && radarCellStates
+                ? radarCellStates.get(cellKey)
+                : undefined;
           const isWeaponPreview =
             !isMe && weaponPreviewCells?.has(cellKey);
 
@@ -169,6 +177,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
               isAttackable={isAttackable}
               isPending={isPending}
               highlight={highlight}
+              highlightCellState={highlightCellState}
               isWeaponPreview={!!isWeaponPreview}
               weaponPreviewType={!isMe ? weaponPreviewType : null}
               isWeaponClickable={isWeaponClickable}

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -43,6 +43,7 @@ interface AttackPlayerBoardProps {
   onAttack?: (targetPlayerId: string, row: number, col: number) => void;
   onCellHover?: (playerId: string, row: number, col: number) => void;
   onCellHoverEnd?: () => void;
+  weaponMode?: boolean;
   t: (key: TranslationKey) => string;
 }
 
@@ -65,6 +66,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   onAttack,
   onCellHover,
   onCellHoverEnd,
+  weaponMode = false,
   t,
 }: AttackPlayerBoardProps) {
   const isAttackDisabled = disabled || isTeammate;
@@ -94,18 +96,24 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   const handleGridClick = useCallback(
     (e: React.MouseEvent) => {
       if (!isMyTurn || isAttackDisabled || !onAttack) return;
-      const cell = (e.target as HTMLElement).closest('.sb-cell.sb-attackable');
+      const cell = (e.target as HTMLElement).closest(
+        weaponMode
+          ? '.sb-cell[data-row]'
+          : '.sb-cell.sb-attackable',
+      );
       if (!cell) return;
       const row = cell.getAttribute('data-row');
       const col = cell.getAttribute('data-col');
       if (row !== null && col !== null) {
         const r = parseInt(row);
         const c = parseInt(col);
-        setPendingCell({ r, c });
+        if (!weaponMode) {
+          setPendingCell({ r, c });
+        }
         onAttack(player.playerId, r, c);
       }
     },
-    [isMyTurn, isAttackDisabled, onAttack, player.playerId],
+    [isMyTurn, isAttackDisabled, onAttack, player.playerId, weaponMode],
   );
 
   const boardGrid = (
@@ -141,6 +149,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
             cellState !== CELL_STATE.MISS &&
             !isSunk &&
             !isPending;
+          const isWeaponClickable = !isMe && !isTeammate && !!weaponMode;
           const cellKey = `${player.playerId}-${rIndex}-${cIndex}`;
           const highlight: 'sonar' | 'radar' | null =
             !isMe && sonarHighlightCells?.has(cellKey)
@@ -162,6 +171,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
               highlight={highlight}
               isWeaponPreview={!!isWeaponPreview}
               weaponPreviewType={!isMe ? weaponPreviewType : null}
+              isWeaponClickable={isWeaponClickable}
               theme={theme}
               rIndex={rIndex}
               cIndex={cIndex}

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -38,7 +38,11 @@ interface AttackPlayerBoardProps {
   sunkCellSet: Set<string>;
   sonarHighlightCells?: Set<string> | null;
   radarHighlightCells?: Set<string> | null;
+  weaponPreviewCells?: Set<string> | null;
+  weaponPreviewType?: 'sonar' | 'radar' | null;
   onAttack?: (targetPlayerId: string, row: number, col: number) => void;
+  onCellHover?: (playerId: string, row: number, col: number) => void;
+  onCellHoverEnd?: () => void;
   t: (key: TranslationKey) => string;
 }
 
@@ -56,7 +60,11 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   sunkCellSet,
   sonarHighlightCells,
   radarHighlightCells,
+  weaponPreviewCells,
+  weaponPreviewType,
   onAttack,
+  onCellHover,
+  onCellHoverEnd,
   t,
 }: AttackPlayerBoardProps) {
   const isAttackDisabled = disabled || isTeammate;
@@ -140,6 +148,8 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
               : !isMe && radarHighlightCells?.has(cellKey)
                 ? 'radar'
                 : null;
+          const isWeaponPreview =
+            !isMe && weaponPreviewCells?.has(cellKey);
 
           return (
             <AttackBoardCell
@@ -150,10 +160,18 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
               isAttackable={isAttackable}
               isPending={isPending}
               highlight={highlight}
+              isWeaponPreview={!!isWeaponPreview}
+              weaponPreviewType={!isMe ? weaponPreviewType : null}
               theme={theme}
               rIndex={rIndex}
               cIndex={cIndex}
               isMe={isMe}
+              onMouseEnter={
+                !isMe && onCellHover
+                  ? () => onCellHover(player.playerId, rIndex, cIndex)
+                  : undefined
+              }
+              onMouseLeave={!isMe && onCellHoverEnd ? onCellHoverEnd : undefined}
             />
           );
         }),

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { memo, useMemo, useRef } from 'react';
+import { memo, useMemo, useState } from 'react';
 import type {
   SeaBattlePlayerState,
   SeaBattleSnapshot,
@@ -78,18 +78,26 @@ export const AttackBoard = memo(function AttackBoard({
   // Cache lastSonar/lastRadar across state updates — they may disappear
   // from the snapshot after a re-broadcast but should remain visible until
   // a new weapon is used or the game ends.
-  const cachedLastSonar = useRef(snapshot?.lastSonar ?? null);
-  const cachedLastRadar = useRef(snapshot?.lastRadar ?? null);
+  const [cachedLastSonar, setCachedLastSonar] = useState(
+    () => snapshot?.lastSonar ?? null,
+  );
+  const [cachedLastRadar, setCachedLastRadar] = useState(
+    () => snapshot?.lastRadar ?? null,
+  );
 
-  if (snapshot?.lastSonar) cachedLastSonar.current = snapshot.lastSonar;
-  if (snapshot?.lastRadar) cachedLastRadar.current = snapshot.lastRadar;
-  if (snapshot?.phase !== 'battle') {
-    cachedLastSonar.current = null;
-    cachedLastRadar.current = null;
-  }
+  const nextCachedSonar =
+    snapshot?.phase !== 'battle'
+      ? null
+      : (snapshot?.lastSonar ?? cachedLastSonar);
+  const nextCachedRadar =
+    snapshot?.phase !== 'battle'
+      ? null
+      : (snapshot?.lastRadar ?? cachedLastRadar);
+  if (nextCachedSonar !== cachedLastSonar) setCachedLastSonar(nextCachedSonar);
+  if (nextCachedRadar !== cachedLastRadar) setCachedLastRadar(nextCachedRadar);
 
-  const effectiveLastSonar = snapshot?.lastSonar ?? cachedLastSonar.current;
-  const effectiveLastRadar = snapshot?.lastRadar ?? cachedLastRadar.current;
+  const effectiveLastSonar = snapshot?.lastSonar ?? cachedLastSonar;
+  const effectiveLastRadar = snapshot?.lastRadar ?? cachedLastRadar;
 
   const sonarHighlightSet = (() => {
     const ls = effectiveLastSonar;
@@ -104,7 +112,9 @@ export const AttackBoard = memo(function AttackBoard({
     const ls = effectiveLastSonar;
     if (!ls) return null;
     const map = new Map<string, number>();
-    ls.cells.forEach((c) => map.set(`${ls.targetId}-${c.row}-${c.col}`, c.state));
+    ls.cells.forEach((c) =>
+      map.set(`${ls.targetId}-${c.row}-${c.col}`, c.state),
+    );
     return map;
   })();
 
@@ -121,7 +131,9 @@ export const AttackBoard = memo(function AttackBoard({
     const lr = effectiveLastRadar;
     if (!lr) return null;
     const map = new Map<string, number>();
-    lr.cells.forEach((c) => map.set(`${lr.targetId}-${c.row}-${c.col}`, c.state));
+    lr.cells.forEach((c) =>
+      map.set(`${lr.targetId}-${c.row}-${c.col}`, c.state),
+    );
     return map;
   })();
 
@@ -184,9 +196,7 @@ export const AttackBoard = memo(function AttackBoard({
                   ? weaponPreviewType
                   : null
               }
-              onCellHover={
-                isTeammate ? undefined : onCellHover
-              }
+              onCellHover={isTeammate ? undefined : onCellHover}
               onCellHoverEnd={onCellHoverEnd}
               weaponMode={weaponMode}
               t={t}

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -28,6 +28,7 @@ export interface AttackBoardProps {
   weaponPreviewType?: 'sonar' | 'radar' | null;
   onCellHover?: (playerId: string, row: number, col: number) => void;
   onCellHoverEnd?: () => void;
+  weaponMode?: boolean;
 }
 
 export const AttackBoard = memo(function AttackBoard({
@@ -45,6 +46,7 @@ export const AttackBoard = memo(function AttackBoard({
   weaponPreviewType,
   onCellHover,
   onCellHoverEnd,
+  weaponMode,
 }: AttackBoardProps) {
   const { t } = useTranslation();
   const theme = useSeaBattleTheme();
@@ -152,6 +154,7 @@ export const AttackBoard = memo(function AttackBoard({
                 isTeammate ? undefined : onCellHover
               }
               onCellHoverEnd={onCellHoverEnd}
+              weaponMode={weaponMode}
               t={t}
             />
           );

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -24,6 +24,10 @@ export interface AttackBoardProps {
   teams?: SeaBattleTeam[];
   gridSize?: number;
   snapshot?: SeaBattleSnapshot | null;
+  weaponPreviewCells?: Set<string> | null;
+  weaponPreviewType?: 'sonar' | 'radar' | null;
+  onCellHover?: (playerId: string, row: number, col: number) => void;
+  onCellHoverEnd?: () => void;
 }
 
 export const AttackBoard = memo(function AttackBoard({
@@ -37,6 +41,10 @@ export const AttackBoard = memo(function AttackBoard({
   teammateIds,
   teams,
   snapshot,
+  weaponPreviewCells,
+  weaponPreviewType,
+  onCellHover,
+  onCellHoverEnd,
 }: AttackBoardProps) {
   const { t } = useTranslation();
   const theme = useSeaBattleTheme();
@@ -130,6 +138,20 @@ export const AttackBoard = memo(function AttackBoard({
               onAttack={isTeammate ? undefined : onAttack}
               sonarHighlightCells={isSonarTarget ? sonarHighlightSet : null}
               radarHighlightCells={isRadarTarget ? radarHighlightSet : null}
+              weaponPreviewCells={
+                weaponPreviewType && weaponPreviewCells
+                  ? weaponPreviewCells
+                  : null
+              }
+              weaponPreviewType={
+                weaponPreviewType && weaponPreviewCells
+                  ? weaponPreviewType
+                  : null
+              }
+              onCellHover={
+                isTeammate ? undefined : onCellHover
+              }
+              onCellHoverEnd={onCellHoverEnd}
               t={t}
             />
           );

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useRef } from 'react';
 import type {
   SeaBattlePlayerState,
   SeaBattleSnapshot,
@@ -75,8 +75,24 @@ export const AttackBoard = memo(function AttackBoard({
     return set;
   }, [players]);
 
+  // Cache lastSonar/lastRadar across state updates — they may disappear
+  // from the snapshot after a re-broadcast but should remain visible until
+  // a new weapon is used or the game ends.
+  const cachedLastSonar = useRef(snapshot?.lastSonar ?? null);
+  const cachedLastRadar = useRef(snapshot?.lastRadar ?? null);
+
+  if (snapshot?.lastSonar) cachedLastSonar.current = snapshot.lastSonar;
+  if (snapshot?.lastRadar) cachedLastRadar.current = snapshot.lastRadar;
+  if (snapshot?.phase !== 'battle') {
+    cachedLastSonar.current = null;
+    cachedLastRadar.current = null;
+  }
+
+  const effectiveLastSonar = snapshot?.lastSonar ?? cachedLastSonar.current;
+  const effectiveLastRadar = snapshot?.lastRadar ?? cachedLastRadar.current;
+
   const sonarHighlightSet = (() => {
-    const ls = snapshot?.lastSonar;
+    const ls = effectiveLastSonar;
     if (!ls) return null;
     const set = new Set<string>();
     ls.cells.forEach((c) => set.add(`${ls.targetId}-${c.row}-${c.col}`));
@@ -85,7 +101,7 @@ export const AttackBoard = memo(function AttackBoard({
 
   // Map cellKey → state for sonar scanned cells (SHIP=1, EMPTY=0, etc.)
   const sonarCellStates = (() => {
-    const ls = snapshot?.lastSonar;
+    const ls = effectiveLastSonar;
     if (!ls) return null;
     const map = new Map<string, number>();
     ls.cells.forEach((c) => map.set(`${ls.targetId}-${c.row}-${c.col}`, c.state));
@@ -93,7 +109,7 @@ export const AttackBoard = memo(function AttackBoard({
   })();
 
   const radarHighlightSet = (() => {
-    const lr = snapshot?.lastRadar;
+    const lr = effectiveLastRadar;
     if (!lr) return null;
     const set = new Set<string>();
     lr.cells.forEach((c) => set.add(`${lr.targetId}-${c.row}-${c.col}`));
@@ -102,7 +118,7 @@ export const AttackBoard = memo(function AttackBoard({
 
   // Map cellKey → state for radar scanned cells
   const radarCellStates = (() => {
-    const lr = snapshot?.lastRadar;
+    const lr = effectiveLastRadar;
     if (!lr) return null;
     const map = new Map<string, number>();
     lr.cells.forEach((c) => map.set(`${lr.targetId}-${c.row}-${c.col}`, c.state));
@@ -136,9 +152,9 @@ export const AttackBoard = memo(function AttackBoard({
             tt.playerIds.includes(opponent.playerId),
           );
           const isSonarTarget =
-            snapshot?.lastSonar?.targetId === opponent.playerId;
+            effectiveLastSonar?.targetId === opponent.playerId;
           const isRadarTarget =
-            snapshot?.lastRadar?.targetId === opponent.playerId;
+            effectiveLastRadar?.targetId === opponent.playerId;
           return (
             <AttackPlayerBoard
               key={opponent.playerId}

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -79,20 +79,34 @@ export const AttackBoard = memo(function AttackBoard({
     const ls = snapshot?.lastSonar;
     if (!ls) return null;
     const set = new Set<string>();
-    ls.shipPositions.forEach((c) =>
-      set.add(`${ls.targetId}-${c.row}-${c.col}`),
-    );
+    ls.cells.forEach((c) => set.add(`${ls.targetId}-${c.row}-${c.col}`));
     return set;
+  })();
+
+  // Map cellKey → state for sonar scanned cells (SHIP=1, EMPTY=0, etc.)
+  const sonarCellStates = (() => {
+    const ls = snapshot?.lastSonar;
+    if (!ls) return null;
+    const map = new Map<string, number>();
+    ls.cells.forEach((c) => map.set(`${ls.targetId}-${c.row}-${c.col}`, c.state));
+    return map;
   })();
 
   const radarHighlightSet = (() => {
     const lr = snapshot?.lastRadar;
     if (!lr) return null;
     const set = new Set<string>();
-    lr.cells
-      .filter((c) => c.state === 1) // CellState.SHIP = 1
-      .forEach((c) => set.add(`${lr.targetId}-${c.row}-${c.col}`));
+    lr.cells.forEach((c) => set.add(`${lr.targetId}-${c.row}-${c.col}`));
     return set;
+  })();
+
+  // Map cellKey → state for radar scanned cells
+  const radarCellStates = (() => {
+    const lr = snapshot?.lastRadar;
+    if (!lr) return null;
+    const map = new Map<string, number>();
+    lr.cells.forEach((c) => map.set(`${lr.targetId}-${c.row}-${c.col}`, c.state));
+    return map;
   })();
 
   return (
@@ -141,7 +155,9 @@ export const AttackBoard = memo(function AttackBoard({
               sunkCellSet={sunkCellSet}
               onAttack={isTeammate ? undefined : onAttack}
               sonarHighlightCells={isSonarTarget ? sonarHighlightSet : null}
+              sonarCellStates={isSonarTarget ? sonarCellStates : null}
               radarHighlightCells={isRadarTarget ? radarHighlightSet : null}
+              radarCellStates={isRadarTarget ? radarCellStates : null}
               weaponPreviewCells={
                 weaponPreviewType && weaponPreviewCells
                   ? weaponPreviewCells

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -89,7 +89,9 @@ export const AttackBoard = memo(function AttackBoard({
     const lr = snapshot?.lastRadar;
     if (!lr) return null;
     const set = new Set<string>();
-    lr.cells.forEach((c) => set.add(`${lr.targetId}-${c.row}-${c.col}`));
+    lr.cells
+      .filter((c) => c.state === 1) // CellState.SHIP = 1
+      .forEach((c) => set.add(`${lr.targetId}-${c.row}-${c.col}`));
     return set;
   })();
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
@@ -168,7 +168,11 @@ export default function SeaBattleCreationConfig({
               <Text fontSize="$4" fontWeight="600">
                 {t('games.create.seaBattleGridSize') || 'Grid Size'}
               </Text>
-              {ruleComingSoon.get('gridSize') && <ComingSoonBadge />}
+              {ruleComingSoon.get('gridSize') && (
+                <ComingSoonBadge>
+                  {t('games.create.comingSoon') || 'Coming Soon'}
+                </ComingSoonBadge>
+              )}
             </XStack>
             <XStack gap="$2" flexWrap="wrap">
               {GRID_SIZES.map((gs) => (
@@ -214,7 +218,11 @@ export default function SeaBattleCreationConfig({
                   <ExpansionLabel>
                     {t('games.create.seaBattleSonar') || 'Sonar'}
                   </ExpansionLabel>
-                  {ruleComingSoon.get('sonar') && <ComingSoonBadge />}
+                  {ruleComingSoon.get('sonar') && (
+                    <ComingSoonBadge>
+                      {t('games.create.comingSoon') || 'Coming Soon'}
+                    </ComingSoonBadge>
+                  )}
                 </XStack>
                 <ExpansionBadge>
                   {t('games.create.seaBattleSonarHint') ||
@@ -246,7 +254,11 @@ export default function SeaBattleCreationConfig({
                   <ExpansionLabel>
                     {t('games.create.seaBattleRadar') || 'Radar'}
                   </ExpansionLabel>
-                  {ruleComingSoon.get('radar') && <ComingSoonBadge />}
+                  {ruleComingSoon.get('radar') && (
+                    <ComingSoonBadge>
+                      {t('games.create.comingSoon') || 'Coming Soon'}
+                    </ComingSoonBadge>
+                  )}
                 </XStack>
                 <ExpansionBadge>
                   {t('games.create.seaBattleRadarHint') ||

--- a/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
@@ -50,6 +50,9 @@ export default function SeaBattleCreationConfig({
   const [allowedVariants, setAllowedVariants] = useState<
     CatalogVariant[] | null
   >(null);
+  const [ruleComingSoon, setRuleComingSoon] = useState<Map<string, boolean>>(
+    new Map(),
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -59,6 +62,13 @@ export default function SeaBattleCreationConfig({
         if (cancelled) return;
         const entry = res.games.find((g) => g.gameId === 'sea_battle_v1');
         setAllowedVariants(entry?.variants ?? null);
+        if (entry?.rules) {
+          const map = new Map<string, boolean>();
+          for (const r of entry.rules) {
+            map.set(r.ruleId, r.comingSoon);
+          }
+          setRuleComingSoon(map);
+        }
       })
       .catch(() => {
         if (!cancelled) setAllowedVariants(null);
@@ -154,9 +164,12 @@ export default function SeaBattleCreationConfig({
       <Section title={t('games.create.sectionHouseRules')}>
         <YStack gap="$3">
           <YStack gap="$1">
-            <Text fontSize="$4" fontWeight="600">
-              {t('games.create.seaBattleGridSize') || 'Grid Size'}
-            </Text>
+            <XStack alignItems="center" gap="$2">
+              <Text fontSize="$4" fontWeight="600">
+                {t('games.create.seaBattleGridSize') || 'Grid Size'}
+              </Text>
+              {ruleComingSoon.get('gridSize') && <ComingSoonBadge />}
+            </XStack>
             <XStack gap="$2" flexWrap="wrap">
               {GRID_SIZES.map((gs) => (
                 <Button
@@ -164,7 +177,11 @@ export default function SeaBattleCreationConfig({
                   variant="secondary"
                   size="sm"
                   isActive={(options.gridSize ?? 10) === gs.value}
-                  onClick={() => handleUpdate({ gridSize: gs.value })}
+                  disabled={!!ruleComingSoon.get('gridSize')}
+                  onClick={() =>
+                    !ruleComingSoon.get('gridSize') &&
+                    handleUpdate({ gridSize: gs.value })
+                  }
                   data-testid={`grid-size-${gs.value}`}
                 >
                   {gs.label}
@@ -174,10 +191,15 @@ export default function SeaBattleCreationConfig({
           </YStack>
 
           <ExpansionGrid>
-            <ExpansionCheckbox>
+            <ExpansionCheckbox
+              style={{
+                opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
+              }}
+            >
               <input
                 type="checkbox"
                 checked={!!options.specialWeapons?.sonar}
+                disabled={!!ruleComingSoon.get('sonar')}
                 onChange={() =>
                   handleUpdate({
                     specialWeapons: {
@@ -188,9 +210,12 @@ export default function SeaBattleCreationConfig({
                 }
               />
               <YStack flex={1} gap="$0.5">
-                <ExpansionLabel>
-                  {t('games.create.seaBattleSonar') || 'Sonar'}
-                </ExpansionLabel>
+                <XStack alignItems="center" gap="$2">
+                  <ExpansionLabel>
+                    {t('games.create.seaBattleSonar') || 'Sonar'}
+                  </ExpansionLabel>
+                  {ruleComingSoon.get('sonar') && <ComingSoonBadge />}
+                </XStack>
                 <ExpansionBadge>
                   {t('games.create.seaBattleSonarHint') ||
                     'Reveal ship locations'}
@@ -198,10 +223,15 @@ export default function SeaBattleCreationConfig({
               </YStack>
             </ExpansionCheckbox>
 
-            <ExpansionCheckbox>
+            <ExpansionCheckbox
+              style={{
+                opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
+              }}
+            >
               <input
                 type="checkbox"
                 checked={!!options.specialWeapons?.radar}
+                disabled={!!ruleComingSoon.get('radar')}
                 onChange={() =>
                   handleUpdate({
                     specialWeapons: {
@@ -212,9 +242,12 @@ export default function SeaBattleCreationConfig({
                 }
               />
               <YStack flex={1} gap="$0.5">
-                <ExpansionLabel>
-                  {t('games.create.seaBattleRadar') || 'Radar'}
-                </ExpansionLabel>
+                <XStack alignItems="center" gap="$2">
+                  <ExpansionLabel>
+                    {t('games.create.seaBattleRadar') || 'Radar'}
+                  </ExpansionLabel>
+                  {ruleComingSoon.get('radar') && <ComingSoonBadge />}
+                </XStack>
                 <ExpansionBadge>
                   {t('games.create.seaBattleRadarHint') ||
                     'Scan a row or column'}

--- a/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.visibility.test.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.visibility.test.tsx
@@ -44,6 +44,7 @@ describe('Sea Battle CreationConfig — variant visibility filter', () => {
             { id: 'classic', comingSoon: false },
             { id: 'pixel', comingSoon: false },
           ],
+          rules: [],
         }, // cyber hidden
       ],
     });
@@ -84,6 +85,7 @@ describe('Sea Battle CreationConfig — variant visibility filter', () => {
             { id: 'classic', comingSoon: false },
             { id: 'cyber', comingSoon: true },
           ],
+          rules: [],
         },
       ],
     });

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -15,7 +15,7 @@ import type {
   ShipCell,
 } from '../types';
 
-type WeaponMode = null | { weapon: 'sonar' | 'radar'; targetPlayerId: string };
+type WeaponMode = null | { weapon: 'sonar' | 'radar'; targetPlayerId: string; radarAxis?: 'row' | 'col' };
 
 interface SeaBattleBoardsProps {
   isPlacementPhase: boolean;
@@ -98,8 +98,12 @@ export function SeaBattleBoards({
       if (weaponMode.weapon === 'sonar' && onSonar) {
         onSonar(targetPlayerId, row, col);
       } else if (weaponMode.weapon === 'radar' && onRadar) {
-        // Radar scans the row of the clicked cell
-        onRadar(targetPlayerId, row, undefined);
+        const axis = weaponMode.radarAxis ?? 'row';
+        onRadar(
+          targetPlayerId,
+          axis === 'row' ? row : undefined,
+          axis === 'col' ? col : undefined,
+        );
       }
       setWeaponMode(null);
       setHoveredCell(null);
@@ -128,14 +132,19 @@ export function SeaBattleBoards({
     return cells;
   })();
 
-  // Compute preview cells for radar (entire row of hovered cell)
+  // Compute preview cells for radar (row or column of hovered cell)
   const radarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'radar' || !hoveredCell) return null;
     const cells = new Set<string>();
-    for (let c = 0; c < gridSize; c++) {
-      cells.add(
-        `${weaponMode.targetPlayerId}-${hoveredCell.row}-${c}`,
-      );
+    const axis = weaponMode.radarAxis ?? 'row';
+    if (axis === 'row') {
+      for (let c = 0; c < gridSize; c++) {
+        cells.add(`${weaponMode.targetPlayerId}-${hoveredCell.row}-${c}`);
+      }
+    } else {
+      for (let r = 0; r < gridSize; r++) {
+        cells.add(`${weaponMode.targetPlayerId}-${r}-${hoveredCell.col}`);
+      }
     }
     return cells;
   })();
@@ -252,37 +261,76 @@ export function SeaBattleBoards({
                 </button>
               )}
               {hasRadar && !radarUsed && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (opponents?.length === 1) {
+                <div style={{ display: 'flex', gap: 4 }}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (opponents?.length === 1) {
+                        setWeaponMode({
+                          weapon: 'radar',
+                          targetPlayerId: opponents[0].playerId,
+                          radarAxis: 'row',
+                        });
+                      } else if (opponents && opponents.length > 1) {
+                        setWeaponMode({
+                          weapon: 'radar',
+                          targetPlayerId: opponents[0].playerId,
+                          radarAxis: 'row',
+                        });
+                      }
+                    }}
+                    style={{
+                      ...buttonBase,
+                      color:
+                        weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
+                      borderColor:
+                        weaponMode?.weapon === 'radar'
+                          ? '#a855f7'
+                          : 'rgba(168,85,247,0.3)',
+                      background:
+                        weaponMode?.weapon === 'radar'
+                          ? 'rgba(168,85,247,0.15)'
+                          : 'rgba(168,85,247,0.05)',
+                      borderRight: 'none',
+                      borderRadius: '8px 0 0 8px',
+                    }}
+                  >
+                    📡 {t('games.create.seaBattleRadar') || 'Radar'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const targetId = opponents?.[0]?.playerId;
+                      if (!targetId) return;
                       setWeaponMode({
                         weapon: 'radar',
-                        targetPlayerId: opponents[0].playerId,
+                        targetPlayerId: targetId,
+                        radarAxis: weaponMode?.radarAxis === 'col' ? 'row' : 'col',
                       });
-                    } else if (opponents && opponents.length > 1) {
-                      setWeaponMode({
-                        weapon: 'radar',
-                        targetPlayerId: opponents[0].playerId,
-                      });
-                    }
-                  }}
-                  style={{
-                    ...buttonBase,
-                    color:
-                      weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
-                    borderColor:
-                      weaponMode?.weapon === 'radar'
-                        ? '#a855f7'
-                        : 'rgba(168,85,247,0.3)',
-                    background:
-                      weaponMode?.weapon === 'radar'
-                        ? 'rgba(168,85,247,0.15)'
-                        : 'rgba(168,85,247,0.05)',
-                  }}
-                >
-                  📡 {t('games.create.seaBattleRadar') || 'Radar'}
-                </button>
+                    }}
+                    style={{
+                      ...buttonBase,
+                      padding: '8px 10px',
+                      color:
+                        weaponMode?.weapon === 'radar'
+                          ? '#c084fc'
+                          : '#a0a0a0',
+                      borderColor:
+                        weaponMode?.weapon === 'radar'
+                          ? '#a855f7'
+                          : 'rgba(168,85,247,0.3)',
+                      background:
+                        weaponMode?.weapon === 'radar'
+                          ? 'rgba(168,85,247,0.15)'
+                          : 'rgba(168,85,247,0.05)',
+                      borderRadius: '0 8px 8px 0',
+                      fontSize: 11,
+                    }}
+                    title="Toggle row / column"
+                  >
+                    {weaponMode?.radarAxis === 'col' ? '↕' : '↔'}
+                  </button>
+                </div>
               )}
               {isWeaponMode && (
                 <button
@@ -308,7 +356,7 @@ export function SeaBattleBoards({
                 >
                   {weaponMode.weapon === 'sonar'
                     ? 'Tap a cell on the target board'
-                    : 'Tap a cell to scan its row'}
+                    : `Tap a cell to scan its ${weaponMode.radarAxis === 'col' ? 'column' : 'row'}`}
                 </span>
               )}
             </div>

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -218,68 +218,71 @@ export function SeaBattleBoards({
               }}
             >
               {hasSonar && !sonarUsed && (
-                <select
-                  style={{
-                    padding: '6px 12px',
-                    borderRadius: 6,
-                    border:
-                      weaponMode?.weapon === 'sonar'
-                        ? '2px solid #06b6d4'
-                        : '1px solid #555',
-                    background: '#1a1a2e',
-                    color: '#e0e0e0',
-                    fontSize: 13,
-                    cursor: 'pointer',
-                  }}
-                  value={weaponMode?.weapon === 'sonar' ? weaponMode.targetPlayerId : ''}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    if (val) {
-                      setWeaponMode({ weapon: 'sonar', targetPlayerId: val });
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (opponents?.length === 1) {
+                      setWeaponMode({
+                        weapon: 'sonar',
+                        targetPlayerId: opponents[0].playerId,
+                      });
+                    } else if (opponents && opponents.length > 1) {
+                      // Multi-opponent: cycle through or use first
+                      setWeaponMode({
+                        weapon: 'sonar',
+                        targetPlayerId: opponents[0].playerId,
+                      });
                     }
                   }}
+                  style={{
+                    ...buttonBase,
+                    color:
+                      weaponMode?.weapon === 'sonar' ? '#06b6d4' : '#e0e0e0',
+                    borderColor:
+                      weaponMode?.weapon === 'sonar'
+                        ? '#06b6d4'
+                        : 'rgba(6,182,212,0.3)',
+                    background:
+                      weaponMode?.weapon === 'sonar'
+                        ? 'rgba(6,182,212,0.15)'
+                        : 'rgba(6,182,212,0.05)',
+                  }}
                 >
-                  <option value="">
-                    🔊 {t('games.create.seaBattleSonar') || 'Sonar'}
-                  </option>
-                  {opponents?.map((p) => (
-                    <option key={p.playerId} value={p.playerId}>
-                      {resolveDisplayNameBound(p.playerId, p.playerId)}
-                    </option>
-                  ))}
-                </select>
+                  🔊 {t('games.create.seaBattleSonar') || 'Sonar'}
+                </button>
               )}
               {hasRadar && !radarUsed && (
-                <select
-                  style={{
-                    padding: '6px 12px',
-                    borderRadius: 6,
-                    border:
-                      weaponMode?.weapon === 'radar'
-                        ? '2px solid #a855f7'
-                        : '1px solid #555',
-                    background: '#1a1a2e',
-                    color: '#e0e0e0',
-                    fontSize: 13,
-                    cursor: 'pointer',
-                  }}
-                  value={weaponMode?.weapon === 'radar' ? weaponMode.targetPlayerId : ''}
-                  onChange={(e) => {
-                    const val = e.target.value;
-                    if (val) {
-                      setWeaponMode({ weapon: 'radar', targetPlayerId: val });
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (opponents?.length === 1) {
+                      setWeaponMode({
+                        weapon: 'radar',
+                        targetPlayerId: opponents[0].playerId,
+                      });
+                    } else if (opponents && opponents.length > 1) {
+                      setWeaponMode({
+                        weapon: 'radar',
+                        targetPlayerId: opponents[0].playerId,
+                      });
                     }
                   }}
+                  style={{
+                    ...buttonBase,
+                    color:
+                      weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
+                    borderColor:
+                      weaponMode?.weapon === 'radar'
+                        ? '#a855f7'
+                        : 'rgba(168,85,247,0.3)',
+                    background:
+                      weaponMode?.weapon === 'radar'
+                        ? 'rgba(168,85,247,0.15)'
+                        : 'rgba(168,85,247,0.05)',
+                  }}
                 >
-                  <option value="">
-                    📡 {t('games.create.seaBattleRadar') || 'Radar'}
-                  </option>
-                  {opponents?.map((p) => (
-                    <option key={p.playerId} value={p.playerId}>
-                      {resolveDisplayNameBound(p.playerId, p.playerId)}
-                    </option>
-                  ))}
-                </select>
+                  📡 {t('games.create.seaBattleRadar') || 'Radar'}
+                </button>
               )}
               {isWeaponMode && (
                 <button
@@ -338,6 +341,7 @@ export function SeaBattleBoards({
                 : undefined
             }
             onCellHoverEnd={isWeaponMode ? () => setHoveredCell(null) : undefined}
+            weaponMode={isWeaponMode}
           />
         </>
       )}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import {
   useTranslation,
   type TranslationKey,
@@ -14,6 +14,8 @@ import type {
   SeaBattleTeam,
   ShipCell,
 } from '../types';
+
+type WeaponMode = null | { weapon: 'sonar' | 'radar'; targetPlayerId: string };
 
 interface SeaBattleBoardsProps {
   isPlacementPhase: boolean;
@@ -68,9 +70,11 @@ export function SeaBattleBoards({
   teams,
 }: SeaBattleBoardsProps) {
   const { t } = useTranslation();
-  const [radarMode, setRadarMode] = useState<'row' | 'col' | null>(null);
-  const [radarTarget, setRadarTarget] = useState<string | null>(null);
-  const [sonarTarget, setSonarTarget] = useState<string | null>(null);
+  const [weaponMode, setWeaponMode] = useState<WeaponMode>(null);
+  const [hoveredCell, setHoveredCell] = useState<{
+    row: number;
+    col: number;
+  } | null>(null);
 
   const opponents = snapshot?.players.filter(
     (p) =>
@@ -85,6 +89,71 @@ export function SeaBattleBoards({
     snapshot?.specialWeaponUsage?.[currentUserId ?? '']?.radarUsed ?? false;
   const hasSonar = !!snapshot?.specialWeapons?.sonar;
   const hasRadar = !!snapshot?.specialWeapons?.radar;
+
+  const gridSize = snapshot?.gridSize ?? 10;
+
+  const handleWeaponFire = useCallback(
+    (targetPlayerId: string, row: number, col: number) => {
+      if (!weaponMode) return;
+      if (weaponMode.weapon === 'sonar' && onSonar) {
+        onSonar(targetPlayerId, row, col);
+      } else if (weaponMode.weapon === 'radar' && onRadar) {
+        // Radar scans the row of the clicked cell
+        onRadar(targetPlayerId, row, undefined);
+      }
+      setWeaponMode(null);
+      setHoveredCell(null);
+    },
+    [weaponMode, onSonar, onRadar],
+  );
+
+  const cancelWeaponMode = useCallback(() => {
+    setWeaponMode(null);
+    setHoveredCell(null);
+  }, []);
+
+  // Compute preview cells for sonar (3×3 area around hovered cell)
+  const sonarPreviewCells = (() => {
+    if (weaponMode?.weapon !== 'sonar' || !hoveredCell) return null;
+    const cells = new Set<string>();
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        const r = hoveredCell.row + dr;
+        const c = hoveredCell.col + dc;
+        if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {
+          cells.add(`${weaponMode.targetPlayerId}-${r}-${c}`);
+        }
+      }
+    }
+    return cells;
+  })();
+
+  // Compute preview cells for radar (entire row of hovered cell)
+  const radarPreviewCells = (() => {
+    if (weaponMode?.weapon !== 'radar' || !hoveredCell) return null;
+    const cells = new Set<string>();
+    for (let c = 0; c < gridSize; c++) {
+      cells.add(
+        `${weaponMode.targetPlayerId}-${hoveredCell.row}-${c}`,
+      );
+    }
+    return cells;
+  })();
+
+  const isWeaponMode = weaponMode !== null;
+
+  const buttonBase: React.CSSProperties = {
+    padding: '8px 16px',
+    borderRadius: 8,
+    border: '1px solid',
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: 'pointer',
+    transition: 'all 0.15s ease',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+  };
 
   return (
     <>
@@ -145,177 +214,99 @@ export function SeaBattleBoards({
                 padding: '8px 16px',
                 justifyContent: 'center',
                 flexWrap: 'wrap',
+                alignItems: 'center',
               }}
             >
               {hasSonar && !sonarUsed && (
-                <>
-                  {sonarTarget ? (
-                    <div
-                      style={{ display: 'flex', gap: 4, alignItems: 'center' }}
-                    >
-                      <span style={{ fontSize: 12, color: '#aaa' }}>
-                        Sonar cell:
-                      </span>
-                      {Array.from(
-                        { length: snapshot.gridSize ?? 10 },
-                        (_, i) => i,
-                      ).map((r) =>
-                        Array.from(
-                          { length: snapshot.gridSize ?? 10 },
-                          (_, i) => i,
-                        ).map((c) => (
-                          <button
-                            key={`${r}-${c}`}
-                            style={{
-                              width: 20,
-                              height: 20,
-                              borderRadius: 3,
-                              border: '1px solid #555',
-                              background: '#1a1a2e',
-                              color: '#e0e0e0',
-                              fontSize: 9,
-                              cursor: 'pointer',
-                            }}
-                            onClick={() => {
-                              if (onSonar) {
-                                onSonar(sonarTarget, r, c);
-                                setSonarTarget(null);
-                              }
-                            }}
-                          >
-                            {r},{c}
-                          </button>
-                        )),
-                      )}
-                      <button
-                        style={{
-                          fontSize: 11,
-                          color: '#f87171',
-                          background: 'none',
-                          border: 'none',
-                          cursor: 'pointer',
-                        }}
-                        onClick={() => setSonarTarget(null)}
-                      >
-                        ✕
-                      </button>
-                    </div>
-                  ) : (
-                    <select
-                      style={{
-                        padding: '6px 12px',
-                        borderRadius: 6,
-                        border: '1px solid #555',
-                        background: '#1a1a2e',
-                        color: '#e0e0e0',
-                        fontSize: 13,
-                        cursor: 'pointer',
-                      }}
-                      value=""
-                      onChange={(e) => {
-                        if (e.target.value) {
-                          setSonarTarget(e.target.value);
-                        }
-                      }}
-                    >
-                      <option value="">
-                        {t('games.create.seaBattleSonar') || 'Sonar'}
-                      </option>
-                      {opponents?.map((p) => (
-                        <option key={p.playerId} value={p.playerId}>
-                          {resolveDisplayNameBound(p.playerId, p.playerId)}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </>
+                <select
+                  style={{
+                    padding: '6px 12px',
+                    borderRadius: 6,
+                    border:
+                      weaponMode?.weapon === 'sonar'
+                        ? '2px solid #06b6d4'
+                        : '1px solid #555',
+                    background: '#1a1a2e',
+                    color: '#e0e0e0',
+                    fontSize: 13,
+                    cursor: 'pointer',
+                  }}
+                  value={weaponMode?.weapon === 'sonar' ? weaponMode.targetPlayerId : ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (val) {
+                      setWeaponMode({ weapon: 'sonar', targetPlayerId: val });
+                    }
+                  }}
+                >
+                  <option value="">
+                    🔊 {t('games.create.seaBattleSonar') || 'Sonar'}
+                  </option>
+                  {opponents?.map((p) => (
+                    <option key={p.playerId} value={p.playerId}>
+                      {resolveDisplayNameBound(p.playerId, p.playerId)}
+                    </option>
+                  ))}
+                </select>
               )}
               {hasRadar && !radarUsed && (
-                <>
-                  {radarMode && radarTarget ? (
-                    <div
-                      style={{ display: 'flex', gap: 4, alignItems: 'center' }}
-                    >
-                      <span style={{ fontSize: 12, color: '#aaa' }}>
-                        {radarMode === 'row' ? 'Row' : 'Col'}:
-                      </span>
-                      {Array.from(
-                        { length: snapshot.gridSize ?? 10 },
-                        (_, i) => i,
-                      ).map((i) => (
-                        <button
-                          key={i}
-                          style={{
-                            width: 24,
-                            height: 24,
-                            borderRadius: 4,
-                            border: '1px solid #555',
-                            background: '#1a1a2e',
-                            color: '#e0e0e0',
-                            fontSize: 11,
-                            cursor: 'pointer',
-                          }}
-                          onClick={() => {
-                            if (onRadar) {
-                              onRadar(
-                                radarTarget,
-                                radarMode === 'row' ? i : undefined,
-                                radarMode === 'col' ? i : undefined,
-                              );
-                              setRadarMode(null);
-                              setRadarTarget(null);
-                            }
-                          }}
-                        >
-                          {i}
-                        </button>
-                      ))}
-                      <button
-                        style={{
-                          fontSize: 11,
-                          color: '#f87171',
-                          background: 'none',
-                          border: 'none',
-                          cursor: 'pointer',
-                        }}
-                        onClick={() => {
-                          setRadarMode(null);
-                          setRadarTarget(null);
-                        }}
-                      >
-                        ✕
-                      </button>
-                    </div>
-                  ) : (
-                    <select
-                      style={{
-                        padding: '6px 12px',
-                        borderRadius: 6,
-                        border: '1px solid #555',
-                        background: '#1a1a2e',
-                        color: '#e0e0e0',
-                        fontSize: 13,
-                        cursor: 'pointer',
-                      }}
-                      value=""
-                      onChange={(e) => {
-                        if (e.target.value) {
-                          setRadarTarget(e.target.value);
-                          setRadarMode('row');
-                        }
-                      }}
-                    >
-                      <option value="">
-                        {t('games.create.seaBattleRadar') || 'Radar'}
-                      </option>
-                      {opponents?.map((p) => (
-                        <option key={p.playerId} value={p.playerId}>
-                          {resolveDisplayNameBound(p.playerId, p.playerId)}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </>
+                <select
+                  style={{
+                    padding: '6px 12px',
+                    borderRadius: 6,
+                    border:
+                      weaponMode?.weapon === 'radar'
+                        ? '2px solid #a855f7'
+                        : '1px solid #555',
+                    background: '#1a1a2e',
+                    color: '#e0e0e0',
+                    fontSize: 13,
+                    cursor: 'pointer',
+                  }}
+                  value={weaponMode?.weapon === 'radar' ? weaponMode.targetPlayerId : ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (val) {
+                      setWeaponMode({ weapon: 'radar', targetPlayerId: val });
+                    }
+                  }}
+                >
+                  <option value="">
+                    📡 {t('games.create.seaBattleRadar') || 'Radar'}
+                  </option>
+                  {opponents?.map((p) => (
+                    <option key={p.playerId} value={p.playerId}>
+                      {resolveDisplayNameBound(p.playerId, p.playerId)}
+                    </option>
+                  ))}
+                </select>
+              )}
+              {isWeaponMode && (
+                <button
+                  type="button"
+                  onClick={cancelWeaponMode}
+                  style={{
+                    ...buttonBase,
+                    color: '#f87171',
+                    borderColor: 'rgba(239,68,68,0.4)',
+                    background: 'rgba(239,68,68,0.1)',
+                  }}
+                >
+                  ✕ Cancel
+                </button>
+              )}
+              {isWeaponMode && (
+                <span
+                  style={{
+                    fontSize: 12,
+                    color: weaponMode.weapon === 'sonar' ? '#06b6d4' : '#a855f7',
+                    fontWeight: 600,
+                  }}
+                >
+                  {weaponMode.weapon === 'sonar'
+                    ? 'Tap a cell on the target board'
+                    : 'Tap a cell to scan its row'}
+                </span>
               )}
             </div>
           )}
@@ -325,12 +316,28 @@ export function SeaBattleBoards({
             currentUserId={currentUserId}
             currentTurnPlayerId={currentTurnPlayerId}
             isMyTurn={isMyTurn}
-            onAttack={attack}
+            onAttack={isWeaponMode ? handleWeaponFire : attack}
             resolveDisplayName={resolveDisplayNameBound}
             teammateIds={teammateIds}
             teams={teams}
             gridSize={snapshot.gridSize}
             snapshot={snapshot}
+            weaponPreviewCells={
+              weaponMode?.weapon === 'sonar'
+                ? sonarPreviewCells
+                : radarPreviewCells
+            }
+            weaponPreviewType={weaponMode?.weapon ?? null}
+            onCellHover={
+              isWeaponMode
+                ? (playerId: string, row: number, col: number) => {
+                    if (playerId === weaponMode.targetPlayerId) {
+                      setHoveredCell({ row, col });
+                    }
+                  }
+                : undefined
+            }
+            onCellHoverEnd={isWeaponMode ? () => setHoveredCell(null) : undefined}
           />
         </>
       )}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -116,12 +116,12 @@ export function SeaBattleBoards({
     setHoveredCell(null);
   }, []);
 
-  // Compute preview cells for sonar (3×3 area around hovered cell)
+  // Compute preview cells for sonar (5×5 area around hovered cell, matching SONAR_RADIUS=2)
   const sonarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'sonar' || !hoveredCell) return null;
     const cells = new Set<string>();
-    for (let dr = -1; dr <= 1; dr++) {
-      for (let dc = -1; dc <= 1; dc++) {
+    for (let dr = -2; dr <= 2; dr++) {
+      for (let dc = -2; dc <= 2; dc++) {
         const r = hoveredCell.row + dr;
         const c = hoveredCell.col + dc;
         if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -154,7 +154,6 @@ export function SeaBattleBoards({
   const buttonBase: React.CSSProperties = {
     padding: '8px 16px',
     borderRadius: 8,
-    border: '1px solid',
     fontSize: 13,
     fontWeight: 600,
     cursor: 'pointer',
@@ -236,7 +235,6 @@ export function SeaBattleBoards({
                         targetPlayerId: opponents[0].playerId,
                       });
                     } else if (opponents && opponents.length > 1) {
-                      // Multi-opponent: cycle through or use first
                       setWeaponMode({
                         weapon: 'sonar',
                         targetPlayerId: opponents[0].playerId,
@@ -247,10 +245,10 @@ export function SeaBattleBoards({
                     ...buttonBase,
                     color:
                       weaponMode?.weapon === 'sonar' ? '#06b6d4' : '#e0e0e0',
-                    borderColor:
-                      weaponMode?.weapon === 'sonar'
-                        ? '#06b6d4'
-                        : 'rgba(6,182,212,0.3)',
+                    borderTop: `1px solid ${weaponMode?.weapon === 'sonar' ? '#06b6d4' : 'rgba(6,182,212,0.3)'}`,
+                    borderBottom: `1px solid ${weaponMode?.weapon === 'sonar' ? '#06b6d4' : 'rgba(6,182,212,0.3)'}`,
+                    borderLeft: `1px solid ${weaponMode?.weapon === 'sonar' ? '#06b6d4' : 'rgba(6,182,212,0.3)'}`,
+                    borderRight: `1px solid ${weaponMode?.weapon === 'sonar' ? '#06b6d4' : 'rgba(6,182,212,0.3)'}`,
                     background:
                       weaponMode?.weapon === 'sonar'
                         ? 'rgba(6,182,212,0.15)'
@@ -283,15 +281,14 @@ export function SeaBattleBoards({
                       ...buttonBase,
                       color:
                         weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
-                      borderColor:
-                        weaponMode?.weapon === 'radar'
-                          ? '#a855f7'
-                          : 'rgba(168,85,247,0.3)',
+                      borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
+                      borderBottom: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
+                      borderLeft: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
+                      borderRight: 'none',
                       background:
                         weaponMode?.weapon === 'radar'
                           ? 'rgba(168,85,247,0.15)'
                           : 'rgba(168,85,247,0.05)',
-                      borderRight: 'none',
                       borderRadius: '8px 0 0 8px',
                     }}
                   >
@@ -315,10 +312,10 @@ export function SeaBattleBoards({
                         weaponMode?.weapon === 'radar'
                           ? '#c084fc'
                           : '#a0a0a0',
-                      borderColor:
-                        weaponMode?.weapon === 'radar'
-                          ? '#a855f7'
-                          : 'rgba(168,85,247,0.3)',
+                      borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
+                      borderBottom: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
+                      borderLeft: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
+                      borderRight: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
                       background:
                         weaponMode?.weapon === 'radar'
                           ? 'rgba(168,85,247,0.15)'
@@ -339,7 +336,10 @@ export function SeaBattleBoards({
                   style={{
                     ...buttonBase,
                     color: '#f87171',
-                    borderColor: 'rgba(239,68,68,0.4)',
+                    borderTop: '1px solid rgba(239,68,68,0.4)',
+                    borderBottom: '1px solid rgba(239,68,68,0.4)',
+                    borderLeft: '1px solid rgba(239,68,68,0.4)',
+                    borderRight: '1px solid rgba(239,68,68,0.4)',
                     background: 'rgba(239,68,68,0.1)',
                   }}
                 >

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -382,9 +382,10 @@ export function SeaBattleBoards({
             onCellHover={
               isWeaponMode
                 ? (playerId: string, row: number, col: number) => {
-                    if (playerId === weaponMode.targetPlayerId) {
-                      setHoveredCell({ row, col });
-                    }
+                    setWeaponMode((prev) =>
+                      prev ? { ...prev, targetPlayerId: playerId } : prev,
+                    );
+                    setHoveredCell({ row, col });
                   }
                 : undefined
             }

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -116,12 +116,12 @@ export function SeaBattleBoards({
     setHoveredCell(null);
   }, []);
 
-  // Compute preview cells for sonar (5×5 area around hovered cell, matching SONAR_RADIUS=2)
+  // Compute preview cells for sonar (3×3 area around hovered cell, matching SONAR_RADIUS=1)
   const sonarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'sonar' || !hoveredCell) return null;
     const cells = new Set<string>();
-    for (let dr = -2; dr <= 2; dr++) {
-      for (let dc = -2; dc <= 2; dc++) {
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
         const r = hoveredCell.row + dr;
         const c = hoveredCell.col + dc;
         if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -289,112 +289,101 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
 
       {isHost && room.status === 'lobby' && (
           <YStack gap="$3" paddingVertical="$2">
-          <Text fontSize="$4" fontWeight="600">
-            {t('games.create.sectionHouseRules') || 'House Rules'}
-          </Text>
-          <YStack gap="$2">
-            <XStack alignItems="center" gap="$2">
+          {(!ruleComingSoon.get('gridSize') ||
+            !ruleComingSoon.get('sonar') ||
+            !ruleComingSoon.get('radar')) && (
+            <Text fontSize="$4" fontWeight="600">
+              {t('games.create.sectionHouseRules') || 'House Rules'}
+            </Text>
+          )}
+          {!ruleComingSoon.get('gridSize') && (
+            <YStack gap="$2">
               <Text fontSize="$3" fontWeight="600">
                 {t('games.create.seaBattleGridSize') || 'Grid Size'}
               </Text>
-              {ruleComingSoon.get('gridSize') && (
-                <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                  {t('games.create.comingSoon') || 'Coming Soon'}
-                </Text>
-              )}
-            </XStack>
-            <XStack gap="$2" flexWrap="wrap">
-              {([10, 15, 20] as const).map((gs) => {
-                const disabled = !!ruleComingSoon.get('gridSize');
-                const active = (effectiveRoom.gameOptions?.gridSize ?? 10) === gs;
-                return (
-                  <button
-                    key={gs}
-                    type="button"
-                    disabled={disabled}
-                    onClick={() => !disabled && handleOptionChange({ gridSize: gs })}
-                    style={{
-                      padding: '6px 14px',
-                      borderRadius: 8,
-                      border: `1px solid ${active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'}`,
-                      backgroundColor: active
-                        ? 'rgba(59,130,246,0.15)'
-                        : 'transparent',
-                      color: disabled
-                        ? '#52525b'
-                        : active
+              <XStack gap="$2" flexWrap="wrap">
+                {([10, 15, 20] as const).map((gs) => {
+                  const active = (effectiveRoom.gameOptions?.gridSize ?? 10) === gs;
+                  return (
+                    <button
+                      key={gs}
+                      type="button"
+                      onClick={() => handleOptionChange({ gridSize: gs })}
+                      style={{
+                        padding: '6px 14px',
+                        borderRadius: 8,
+                        border: `1px solid ${active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'}`,
+                        backgroundColor: active
+                          ? 'rgba(59,130,246,0.15)'
+                          : 'transparent',
+                        color: active
                           ? 'var(--color, #3b82f6)'
                           : '#e2e8f0',
-                      fontWeight: 600,
-                      fontSize: 13,
-                      cursor: disabled ? 'not-allowed' : 'pointer',
-                      opacity: disabled ? 0.4 : 1,
-                    }}
-                  >
-                    {gs}×{gs}
-                  </button>
-                );
-              })}
-            </XStack>
-          </YStack>
-          <YStack gap="$2">
-            <XStack alignItems="center" gap="$2">
+                        fontWeight: 600,
+                        fontSize: 13,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      {gs}×{gs}
+                    </button>
+                  );
+                })}
+              </XStack>
+            </YStack>
+          )}
+          {(!ruleComingSoon.get('sonar') || !ruleComingSoon.get('radar')) && (
+            <YStack gap="$2">
               <Text fontSize="$3" fontWeight="600">
                 {t('games.create.specialWeapons') || 'Special Weapons'}
               </Text>
-              {(ruleComingSoon.get('sonar') || ruleComingSoon.get('radar')) && (
-                <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                  {t('games.create.comingSoon') || 'Coming Soon'}
-                </Text>
+              {!ruleComingSoon.get('sonar') && (
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    fontSize: 13,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!!sw?.sonar}
+                    onChange={() =>
+                      handleOptionChange({
+                        specialWeapons: { ...sw, sonar: !sw?.sonar },
+                      })
+                    }
+                  />
+                  {t('games.create.seaBattleSonar') || 'Sonar'} —{' '}
+                  {t('games.create.seaBattleSonarHint') || 'Reveal ship locations'}
+                </label>
               )}
-            </XStack>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                fontSize: 13,
-                opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
-                cursor: ruleComingSoon.get('sonar') ? 'not-allowed' : 'pointer',
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!sw?.sonar}
-                disabled={!!ruleComingSoon.get('sonar')}
-                onChange={() =>
-                  handleOptionChange({
-                    specialWeapons: { ...sw, sonar: !sw?.sonar },
-                  })
-                }
-              />
-              {t('games.create.seaBattleSonar') || 'Sonar'} —{' '}
-              {t('games.create.seaBattleSonarHint') || 'Reveal ship locations'}
-            </label>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                fontSize: 13,
-                opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
-                cursor: ruleComingSoon.get('radar') ? 'not-allowed' : 'pointer',
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!sw?.radar}
-                disabled={!!ruleComingSoon.get('radar')}
-                onChange={() =>
-                  handleOptionChange({
-                    specialWeapons: { ...sw, radar: !sw?.radar },
-                  })
-                }
-              />
-              {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
-              {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
-            </label>
-          </YStack>
+              {!ruleComingSoon.get('radar') && (
+                <label
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    fontSize: 13,
+                    cursor: 'pointer',
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={!!sw?.radar}
+                    onChange={() =>
+                      handleOptionChange({
+                        specialWeapons: { ...sw, radar: !sw?.radar },
+                      })
+                    }
+                  />
+                  {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
+                  {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
+                </label>
+              )}
+            </YStack>
+          )}
         </YStack>
       )}
     </>

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -299,7 +299,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
               </Text>
               {ruleComingSoon.get('gridSize') && (
                 <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                  Coming Soon
+                  {t('games.create.comingSoon') || 'Coming Soon'}
                 </Text>
               )}
             </XStack>
@@ -344,7 +344,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
               </Text>
               {(ruleComingSoon.get('sonar') || ruleComingSoon.get('radar')) && (
                 <Text fontSize={10} color="#f59e0b" fontWeight="600">
-                  Coming Soon
+                  {t('games.create.comingSoon') || 'Coming Soon'}
                 </Text>
               )}
             </XStack>

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -74,6 +74,10 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
     userId: userId ?? '',
   });
   const media = useMedia();
+
+  const [ruleComingSoon, setRuleComingSoon] = React.useState<
+    Map<string, boolean>
+  >(new Map());
   // gtSm = wide enough for side-by-side preview + vertical list. Below that
   // (web mobile / narrow tablets) we flip to a horizontal scrollable list
   // sitting above the preview so the field doesn't get squeezed.
@@ -284,57 +288,80 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       ) : null}
 
       {isHost && room.status === 'lobby' && (
-        <YStack gap="$3" paddingVertical="$2">
+          <YStack gap="$3" paddingVertical="$2">
           <Text fontSize="$4" fontWeight="600">
             {t('games.create.sectionHouseRules') || 'House Rules'}
           </Text>
           <YStack gap="$2">
-            <Text fontSize="$3" fontWeight="600">
-              {t('games.create.seaBattleGridSize') || 'Grid Size'}
-            </Text>
+            <XStack alignItems="center" gap="$2">
+              <Text fontSize="$3" fontWeight="600">
+                {t('games.create.seaBattleGridSize') || 'Grid Size'}
+              </Text>
+              {ruleComingSoon.get('gridSize') && (
+                <Text fontSize={10} color="#f59e0b" fontWeight="600">
+                  Coming Soon
+                </Text>
+              )}
+            </XStack>
             <XStack gap="$2" flexWrap="wrap">
-              {([10, 15, 20] as const).map((gs) => (
-                <button
-                  key={gs}
-                  type="button"
-                  onClick={() => handleOptionChange({ gridSize: gs })}
-                  style={{
-                    padding: '6px 14px',
-                    borderRadius: 8,
-                    border: `1px solid ${(effectiveRoom.gameOptions?.gridSize ?? 10) === gs ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'}`,
-                    backgroundColor:
-                      (effectiveRoom.gameOptions?.gridSize ?? 10) === gs
+              {([10, 15, 20] as const).map((gs) => {
+                const disabled = !!ruleComingSoon.get('gridSize');
+                const active = (effectiveRoom.gameOptions?.gridSize ?? 10) === gs;
+                return (
+                  <button
+                    key={gs}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => !disabled && handleOptionChange({ gridSize: gs })}
+                    style={{
+                      padding: '6px 14px',
+                      borderRadius: 8,
+                      border: `1px solid ${active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'}`,
+                      backgroundColor: active
                         ? 'rgba(59,130,246,0.15)'
                         : 'transparent',
-                    color:
-                      (effectiveRoom.gameOptions?.gridSize ?? 10) === gs
-                        ? 'var(--color, #3b82f6)'
-                        : '#e2e8f0',
-                    fontWeight: 600,
-                    fontSize: 13,
-                    cursor: 'pointer',
-                  }}
-                >
-                  {gs}×{gs}
-                </button>
-              ))}
+                      color: disabled
+                        ? '#52525b'
+                        : active
+                          ? 'var(--color, #3b82f6)'
+                          : '#e2e8f0',
+                      fontWeight: 600,
+                      fontSize: 13,
+                      cursor: disabled ? 'not-allowed' : 'pointer',
+                      opacity: disabled ? 0.4 : 1,
+                    }}
+                  >
+                    {gs}×{gs}
+                  </button>
+                );
+              })}
             </XStack>
           </YStack>
           <YStack gap="$2">
-            <Text fontSize="$3" fontWeight="600">
-              {t('games.create.specialWeapons') || 'Special Weapons'}
-            </Text>
+            <XStack alignItems="center" gap="$2">
+              <Text fontSize="$3" fontWeight="600">
+                {t('games.create.specialWeapons') || 'Special Weapons'}
+              </Text>
+              {(ruleComingSoon.get('sonar') || ruleComingSoon.get('radar')) && (
+                <Text fontSize={10} color="#f59e0b" fontWeight="600">
+                  Coming Soon
+                </Text>
+              )}
+            </XStack>
             <label
               style={{
                 display: 'flex',
                 alignItems: 'center',
                 gap: 8,
                 fontSize: 13,
+                opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
+                cursor: ruleComingSoon.get('sonar') ? 'not-allowed' : 'pointer',
               }}
             >
               <input
                 type="checkbox"
                 checked={!!sw?.sonar}
+                disabled={!!ruleComingSoon.get('sonar')}
                 onChange={() =>
                   handleOptionChange({
                     specialWeapons: { ...sw, sonar: !sw?.sonar },
@@ -350,11 +377,14 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
                 alignItems: 'center',
                 gap: 8,
                 fontSize: 13,
+                opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
+                cursor: ruleComingSoon.get('radar') ? 'not-allowed' : 'pointer',
               }}
             >
               <input
                 type="checkbox"
                 checked={!!sw?.radar}
+                disabled={!!ruleComingSoon.get('radar')}
                 onChange={() =>
                   handleOptionChange({
                     specialWeapons: { ...sw, radar: !sw?.radar },
@@ -419,6 +449,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
         optionsSlot={optionsSlot}
         headerActionsSlot={headerActionsSlot}
         enableBots={true}
+        onRuleComingSoonChange={setRuleComingSoon}
       />
     </YStack>
   );

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -289,101 +289,108 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
 
       {isHost && room.status === 'lobby' && (
           <YStack gap="$3" paddingVertical="$2">
-          {(!ruleComingSoon.get('gridSize') ||
-            !ruleComingSoon.get('sonar') ||
-            !ruleComingSoon.get('radar')) && (
-            <Text fontSize="$4" fontWeight="600">
-              {t('games.create.sectionHouseRules') || 'House Rules'}
+          <Text fontSize="$4" fontWeight="600">
+            {t('games.create.sectionHouseRules') || 'House Rules'}
+          </Text>
+          <YStack gap="$2">
+            <Text fontSize="$3" fontWeight="600">
+              {t('games.create.seaBattleGridSize') || 'Grid Size'}
+              {ruleComingSoon.get('gridSize') && (
+                <Text fontSize={10} color="#f59e0b" fontWeight="600" marginLeft={8}>
+                  {t('games.create.comingSoon') || 'Coming Soon'}
+                </Text>
+              )}
             </Text>
-          )}
-          {!ruleComingSoon.get('gridSize') && (
-            <YStack gap="$2">
-              <Text fontSize="$3" fontWeight="600">
-                {t('games.create.seaBattleGridSize') || 'Grid Size'}
-              </Text>
-              <XStack gap="$2" flexWrap="wrap">
-                {([10, 15, 20] as const).map((gs) => {
-                  const active = (effectiveRoom.gameOptions?.gridSize ?? 10) === gs;
-                  return (
-                    <button
-                      key={gs}
-                      type="button"
-                      onClick={() => handleOptionChange({ gridSize: gs })}
-                      style={{
-                        padding: '6px 14px',
-                        borderRadius: 8,
-                        border: `1px solid ${active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'}`,
-                        backgroundColor: active
-                          ? 'rgba(59,130,246,0.15)'
-                          : 'transparent',
-                        color: active
+            <XStack gap="$2" flexWrap="wrap">
+              {([10, 15, 20] as const).map((gs) => {
+                const disabled = !!ruleComingSoon.get('gridSize');
+                const active = (effectiveRoom.gameOptions?.gridSize ?? 10) === gs;
+                return (
+                  <button
+                    key={gs}
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => !disabled && handleOptionChange({ gridSize: gs })}
+                    style={{
+                      padding: '6px 14px',
+                      borderRadius: 8,
+                      border: `1px solid ${active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'}`,
+                      backgroundColor: active
+                        ? 'rgba(59,130,246,0.15)'
+                        : 'transparent',
+                      color: disabled
+                        ? '#52525b'
+                        : active
                           ? 'var(--color, #3b82f6)'
                           : '#e2e8f0',
-                        fontWeight: 600,
-                        fontSize: 13,
-                        cursor: 'pointer',
-                      }}
-                    >
-                      {gs}×{gs}
-                    </button>
-                  );
-                })}
-              </XStack>
-            </YStack>
-          )}
-          {(!ruleComingSoon.get('sonar') || !ruleComingSoon.get('radar')) && (
-            <YStack gap="$2">
-              <Text fontSize="$3" fontWeight="600">
-                {t('games.create.specialWeapons') || 'Special Weapons'}
-              </Text>
-              {!ruleComingSoon.get('sonar') && (
-                <label
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    fontSize: 13,
-                    cursor: 'pointer',
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={!!sw?.sonar}
-                    onChange={() =>
-                      handleOptionChange({
-                        specialWeapons: { ...sw, sonar: !sw?.sonar },
-                      })
-                    }
-                  />
-                  {t('games.create.seaBattleSonar') || 'Sonar'} —{' '}
-                  {t('games.create.seaBattleSonarHint') || 'Reveal ship locations'}
-                </label>
+                      fontWeight: 600,
+                      fontSize: 13,
+                      cursor: disabled ? 'not-allowed' : 'pointer',
+                      opacity: disabled ? 0.4 : 1,
+                    }}
+                  >
+                    {gs}×{gs}
+                  </button>
+                );
+              })}
+            </XStack>
+          </YStack>
+          <YStack gap="$2">
+            <Text fontSize="$3" fontWeight="600">
+              {t('games.create.specialWeapons') || 'Special Weapons'}
+              {(ruleComingSoon.get('sonar') || ruleComingSoon.get('radar')) && (
+                <Text fontSize={10} color="#f59e0b" fontWeight="600" marginLeft={8}>
+                  {t('games.create.comingSoon') || 'Coming Soon'}
+                </Text>
               )}
-              {!ruleComingSoon.get('radar') && (
-                <label
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 8,
-                    fontSize: 13,
-                    cursor: 'pointer',
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={!!sw?.radar}
-                    onChange={() =>
-                      handleOptionChange({
-                        specialWeapons: { ...sw, radar: !sw?.radar },
-                      })
-                    }
-                  />
-                  {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
-                  {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
-                </label>
-              )}
-            </YStack>
-          )}
+            </Text>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                fontSize: 13,
+                opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
+                cursor: ruleComingSoon.get('sonar') ? 'not-allowed' : 'pointer',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={!!sw?.sonar}
+                disabled={!!ruleComingSoon.get('sonar')}
+                onChange={() =>
+                  handleOptionChange({
+                    specialWeapons: { ...sw, sonar: !sw?.sonar },
+                  })
+                }
+              />
+              {t('games.create.seaBattleSonar') || 'Sonar'} —{' '}
+              {t('games.create.seaBattleSonarHint') || 'Reveal ship locations'}
+            </label>
+            <label
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                fontSize: 13,
+                opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
+                cursor: ruleComingSoon.get('radar') ? 'not-allowed' : 'pointer',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={!!sw?.radar}
+                disabled={!!ruleComingSoon.get('radar')}
+                onChange={() =>
+                  handleOptionChange({
+                    specialWeapons: { ...sw, radar: !sw?.radar },
+                  })
+                }
+              />
+              {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
+              {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
+            </label>
+          </YStack>
         </YStack>
       )}
     </>

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,5 +1,9 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 import './src/shared/config/tamagui.config';
+
+// server-only throws in non-Server-Component contexts (tests, client).
+vi.mock('server-only', () => ({}));
 
 // Mock matchMedia for Tamagui
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
## What
Fix daily reward 403 error, enforce game rule visibility in lobby UI and engine, and completely redesign sonar/radar UX in Sea Battle.

## Why
- Daily reward claim was broken due to missing CSRF header on server actions
- 10+ duplicate `authFetch`/`adminFetch` helpers lacked the header
- Game rules excluded by admin had no effect — lobby showed them as enabled and engine accepted excluded options
- Sonar/radar had terrible UX (tiny grid of buttons, no hover preview) and multiple bugs (wrong area size, highlights disappearing)

## Changes

### CSRF fix & server action consolidation
- Created shared `serverAuthFetch` utility with `X-Requested-With: XMLHttpRequest` header
- Replaced 10+ duplicate `authFetch`/`adminFetch` helpers across shop, gems, battle-pass, daily-rewards, and all admin features
- Added CSRF header to `gamesApi.ts` fetch calls

### Game rule visibility enforcement
- **Backend**: Added `stripDisabledRules()` to `GamesController.createRoom()` and `GamesService.updateRoomOptions()` — excluded rules are stripped from `gameOptions` before engine init
- **Catalog**: Added missing `sonar`, `radar`, `gridSize`, `botWeapons` rules to sea battle; added `description` field to all rules
- **Lobby UI**: All excluded rules show as disabled with "Coming Soon" badge (idle, spectators, gridSize, sonar, radar, combos, teams)
- **Bot weapons**: Bots now use sonar/radar when enabled in game state

### Sea Battle sonar/radar redesign
- **Sonar**: 3×3 hover preview on opponent board, click to fire
- **Radar**: Row/column toggle (↔/↕), hover preview shows full row or column
- Both weapons work on any opponent board in multiplayer
- Results persist via frontend cache (ref) across state updates
- All scanned cells highlighted: ships get strong glow + 🚢, empty cells get subtle glow + scan icon
- Fixed backend: gateway was dropping `row`/`col` from sonar payload
- Fixed backend: `markModified('state')` on all Mongoose session saves to persist `lastSonar`/`lastRadar`

### Pre-existing type fixes
- `WalletBalance` fixtures: added `arcadeum` field
- `CatalogGame` fixtures: added `rules: []`
- `AdminUserItem`/`UsersTableProps`: added missing fields
- `GameResult` type narrowing fix in test
- Global `server-only` mock in `vitest.setup.ts`

### Files
- `apps/web/src/shared/lib/server-auth-fetch.ts` (new)
- `apps/be/src/games/games.controller.ts` — rule stripping + catalog fix
- `apps/be/src/games/games.service.ts` — rule stripping in updateRoomOptions
- `apps/be/src/games/games.catalog.ts` — new rules + descriptions
- `apps/be/src/games/sea-battle.gateway.ts` — pass row/col to sonar
- `apps/be/src/games/sea-battle/sea-battle-bot.service.ts` — bot weapons
- `apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts` — sonar 3×3 + all cells
- `apps/be/src/games/sessions/game-sessions.service.ts` — markModified
- `apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx` — full weapon UX rewrite
- `apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/*` — hover preview, cell states, cache
- 10+ web server action files — shared utility migration