### PR TITLE
fix(task-bot): shell escape and duplicate check

### DIFF
--- a/bots/task-bot/src/github/github.service.ts
+++ b/bots/task-bot/src/github/github.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 
 interface GitHubIssue {
   arc: string | null;
@@ -25,19 +25,17 @@ export class GitHubService {
     const title = issue.arc ? `${issue.arc}: ${issue.title}` : issue.title;
     const body = this.buildIssueBody(issue);
     const labels = ['task', 'automated'];
-    if (issue.arc) labels.push(issue.arc);
     if (issue.priority === 'high' || issue.priority === 'urgent') {
       labels.push('priority');
     }
 
-    const labelFlags = labels.map((l) => `--label "${l}"`).join(' ');
-    const escapedBody = body.replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    const escapedTitle = title.replace(/"/g, '\\"');
-
-    const cmd = `gh issue create --title "${escapedTitle}" --body "${escapedBody}" ${labelFlags}`;
+    const args = ['issue', 'create', '--title', title, '--body', body];
+    for (const label of labels) {
+      args.push('--label', label);
+    }
 
     try {
-      const result = execSync(cmd, {
+      const result = execFileSync('gh', args, {
         encoding: 'utf-8',
         cwd: this.getCwd(),
       });
@@ -55,8 +53,9 @@ export class GitHubService {
 
   triggerWorkflow(issueNumber: string, engine: string): boolean {
     try {
-      execSync(
-        `gh workflow run implement-task.yml --ref develop -f issue_number=${issueNumber} -f engine=${engine}`,
+      execFileSync(
+        'gh',
+        ['workflow', 'run', 'implement-task.yml', '--ref', 'develop', '-f', `issue_number=${issueNumber}`, '-f', `engine=${engine}`],
         { encoding: 'utf-8', cwd: this.getCwd(), stdio: 'pipe' },
       );
       this.logger.log(

--- a/bots/task-bot/src/github/github.service.ts
+++ b/bots/task-bot/src/github/github.service.ts
@@ -149,6 +149,22 @@ export class GitHubService {
     }
   }
 
+  findDuplicateIssue(title: string): { number: number; title: string; state: string } | null {
+    try {
+      const result = execSync(
+        `gh issue list --state all --json number,title,state --limit 100`,
+        { encoding: 'utf-8', cwd: this.getCwd() },
+      );
+      const issues = JSON.parse(result) as Array<{ number: number; title: string; state: string }>;
+      const normalizedTitle = title.toLowerCase().replace(/^arc-\d+:\s*/, '');
+      return issues.find(
+        (i) => i.title.toLowerCase().replace(/^arc-\d+:\s*/, '') === normalizedTitle,
+      ) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private buildIssueBody(issue: GitHubIssue): string {
     const requirements =
       issue.requirements.length > 0

--- a/bots/task-bot/src/task-bot/task-bot.service.ts
+++ b/bots/task-bot/src/task-bot/task-bot.service.ts
@@ -200,6 +200,15 @@ export class TaskBotService implements OnApplicationBootstrap {
   }
 
   private async createAndTriggerTask(task: ParsedTask, ctx: Context) {
+    const existing = this.githubService.findDuplicateIssue(task.title);
+    if (existing) {
+      await ctx.reply(
+        `Issue already exists: #${existing.number} — ${existing.title} [${existing.state}]\n\nUse /implement #${existing.number} to trigger implementation.`,
+        { parse_mode: 'Markdown' },
+      );
+      return;
+    }
+
     const prioBadge =
       task.priority !== 'normal' ? ` [${task.priority.toUpperCase()}]` : '';
     await ctx.reply(


### PR DESCRIPTION
## What
Fix two critical bugs in task bot automation:

1. **Shell backtick interpretation**: `execSync` runs through a shell, which interprets backticks in the issue body as command substitution (`ARC-877`, `opencode`, `any` were being executed as commands). Fixed by switching to `execFileSync`.

2. **Duplicate issue prevention**: Bot now checks existing issues by normalized title before creating a new one. Shows existing issue link instead of creating duplicates.

## Changes
- `bots/task-bot/src/github/github.service.ts`: Use `execFileSync` instead of `execSync` for `gh` commands, add `findDuplicateIssue()` method, remove ARC label from issue creation
- `bots/task-bot/src/task-bot/task-bot.service.ts`: Check for duplicates before creating issue

## Test plan
- [x] Type check passes
- [x] Lint passes
- [x] Issue creation works (tested on OCI VM)
- [x] Duplicate check prevents re-creation