### PR TITLE
fix(web): enable music player from header nav without in-game toggle

### DIFF
--- a/apps/web/src/widgets/header/ui/HeaderInteractive.tsx
+++ b/apps/web/src/widgets/header/ui/HeaderInteractive.tsx
@@ -54,6 +54,7 @@ import {
 import { useHeaderAuth } from './useHeaderAuth';
 import { useMobileMenu } from './useMobileMenu';
 import { useIsMounted } from '@/shared/hooks/useIsMounted';
+import { saveStoredSettings } from '@/shared/lib/settings-storage';
 
 export function HeaderInteractive() {
   const isMounted = useIsMounted();
@@ -70,6 +71,7 @@ export function HeaderInteractive() {
     useMobileMenu();
 
   const toggleMusic = useCallback(() => {
+    saveStoredSettings({ musicEnabled: true });
     window.dispatchEvent(new CustomEvent('arcadeum:toggle-music'));
   }, []);
 


### PR DESCRIPTION
## What
Header Music button now sets `musicEnabled=true` in localStorage before dispatching the toggle-music event, so the player renders on any page without requiring the user to first enable it in the in-game control panel.

## Why
`GameMusic` returns `null` when `musicEnabled` is false (default). The header Music nav link only toggled `visible` via CustomEvent, so the player never appeared for users who hadn't entered a game and clicked the in-game music toggle.

## Changes
- `apps/web/src/widgets/header/ui/HeaderInteractive.tsx`: `toggleMusic` now calls `saveStoredSettings({ musicEnabled: true })` before dispatching the event