### PR TITLE
chore: reset version to 1.23.3 and use PAT for version bump

### DIFF
--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -5,7 +5,7 @@ description: Writes pull request descriptions. Use when creating a PR, writing a
 
 When writing a PR description:
 
-1. Run `git diff main...HEAD` to see all changes on this branch
+1. Run `git diff develop...HEAD` to see all changes on this branch
 2. Write a description following this format:
 
 ## What

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
       - staging
 
 jobs:

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      - develop
+      - staging
 
 jobs:
   check-pr-title:

--- a/.github/workflows/release-social-poster.yml
+++ b/.github/workflows/release-social-poster.yml
@@ -255,43 +255,63 @@ jobs:
                   else:
                       linkedin_texts.append(f"🚀 New Release: v{version} (continued)\n\n{chunk}")
 
-              # 6. Post to Buffer (REST API)
+              # 6. Post to Buffer (GraphQL API)
               buffer_token = os.environ.get('BUFFER_API_TOKEN', '')
               if buffer_token:
-                  buffer_url = "https://api.bufferapp.com"
+                  buffer_url = "https://api.buffer.com"
                   headers = {
                       "Authorization": f"Bearer {buffer_token}",
                       "Content-Type": "application/json",
                   }
 
                   channels = [
-                      (os.environ.get('FACEBOOK_ID', ''), facebook_texts, "Facebook"),
-                      (os.environ.get('THREADS_ID', ''), threads_texts, "Threads"),
-                      (os.environ.get('LINKEDIN_ID', ''), linkedin_texts, "LinkedIn"),
+                      (os.environ.get('FACEBOOK_ID', ''), facebook_texts, "Facebook", "facebook"),
+                      (os.environ.get('THREADS_ID', ''), threads_texts, "Threads", "threads"),
+                      (os.environ.get('LINKEDIN_ID', ''), linkedin_texts, "LinkedIn", "linkedin"),
                   ]
 
-                  for channel_id, texts, name in channels:
+                  for channel_id, texts, name, platform in channels:
                       if not channel_id:
                           print(f"Skipping Buffer post to {name} — channel ID not set")
                           continue
+                      metadata_key = platform
+                      metadata_json = json.dumps({metadata_key: {"type": "post"}})
                       for i, text in enumerate(texts):
-                          payload = {
-                              "profile_ids": [channel_id],
+                          variables = {
                               "text": text,
-                              "now": True,
+                              "channelId": channel_id,
+                              "metadata": json.loads(metadata_json),
                           }
-                          resp = requests.post(
-                              f"{buffer_url}/1/updates/create.json",
-                              headers=headers,
-                              data=payload,
-                          )
+                          query = """
+                          mutation CreatePost($text: String!, $channelId: ChannelId!, $metadata: PostInputMetaData) {
+                            createPost(input: {
+                              text: $text
+                              channelId: $channelId
+                              schedulingType: automatic
+                              mode: now
+                              assets: []
+                              metadata: $metadata
+                            }) {
+                              ... on PostActionSuccess {
+                                post { id text status }
+                              }
+                              ... on MutationError {
+                                message
+                              }
+                            }
+                          }
+                          """
+                          payload = {"query": query, "variables": variables}
+                          resp = requests.post(buffer_url, headers=headers, json=payload)
                           if resp.status_code == 200:
                               result = resp.json()
-                              if result.get("success"):
+                              if "errors" in result:
+                                  print(f"Failed to post to {name}: {result['errors']}")
+                              elif result.get("data", {}).get("createPost", {}).get("message"):
+                                  print(f"Failed to post to {name}: {result['data']['createPost']['message']}")
+                              else:
                                   suffix = f" (part {i + 1}/{len(texts)})" if len(texts) > 1 else ""
                                   print(f"Posted release v{version} to {name}{suffix}")
-                              else:
-                                  print(f"Failed to post to {name}: {result}")
                           else:
                               print(f"Failed to post to {name}: {resp.text}")
               else:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -2,7 +2,7 @@ name: Version Bump & Changelog
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, main ]
 
 jobs:
   bump-version:
@@ -24,12 +24,20 @@ jobs:
         shell: bash
         run: |
           CURRENT_VERSION=$(node -p "require('./apps/web/package.json').version")
+          BRANCH_NAME="${{ github.ref_name }}"
           
           echo "Current Version: $CURRENT_VERSION"
+          echo "Branch: $BRANCH_NAME"
           
-          # Patch bump: 1.7.18 -> 1.7.19
-          NEW_VERSION=$(node -p "const v = '$CURRENT_VERSION'.split('.'); v[2]++; v.join('.')")
-          COMMIT_MSG="chore: bump version to v${NEW_VERSION} and update changelog [skip ci]"
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            # Minor bump: 1.23.4 -> 1.24.0
+            NEW_VERSION=$(node -p "const v = '$CURRENT_VERSION'.split('.'); v[1]++; v[2]=0; v.join('.')")
+            COMMIT_MSG="chore: start next minor version v${NEW_VERSION} [skip ci]"
+          else
+            # Patch bump: 1.23.4 -> 1.23.5
+            NEW_VERSION=$(node -p "const v = '$CURRENT_VERSION'.split('.'); v[2]++; v.join('.')")
+            COMMIT_MSG="chore: bump version to v${NEW_VERSION} and update changelog [skip ci]"
+          fi
           
           echo "New Version: $NEW_VERSION"
           echo "Commit Message: $COMMIT_MSG"
@@ -55,6 +63,8 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           
+          BRANCH_NAME="${{ github.ref_name }}"
+          
           # Stage changes
           find . -name "package.json" -not -path "*/node_modules/*" -exec git add {} +
           git add CHANGELOG.md
@@ -62,6 +72,11 @@ jobs:
           git commit -m "$COMMIT_MSG"
           git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           
-          echo "Pushing patch bump to develop"
-          git push origin HEAD:develop --follow-tags
+          if [[ "$BRANCH_NAME" == "main" ]]; then
+            echo "Pushing minor bump to develop"
+            git push origin HEAD:develop --follow-tags
+          else
+            echo "Pushing patch bump to develop"
+            git push origin HEAD:develop --follow-tags
+          fi
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -2,7 +2,7 @@ name: Version Bump & Changelog
 
 on:
   push:
-    branches: [ develop, main ]
+    branches: [ develop ]
 
 jobs:
   bump-version:
@@ -24,22 +24,12 @@ jobs:
         shell: bash
         run: |
           CURRENT_VERSION=$(node -p "require('./apps/web/package.json').version")
-          BRANCH_NAME="${{ github.ref_name }}"
           
           echo "Current Version: $CURRENT_VERSION"
-          echo "Branch: $BRANCH_NAME"
           
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            # Minor bump: 1.7.18 -> 1.8.0
-            NEW_VERSION=$(node -p "const v = '$CURRENT_VERSION'.split('.'); v[1]++; v[2]=0; v.join('.')")
-            COMMIT_MSG="chore: start next minor version v${NEW_VERSION} [skip ci]"
-            IS_RELEASE="true"
-          else
-            # Patch bump: 1.7.18 -> 1.7.19
-            NEW_VERSION=$(node -p "const v = '$CURRENT_VERSION'.split('.'); v[2]++; v.join('.')")
-            COMMIT_MSG="chore: bump version to v${NEW_VERSION} and update changelog [skip ci]"
-            IS_RELEASE="false"
-          fi
+          # Patch bump: 1.7.18 -> 1.7.19
+          NEW_VERSION=$(node -p "const v = '$CURRENT_VERSION'.split('.'); v[2]++; v.join('.')")
+          COMMIT_MSG="chore: bump version to v${NEW_VERSION} and update changelog [skip ci]"
           
           echo "New Version: $NEW_VERSION"
           echo "Commit Message: $COMMIT_MSG"
@@ -65,9 +55,6 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           
-          # BRANCH_NAME, NEW_VERSION, and COMMIT_MSG are available from the environment
-          BRANCH_NAME="${{ github.ref_name }}"
-          
           # Stage changes
           find . -name "package.json" -not -path "*/node_modules/*" -exec git add {} +
           git add CHANGELOG.md
@@ -75,12 +62,6 @@ jobs:
           git commit -m "$COMMIT_MSG"
           git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            echo "Pushing minor bump to develop"
-            git fetch origin develop
-            git push origin HEAD:develop --follow-tags
-          else
-            echo "Pushing patch bump to $BRANCH_NAME"
-            git push origin HEAD:${BRANCH_NAME} --follow-tags
-          fi
+          echo "Pushing patch bump to develop"
+          git push origin HEAD:develop --follow-tags
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0  # Needed for git describe
 
       - name: Setup Node.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Branch naming: `ARC-XXX` (Jira tickets). Footer: `(ARC-XXX)` for issue tracking.
 
 ### Project skills
 
-- `/pr-description` — write PR descriptions (runs `git diff main...HEAD`, formats as What/Why/Changes)
+- `/pr-description` — write PR descriptions (runs `git diff develop...HEAD`, formats as What/Why/Changes)
 - `/commit` — create a commit following Conventional Commits with ARC-XXX scope
 - `/new-web-page` — add a Next.js App Router page (`page.tsx` + `*Client.tsx` + `*View.tsx` + i18n)
 - `/new-be-module` — add a NestJS module (controller, service, module, DTOs, Mongoose schema)

--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "be",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "description": "",
   "author": "",
   "private": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile",
   "main": "expo-router/entry",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "scripts": {
     "dev": "node ./scripts/dev.js",
     "start": "expo start",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mobile",
   "main": "expo-router/entry",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "scripts": {
     "dev": "node ./scripts/dev.js",
     "start": "expo start",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "private": true,
   "browserslist": [
     "chrome >= 87",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "private": true,
   "browserslist": [
     "chrome >= 87",

--- a/bots/task-bot/package.json
+++ b/bots/task-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-bot",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "description": "Telegram bot for automated task implementation",
   "private": true,
   "license": "UNLICENSED",

--- a/bots/task-bot/package.json
+++ b/bots/task-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-bot",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "description": "Telegram bot for automated task implementation",
   "private": true,
   "license": "UNLICENSED",

--- a/bots/tg-bot/package.json
+++ b/bots/tg-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-bot",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "description": "Telegram bot for PumpFun transaction monitoring",
   "private": true,
   "license": "UNLICENSED",

--- a/bots/tg-bot/package.json
+++ b/bots/tg-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tg-bot",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "description": "Telegram bot for PumpFun transaction monitoring",
   "private": true,
   "license": "UNLICENSED",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicoapp-monorepo",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicoapp-monorepo",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "private": true,
   "packageManager": "pnpm@9.15.0",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeum/ui",
-  "version": "1.23.0",
+  "version": "1.23.3",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcadeum/ui",
-  "version": "1.24.1",
+  "version": "1.23.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Changes
- Reset version from 1.24.1 back to 1.23.3 (1.24 was created by mistake)
- Update `version-bump.yml` to use `GH_PAT` secret instead of `GITHUB_TOKEN` so it can push to protected branches