### PR TITLE
feat(web): show emotes and messages as floating bubbles in game room

### DIFF
--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -9,7 +9,7 @@ import { ConnectionOverlay } from '@arcadeum/ui/components/ConnectionOverlay/Con
 import { GamesControlPanel } from '@/widgets/GamesControlPanel';
 import { GameChat, useGameChatStore } from '@/widgets/GameChat';
 import { useEmotes } from '@/features/games/hooks/useEmotes';
-import { EmoteBubble } from '@/features/games/ui/EmoteBubble';
+import { ActiveEmotesProvider } from '@/features/games/ui/GameWidgetContainer';
 import type { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
 import { AutoExitFullscreenOnFinish } from './AutoExitFullscreenOnFinish';
@@ -187,15 +187,9 @@ export function GamePageLayout(props: GamePageLayoutProps) {
         />
 
         <GameRow flexDirection={roomFlexDirection}>
-          {children({ isFullscreen, toggleFullscreen })}
-
-          {activeEmotes.map((emote) => (
-            <EmoteBubble
-              key={emote.key}
-              playerId={emote.userId}
-              activeEmotes={[{ id: emote.userId, emoteId: emote.emoteId }]}
-            />
-          ))}
+          <ActiveEmotesProvider value={{ emotes: activeEmotes, resolveDisplayName }}>
+            {children({ isFullscreen, toggleFullscreen })}
+          </ActiveEmotesProvider>
 
           <ChatPanel visible={showChat} data-testid="game-chat-area">
             <GameChat

--- a/apps/web/src/features/games/ui/EmoteBubble.tsx
+++ b/apps/web/src/features/games/ui/EmoteBubble.tsx
@@ -1,10 +1,6 @@
 'use client';
 
 import { useRef, useEffect } from 'react';
-import {
-  useTranslation,
-  type TranslationKey,
-} from '@/shared/lib/useTranslation';
 import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
 
 const KEYFRAMES_CSS = `
@@ -64,6 +60,7 @@ interface ActiveEmote {
 interface EmoteBubbleProps {
   playerId: string;
   activeEmotes: ActiveEmote[];
+  senderName?: string;
 }
 
 function findEmoji(emoteId: EmoteId): string {
@@ -72,9 +69,8 @@ function findEmoji(emoteId: EmoteId): string {
 
 let stylesInjected = false;
 
-export function EmoteBubble({ playerId, activeEmotes }: EmoteBubbleProps) {
+export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const { t } = useTranslation();
 
   useEffect(() => {
     if (!stylesInjected) {
@@ -97,14 +93,12 @@ export function EmoteBubble({ playerId, activeEmotes }: EmoteBubbleProps) {
   const current = activeEmotes.find((e) => e.id === playerId);
   if (!current) return null;
 
-  const label = t(`games.emotes.${current.emoteId}` as TranslationKey);
-
   return (
     <div
       ref={ref}
       style={{
         position: 'absolute',
-        top: '50%',
+        top: 24,
         right: 24,
         zIndex: 10,
         pointerEvents: 'none',
@@ -134,12 +128,12 @@ export function EmoteBubble({ playerId, activeEmotes }: EmoteBubbleProps) {
       >
         {findEmoji(current.emoteId)}
       </div>
-      {label && (
+      {senderName && (
         <div
           data-emote-label=""
           style={{
             color: '#fff',
-            fontSize: 16,
+            fontSize: 12,
             fontWeight: 800,
             textShadow:
               '0 0 8px rgba(236,72,153,0.9), 0 2px 10px rgba(0,0,0,0.8)',
@@ -151,7 +145,7 @@ export function EmoteBubble({ playerId, activeEmotes }: EmoteBubbleProps) {
             opacity: 0,
           }}
         >
-          {label}
+          {senderName}
         </div>
       )}
     </div>

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -20,6 +20,7 @@ import {
   type TurnContract,
 } from './TurnIndicator';
 import { EmoteBubble } from './EmoteBubble';
+import type { EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
 
 /**
  * Exposes the widget's fullscreen state to children (e.g. MatchWidget →
@@ -514,7 +515,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
             <EmoteBubble
               key={emote.key}
               playerId={emote.userId}
-              activeEmotes={[{ id: emote.userId, emoteId: emote.emoteId }]}
+              activeEmotes={[{ id: emote.userId, emoteId: emote.emoteId as EmoteId }]}
               senderName={activeEmotes.resolveDisplayName?.(emote.userId)}
             />
           ))}

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -19,6 +19,7 @@ import {
   resolveTurnStatus,
   type TurnContract,
 } from './TurnIndicator';
+import { EmoteBubble } from './EmoteBubble';
 
 /**
  * Exposes the widget's fullscreen state to children (e.g. MatchWidget →
@@ -29,6 +30,39 @@ const WidgetFullscreenContext = createContext<boolean>(false);
 
 export function useWidgetFullscreen(): boolean {
   return useContext(WidgetFullscreenContext);
+}
+
+interface ActiveEmote {
+  key: string;
+  userId: string;
+  emoteId: string;
+}
+
+interface ActiveEmotesContextValue {
+  emotes: ActiveEmote[];
+  resolveDisplayName?: (id?: string, fallback?: string) => string | undefined;
+}
+
+const ActiveEmotesContext = createContext<ActiveEmotesContextValue>({
+  emotes: [],
+});
+
+export function useActiveEmotes(): ActiveEmotesContextValue {
+  return useContext(ActiveEmotesContext);
+}
+
+export function ActiveEmotesProvider({
+  value,
+  children,
+}: {
+  value: ActiveEmotesContextValue;
+  children: React.ReactNode;
+}) {
+  return (
+    <ActiveEmotesContext.Provider value={value}>
+      {children}
+    </ActiveEmotesContext.Provider>
+  );
 }
 
 // --- Styled components (based on CriticalGame's layout.tsx) ---
@@ -357,6 +391,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   showChatPopup = true,
 }: GameWidgetContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const activeEmotes = useActiveEmotes();
   // Widget-only fullscreen — independent of the page-level toggle in
   // `GamePageLayout`. Page level expands [control panel + widget + chat];
   // this expands only the widget. Keyboard disabled so the global `f`
@@ -449,31 +484,41 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   return (
     <>
       <WidgetFullscreenContext.Provider value={isFullscreen}>
-        <Container
-          ref={containerRef as React.RefObject<never>}
-          className="game-widget-container"
-          $isMyTurn={!!isMyTurn}
-          isFullscreen={isFullscreen}
-          $variant={variant as GameVariant}
-          data-testid="game-widget-container"
-        >
-          {renderedHeader}
-          <SharedGameBoard data-testid="game-board-section">
-            {board}
-          </SharedGameBoard>
-          {tableArea && (
-            <SharedTableArea data-testid="game-table-section">
-              {tableArea}
-            </SharedTableArea>
-          )}
-          {handSection && (
-            <SharedHandSection data-testid="game-hand-section">
-              {handSection}
-            </SharedHandSection>
-          )}
-          {modals}
+        <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+          <Container
+            ref={containerRef as React.RefObject<never>}
+            className="game-widget-container"
+            $isMyTurn={!!isMyTurn}
+            isFullscreen={isFullscreen}
+            $variant={variant as GameVariant}
+            data-testid="game-widget-container"
+          >
+            {renderedHeader}
+            <SharedGameBoard data-testid="game-board-section">
+              {board}
+            </SharedGameBoard>
+            {tableArea && (
+              <SharedTableArea data-testid="game-table-section">
+                {tableArea}
+              </SharedTableArea>
+            )}
+            {handSection && (
+              <SharedHandSection data-testid="game-hand-section">
+                {handSection}
+              </SharedHandSection>
+            )}
+            {modals}
+          </Container>
           {showChatPopup && <GameChatPopupOverlay />}
-        </Container>
+          {activeEmotes.emotes.map((emote) => (
+            <EmoteBubble
+              key={emote.key}
+              playerId={emote.userId}
+              activeEmotes={[{ id: emote.userId, emoteId: emote.emoteId }]}
+              senderName={activeEmotes.resolveDisplayName?.(emote.userId)}
+            />
+          ))}
+        </div>
       </WidgetFullscreenContext.Provider>
     </>
   );

--- a/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
@@ -1,6 +1,58 @@
 'use client';
 
-import { ChatMessageBubble } from './ChatMessageBubble';
+import { useRef, useEffect } from 'react';
+import { EMOTES, type EmoteId } from './EmotePicker';
+
+const KEYFRAMES_CSS = `
+@keyframes chatBubbleFloat {
+  0% {
+    opacity: 0;
+    transform: translateY(140px) translateX(10px) scale(0.4) rotate(-8deg);
+  }
+  10% {
+    opacity: 1;
+    transform: translateY(70px) translateX(-15px) scale(1.2) rotate(5deg);
+  }
+  20% {
+    transform: translateY(20px) translateX(8px) scale(0.95) rotate(-3deg);
+  }
+  30% {
+    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
+  }
+  65% {
+    opacity: 1;
+    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-140px) translateX(-5px) scale(0.6) rotate(4deg);
+  }
+}
+
+@keyframes chatLabelPop {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) scale(0.5);
+  }
+  15% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.15);
+  }
+  30% {
+    transform: translateY(0) scale(1);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.8);
+  }
+}
+`;
+
+let stylesInjected = false;
 
 interface ChatMessagePopupProps {
   senderId?: string | null;
@@ -18,56 +70,100 @@ interface ChatMessagePopupProps {
 }
 
 export function ChatMessagePopup({
-  senderId,
   senderName,
-  senderEquippedAvatarId,
-  senderEquippedBadgeId,
-  senderEquippedNameColorId,
-  senderEquippedFrameId,
-  senderEquippedAuraId,
-  senderEquippedBannerId,
   message,
   visible,
   onDismiss,
-  isOwn,
 }: ChatMessagePopupProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!stylesInjected) {
+      const style = document.createElement('style');
+      style.textContent = KEYFRAMES_CSS;
+      document.head.appendChild(style);
+      stylesInjected = true;
+    }
+    const el = ref.current;
+    if (el) {
+      el.style.animation = 'chatBubbleFloat 3s ease-out forwards';
+      const label = el.querySelector('[data-msg-label]');
+      if (label) {
+        (label as HTMLElement).style.animation =
+          'chatLabelPop 3s ease-out forwards';
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const timer = setTimeout(() => onDismiss(), 3000);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
   if (!visible) return null;
 
   return (
     <div
+      ref={ref}
       onClick={onDismiss}
-      onAnimationEnd={(e) => {
-        e.stopPropagation();
-        if (e.animationName === 'popupAutoDismiss') {
-          onDismiss();
-        }
-      }}
       data-testid="chat-message-popup"
       style={{
-        cursor: 'pointer',
-        maxWidth: 340,
         position: 'absolute',
         top: 24,
-        right: 24,
+        right: 8,
         zIndex: 10000,
         pointerEvents: 'auto',
-        animation:
-          'popupAutoDismiss var(--popup-dismiss-duration, 5s) forwards',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 6,
+        opacity: 0,
+        cursor: 'pointer',
+        maxWidth: 220,
       }}
     >
-      <ChatMessageBubble
-        senderId={senderId ?? null}
-        senderName={senderName}
-        senderEquippedAvatarId={senderEquippedAvatarId ?? null}
-        senderEquippedBadgeId={senderEquippedBadgeId ?? null}
-        senderEquippedNameColorId={senderEquippedNameColorId ?? null}
-        senderEquippedFrameId={senderEquippedFrameId ?? null}
-        senderEquippedAuraId={senderEquippedAuraId ?? null}
-        senderEquippedBannerId={senderEquippedBannerId ?? null}
-        message={message}
-        type="message"
-        isOwn={isOwn}
-      />
+      <div
+        style={{
+          padding: '8px 14px',
+          borderRadius: 16,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'rgba(15, 5, 24, 0.88)',
+          borderWidth: 1.5,
+          borderStyle: 'solid',
+          borderColor: 'rgba(99, 102, 241, 0.5)',
+          boxShadow: '0 0 18px 2px rgba(99, 102, 241, 0.45)',
+          fontSize: 13,
+          lineHeight: '18px',
+          color: '#fff',
+          fontWeight: 600,
+          textAlign: 'center',
+          wordBreak: 'break-word',
+        }}
+      >
+        {message}
+      </div>
+      {senderName && (
+        <div
+          data-msg-label=""
+          style={{
+            color: '#fff',
+            fontSize: 12,
+            fontWeight: 800,
+            textShadow:
+              '0 0 8px rgba(99,102,241,0.9), 0 2px 10px rgba(0,0,0,0.8)',
+            letterSpacing: 1,
+            padding: '3px 10px',
+            borderRadius: 8,
+            backgroundColor: 'rgba(99, 102, 241, 0.35)',
+            whiteSpace: 'nowrap',
+            opacity: 0,
+          }}
+        >
+          {senderName}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatPopupOverlay.tsx
@@ -12,11 +12,9 @@ export function GameChatPopupOverlay() {
   );
   const resolveEquipped = useGameChatStore((s) => s.resolveEquipped);
   const currentUserId = useGameChatStore((s) => s.currentUserId);
-  const chatPanelOpen = useGameChatStore((s) => s.chatPanelOpen);
 
   const { latestMessage, dismiss } = useLatestChatMessage(logs);
 
-  if (chatPanelOpen) return null;
   if (!latestMessage) return null;
 
   const senderIdArg = latestMessage.senderId ?? undefined;

--- a/apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/GameChatPopupOverlay.test.tsx
@@ -57,11 +57,11 @@ describe('GameChatPopupOverlay', () => {
     );
   });
 
-  it('renders nothing when chat panel is open', () => {
+  it('renders popup even when chat panel is open', () => {
     useGameChatStore.getState().setLogs([baseLog]);
     useGameChatStore.getState().setChatPanelOpen(true);
     render(<GameChatPopupOverlay />);
-    expect(screen.queryByTestId('chat-message-popup')).toBeNull();
+    expect(screen.getByTestId('chat-message-popup')).toBeTruthy();
   });
 
   it('prefers game resolver over fallback for sender name', () => {


### PR DESCRIPTION
## Summary
- Emotes and chat messages now appear as animated floating bubbles in the top-right corner of the game room area
- Both use the same visual style (dark pill + sender name label) and float animation
- Messages display regardless of chat panel open/closed state
- Bubbles stay visible while scrolling game content

## Changes
- `GameWidgetContainer`: added `ActiveEmotesContext` to pass emote data + name resolver; renders `EmoteBubble` and `GameChatPopupOverlay` outside the scrollable Container in a positioned wrapper
- `EmoteBubble`: removed translation label, now shows sender name instead; cleaned up unused imports
- `ChatMessagePopup`: rewritten with matching float animation and bubble style (dark pill with indigo glow + sender name label below)
- `GameChatPopupOverlay`: removed `chatPanelOpen` guard so messages always show in the room
- `GamePageLayout`: wraps game widget in `ActiveEmotesProvider` to supply emotes + name resolver