### PR TITLE
feat(ARC-877): add chess game

### DIFF
--- a/apps/be/src/games/chess.gateway.ts
+++ b/apps/be/src/games/chess.gateway.ts
@@ -1,0 +1,158 @@
+import {
+  ConnectedSocket,
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+  WsException,
+} from '@nestjs/websockets';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import type { Server, Socket } from 'socket.io';
+
+import { ChessService } from './chess/chess.service';
+import { extractRoomAndUser, handleError } from './games.gateway.utils';
+import { maybeEncrypt } from '../common/utils/socket-encryption.util';
+import { corsOriginMatcher } from '../common/utils/cors.util';
+import { verifySocketJwt } from '../common/utils/socket-jwt.util';
+
+@WebSocketGateway({
+  namespace: 'games',
+  cors: { origin: corsOriginMatcher },
+})
+@Injectable()
+export class ChessGateway {
+  private readonly logger = new Logger(ChessGateway.name);
+
+  @WebSocketServer() server: Server;
+
+  constructor(
+    private readonly chessService: ChessService,
+    private readonly jwt: JwtService,
+    private readonly config: ConfigService,
+  ) {}
+
+  async handleConnection(client: Socket): Promise<void> {
+    this.logger.verbose(`Client connected ${client.id}`);
+
+    const authUserId = await verifySocketJwt(
+      client,
+      this.jwt,
+      this.config,
+      this.logger,
+      'ChessGateway',
+    );
+
+    if (authUserId) {
+      this.logger.debug(
+        `Authenticated user ${authUserId} connected to Chess namespace`,
+      );
+    } else {
+      this.logger.verbose(
+        `Anonymous client connected to Chess namespace: ${client.id}`,
+      );
+    }
+  }
+
+  @SubscribeMessage('chess.session.start')
+  async handleSessionStart(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: {
+      roomId?: string;
+      userId?: string;
+      withBots?: boolean;
+      botCount?: number;
+    },
+  ): Promise<void> {
+    const { roomId, userId } = extractRoomAndUser(payload);
+    try {
+      const result = await this.chessService.startSession(
+        userId,
+        roomId,
+        !!payload?.withBots,
+        payload?.botCount,
+      );
+      client.emit('chess.session.started', maybeEncrypt(result));
+    } catch (error) {
+      handleError(
+        this.logger,
+        error,
+        { action: 'start Chess session', roomId, userId },
+        'Unable to start session.',
+      );
+    }
+  }
+
+  @SubscribeMessage('chess.session.move')
+  async handleMove(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: {
+      roomId?: string;
+      userId?: string;
+      fromFile?: string;
+      fromRank?: number;
+      toFile?: string;
+      toRank?: number;
+      promotion?: string;
+    },
+  ): Promise<void> {
+    const { roomId, userId } = extractRoomAndUser(payload);
+    if (
+      !payload?.fromFile ||
+      !payload?.fromRank ||
+      !payload?.toFile ||
+      !payload?.toRank
+    ) {
+      throw new WsException('fromFile, fromRank, toFile, toRank are required');
+    }
+    try {
+      await this.chessService.move(userId, roomId, {
+        fromFile: payload.fromFile,
+        fromRank: payload.fromRank,
+        toFile: payload.toFile,
+        toRank: payload.toRank,
+        promotion: payload.promotion,
+      });
+      client.emit(
+        'chess.session.moved',
+        maybeEncrypt({
+          roomId,
+          userId,
+          fromFile: payload.fromFile,
+          fromRank: payload.fromRank,
+          toFile: payload.toFile,
+          toRank: payload.toRank,
+        }),
+      );
+    } catch (error) {
+      handleError(
+        this.logger,
+        error,
+        { action: 'move', roomId, userId },
+        'Unable to make move.',
+      );
+    }
+  }
+
+  @SubscribeMessage('chess.session.resign')
+  async handleForfeit(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() payload: { roomId?: string; userId?: string },
+  ): Promise<void> {
+    const { roomId, userId } = extractRoomAndUser(payload);
+    try {
+      await this.chessService.forfeit(userId, roomId);
+      client.emit('chess.session.resigned', maybeEncrypt({ roomId, userId }));
+    } catch (error) {
+      handleError(
+        this.logger,
+        error,
+        { action: 'resign', roomId, userId },
+        'Unable to resign.',
+      );
+    }
+  }
+}

--- a/apps/be/src/games/chess/chess.service.ts
+++ b/apps/be/src/games/chess/chess.service.ts
@@ -1,0 +1,277 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+  forwardRef,
+} from '@nestjs/common';
+import { GameRoomsService } from '../rooms/game-rooms.service';
+import {
+  GameSessionsService,
+  type GameSessionSummary,
+} from '../sessions/game-sessions.service';
+import { GameHistoryService } from '../history/game-history.service';
+import { GamesRealtimeService } from '../games.realtime.service';
+import type { StartGameSessionResult } from '../games.types';
+import {
+  CHESS_VARIANTS,
+  type ChessVariant,
+} from '../engines/chess/chess.constants';
+import type {
+  ChessOptions,
+  TimeControlType,
+  TimeIncrement,
+} from '../engines/chess/chess.types';
+import { ChessBotService } from '../engines/chess/chess-bot.service';
+
+const MIN_PLAYERS = 2;
+const MAX_PLAYERS = 2;
+
+const WATCHDOG_INTERVAL_MS = 10000;
+const WATCHDOG_STALE_THRESHOLD_MS = 20000;
+
+@Injectable()
+export class ChessService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(ChessService.name);
+  private watchdogInterval: NodeJS.Timeout | null = null;
+  private readonly roomLocks = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly roomsService: GameRoomsService,
+    private readonly sessionsService: GameSessionsService,
+    private readonly historyService: GameHistoryService,
+    private readonly realtimeService: GamesRealtimeService,
+    @Inject(forwardRef(() => ChessBotService))
+    private readonly botService: ChessBotService,
+  ) {}
+
+  onModuleInit() {
+    this.botService.setMoveFn(
+      this.move.bind(this) as (
+        userId: string,
+        roomId: string,
+        payload: {
+          fromFile: string;
+          fromRank: number;
+          toFile: string;
+          toRank: number;
+          promotion?: string;
+        },
+      ) => Promise<unknown>,
+    );
+    this.watchdogInterval = setInterval(() => {
+      void this.runWatchdog();
+    }, WATCHDOG_INTERVAL_MS);
+  }
+
+  onModuleDestroy() {
+    if (this.watchdogInterval) {
+      clearInterval(this.watchdogInterval);
+      this.watchdogInterval = null;
+    }
+  }
+
+  async findSessionByRoom(roomId: string) {
+    const session = await this.sessionsService.findSessionByRoom(roomId);
+    if (!session) return null;
+    return this.afterSessionStep(session);
+  }
+
+  async startSession(
+    userId: string,
+    roomId: string,
+    withBots?: boolean,
+    botCount?: number,
+  ): Promise<StartGameSessionResult> {
+    const room = await this.roomsService.getRoom(roomId, userId);
+    if (room.hostId !== userId) {
+      throw new Error('Only the host can start the game');
+    }
+
+    const options = this.resolveOptions(room.gameOptions);
+    const participants = await this.roomsService.getRoomParticipants(roomId);
+    const playerIds = [...participants];
+
+    if (withBots || playerIds.length === 1) {
+      const desiredCount =
+        botCount !== undefined ? botCount : Math.max(0, 2 - playerIds.length);
+      const cap = Math.min(MAX_PLAYERS - playerIds.length, desiredCount);
+      for (let i = 0; i < cap; i++) {
+        playerIds.push(`bot-${Math.random().toString(36).slice(2, 10)}`);
+      }
+    }
+
+    if (playerIds.length < MIN_PLAYERS) {
+      throw new Error('Not enough players to start Chess (minimum 2)');
+    }
+    if (playerIds.length > MAX_PLAYERS) {
+      throw new Error(`Chess supports up to ${MAX_PLAYERS} players.`);
+    }
+
+    const session = await this.sessionsService.createSession({
+      roomId,
+      gameId: 'chess_v1',
+      playerIds,
+      config: { options },
+    });
+
+    await this.roomsService.updateRoomStatus(roomId, 'in_progress');
+    const updatedRoom = { ...room, status: 'in_progress' as const };
+    await this.realtimeService.emitGameStarted(
+      updatedRoom,
+      session,
+      async (s, pId) => {
+        const sanitized = await this.sessionsService.getSanitizedStateForPlayer(
+          s.id,
+          pId,
+        );
+        if (sanitized && typeof sanitized === 'object') {
+          return { ...s, state: sanitized as Record<string, unknown> };
+        }
+        return s;
+      },
+    );
+
+    const updatedSession = await this.afterSessionStep(session);
+    return { room: updatedRoom, session: updatedSession };
+  }
+
+  async move(
+    userId: string,
+    roomId: string,
+    payload: {
+      fromFile: string;
+      fromRank: number;
+      toFile: string;
+      toRank: number;
+      promotion?: string;
+    },
+  ) {
+    return this.runAction(userId, roomId, 'move', payload);
+  }
+
+  async forfeit(userId: string, roomId: string) {
+    return this.runAction(userId, roomId, 'forfeit', {});
+  }
+
+  private async runAction(
+    userId: string,
+    roomId: string,
+    action: string,
+    payload: unknown,
+  ) {
+    const prev = this.roomLocks.get(roomId) ?? Promise.resolve();
+    let release: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.roomLocks.set(roomId, next);
+    await prev;
+
+    try {
+      const session = await this.sessionsService.findSessionByRoom(roomId);
+      if (!session) throw new Error('Session not found');
+
+      const updatedSession = await this.sessionsService.executeAction({
+        sessionId: session.id,
+        userId,
+        action,
+        payload,
+      });
+
+      await this.afterSessionStep(updatedSession);
+      await this.emitSessionUpdate(updatedSession);
+      return updatedSession;
+    } finally {
+      release!();
+      if (this.roomLocks.get(roomId) === next) {
+        this.roomLocks.delete(roomId);
+      }
+    }
+  }
+
+  private async afterSessionStep(session: GameSessionSummary) {
+    if (session.status === 'completed') {
+      await this.roomsService.updateRoomStatus(session.roomId, 'completed');
+    } else {
+      this.botService.checkAndPlay(session).catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error(
+          `Bot turn failed for room ${session.roomId}: ${message}`,
+        );
+      });
+    }
+    return session;
+  }
+
+  private async emitSessionUpdate(session: GameSessionSummary) {
+    await this.realtimeService.emitSessionSnapshot(
+      session.roomId,
+      session,
+      (s, pId) => {
+        const sanitized = this.sessionsService.sanitizeSummaryForPlayer(s, pId);
+        if (sanitized && typeof sanitized === 'object') {
+          return Promise.resolve({
+            ...s,
+            state: sanitized as Record<string, unknown>,
+          });
+        }
+        return Promise.resolve(s);
+      },
+    );
+  }
+
+  private async runWatchdog() {
+    try {
+      const stale = await this.sessionsService.findStaleActiveSessions(
+        'chess_v1',
+        WATCHDOG_STALE_THRESHOLD_MS,
+        100,
+      );
+      for (const session of stale) {
+        this.botService
+          .checkAndPlay(session)
+          .catch((err) =>
+            this.logger.error(
+              `Watchdog trigger failed for room ${session.roomId}: ${err}`,
+            ),
+          );
+      }
+    } catch (err) {
+      this.logger.error(`Watchdog failed: ${err}`);
+    }
+  }
+
+  private resolveOptions(raw: unknown): ChessOptions {
+    const r = (raw ?? {}) as Partial<{
+      variant: string;
+      timeControl: {
+        type: string;
+        initialSeconds: number;
+        incrementSeconds: number;
+      } | null;
+    }>;
+    const variant = CHESS_VARIANTS.includes(r.variant as ChessVariant)
+      ? (r.variant as ChessVariant)
+      : ('standard' as ChessVariant);
+    const rawTc = r.timeControl;
+    let timeControl: ChessOptions['timeControl'] = null;
+    if (rawTc && typeof rawTc === 'object') {
+      const validTypes: TimeControlType[] = ['blitz', 'rapid', 'classical'];
+      const type = validTypes.includes(rawTc.type as TimeControlType)
+        ? (rawTc.type as TimeControlType)
+        : 'blitz';
+      const validIncs: TimeIncrement[] = [0, 3, 5, 10, 15, 30];
+      const inc = validIncs.includes(rawTc.incrementSeconds as TimeIncrement)
+        ? (rawTc.incrementSeconds as TimeIncrement)
+        : 0;
+      timeControl = {
+        type,
+        initialSeconds: rawTc.initialSeconds,
+        incrementSeconds: inc,
+      };
+    }
+    return { variant, timeControl };
+  }
+}

--- a/apps/be/src/games/chess/chess.service.ts
+++ b/apps/be/src/games/chess/chess.service.ts
@@ -22,8 +22,10 @@ import type {
   ChessOptions,
   TimeControlType,
   TimeIncrement,
+  ChessState,
 } from '../engines/chess/chess.types';
 import { ChessBotService } from '../engines/chess/chess-bot.service';
+import { getLegalMoves } from '../engines/chess/chess.move-generator';
 
 const MIN_PLAYERS = 2;
 const MAX_PLAYERS = 2;
@@ -75,6 +77,7 @@ export class ChessService implements OnModuleInit, OnModuleDestroy {
   async findSessionByRoom(roomId: string) {
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (!session) return null;
+    this.backfillLegalMoves(session);
     return this.afterSessionStep(session);
   }
 
@@ -206,6 +209,7 @@ export class ChessService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async emitSessionUpdate(session: GameSessionSummary) {
+    this.backfillLegalMoves(session);
     await this.realtimeService.emitSessionSnapshot(
       session.roomId,
       session,
@@ -273,5 +277,14 @@ export class ChessService implements OnModuleInit, OnModuleDestroy {
       };
     }
     return { variant, timeControl };
+  }
+
+  private backfillLegalMoves(session: GameSessionSummary) {
+    const state = session.state as ChessState | undefined;
+    if (!state || state.legalMovesForCurrentPlayer) return;
+    state.legalMovesForCurrentPlayer = getLegalMoves(
+      state,
+      state.currentTurnColor,
+    ).map((m) => ({ from: m.from, to: m.to, promotion: m.promotion }));
   }
 }

--- a/apps/be/src/games/engines/chess/chess-bot.service.ts
+++ b/apps/be/src/games/engines/chess/chess-bot.service.ts
@@ -5,6 +5,7 @@ import type { ChessMove, ChessState, Rank } from './chess.types';
 import { posToBoardCoords, oppositeColor } from './chess.board';
 import { getLegalMoves } from './chess.move-generator';
 import { isInCheck } from './chess.attacks';
+import type { GameSessionSummary } from '../../sessions/game-sessions.service';
 
 const MAX_DEPTH = 4;
 const INFINITY = 999999;
@@ -75,6 +76,76 @@ const PIECE_SQUARE_TABLES: Record<PieceType, number[][]> = {
 @Injectable()
 export class ChessBotService {
   private readonly logger = new Logger(ChessBotService.name);
+  private readonly processing = new Set<string>();
+  private moveFn:
+    | ((
+        userId: string,
+        roomId: string,
+        payload: {
+          fromFile: string;
+          fromRank: number;
+          toFile: string;
+          toRank: number;
+          promotion?: string;
+        },
+      ) => Promise<unknown>)
+    | null = null;
+
+  setMoveFn(
+    fn: (
+      userId: string,
+      roomId: string,
+      payload: {
+        fromFile: string;
+        fromRank: number;
+        toFile: string;
+        toRank: number;
+        promotion?: string;
+      },
+    ) => Promise<unknown>,
+  ) {
+    this.moveFn = fn;
+  }
+
+  isBot(userId: string): boolean {
+    return userId.startsWith('bot-');
+  }
+
+  async checkAndPlay(session: GameSessionSummary): Promise<void> {
+    if (session.status !== 'active') return;
+    const state = session.state as unknown as ChessState | undefined;
+    if (!state) return;
+
+    const currentId = state.players.find(
+      (p) => p.color === state.currentTurnColor,
+    )?.playerId;
+    if (!currentId || !this.isBot(currentId)) return;
+
+    if (this.processing.has(session.roomId)) return;
+    this.processing.add(session.roomId);
+
+    try {
+      const move = this.findBestMove(state);
+      if (!move) return;
+
+      const delay = 400 + Math.random() * 700;
+      await new Promise((r) => setTimeout(r, delay));
+
+      if (this.moveFn) {
+        await this.moveFn(currentId, session.roomId, {
+          fromFile: move.from.file,
+          fromRank: move.from.rank,
+          toFile: move.to.file,
+          toRank: move.to.rank,
+          promotion: move.promotion ?? undefined,
+        });
+      }
+    } catch (err) {
+      this.logger.error(`Bot move failed for room ${session.roomId}: ${err}`);
+    } finally {
+      this.processing.delete(session.roomId);
+    }
+  }
 
   findBestMove(state: ChessState): ChessMove | null {
     const legalMoves = getLegalMoves(state, state.currentTurnColor);

--- a/apps/be/src/games/engines/chess/chess.engine.ts
+++ b/apps/be/src/games/engines/chess/chess.engine.ts
@@ -76,10 +76,11 @@ export class ChessEngine extends BaseGameEngine<ChessState> {
         }
       : null;
 
-    return {
+    const initialBoard = parseFen(INITIAL_BOARD_FEN);
+    const initialState = {
       variant: config?.variant ?? 'standard',
-      board: parseFen(INITIAL_BOARD_FEN),
-      currentTurnColor: 'white',
+      board: initialBoard,
+      currentTurnColor: 'white' as const,
       castlingRights: { ...INITIAL_CASTLING_RIGHTS },
       enPassantTarget: null,
       halfMoveClock: 0,
@@ -99,7 +100,17 @@ export class ChessEngine extends BaseGameEngine<ChessState> {
       logs: [
         this.createLogEntry('system', 'Chess game started. White moves first.'),
       ],
+      legalMovesForCurrentPlayer: getLegalMoves(
+        {
+          board: initialBoard,
+          currentTurnColor: 'white',
+          castlingRights: { ...INITIAL_CASTLING_RIGHTS },
+          enPassantTarget: null,
+        } as ChessState,
+        'white',
+      ).map((m) => ({ from: m.from, to: m.to, promotion: m.promotion })),
     };
+    return initialState;
   }
 
   validateAction(
@@ -358,6 +369,11 @@ export class ChessEngine extends BaseGameEngine<ChessState> {
         this.createLogEntry('system', 'Draw by threefold repetition.'),
       );
     }
+
+    newState.legalMovesForCurrentPlayer = getLegalMoves(
+      newState,
+      newState.currentTurnColor,
+    ).map((m) => ({ from: m.from, to: m.to, promotion: m.promotion }));
 
     return this.successResult(newState);
   }

--- a/apps/be/src/games/engines/chess/chess.types.ts
+++ b/apps/be/src/games/engines/chess/chess.types.ts
@@ -62,6 +62,12 @@ export interface PlayerClock {
   lastMoveTimestamp: number;
 }
 
+export interface LegalMove {
+  from: BoardPosition;
+  to: BoardPosition;
+  promotion: PieceType | null;
+}
+
 export interface ChessState extends BaseGameState {
   variant: ChessVariant;
   board: Board;
@@ -81,6 +87,7 @@ export interface ChessState extends BaseGameState {
   isInsufficientMaterial: boolean;
   clocks: Record<PieceColor, PlayerClock> | null;
   positionHistory: string[];
+  legalMovesForCurrentPlayer: LegalMove[];
 }
 
 export interface MovePayload {

--- a/apps/be/src/games/games.module.ts
+++ b/apps/be/src/games/games.module.ts
@@ -52,6 +52,9 @@ import { TicTacToeBotService } from './tic-tac-toe/tic-tac-toe-bot.service';
 import { CascadeGateway } from './cascade.gateway';
 import { CascadeService } from './cascade/cascade.service';
 import { CascadeBotService } from './cascade/cascade-bot.service';
+import { ChessGateway } from './chess.gateway';
+import { ChessService } from './chess/chess.service';
+import { ChessBotService } from './engines/chess/chess-bot.service';
 import { AuthModule } from '../auth/auth.module';
 import { LeaderboardsModule } from '../leaderboards/leaderboards.module';
 import { WalletModule } from '../wallet/wallet.module';
@@ -121,6 +124,9 @@ import { resolveJwtSecret } from '../common/utils/jwt-secret.util';
     // Cascade
     CascadeService,
     CascadeBotService,
+    // Chess
+    ChessService,
+    ChessBotService,
     // Utilities
     GameUtilitiesService,
     // Facade service (main entry point)
@@ -137,6 +143,7 @@ import { resolveJwtSecret } from '../common/utils/jwt-secret.util';
     GlimwormGateway,
     TicTacToeGateway,
     CascadeGateway,
+    ChessGateway,
   ],
   exports: [GameHistoryStatsService],
 })

--- a/apps/web/e2e/home-games-slider.spec.ts
+++ b/apps/web/e2e/home-games-slider.spec.ts
@@ -15,13 +15,14 @@ test.describe('Home Page Games Grid Refinement', () => {
     // We are filtering to only show available (playable) games
     const gamesSection = page.locator('#games');
     const gameCards = gamesSection.locator('h3');
-    await expect(gameCards).toHaveCount(5);
+    await expect(gameCards).toHaveCount(6);
 
     await expect(gameCards.nth(0)).toHaveText(/Critical/i);
     await expect(gameCards.nth(1)).toHaveText(/Sea Battle/i);
     await expect(gameCards.nth(2)).toHaveText(/Glimworm/i);
     await expect(gameCards.nth(3)).toHaveText(/Tic-Tac-Toe/i);
     await expect(gameCards.nth(4)).toHaveText(/Cascade/i);
+    await expect(gameCards.nth(5)).toHaveText(/Chess/i);
   });
 
   test('should navigate slider via arrows', async ({ page }) => {

--- a/apps/web/src/app/[locale]/home/components/featured-games/gameMeta.tsx
+++ b/apps/web/src/app/[locale]/home/components/featured-games/gameMeta.tsx
@@ -4,6 +4,7 @@ import { SeaBattleSymbol } from './symbols/SeaBattleSymbol';
 import { GlimwormSymbol } from './symbols/GlimwormSymbol';
 import { TicTacToeSymbol } from './symbols/TicTacToeSymbol';
 import { CascadeSymbol } from './symbols/CascadeSymbol';
+import { ChessSymbol } from './symbols/ChessSymbol';
 
 export const FALLBACK_ACCENT = '#38bdf8';
 
@@ -23,6 +24,8 @@ export function GameSymbol({ gameId, ...rest }: GameSymbolProps) {
       return <TicTacToeSymbol {...rest} />;
     case 'cascade_v1':
       return <CascadeSymbol {...rest} />;
+    case 'chess_v1':
+      return <ChessSymbol {...rest} />;
     default:
       return null;
   }

--- a/apps/web/src/app/[locale]/home/components/featured-games/symbols/ChessSymbol.tsx
+++ b/apps/web/src/app/[locale]/home/components/featured-games/symbols/ChessSymbol.tsx
@@ -1,0 +1,40 @@
+import type { SVGProps } from 'react';
+
+export function ChessSymbol(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      {...props}
+    >
+      <rect x="8" y="8" width="48" height="48" rx="3" />
+      <line x1="14" y1="8" x2="14" y2="56" />
+      <line x1="20" y1="8" x2="20" y2="56" />
+      <line x1="26" y1="8" x2="26" y2="56" />
+      <line x1="32" y1="8" x2="32" y2="56" />
+      <line x1="38" y1="8" x2="38" y2="56" />
+      <line x1="44" y1="8" x2="44" y2="56" />
+      <line x1="50" y1="8" x2="50" y2="56" />
+      <line x1="8" y1="14" x2="56" y2="14" />
+      <line x1="8" y1="20" x2="56" y2="20" />
+      <line x1="8" y1="26" x2="56" y2="26" />
+      <line x1="8" y1="32" x2="56" y2="32" />
+      <line x1="8" y1="38" x2="56" y2="38" />
+      <line x1="8" y1="44" x2="56" y2="44" />
+      <line x1="8" y1="50" x2="56" y2="50" />
+      <text
+        x="32"
+        y="36"
+        textAnchor="middle"
+        fill="currentColor"
+        stroke="none"
+        fontSize="18"
+        fontWeight="bold"
+      >
+        ♚
+      </text>
+    </svg>
+  );
+}

--- a/apps/web/src/app/[locale]/home/components/featured-games/symbols/index.ts
+++ b/apps/web/src/app/[locale]/home/components/featured-games/symbols/index.ts
@@ -3,3 +3,4 @@ export * from './SeaBattleSymbol';
 export * from './GlimwormSymbol';
 export * from './TicTacToeSymbol';
 export * from './CascadeSymbol';
+export * from './ChessSymbol';

--- a/apps/web/src/app/[locale]/home/data/games.ts
+++ b/apps/web/src/app/[locale]/home/data/games.ts
@@ -43,6 +43,7 @@ import { SEA_BATTLE_VARIANTS } from '@/widgets/SeaBattleGame/lib/constants';
 import { GLIMWORM_VARIANTS } from '@/features/games/lib/glimwormVariants';
 import { TIC_TAC_TOE_VARIANTS } from '@/widgets/TicTacToeGame/lib/constants';
 import { CASCADE_VARIANTS } from '@/widgets/CascadeGame/lib/constants';
+import { CHESS_VARIANTS } from '@/widgets/ChessGame/lib/constants';
 
 export const featuredGames: FeaturedGame[] = [
   {
@@ -146,6 +147,26 @@ export const featuredGames: FeaturedGame[] = [
     rulesPrefix: 'games.cascade_v1.rules',
     rulesKeys: ['objective', 'steps', 'actionCards', 'stacking'],
     variants: CASCADE_VARIANTS.map((v) => ({
+      id: v.id,
+      nameKey: v.name as TranslationKey,
+    })),
+  },
+  {
+    id: 'chess_v1',
+    nameKey: 'games.chess_v1.name' as TranslationKey,
+    descriptionKey: 'games.chess_v1.description' as TranslationKey,
+    accentColor: '#e2e8f0',
+    genre: 'Board',
+    pace: 'Strategy',
+    players: '2',
+    duration: '15 min',
+    playingNow: null,
+    isPlayable: true,
+    landingHref: '/games/chess',
+    type: 'board',
+    rulesPrefix: 'games.chess_v1.rules',
+    rulesKeys: ['objective', 'pieces', 'special'],
+    variants: CHESS_VARIANTS.map((v) => ({
       id: v.id,
       nameKey: v.name as TranslationKey,
     })),

--- a/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
@@ -40,6 +40,7 @@ const URL_TO_GAME_ID: Record<string, GameId> = {
   glimworm_v1: 'glimworm_v1',
   tic_tac_toe_v1: 'tic_tac_toe_v1',
   cascade_v1: 'cascade_v1',
+  chess_v1: 'chess_v1',
 };
 
 function parseInitialGameId(raw: string | null | undefined): GameId {
@@ -84,6 +85,11 @@ function buildGameOptions(form: CreateRoomForm): Record<string, unknown> {
   if (form.gameId === 'critical_v1') {
     return {
       expansionPacks: form.expansionPackIds.filter((id) => id !== 'core'),
+    };
+  }
+  if (form.gameId === 'chess_v1') {
+    return {
+      variant: form.themeId || 'standard',
     };
   }
   return {};

--- a/apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx
@@ -31,6 +31,11 @@ const CascadeRulesModal = dynamic(
   { ssr: false },
 );
 
+const ChessRulesModal = dynamic(
+  () => import('@/widgets/ChessGame/ui/RulesModal').then((m) => m.RulesModal),
+  { ssr: false },
+);
+
 interface Props {
   gameId: GameId;
   themeId: string;
@@ -92,6 +97,9 @@ export function RulesAccess({ gameId, themeId }: Props) {
           // themeId is safe here.
           variant={themeId as never}
         />
+      ) : null}
+      {gameId === 'chess_v1' ? (
+        <ChessRulesModal open={open} onClose={() => setOpen(false)} />
       ) : null}
     </>
   );

--- a/apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx
@@ -7,15 +7,18 @@ import { CriticalMiniCluster } from './art/CriticalMiniCluster';
 import { SeaBattleBoardPoster } from './art/SeaBattleBoardPoster';
 import { TicTacToeBoardPoster } from './art/TicTacToeBoardPoster';
 import { CascadeBoardPoster } from './art/CascadeBoardPoster';
+import { ChessBoardPoster } from './art/ChessBoardPoster';
 import {
   CRITICAL_THEMES,
   SEA_BATTLE_THEMES,
   TIC_TAC_TOE_THEMES,
   CASCADE_THEMES,
+  CHESS_THEMES,
   type CriticalTheme,
   type SeaBattleThemeMeta,
   type TicTacToeThemeMeta,
   type CascadeThemeMeta,
+  type ChessThemeMeta,
   type GameId,
 } from './data/themes';
 
@@ -202,6 +205,49 @@ export function ThemePicker({ gameId, value, onChange }: Props) {
     );
   }
 
+  if (gameId === 'chess_v1') {
+    return (
+      <div className={s.themeStripWrap}>
+        <div
+          className={s.themeStrip}
+          role="radiogroup"
+          aria-label="Chess variant"
+          data-testid="theme-picker-chess"
+        >
+          {CHESS_THEMES.map((theme) => {
+            const active = value === theme.id;
+            return (
+              <button
+                key={theme.id}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                data-testid={`theme-${theme.id}`}
+                onClick={() => onChange(theme.id)}
+                style={{ '--theme-color': theme.color } as CSSProperties}
+                className={`${s.themeCard} ${active ? s.themeCardActive : ''}`}
+              >
+                <div className={s.themeArt}>
+                  <ChessThumbnail theme={theme} />
+                </div>
+                <div className={s.themeBody}>
+                  <div className={s.themeRow}>
+                    <span className={s.themeDot} />
+                    <span className={s.themeName}>{theme.name}</span>
+                  </div>
+                  <p className={s.themeDesc}>{theme.desc}</p>
+                </div>
+                <span className={s.themeCheck} aria-hidden="true">
+                  ✓
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
   return null;
 }
 
@@ -211,6 +257,10 @@ function TicTacToeThumbnail({ theme }: { theme: TicTacToeThemeMeta }) {
 
 function CascadeThumbnail({ theme }: { theme: CascadeThemeMeta }) {
   return <CascadeBoardPoster theme={theme} size="sm" />;
+}
+
+function ChessThumbnail({ theme }: { theme: ChessThemeMeta }) {
+  return <ChessBoardPoster theme={theme} size="sm" />;
 }
 
 // Three-card fan. The SVG poster shows as a placeholder until the variant's

--- a/apps/web/src/features/games/ui/create/redesign/art/ChessBoardPoster.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/art/ChessBoardPoster.tsx
@@ -1,0 +1,91 @@
+import type { ChessThemeMeta } from '../data/themes';
+
+interface Props {
+  theme: ChessThemeMeta;
+  size?: 'sm' | 'lg';
+}
+
+export function ChessBoardPoster({ theme, size = 'sm' }: Props) {
+  const big = size === 'lg';
+  const w = big ? 400 : 240;
+  const h = big ? 320 : 135;
+  const cellSize = big ? 36 : 22;
+  const boardSize = cellSize * 8;
+  const offsetX = (w - boardSize) / 2;
+  const offsetY = (h - boardSize) / 2;
+
+  const lightSquare = theme.id === 'chess960' ? '#c8d6e5' : '#f0f0f0';
+  const darkSquare = theme.id === 'chess960' ? '#5b7fa5' : '#769656';
+  const bgColor = theme.id === 'chess960' ? '#1a2a3a' : '#1a1a2e';
+
+  const squares: React.ReactElement[] = [];
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      const isLight = (r + c) % 2 === 0;
+      squares.push(
+        <rect
+          key={`${r}-${c}`}
+          x={offsetX + c * cellSize}
+          y={offsetY + r * cellSize}
+          width={cellSize}
+          height={cellSize}
+          fill={isLight ? lightSquare : darkSquare}
+        />,
+      );
+    }
+  }
+
+  const pieces: Array<{
+    r: number;
+    c: number;
+    symbol: string;
+    fill: string;
+  }> = [
+    { r: 7, c: 0, symbol: '♜', fill: '#1a1a2e' },
+    { r: 7, c: 1, symbol: '♞', fill: '#1a1a2e' },
+    { r: 7, c: 2, symbol: '♝', fill: '#1a1a2e' },
+    { r: 7, c: 3, symbol: '♛', fill: '#1a1a2e' },
+    { r: 7, c: 4, symbol: '♚', fill: '#1a1a2e' },
+    { r: 7, c: 5, symbol: '♝', fill: '#1a1a2e' },
+    { r: 7, c: 6, symbol: '♞', fill: '#1a1a2e' },
+    { r: 7, c: 7, symbol: '♜', fill: '#1a1a2e' },
+    { r: 6, c: 3, symbol: '♟', fill: '#1a1a2e' },
+    { r: 6, c: 4, symbol: '♟', fill: '#1a1a2e' },
+    { r: 0, c: 0, symbol: '♖', fill: '#f5f5f5' },
+    { r: 0, c: 1, symbol: '♘', fill: '#f5f5f5' },
+    { r: 0, c: 2, symbol: '♗', fill: '#f5f5f5' },
+    { r: 0, c: 3, symbol: '♕', fill: '#f5f5f5' },
+    { r: 0, c: 4, symbol: '♔', fill: '#f5f5f5' },
+    { r: 0, c: 5, symbol: '♗', fill: '#f5f5f5' },
+    { r: 0, c: 6, symbol: '♘', fill: '#f5f5f5' },
+    { r: 0, c: 7, symbol: '♖', fill: '#f5f5f5' },
+    { r: 1, c: 3, symbol: '♙', fill: '#f5f5f5' },
+    { r: 1, c: 4, symbol: '♙', fill: '#f5f5f5' },
+  ];
+
+  const pieceElements = pieces.map((p) => (
+    <text
+      key={`${p.r}-${p.c}`}
+      x={offsetX + p.c * cellSize + cellSize / 2}
+      y={offsetY + p.r * cellSize + cellSize * 0.78}
+      textAnchor="middle"
+      fill={p.fill}
+      stroke="none"
+      fontSize={cellSize * 0.75}
+    >
+      {p.symbol}
+    </text>
+  ));
+
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden="true"
+    >
+      <rect width={w} height={h} fill={bgColor} />
+      {squares}
+      {pieceElements}
+    </svg>
+  );
+}

--- a/apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx
@@ -2,8 +2,10 @@ import { CriticalCardPoster } from './CriticalCardPoster';
 import { SeaBattleBoardPoster } from './SeaBattleBoardPoster';
 import { TicTacToeBoardPoster } from './TicTacToeBoardPoster';
 import { CascadeBoardPoster } from './CascadeBoardPoster';
+import { ChessBoardPoster } from './ChessBoardPoster';
 import {
   findCascadeTheme,
+  findChessTheme,
   findCriticalTheme,
   findSeaBattleTheme,
   findTicTacToeTheme,
@@ -34,6 +36,10 @@ export function GameArt({ gameId, themeId, size = 'sm' }: Props) {
   if (gameId === 'cascade_v1') {
     const theme = findCascadeTheme(themeId);
     return <CascadeBoardPoster theme={theme} size={size} />;
+  }
+  if (gameId === 'chess_v1') {
+    const theme = findChessTheme(themeId);
+    return <ChessBoardPoster theme={theme} size={size} />;
   }
   return <GlimwormPoster size={size} />;
 }

--- a/apps/web/src/features/games/ui/create/redesign/data/chess-themes.ts
+++ b/apps/web/src/features/games/ui/create/redesign/data/chess-themes.ts
@@ -1,0 +1,25 @@
+export interface ChessThemeMeta {
+  id: string;
+  name: string;
+  desc: string;
+  color: string;
+}
+
+export const CHESS_THEMES: ChessThemeMeta[] = [
+  {
+    id: 'standard',
+    name: 'Standard',
+    desc: 'Classic chess with the traditional starting position.',
+    color: '#e2e8f0',
+  },
+  {
+    id: 'chess960',
+    name: 'Chess960',
+    desc: 'Randomized starting position with 960 possible setups.',
+    color: '#93c5fd',
+  },
+];
+
+export function findChessTheme(id: string | undefined): ChessThemeMeta {
+  return CHESS_THEMES.find((t) => t.id === id) ?? CHESS_THEMES[0];
+}

--- a/apps/web/src/features/games/ui/create/redesign/data/expansion-packs.ts
+++ b/apps/web/src/features/games/ui/create/redesign/data/expansion-packs.ts
@@ -1,0 +1,49 @@
+// Expansion packs surfaced in the redesign. `core` is always selected.
+// Other IDs map to ExpansionId in features/games/ui/create/constants.ts.
+export interface ExpansionPack {
+  id: string;
+  name: string;
+  desc: string;
+  count: number;
+  locked?: boolean;
+}
+
+export const EXPANSION_PACK_LIST: ExpansionPack[] = [
+  {
+    id: 'core',
+    name: 'Core',
+    desc: 'The base 31-card deck.',
+    count: 31,
+    locked: true,
+  },
+  {
+    id: 'attack',
+    name: 'Attack Pack',
+    desc: 'Targeted strikes, mega evade, and invert chaos.',
+    count: 13,
+  },
+  {
+    id: 'future',
+    name: 'Future Pack',
+    desc: 'See, alter, and reveal the top of the deck.',
+    count: 25,
+  },
+  {
+    id: 'theft',
+    name: 'Theft Pack',
+    desc: 'Wildcards, marks, and steal-draw mayhem.',
+    count: 12,
+  },
+  {
+    id: 'chaos',
+    name: 'Chaos Pack',
+    desc: 'Critical implosions, fission, and blackouts.',
+    count: 7,
+  },
+  {
+    id: 'deity',
+    name: 'Deity Pack',
+    desc: 'Omniscience, miracles, smites, and rapture.',
+    count: 9,
+  },
+];

--- a/apps/web/src/features/games/ui/create/redesign/data/themes.ts
+++ b/apps/web/src/features/games/ui/create/redesign/data/themes.ts
@@ -3,7 +3,8 @@ export type GameId =
   | 'sea_battle_v1'
   | 'glimworm_v1'
   | 'tic_tac_toe_v1'
-  | 'cascade_v1';
+  | 'cascade_v1'
+  | 'chess_v1';
 
 export interface GameMeta {
   id: GameId;
@@ -73,6 +74,17 @@ export const GAMES: Record<GameId, GameMeta> = {
     hasThemes: true,
     rules: ['idle', 'spectators'],
   },
+  chess_v1: {
+    id: 'chess_v1',
+    title: 'Chess',
+    desc: 'The classic strategy board game with standard and Chess960 variants.',
+    players: { min: 2, max: 2, label: '2' },
+    duration: '15 min',
+    kind: 'Board · strategy',
+    hasExpansion: false,
+    hasThemes: false,
+    rules: ['idle', 'spectators'],
+  },
 };
 
 export const VISIBLE_GAMES: GameId[] = [
@@ -81,6 +93,7 @@ export const VISIBLE_GAMES: GameId[] = [
   'glimworm_v1',
   'tic_tac_toe_v1',
   'cascade_v1',
+  'chess_v1',
 ];
 
 // Critical theme registry. The `id` here is the value sent to the API
@@ -420,13 +433,21 @@ import {
   type CascadeThemeMeta,
 } from './cascade-themes';
 
+import {
+  CHESS_THEMES,
+  findChessTheme,
+  type ChessThemeMeta,
+} from './chess-themes';
+
 export { CASCADE_THEMES, findCascadeTheme, type CascadeThemeMeta };
+export { CHESS_THEMES, findChessTheme, type ChessThemeMeta };
 
 export function themesFor(gameId: GameId) {
   if (gameId === 'critical_v1') return CRITICAL_THEMES;
   if (gameId === 'sea_battle_v1') return SEA_BATTLE_THEMES;
   if (gameId === 'tic_tac_toe_v1') return TIC_TAC_TOE_THEMES;
   if (gameId === 'cascade_v1') return CASCADE_THEMES;
+  if (gameId === 'chess_v1') return CHESS_THEMES;
   return [];
 }
 
@@ -442,52 +463,4 @@ export function findSeaBattleTheme(id: string | undefined): SeaBattleThemeMeta {
   return SEA_BATTLE_THEMES.find((t) => t.id === id) ?? SEA_BATTLE_THEMES[0];
 }
 
-// Expansion packs surfaced in the redesign. `core` is always selected.
-// Other IDs map to ExpansionId in features/games/ui/create/constants.ts.
-export interface ExpansionPack {
-  id: string;
-  name: string;
-  desc: string;
-  count: number;
-  locked?: boolean;
-}
-
-export const EXPANSION_PACK_LIST: ExpansionPack[] = [
-  {
-    id: 'core',
-    name: 'Core',
-    desc: 'The base 31-card deck.',
-    count: 31,
-    locked: true,
-  },
-  {
-    id: 'attack',
-    name: 'Attack Pack',
-    desc: 'Targeted strikes, mega evade, and invert chaos.',
-    count: 13,
-  },
-  {
-    id: 'future',
-    name: 'Future Pack',
-    desc: 'See, alter, and reveal the top of the deck.',
-    count: 25,
-  },
-  {
-    id: 'theft',
-    name: 'Theft Pack',
-    desc: 'Wildcards, marks, and steal-draw mayhem.',
-    count: 12,
-  },
-  {
-    id: 'chaos',
-    name: 'Chaos Pack',
-    desc: 'Critical implosions, fission, and blackouts.',
-    count: 7,
-  },
-  {
-    id: 'deity',
-    name: 'Deity Pack',
-    desc: 'Omniscience, miracles, smites, and rapture.',
-    count: 9,
-  },
-];
+export { EXPANSION_PACK_LIST, type ExpansionPack } from './expansion-packs';

--- a/apps/web/src/widgets/ChessGame/lib/constants.ts
+++ b/apps/web/src/widgets/ChessGame/lib/constants.ts
@@ -1,0 +1,4 @@
+export const CHESS_VARIANTS = [
+  { id: 'standard', name: 'Standard' },
+  { id: 'chess960', name: 'Chess960' },
+] as const;

--- a/apps/web/src/widgets/ChessGame/types/index.ts
+++ b/apps/web/src/widgets/ChessGame/types/index.ts
@@ -103,6 +103,12 @@ export interface ChessLogEntry {
   targetId?: string | null;
 }
 
+export interface LegalMove {
+  from: BoardPosition;
+  to: BoardPosition;
+  promotion: PieceType | null;
+}
+
 export interface ChessClientState {
   phase: ChessPhase;
   variant: 'standard' | 'chess960';
@@ -125,6 +131,7 @@ export interface ChessClientState {
   positionHistory: string[];
   currentTurnIndex: number;
   logs: ChessLogEntry[];
+  legalMovesForCurrentPlayer: LegalMove[];
 }
 
 export const PROMOTION_PIECES: PieceType[] = [

--- a/apps/web/src/widgets/ChessGame/ui/ChessClock.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessClock.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { memo, useEffect, useState } from 'react';
+import { XStack, Text } from 'tamagui';
+import type { PieceColor, PlayerClock } from '../types';
+
+interface ChessClockProps {
+  clocks: Record<PieceColor, PlayerClock> | null;
+  currentTurnColor: PieceColor;
+  isGameOver: boolean;
+}
+
+function formatTime(totalSeconds: number): string {
+  const clamped = Math.max(0, totalSeconds);
+  const minutes = Math.floor(clamped / 60);
+  const seconds = clamped % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function computeRemaining(clock: PlayerClock): number {
+  const elapsed = Math.floor((Date.now() - clock.lastMoveTimestamp) / 1000);
+  return Math.max(0, clock.remainingSeconds - elapsed);
+}
+
+function useCountdown(
+  clock: PlayerClock | undefined,
+  isMyTurn: boolean,
+  isGameOver: boolean,
+): number {
+  const [displaySeconds, setDisplaySeconds] = useState(
+    clock?.remainingSeconds ?? 0,
+  );
+
+  useEffect(() => {
+    if (!clock) return;
+    if (isGameOver || !isMyTurn) {
+      setDisplaySeconds(computeRemaining(clock));
+      return;
+    }
+
+    const id = setInterval(() => {
+      setDisplaySeconds(computeRemaining(clock));
+    }, 250);
+
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clock?.remainingSeconds, clock?.lastMoveTimestamp, isMyTurn, isGameOver]);
+
+  return displaySeconds;
+}
+
+function ClockFace({
+  label,
+  clock,
+  isActive,
+  isGameOver,
+}: {
+  label: string;
+  clock: PlayerClock | undefined;
+  isActive: boolean;
+  isGameOver: boolean;
+}) {
+  const seconds = useCountdown(clock, isActive, isGameOver);
+  const isLow = seconds > 0 && seconds <= 30;
+  const isCritical = seconds > 0 && seconds <= 10;
+  const isFlagged = seconds <= 0 && !!clock;
+
+  return (
+    <XStack
+      gap="$2"
+      alignItems="center"
+      padding="$2"
+      paddingHorizontal="$3"
+      borderRadius={8}
+      backgroundColor={
+        isActive ? 'rgba(37, 99, 235, 0.15)' : 'rgba(255, 255, 255, 0.05)'
+      }
+      borderWidth={isActive ? 2 : 1}
+      borderColor={isActive ? '#3b82f6' : 'rgba(255,255,255,0.1)'}
+      opacity={isGameOver && !isActive ? 0.5 : 1}
+    >
+      <Text fontSize="$2" opacity={0.7} fontWeight="600">
+        {label}
+      </Text>
+      <Text
+        fontSize="$4"
+        fontWeight="700"
+        color={
+          isFlagged
+            ? '#ef4444'
+            : isCritical
+              ? '#f97316'
+              : isLow
+                ? '#eab308'
+                : undefined
+        }
+      >
+        {clock ? formatTime(seconds) : '--:--'}
+      </Text>
+    </XStack>
+  );
+}
+
+function ChessClockImpl({
+  clocks,
+  currentTurnColor,
+  isGameOver,
+}: ChessClockProps) {
+  if (!clocks) return null;
+
+  return (
+    <XStack justifyContent="space-between" alignItems="center" gap="$2">
+      <ClockFace
+        label="♔"
+        clock={clocks.white}
+        isActive={currentTurnColor === 'white' && !isGameOver}
+        isGameOver={isGameOver}
+      />
+      <ClockFace
+        label="♚"
+        clock={clocks.black}
+        isActive={currentTurnColor === 'black' && !isGameOver}
+        isGameOver={isGameOver}
+      />
+    </XStack>
+  );
+}
+
+export const ChessClock = memo(ChessClockImpl);

--- a/apps/web/src/widgets/ChessGame/ui/Game.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/Game.tsx
@@ -21,6 +21,7 @@ import { useChessState } from '../hooks/useChessState';
 import { useChessActions } from '../hooks/useChessActions';
 import { ChessLobby } from './ChessLobby';
 import { ChessBoard } from './ChessBoard';
+import { ChessClock } from './ChessClock';
 import { PromotionModal } from './PromotionModal';
 import { RulesModal } from './RulesModal';
 
@@ -253,6 +254,11 @@ function ChessGameImpl({
     <YStack gap="$3" alignItems="stretch" padding="$3" width="100%">
       {snapshot ? (
         <>
+          <ChessClock
+            clocks={snapshot.clocks}
+            currentTurnColor={snapshot.currentTurnColor}
+            isGameOver={isGameOver}
+          />
           <XStack justifyContent="space-between" alignItems="center">
             <Text fontSize="$3" fontWeight="600" opacity={0.8}>
               {snapshot.currentTurnColor === 'white' ? '♔ White' : '♚ Black'} to

--- a/apps/web/src/widgets/ChessGame/ui/Game.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/Game.tsx
@@ -128,7 +128,7 @@ function ChessGameImpl({
   const legalMoves = useMemo(() => {
     if (!selectedSquare || !snapshot) return [];
     const moves: BoardPosition[] = [];
-    for (const m of snapshot.legalMovesForCurrentPlayer) {
+    for (const m of snapshot.legalMovesForCurrentPlayer ?? []) {
       if (
         m.from.file === selectedSquare.file &&
         m.from.rank === selectedSquare.rank

--- a/apps/web/src/widgets/ChessGame/ui/Game.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/Game.tsx
@@ -128,7 +128,7 @@ function ChessGameImpl({
   const legalMoves = useMemo(() => {
     if (!selectedSquare || !snapshot) return [];
     const moves: BoardPosition[] = [];
-    for (const m of snapshot.moveHistory) {
+    for (const m of snapshot.legalMovesForCurrentPlayer) {
       if (
         m.from.file === selectedSquare.file &&
         m.from.rank === selectedSquare.rank


### PR DESCRIPTION
## What
- Add complete chess game: engine, bot, service, gateway, web widget, landing page, create page integration, i18n (5 locales), and chess clock with time controls.

## Why
- Chess is a core multiplayer game requested in the roadmap. It brings standard + Chess960 variants with optional time controls and AI bot support.

## Changes

### Backend
-  — orchestrates sessions, rooms, history, bot turns, watchdog for stale games
-  — socket handlers for , , 
-  — alpha-beta pruning AI at depth 4 with piece-square tables;  +  pattern to avoid circular deps
- Registered in  alongside existing games

### Web Widget
-  — interactive board with piece selection, legal move highlighting, last-move indicators, check display
-  — real-time countdown timers with low-time/critical/flagged visual states
-  — piece selection for pawn promotion
-  — in-game and create-page rules access
-  — full game orchestration: lobby, board, modals, result tracking, chat integration

### Create Page Integration
- Theme picker (Standard / Chess960) with SVG board poster
- , , ,  branches
- Chess-specific  for variant selection

### Home + Landing
- Featured game entry with chess symbol (♚ SVG)
- SEO landing page at  with structured data (VideoGame, FAQ, HowTo)
- OpenGraph image generation

### i18n
- All 5 locales (en, es, fr, ru, by) — landing, lobby, in-game, chat, errors, status
- SEO translations for all locales

### Tests
- BE engine spec (301 lines) — move validation, game over conditions, clock initialization
- Updated  — count bumped to 6, chess assertion added

## Notes
- Bot uses  pattern instead of constructor injection to avoid circular dependency with 
- Chess themes and expansion packs extracted to separate files to keep  under 500 lines
-  count updated from 5→6