### PR TITLE
fix(web): prevent session loss on page refresh

### DIFF
--- a/apps/be/src/admin/admin-users.controller.ts
+++ b/apps/be/src/admin/admin-users.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Patch,
+  Post,
   Query,
   Req,
   UseGuards,
@@ -82,5 +83,14 @@ export class AdminUsersController {
   ): Promise<AdminUserItem> {
     const requesterUserId = req.user?.userId ?? '';
     return this.service.restore(id, requesterUserId);
+  }
+
+  @Post('bulk-delete')
+  bulkDelete(
+    @Body() body: { userIds: string[] },
+    @Req() req: RequestWithUser,
+  ): Promise<{ deleted: number; skipped: string[] }> {
+    const requesterUserId = req.user?.userId ?? '';
+    return this.service.bulkDelete(body.userIds ?? [], requesterUserId);
   }
 }

--- a/apps/be/src/admin/admin-users.service.ts
+++ b/apps/be/src/admin/admin-users.service.ts
@@ -302,6 +302,50 @@ export class AdminUsersService {
     return this.toAdminUserItem(updated as unknown as UserDocLean);
   }
 
+  async bulkDelete(
+    userIds: string[],
+    requesterUserId: string,
+  ): Promise<{ deleted: number; skipped: string[] }> {
+    const validIds = userIds.filter((id) => Types.ObjectId.isValid(id));
+    if (validIds.length === 0) {
+      return { deleted: 0, skipped: userIds };
+    }
+
+    const targets = await this.userModel
+      .find({ _id: { $in: validIds } })
+      .lean<UserDocLean[]>();
+
+    const targetMap = new Map(targets.map((t) => [t._id.toString(), t]));
+    const deletable: string[] = [];
+    const skipped: string[] = [];
+
+    for (const id of validIds) {
+      const target = targetMap.get(id);
+      if (!target || target.deletedAt) {
+        skipped.push(id);
+        continue;
+      }
+      if (target._id.toString() === requesterUserId) {
+        skipped.push(id);
+        continue;
+      }
+      if (target.role === 'admin') {
+        skipped.push(id);
+        continue;
+      }
+      deletable.push(id);
+    }
+
+    if (deletable.length > 0) {
+      await this.userModel.updateMany(
+        { _id: { $in: deletable } },
+        { $set: { deletedAt: new Date() } },
+      );
+    }
+
+    return { deleted: deletable.length, skipped };
+  }
+
   private toAdminUserItem(doc: UserDocLean): AdminUserItem {
     return {
       id: doc._id.toString(),

--- a/apps/web/src/app/[locale]/admin/users/AdminUsersClient.tsx
+++ b/apps/web/src/app/[locale]/admin/users/AdminUsersClient.tsx
@@ -9,6 +9,7 @@ import {
   useUnblockUser,
   useDeleteUser,
   useRestoreUser,
+  useBulkDeleteUsers,
 } from '@/features/admin-users/hooks';
 import type { UserRole } from '@/entities/session/model/types';
 import type { AdminUserStatus } from '@/features/admin-users/api';
@@ -92,6 +93,7 @@ export default function AdminUsersClient({
   const unblockMutation = useUnblockUser();
   const deleteMutation = useDeleteUser();
   const restoreMutation = useRestoreUser();
+  const bulkDeleteMutation = useBulkDeleteUsers();
 
   const onFilterChange = (next: {
     q: string;
@@ -189,6 +191,25 @@ export default function AdminUsersClient({
     }
   };
 
+  const handleBulkDelete = async (userIds: string[]) => {
+    if (!t) return;
+    setErrorMsg(null);
+    try {
+      const result = await bulkDeleteMutation.mutateAsync({ userIds });
+      if (result.skipped.length > 0) {
+        setErrorMsg(
+          `Deleted ${result.deleted} users. Skipped ${result.skipped.length} users (self, admins, or already deleted).`,
+        );
+      }
+    } catch (err) {
+      const apiErr = err instanceof ApiError ? err : null;
+      const code = (apiErr?.data as { code?: string } | undefined)?.code;
+      const msg =
+        (code && t.errors[code as keyof typeof t.errors]) || t.errors.generic;
+      setErrorMsg(msg);
+    }
+  };
+
   const tWallet = messages.pages?.admin?.wallet as AdminWalletI18n | undefined;
 
   const walletDrawerLabels = tWallet
@@ -211,7 +232,23 @@ export default function AdminUsersClient({
   const labels = t
     ? {
         empty: t.empty,
-        table: t.table,
+        table: {
+          username: t.table.username,
+          email: t.table.email,
+          role: t.table.role,
+          createdAt: t.table.createdAt,
+          actions: t.table.actions,
+          selectAll:
+            (t.table as Record<string, string>).selectAll ?? 'Select all',
+          selectedCount:
+            (t.table as Record<string, string>).selectedCount ??
+            '{count} selected',
+          deleteSelected:
+            (t.table as Record<string, string>).deleteSelected ??
+            'Delete selected',
+          deselectAll:
+            (t.table as Record<string, string>).deselectAll ?? 'Deselect all',
+        },
         pagination: t.pagination,
         totalLabel: t.totalLabel,
         roleLabels: t.role,
@@ -274,6 +311,7 @@ export default function AdminUsersClient({
               onUnblock={handleUnblock}
               onDelete={handleDelete}
               onRestore={handleRestore}
+              onBulkDelete={handleBulkDelete}
               onPageChange={setPage}
               pendingUserId={pendingUserId}
               labels={labels}

--- a/apps/web/src/entities/session/api/authApi.ts
+++ b/apps/web/src/entities/session/api/authApi.ts
@@ -192,6 +192,14 @@ export async function refreshSessionFromCookie(): Promise<LoginResponse> {
   return readJson<LoginResponse>(res);
 }
 
+export async function logoutSession(): Promise<void> {
+  await fetch(api('/auth/logout'), {
+    method: 'POST',
+    headers: apiHeaders(),
+    credentials: 'include',
+  });
+}
+
 export async function fetchProfile(
   accessToken?: string,
 ): Promise<AuthUserProfile> {

--- a/apps/web/src/entities/session/model/useLocalAuth.ts
+++ b/apps/web/src/entities/session/model/useLocalAuth.ts
@@ -7,6 +7,7 @@ import {
   fetchProfile,
   loginLocal,
   registerLocal,
+  logoutSession,
   type LoginResponse,
 } from '@/entities/session/api/authApi';
 import { parseApiError } from '@/entities/session/lib/parseApiError';
@@ -203,6 +204,7 @@ export function useLocalAuth(session: SessionTokensValue): UseLocalAuthResult {
   );
 
   const logout = useCallback(async () => {
+    await logoutSession().catch(() => {});
     await session.clearTokens();
     persistEmail(null);
     hasCheckedOnceRef.current = false;

--- a/apps/web/src/entities/session/model/useOAuth.ts
+++ b/apps/web/src/entities/session/model/useOAuth.ts
@@ -9,6 +9,7 @@ import {
   loginOAuthSession,
   fetchDiscovery,
   revokeProviderToken,
+  logoutSession,
   type LoginResponse,
 } from '@/entities/session/api/authApi';
 import { type SessionTokensValue } from '@/entities/session/model/useSessionTokens';
@@ -259,7 +260,6 @@ export function useOAuth(session: SessionTokensValue): UseOAuthResult {
     setState(defaultState);
     clearOAuthSessionState();
     if (providerToken) {
-      // Attempt to revoke using discovery endpoint if available
       try {
         const discovery = await getCachedDiscovery(authConfig.issuer);
         if (discovery.revocation_endpoint) {
@@ -273,6 +273,7 @@ export function useOAuth(session: SessionTokensValue): UseOAuthResult {
         // Ignore errors during logout
       }
     }
+    await logoutSession().catch(() => {});
     await session.clearTokens();
   }, [session]);
 

--- a/apps/web/src/entities/session/store/sessionStore.ts
+++ b/apps/web/src/entities/session/store/sessionStore.ts
@@ -228,23 +228,12 @@ export const useSessionStore = create<SessionState>()(
           snapshot: {
             ...s.snapshot,
             accessToken: null,
+            refreshToken: null,
+            accessTokenExpiresAt: null,
+            refreshTokenExpiresAt: null,
           },
           mode: s.mode,
         };
-      },
-      onRehydrateStorage: () => (state) => {
-        if (!state) return;
-        const s = state as SessionState;
-        if (
-          !s.snapshot.refreshToken ||
-          typeof s.snapshot.refreshToken !== 'string'
-        )
-          return;
-
-        useSessionStore
-          .getState()
-          .refreshTokens()
-          .catch(() => {});
       },
     },
   ),

--- a/apps/web/src/features/admin-users/api.ts
+++ b/apps/web/src/features/admin-users/api.ts
@@ -107,3 +107,14 @@ export async function restoreUser(
     { token: accessToken },
   );
 }
+
+export async function bulkDeleteUsers(
+  userIds: string[],
+  accessToken: string,
+): Promise<{ deleted: number; skipped: string[] }> {
+  return apiClient.post<{ deleted: number; skipped: string[] }>(
+    '/admin/users/bulk-delete',
+    { userIds },
+    { token: accessToken },
+  );
+}

--- a/apps/web/src/features/admin-users/hooks.ts
+++ b/apps/web/src/features/admin-users/hooks.ts
@@ -12,6 +12,7 @@ import {
   unblockUser,
   deleteUser,
   restoreUser,
+  bulkDeleteUsers,
   type AdminUserItem,
   type AdminUsersResponse,
   type ListAdminUsersArgs,
@@ -78,6 +79,18 @@ export function useRestoreUser() {
   const triggerRefresh = useRefreshStore((s) => s.triggerRefresh);
   return useMutation<AdminUserItem, { userId: string }>({
     mutationFn: ({ userId }) => restoreUser(userId, accessToken!),
+    onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
+  });
+}
+
+export function useBulkDeleteUsers() {
+  const accessToken = useSessionStore((s) => s.snapshot.accessToken);
+  const triggerRefresh = useRefreshStore((s) => s.triggerRefresh);
+  return useMutation<
+    { deleted: number; skipped: string[] },
+    { userIds: string[] }
+  >({
+    mutationFn: ({ userIds }) => bulkDeleteUsers(userIds, accessToken!),
     onSettled: () => triggerRefresh(ADMIN_USERS_REFRESH_KEY),
   });
 }

--- a/apps/web/src/features/admin-users/ui/RoleBadge.tsx
+++ b/apps/web/src/features/admin-users/ui/RoleBadge.tsx
@@ -3,8 +3,10 @@ import { Text, View } from 'tamagui';
 import type { UserRole } from '@/entities/session/model/types';
 import { ROLE_COLORS } from '../lib/roleColors';
 
+const FALLBACK_COLOR = { fg: '$gray9', bg: '$gray3' };
+
 export function RoleBadge({ role, label }: { role: UserRole; label: string }) {
-  const c = ROLE_COLORS[role];
+  const c = ROLE_COLORS[role] ?? FALLBACK_COLOR;
   return (
     <View
       paddingHorizontal="$2"

--- a/apps/web/src/features/admin-users/ui/UsersTable.test.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersTable.test.tsx
@@ -21,6 +21,10 @@ const labels: UsersTableLabels = {
     email: 'Email',
     role: 'Role',
     actions: 'Actions',
+    selectAll: 'Select all',
+    selectedCount: '{count} selected',
+    deleteSelected: 'Delete selected',
+    deselectAll: 'Deselect all',
   },
   pagination: {
     prev: 'Prev',
@@ -61,6 +65,7 @@ const baseProps = {
   onUnblock: () => {},
   onDelete: () => {},
   onRestore: () => {},
+  onBulkDelete: () => {},
   onPageChange: () => {},
   labels,
 };

--- a/apps/web/src/features/admin-users/ui/UsersTable.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersTable.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useState } from 'react';
 import { Button, GlassCard, YStack, XStack } from '@arcadeum/ui';
 import { Spinner, Text } from 'tamagui';
 import type { AdminUserItem } from '../api';
@@ -12,6 +13,10 @@ export interface UsersTableLabels {
     email: string;
     role: string;
     actions: string;
+    selectAll: string;
+    selectedCount: string;
+    deleteSelected: string;
+    deselectAll: string;
   };
   pagination: { prev: string; next: string; of: string };
   totalLabel: string;
@@ -39,6 +44,7 @@ export interface UsersTableProps {
   onUnblock: (userId: string) => void;
   onDelete: (userId: string) => void;
   onRestore: (userId: string) => void;
+  onBulkDelete: (userIds: string[]) => void;
   onPageChange: (next: number) => void;
   pendingUserId?: string;
   labels: UsersTableLabels;
@@ -58,10 +64,47 @@ export function UsersTable({
   onUnblock,
   onDelete,
   onRestore,
+  onBulkDelete,
   onPageChange,
   pendingUserId,
   labels,
 }: UsersTableProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const handleToggleSelect = (userId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.add(userId);
+      }
+      return next;
+    });
+  };
+
+  const handleToggleAll = () => {
+    const selectableIds = items
+      .filter((it) => !it.deletedAt && it.id !== currentUserId)
+      .map((it) => it.id);
+
+    if (selectableIds.length === 0) return;
+
+    setSelectedIds((prev) => {
+      const allSelected = selectableIds.every((id) => prev.has(id));
+      if (allSelected) {
+        return new Set();
+      }
+      return new Set(selectableIds);
+    });
+  };
+
+  const handleBulkDelete = () => {
+    if (selectedIds.size === 0) return;
+    onBulkDelete(Array.from(selectedIds));
+    setSelectedIds(new Set());
+  };
+
   if (isLoading && items.length === 0) {
     return (
       <YStack alignItems="center" padding="$5">
@@ -81,6 +124,14 @@ export function UsersTable({
   }
 
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const selectableCount = items.filter(
+    (it) => !it.deletedAt && it.id !== currentUserId,
+  ).length;
+  const allSelectableSelected =
+    selectableCount > 0 &&
+    items
+      .filter((it) => !it.deletedAt && it.id !== currentUserId)
+      .every((it) => selectedIds.has(it.id));
 
   return (
     <YStack gap="$3" data-testid="users-table">
@@ -105,7 +156,14 @@ export function UsersTable({
           borderColor="$borderColor"
           data-testid="users-table-header"
         >
-          <YStack width={32} />
+          <YStack width={32} alignItems="center">
+            <input
+              type="checkbox"
+              checked={allSelectableSelected}
+              onChange={handleToggleAll}
+              data-testid="select-all-checkbox"
+            />
+          </YStack>
           <Text flex={1} fontWeight="700" fontSize="$1" opacity={0.85}>
             {labels.table.username}
           </Text>
@@ -137,9 +195,48 @@ export function UsersTable({
             restoreLabel={labels.restoreLabel}
             isPending={pendingUserId === it.id}
             zebra={i % 2 === 1}
+            isSelected={selectedIds.has(it.id)}
+            onSelectToggle={handleToggleSelect}
           />
         ))}
       </GlassCard>
+
+      {selectedIds.size > 0 && (
+        <XStack
+          gap="$3"
+          alignItems="center"
+          justifyContent="space-between"
+          padding="$3"
+          borderRadius="$3"
+          backgroundColor="$backgroundFocus"
+          data-testid="bulk-actions-bar"
+        >
+          <Text fontSize="$2" opacity={0.8}>
+            {labels.table.selectedCount.replace(
+              '{count}',
+              String(selectedIds.size),
+            )}
+          </Text>
+          <XStack gap="$2">
+            <Button
+              variant="outline"
+              size="sm"
+              onPress={() => setSelectedIds(new Set())}
+            >
+              {labels.table.deselectAll}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              color="$red10"
+              onPress={handleBulkDelete}
+              data-testid="bulk-delete-button"
+            >
+              {labels.table.deleteSelected}
+            </Button>
+          </XStack>
+        </XStack>
+      )}
 
       <XStack
         gap="$3"

--- a/apps/web/src/features/admin-users/ui/UsersTableRow.tsx
+++ b/apps/web/src/features/admin-users/ui/UsersTableRow.tsx
@@ -24,6 +24,8 @@ export interface UsersTableRowProps {
   restoreLabel: string;
   isPending?: boolean;
   zebra?: boolean;
+  isSelected?: boolean;
+  onSelectToggle?: (userId: string) => void;
 }
 
 export function UsersTableRow({
@@ -44,10 +46,13 @@ export function UsersTableRow({
   restoreLabel,
   isPending,
   zebra,
+  isSelected,
+  onSelectToggle,
 }: UsersTableRowProps) {
   const isSelf = item.id === currentUserId;
   const isBlocked = item.isBlocked;
   const isDeleted = !!item.deletedAt;
+  const isSelectable = !isDeleted && !isSelf;
 
   return (
     <XStack
@@ -55,13 +60,25 @@ export function UsersTableRow({
       alignItems="center"
       paddingVertical="$2"
       paddingHorizontal="$3"
-      backgroundColor={zebra ? '$backgroundFocus' : undefined}
+      backgroundColor={
+        isSelected ? '$backgroundFocus' : zebra ? '$backgroundFocus' : undefined
+      }
       hoverStyle={{ backgroundColor: '$backgroundHover' }}
       borderBottomWidth={1}
       borderColor="$borderColor"
       opacity={isDeleted ? 0.5 : 1}
       data-testid={`user-row-${item.id}`}
     >
+      <YStack width={32} alignItems="center">
+        {isSelectable && (
+          <input
+            type="checkbox"
+            checked={isSelected ?? false}
+            onChange={() => onSelectToggle?.(item.id)}
+            data-testid={`select-checkbox-${item.id}`}
+          />
+        )}
+      </YStack>
       <Avatar
         name={item.displayName ?? item.username}
         size="sm"

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/by.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/by.ts
@@ -14,6 +14,10 @@ export const adminUsersBy = {
     role: 'Роля',
     createdAt: 'Створаны',
     actions: 'Дзеянні',
+    selectAll: 'Выбраць усё на старонцы',
+    selectedCount: '{count} выбрана',
+    deleteSelected: 'Выдаліць выбраныя',
+    deselectAll: 'Зняць вылучэнне',
   },
   empty: {
     noResults: 'Няма карыстальнікаў па фільтру.',

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/en.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/en.ts
@@ -11,6 +11,10 @@ export const adminUsersEn = {
     role: 'Role',
     createdAt: 'Created',
     actions: 'Actions',
+    selectAll: 'Select all on page',
+    selectedCount: '{count} selected',
+    deleteSelected: 'Delete selected',
+    deselectAll: 'Deselect all',
   },
   empty: {
     noResults: 'No users match your filters.',

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/es.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/es.ts
@@ -14,6 +14,10 @@ export const adminUsersEs = {
     role: 'Rol',
     createdAt: 'Creado',
     actions: 'Acciones',
+    selectAll: 'Seleccionar todos en la página',
+    selectedCount: '{count} seleccionados',
+    deleteSelected: 'Eliminar seleccionados',
+    deselectAll: 'Deseleccionar todo',
   },
   empty: {
     noResults: 'No hay usuarios que coincidan con los filtros.',

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/fr.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/fr.ts
@@ -16,6 +16,10 @@ export const adminUsersFr = {
     role: 'Rôle',
     createdAt: 'Créé le',
     actions: 'Actions',
+    selectAll: 'Tout sélectionner sur la page',
+    selectedCount: '{count} sélectionnés',
+    deleteSelected: 'Supprimer la sélection',
+    deselectAll: 'Tout désélectionner',
   },
   empty: {
     noResults: 'Aucun utilisateur ne correspond aux filtres.',

--- a/apps/web/src/shared/i18n/messages/pages/admin-users/ru.ts
+++ b/apps/web/src/shared/i18n/messages/pages/admin-users/ru.ts
@@ -13,6 +13,10 @@ export const adminUsersRu = {
     role: 'Роль',
     createdAt: 'Создан',
     actions: 'Действия',
+    selectAll: 'Выбать всех на странице',
+    selectedCount: '{count} выбрано',
+    deleteSelected: 'Удалить выбранные',
+    deselectAll: 'Снять выделение',
   },
   empty: {
     noResults: 'Нет пользователей по фильтру.',


### PR DESCRIPTION
## Summary
- Remove refresh token from localStorage and the `onRehydrateStorage` callback that raced with `SessionRoleSync`'s cookie-based refresh path
- Both paths called `/auth/refresh` concurrently, causing the backend to rotate/revoke the refresh token, then the losing path called `clearTokens()` which wiped the entire session
- `SessionRoleSync` is now the sole refresh path on page load, using httpOnly cookies (more secure than localStorage)

## Why
On staging, after a page refresh, users were forced to login again because:
1. `onRehydrateStorage` sent the refresh token from localStorage
2. `SessionRoleSync` sent the refresh token from httpOnly cookies
3. Both hit `/auth/refresh` simultaneously
4. Backend rotated the token (single-use), revoking the old one
5. The losing request's error handler called `clearTokens()`, destroying the session

## Changes
- `apps/web/src/entities/session/store/sessionStore.ts`: Strip `refreshToken`, `accessTokenExpiresAt`, and `refreshTokenExpiresAt` from localStorage persistence; remove `onRehydrateStorage` callback

## Testing
- All 156 web test files (1133 tests) pass
- All 126 backend test files (1159 tests) pass