### PR TITLE
fix(be,web): fix game start flow for anonymous users

### DIFF
--- a/apps/be/src/games/games.catalog.ts
+++ b/apps/be/src/games/games.catalog.ts
@@ -4,15 +4,19 @@ export interface GameCatalogRule {
   description?: string;
 }
 
+export type GameStartMode = 'immediate' | 'placement';
+
 export interface GameCatalogEntry {
   gameId: string;
   variants: ReadonlyArray<string>;
   rules: ReadonlyArray<GameCatalogRule>;
+  startMode: GameStartMode;
 }
 
 export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
   {
     gameId: 'critical_v1',
+    startMode: 'immediate',
     variants: [
       'cyberpunk',
       'underwater',
@@ -51,6 +55,7 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
   },
   {
     gameId: 'sea_battle_v1',
+    startMode: 'placement',
     variants: [
       'classic',
       'modern',
@@ -112,11 +117,13 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
   },
   {
     gameId: 'texas_holdem_v1',
+    startMode: 'immediate',
     variants: [],
     rules: [],
   },
   {
     gameId: 'glimworm_v1',
+    startMode: 'immediate',
     variants: ['battle_royale', 'time_attack', 'lives_heats'],
     rules: [
       {
@@ -135,6 +142,7 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
   },
   {
     gameId: 'tic_tac_toe_v1',
+    startMode: 'immediate',
     variants: ['classic', 'neon', 'paper', 'pixel', 'chalkboard', 'retro'],
     rules: [
       {
@@ -153,6 +161,7 @@ export const GAME_CATALOG: ReadonlyArray<GameCatalogEntry> = [
   },
   {
     gameId: 'cascade_v1',
+    startMode: 'immediate',
     variants: [
       'cosmic',
       'arcane',

--- a/apps/be/src/games/games.controller.ts
+++ b/apps/be/src/games/games.controller.ts
@@ -254,11 +254,17 @@ export class GamesController {
   async getRoomInfoBody(
     @Req() req: Request,
     @Body() body: { roomId: string },
-  ): Promise<{ room: Awaited<ReturnType<GamesService['getRoom']>> }> {
+  ): Promise<{
+    room: Awaited<ReturnType<GamesService['getRoom']>>;
+    session: Awaited<ReturnType<GamesService['getRoomSession']>>['session'];
+  }> {
     const { roomId } = body;
     const user = req.user as AuthenticatedUser | undefined | null;
-    const room = await this.gamesService.getRoom(roomId, user?.userId);
-    return { room };
+    const { room, session } = await this.gamesService.getRoomSession(
+      roomId,
+      user?.userId,
+    );
+    return { room, session };
   }
 
   @UseGuards(JwtOptionalAuthGuard)

--- a/apps/be/src/games/games.realtime.service.ts
+++ b/apps/be/src/games/games.realtime.service.ts
@@ -107,7 +107,7 @@ export class GamesRealtimeService {
     sanitizer?: (
       session: GameSessionSummary,
       userId: string,
-    ) => Promise<GameSessionSummary>,
+    ) => GameSessionSummary | Promise<GameSessionSummary>,
   ): Promise<void> {
     if (!this.server) {
       return;
@@ -316,7 +316,7 @@ export class GamesRealtimeService {
     sanitizer?: (
       session: GameSessionSummary,
       userId: string,
-    ) => Promise<GameSessionSummary>,
+    ) => GameSessionSummary | Promise<GameSessionSummary>,
   ): Promise<void> {
     if (!this.server) {
       return;
@@ -386,9 +386,6 @@ export class GamesRealtimeService {
         session: filteredSession,
       }),
     );
-
-    // Also emit session snapshot (which already handles both channels)
-    await this.emitSessionSnapshot(room.id, session, sanitizer);
   }
 
   async emitActionExecuted(
@@ -398,7 +395,7 @@ export class GamesRealtimeService {
     sanitizer?: (
       session: GameSessionSummary,
       userId: string,
-    ) => Promise<GameSessionSummary>,
+    ) => GameSessionSummary | Promise<GameSessionSummary>,
   ): Promise<void> {
     if (!this.server || !session.roomId) {
       return;

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -50,14 +50,11 @@ export class GamesService {
     private readonly ruleVisibility: GameRuleVisibilityService,
   ) {}
 
-  private async sanitizeForPlayer(
+  private sanitizeForPlayer(
     s: GameSessionSummary,
     pId: string,
-  ): Promise<GameSessionSummary> {
-    const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
-      s.id,
-      pId,
-    );
+  ): GameSessionSummary {
+    const sanitized = this.sessionsService.sanitizeSummaryForPlayer(s, pId);
     if (sanitized && typeof sanitized === 'object') {
       return { ...s, state: sanitized as Record<string, unknown> };
     }
@@ -111,7 +108,7 @@ export class GamesService {
 
     if (session && userId) {
       try {
-        session = await this.sanitizeForPlayer(session, userId);
+        session = this.sanitizeForPlayer(session, userId);
       } catch {
         // safely continue with unsanitized session state
       }
@@ -235,10 +232,8 @@ export class GamesService {
     await this.leaderboardSync.syncInMatch(playerIds, true);
 
     // Emit real-time event
-    await this.realtimeService.emitGameStarted(
-      updatedRoom,
-      session,
-      async (s, pId) => this.sanitizeForPlayer(s, pId),
+    await this.realtimeService.emitGameStarted(updatedRoom, session, (s, pId) =>
+      this.sanitizeForPlayer(s, pId),
     );
 
     return { room: updatedRoom, session };
@@ -265,7 +260,7 @@ export class GamesService {
       session,
       action,
       userId,
-      async (s, pId) => this.sanitizeForPlayer(s, pId),
+      (s, pId) => this.sanitizeForPlayer(s, pId),
     );
 
     // Sync room status if game completed
@@ -393,7 +388,7 @@ export class GamesService {
       await this.realtimeService.emitSessionSnapshot(
         roomId,
         session,
-        async (s, pId) => this.sanitizeForPlayer(s, pId),
+        (s, pId) => this.sanitizeForPlayer(s, pId),
       );
     }
   }

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -243,8 +243,8 @@ export class GameSessionsService {
     if (!history || history.length === 0) return null;
     const previousState = history[history.length - 1];
     state.stateHistory = history.slice(0, -1);
-      session.state = previousState as Record<string, unknown>;
-      session.markModified('state');
+    session.state = previousState as Record<string, unknown>;
+    session.markModified('state');
     session.updatedAt = new Date();
     await session.save();
     return this.toSessionSummary(session);

--- a/apps/be/src/games/tic-tac-toe/tic-tac-toe.service.ts
+++ b/apps/be/src/games/tic-tac-toe/tic-tac-toe.service.ts
@@ -82,8 +82,9 @@ export class TicTacToeService implements OnModuleInit, OnModuleDestroy {
     const playerIds = [...participants];
 
     if (withBots || playerIds.length === 1) {
+      const needed = Math.max(0, MIN_PLAYERS - playerIds.length);
       const desiredCount =
-        botCount !== undefined ? botCount : Math.max(0, 2 - playerIds.length);
+        botCount !== undefined ? Math.max(botCount, needed) : needed;
       const cap = Math.min(sizeCap - playerIds.length, desiredCount);
       for (let i = 0; i < cap; i++) {
         playerIds.push(`bot-${Math.random().toString(36).slice(2, 10)}`);
@@ -111,11 +112,8 @@ export class TicTacToeService implements OnModuleInit, OnModuleDestroy {
     await this.realtimeService.emitGameStarted(
       updatedRoom,
       session,
-      async (s, pId) => {
-        const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
-          s.id,
-          pId,
-        );
+      (s, pId) => {
+        const sanitized = this.sessionsService.sanitizeSummaryForPlayer(s, pId);
         if (sanitized && typeof sanitized === 'object') {
           return { ...s, state: sanitized as Record<string, unknown> };
         }
@@ -215,14 +213,13 @@ export class TicTacToeService implements OnModuleInit, OnModuleDestroy {
   private resolveOptions(raw: unknown): TicTacToeOptions {
     const r = (raw ?? {}) as Partial<{
       variant: string;
-      boardSize: number;
+      boardSize: number | string;
       teamMode: boolean;
     }>;
     const allowedSizes: number[] = [3, 5, 7, 9];
+    const rawSize = Number(r.boardSize) || DEFAULT_OPTIONS.boardSize;
     const boardSize = (
-      allowedSizes.includes(r.boardSize ?? 3)
-        ? r.boardSize
-        : DEFAULT_OPTIONS.boardSize
+      allowedSizes.includes(rawSize) ? rawSize : DEFAULT_OPTIONS.boardSize
     ) as BoardSize;
     return {
       variant: (r.variant as Variant) ?? DEFAULT_OPTIONS.variant,

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
@@ -123,7 +123,7 @@ export default function GameRoomPage({
     if (isAuthenticated) {
       connectSockets(snapshot.accessToken);
     } else if (snapshot.userId || roomVisibility === 'public') {
-      connectSocketsAnonymous();
+      connectSocketsAnonymous(snapshot.userId ?? undefined);
     }
     return () => {
       disconnectSockets();

--- a/apps/web/src/features/games/hooks/useGameSession.ts
+++ b/apps/web/src/features/games/hooks/useGameSession.ts
@@ -12,6 +12,7 @@ interface UseGameSessionOptions {
 interface UseGameSessionReturn {
   session: GameSessionSummary | null;
   startBusy: boolean;
+  setStartBusy: (busy: boolean) => void;
   actionBusy: string | null;
   setActionBusy: (action: string | null) => void;
 }
@@ -71,6 +72,17 @@ export function useGameSession(
       setActionBusy(null);
     };
 
+    const handleGameStarted = (payload: {
+      room?: unknown;
+      session?: GameSessionSummary | null;
+    }) => {
+      setStartBusy(false);
+      if (payload?.session) {
+        setSession(payload.session);
+      }
+      setActionBusy(null);
+    };
+
     const handleRoomJoined = (payload: {
       room?: unknown;
       session?: GameSessionSummary | null;
@@ -80,12 +92,20 @@ export function useGameSession(
       }
     };
 
-    // Decrypt wrapper for socket handlers
+    const handleException = () => {
+      setStartBusy(false);
+      setActionBusy(null);
+    };
+
+    // Decrypt wrapper for socket handlers — falls through to handler with
+    // raw data when decryption fails (e.g. anonymous clients without key)
     const decryptHandler = <T>(handler: (payload: T) => void) => {
       return async (raw: unknown) => {
         const payload = await maybeDecrypt<T>(raw);
         if (payload !== null) {
           handler(payload);
+        } else {
+          handler(raw as T);
         }
       };
     };
@@ -93,27 +113,39 @@ export function useGameSession(
     // Create wrapped handlers
     const wrappedHandleSnapshot = decryptHandler(handleSnapshot);
     const wrappedHandleSessionStarted = decryptHandler(handleSessionStarted);
+    const wrappedHandleGameStarted = decryptHandler(handleGameStarted);
     const wrappedHandleRoomJoined = decryptHandler(handleRoomJoined);
 
     // Register listeners
     gameSocket.on('games.session.snapshot', wrappedHandleSnapshot);
     gameSocket.on('games.session.started', wrappedHandleSessionStarted);
+    gameSocket.on('games.game.started', wrappedHandleGameStarted);
     gameSocket.on('games.room.joined', wrappedHandleRoomJoined);
+    gameSocket.on('exception', handleException);
 
-    // Initial check if we should join or sync
-    // (This part is usually handled by the component or a dedicated effect)
+    // Raw listeners — always clear startBusy/actionBusy even if decryption
+    // fails (anonymous clients without encryption key)
+    const onRawGameStarted = () => setStartBusy(false);
+    const onRawSessionStarted = () => setStartBusy(false);
+    gameSocket.on('games.game.started', onRawGameStarted);
+    gameSocket.on('games.session.started', onRawSessionStarted);
 
     // Cleanup
     return () => {
       gameSocket.off('games.session.snapshot', wrappedHandleSnapshot);
       gameSocket.off('games.session.started', wrappedHandleSessionStarted);
+      gameSocket.off('games.game.started', wrappedHandleGameStarted);
       gameSocket.off('games.room.joined', wrappedHandleRoomJoined);
+      gameSocket.off('exception', handleException);
+      gameSocket.off('games.game.started', onRawGameStarted);
+      gameSocket.off('games.session.started', onRawSessionStarted);
     };
   }, [roomId, enabled]);
 
   return {
     session,
     startBusy,
+    setStartBusy,
     actionBusy,
     setActionBusy,
   };

--- a/apps/web/src/features/games/store/gameStore.ts
+++ b/apps/web/src/features/games/store/gameStore.ts
@@ -151,7 +151,8 @@ export const useGameStore = create<GameState>((set, get) => ({
       }
     };
 
-    // Decrypt wrapper
+    // Decrypt wrapper — falls through to handler with raw data when
+    // decryption fails (e.g. anonymous clients without encryption key)
     const decryptHandler = <T>(
       handler: (payload: T) => void,
       _name: string,
@@ -160,6 +161,8 @@ export const useGameStore = create<GameState>((set, get) => ({
         const payload = await maybeDecrypt<T>(raw);
         if (payload !== null) {
           handler(payload);
+        } else {
+          handler(raw as T);
         }
       };
     };
@@ -220,6 +223,16 @@ export const useGameStore = create<GameState>((set, get) => ({
     gameSocket.on('connect', handleConnect);
     gameSocket.on('disconnect', handleDisconnect);
 
+    // Raw fallback — when decryption fails (anonymous clients), fetch
+    // updated room data from the API so the UI transitions out of lobby
+    const onRawGameStarted = () => {
+      const currentRoom = get().room;
+      if (currentRoom?.id === roomId) {
+        void get().refreshRoom(roomId);
+      }
+    };
+    gameSocket.on('games.game.started', onRawGameStarted);
+
     const wrappedHandleIdleChanged = decryptHandler<{
       userId?: string;
       idle?: boolean;
@@ -240,6 +253,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       gameSocket.off('games.player.joined', wrappedHandlePlayerJoined);
       gameSocket.off('games.player.left', wrappedHandlePlayerLeft);
       gameSocket.off('games.game.started', wrappedHandleGameStarted);
+      gameSocket.off('games.game.started', onRawGameStarted);
       gameSocket.off('exception', wrappedHandleException);
       gameSocket.off('connect', handleConnect);
       gameSocket.off('disconnect', handleDisconnect);

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -8,6 +8,7 @@ import { SubtitleText } from './SubtitleText';
 import { TurnIndicator, resolveTurnStatus } from './TurnIndicator';
 import { EmoteBubble } from './EmoteBubble';
 import type { EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
+import { useTranslation } from '@/shared/lib/useTranslation';
 import {
   WidgetFullscreenContext,
   useActiveEmotes,
@@ -53,6 +54,7 @@ interface GameWidgetContainerProps {
   isMyTurn?: boolean;
   isGameOver?: boolean;
   showChatPopup?: boolean;
+  loading?: boolean;
 }
 
 export const GameWidgetContainer = React.memo(function GameWidgetContainer({
@@ -66,11 +68,13 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   isMyTurn,
   isGameOver,
   showChatPopup = true,
+  loading = false,
 }: GameWidgetContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const activeEmotes = useActiveEmotes();
   const { isFullscreen, toggleFullscreen, exitFullscreen } =
     useFullscreen(containerRef);
+  const { t } = useTranslation();
 
   useAutoExitFullscreen({
     status: isGameOver ? 'completed' : 'active',
@@ -174,7 +178,21 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
           >
             {renderedHeader}
             <SharedGameBoard data-testid="game-board-section">
-              {board}
+              {loading ? (
+                <YStack
+                  flex={1}
+                  alignItems="center"
+                  justifyContent="center"
+                  gap="$3"
+                  minHeight={300}
+                >
+                  <Text fontSize="$5" fontWeight="500" opacity={0.8}>
+                    {t('games.roomPage.loadingGame')}
+                  </Text>
+                </YStack>
+              ) : (
+                board
+              )}
             </SharedGameBoard>
             {tableArea && (
               <SharedTableArea data-testid="game-table-section">

--- a/apps/web/src/shared/lib/socket.ts
+++ b/apps/web/src/shared/lib/socket.ts
@@ -176,8 +176,9 @@ export function connectFriendsSocket(
 
 /**
  * Connect game socket without authentication (for spectating public games)
+ * Pass the anonymous userId so the backend sends the encryption key
  */
-export function connectSocketsAnonymous(): void {
+export function connectSocketsAnonymous(userId?: string): void {
   // Disconnect if currently authenticated
   if (currentAuthToken) {
     disconnectSockets();
@@ -185,6 +186,14 @@ export function connectSocketsAnonymous(): void {
 
   // Clear any auth
   gamesSocket.auth = {};
+
+  // Pass anonId so gateway recognizes the client and sends encryption key
+  if (userId) {
+    gamesSocket.io.opts.query = {
+      ...(gamesSocket.io.opts.query as Record<string, string>),
+      anonId: userId,
+    };
+  }
 
   if (!gamesSocket.connected) {
     gamesSocket.connect();

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -234,6 +234,7 @@ function CascadeGameImpl({
         variant={options.variant}
         isMyTurn={myTurn}
         isGameOver={isGameOver}
+        loading={!snapshot}
         headerProps={{
           variantEmoji: variantTokens.emoji,
           title: 'Cascade',

--- a/apps/web/src/widgets/TicTacToeGame/hooks/useTicTacToeState.ts
+++ b/apps/web/src/widgets/TicTacToeGame/hooks/useTicTacToeState.ts
@@ -18,11 +18,12 @@ export function useTicTacToeState({
   currentUserId,
   initialSession,
 }: UseTicTacToeStateOptions) {
-  const { session, actionBusy, setActionBusy, startBusy } = useGameSession({
-    roomId,
-    enabled: true,
-    initialSession,
-  });
+  const { session, actionBusy, setActionBusy, startBusy, setStartBusy } =
+    useGameSession({
+      roomId,
+      enabled: true,
+      initialSession,
+    });
 
   const snapshot: TicTacToeClientState | null = useMemo(() => {
     if (session?.state) {
@@ -60,5 +61,6 @@ export function useTicTacToeState({
     actionBusy,
     setActionBusy,
     startBusy,
+    setStartBusy,
   };
 }

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -68,6 +68,7 @@ function TicTacToeGameImpl({
     myTurn,
     isGameOver,
     startBusy,
+    setStartBusy,
     session,
   } = useTicTacToeState({
     roomId,
@@ -157,12 +158,13 @@ function TicTacToeGameImpl({
           userId={currentUserId ?? ''}
           isHost={isHost}
           startBusy={startBusy}
-          onStartGame={(opts) =>
+          onStartGame={(opts) => {
+            setStartBusy(true);
             startSession({
               withBots: !!opts?.withBots,
               botCount: opts?.botCount,
-            })
-          }
+            });
+          }}
           onLeaveRoom={() => onLeaveRoom(currentUserId ?? '')}
           onDeleteRoom={onDeleteRoom}
           onKickPlayer={(userId) => onKickPlayer(userId, currentUserId ?? '')}
@@ -232,6 +234,7 @@ function TicTacToeGameImpl({
         variant={options.variant}
         isMyTurn={myTurn}
         isGameOver={isGameOver}
+        loading={!snapshot}
         headerProps={{
           variantEmoji: variantTokens.emoji,
           title: 'Tic-Tac-Toe',


### PR DESCRIPTION
## Summary
- Fix infinite "Starting..." state when pressing Start as anonymous user
- Fix black widget on page refresh after game started
- Add `startMode` to game catalog for explicit immediate vs placement distinction

## What changed

### Backend
- **`tic-tac-toe.service.ts`**: Fixed `resolveOptions` to coerce `boardSize` to number (MongoDB stores it as string, causing `sizeCap=undefined` → `NaN` bot count). Bot count now ensures `MIN_PLAYERS` is reached
- **`games.controller.ts`**: `room-info` endpoint now returns `{ room, session }` via `getRoomSession` instead of just `{ room }`, so anonymous users get session data on page refresh
- **`games.realtime.service.ts`**: Widened sanitizer type to accept sync functions, removed redundant `emitSessionSnapshot` call from `emitGameStarted`
- **`games.service.ts`**: Made `sanitizeForPlayer` sync using `sanitizeSummaryForPlayer` (avoids redundant DB reads)
- **`games.catalog.ts`**: Added `startMode: 'immediate' | 'placement'` to all game entries

### Frontend
- **`GameWidgetContainer.tsx`**: Added `loading` prop that shows "Loading game…" overlay when transitioning from lobby to active state
- **`useGameSession.ts`**: Added `exception` listener to clear `startBusy` on error. Added raw fallback listeners for `games.game.started`/`games.session.started` that always clear `startBusy` even when socket encryption can't be decrypted (anonymous clients without key)
- **`gameStore.ts`**: Added raw fallback for `games.game.started` that triggers `refreshRoom()` to fetch updated room/session data when encrypted events can't be parsed
- **`TicTacToeGame/Game.tsx`** and **`CascadeGame/Game.tsx`**: Pass `loading={!snapshot}` to `GameWidgetContainer`