### PR TITLE
fix(be,web): fix game not showing after start and tic-tac-toe cell overflow

### DIFF
--- a/apps/be/src/games/critical/critical.service.ts
+++ b/apps/be/src/games/critical/critical.service.ts
@@ -264,8 +264,9 @@ export class CriticalService implements OnModuleInit, OnModuleDestroy {
     });
 
     await this.roomsService.updateRoomStatus(effectiveRoomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
     await this.realtimeService.emitGameStarted(
-      room,
+      updatedRoom,
       session,
       async (s, pId) => {
         const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
@@ -279,7 +280,7 @@ export class CriticalService implements OnModuleInit, OnModuleDestroy {
       },
     );
 
-    return { room, session };
+    return { room: updatedRoom, session };
   }
 
   /**

--- a/apps/be/src/games/games.service.spec.ts
+++ b/apps/be/src/games/games.service.spec.ts
@@ -237,11 +237,14 @@ describe('GamesService', () => {
         'in_progress',
       );
       expect(realtimeService.emitGameStarted).toHaveBeenCalledWith(
-        room,
+        { ...room, status: 'in_progress' },
         session,
         expect.any(Function),
       );
-      expect(result).toEqual({ room, session });
+      expect(result).toEqual({
+        room: { ...room, status: 'in_progress' },
+        session,
+      });
     });
 
     it('should throw if user is not host', async () => {

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -229,16 +229,19 @@ export class GamesService {
 
     // Update room status
     await this.roomsService.updateRoomStatus(roomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
 
     // Mark players as in-match for the leaderboard LIVE chip.
     await this.leaderboardSync.syncInMatch(playerIds, true);
 
     // Emit real-time event
-    await this.realtimeService.emitGameStarted(room, session, async (s, pId) =>
-      this.sanitizeForPlayer(s, pId),
+    await this.realtimeService.emitGameStarted(
+      updatedRoom,
+      session,
+      async (s, pId) => this.sanitizeForPlayer(s, pId),
     );
 
-    return { room, session };
+    return { room: updatedRoom, session };
   }
 
   /**

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -225,8 +225,9 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     });
 
     await this.roomsService.updateRoomStatus(roomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
     await this.realtimeService.emitGameStarted(
-      room,
+      updatedRoom,
       session,
       async (s, pId) => {
         const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
@@ -241,7 +242,7 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     );
 
     const updatedSession = await this.checkAndSyncRoomStatus(session);
-    return { room, session: updatedSession };
+    return { room: updatedRoom, session: updatedSession };
   }
 
   /**

--- a/apps/be/src/games/texas-holdem/texas-holdem.service.ts
+++ b/apps/be/src/games/texas-holdem/texas-holdem.service.ts
@@ -122,8 +122,9 @@ export class TexasHoldemService {
     });
 
     await this.roomsService.updateRoomStatus(effectiveRoomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
     await this.realtimeService.emitGameStarted(
-      room,
+      updatedRoom,
       session,
       async (s, pId) => {
         const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
@@ -137,7 +138,7 @@ export class TexasHoldemService {
       },
     );
 
-    return { room, session };
+    return { room: updatedRoom, session };
   }
 
   /**

--- a/apps/be/src/games/tic-tac-toe/tic-tac-toe.service.ts
+++ b/apps/be/src/games/tic-tac-toe/tic-tac-toe.service.ts
@@ -107,8 +107,9 @@ export class TicTacToeService implements OnModuleInit, OnModuleDestroy {
     });
 
     await this.roomsService.updateRoomStatus(roomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
     await this.realtimeService.emitGameStarted(
-      room,
+      updatedRoom,
       session,
       async (s, pId) => {
         const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
@@ -123,7 +124,7 @@ export class TicTacToeService implements OnModuleInit, OnModuleDestroy {
     );
 
     const updatedSession = await this.afterSessionStep(session);
-    return { room, session: updatedSession };
+    return { room: updatedRoom, session: updatedSession };
   }
 
   async placeMark(userId: string, roomId: string, payload: PlaceMarkPayload) {

--- a/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
@@ -80,6 +80,7 @@ function TicTacToeBoardImpl({
         aspectRatio: '1 / 1',
         margin: '0 auto',
         boxSizing: 'border-box',
+        containerType: 'inline-size',
       }}
     >
       {board.map((row, rowIdx) =>
@@ -108,9 +109,10 @@ function TicTacToeBoardImpl({
                 borderRadius: theme.borderRadius,
                 fontFamily: theme.markFont,
                 fontWeight: 700,
-                fontSize: `clamp(1rem, ${Math.max(2, 6 - size * 0.3)}vmin, 3rem)`,
+                fontSize: `clamp(0.8rem, ${(55 / size).toFixed(1)}cqw, 3rem)`,
                 cursor: cellDisabled ? 'default' : 'pointer',
                 transition: 'background-color 120ms ease',
+                overflow: 'hidden',
               }}
               onMouseEnter={(e) => {
                 if (!cellDisabled) {


### PR DESCRIPTION
## What
- **BE**: Fixed `emitGameStarted` sending stale room object (status: `lobby`) to clients after `updateRoomStatus` had already written `in_progress` to the DB. The frontend saw `lobby` status and never transitioned to the game view. Applied fix across all 5 game services (tic-tac-toe, sea-battle, cascade, texas-holdem, critical) and the generic `games.service.ts`.
- **Web**: Fixed tic-tac-toe marks overflowing their cells on larger boards (5x5, 7x7, 9x9). Replaced viewport-relative `vmin` font sizing with container-relative `cqw` units so marks scale proportionally with cell size.

## Why
Two separate bugs: (1) the BE emitted a stale room with `status: 'lobby'` because the local variable wasn't updated after the DB write, causing the frontend to remain stuck in lobby view; (2) the tic-tac-toe board used viewport-relative font sizes that didn't account for actual cell dimensions, causing marks to overflow on smaller/larger boards.

## Changes
- `apps/be/src/games/tic-tac-toe/tic-tac-toe.service.ts` — create `updatedRoom` with `status: 'in_progress'` before emitting
- `apps/be/src/games/sea-battle/sea-battle.service.ts` — same pattern
- `apps/be/src/games/critical/critical.service.ts` — same pattern
- `apps/be/src/games/texas-holdem/texas-holdem.service.ts` — same pattern
- `apps/be/src/games/games.service.ts` — same pattern (generic start)
- `apps/be/src/games/games.service.spec.ts` — updated test expectations
- `apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx` — added `containerType: 'inline-size'` to grid, switched to `cqw` font units, added `overflow: hidden`