### PR TITLE
fix(web): remove duplicate border in game chat panel

### DIFF
--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/layoutStyles.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/layoutStyles.tsx
@@ -45,12 +45,8 @@ export const ChatPanel = styled(YStack, {
   height: '100%',
   minHeight: 350,
   flexShrink: 0,
-  backgroundColor: '$glassBg',
   borderRadius: '$4',
-  borderWidth: 1,
-  borderColor: '$glassBorder',
   overflow: 'hidden',
-  boxShadow: '0 8px 32px rgba(0, 0, 0, 0.2)',
 
   $md: {
     width: '100%',


### PR DESCRIPTION
## What
Remove duplicate border around the game chat panel by cleaning up redundant styles from the wrapper component.

## Why
The `ChatPanel` wrapper had its own `borderWidth: 1`, `backgroundColor`, and `boxShadow` while the inner `GameChat Panel` component already provides identical glassmorphism styling. This caused two visible borders around the chat.

## Changes
- Removed `borderWidth`, `borderColor`, `backgroundColor`, and `boxShadow` from `ChatPanel` wrapper
- Kept `borderRadius` and `overflow: 'hidden'` for proper clipping