### PR TITLE
fix(tg-bot): send health alerts to DM instead of group

### DIFF
--- a/bots/tg-bot/.env.example
+++ b/bots/tg-bot/.env.example
@@ -35,3 +35,5 @@ REPO_PATH=
 BE_URL=
 # Discord webhook URL for health alerts (separate from social media webhooks)
 DISCORD_WEBHOOK_URL=
+# Telegram user ID for DM health alerts (optional, sends to DM instead of group)
+TELEGRAM_DM_CHAT_ID=

--- a/bots/tg-bot/src/health-monitor/health-monitor.module.ts
+++ b/bots/tg-bot/src/health-monitor/health-monitor.module.ts
@@ -1,9 +1,7 @@
 import { Module } from '@nestjs/common';
 import { HealthMonitorService } from './health-monitor.service';
-import { TelegramModule } from '../telegram/telegram.module';
 
 @Module({
-  imports: [TelegramModule],
   providers: [HealthMonitorService],
 })
 export class HealthMonitorModule {}

--- a/bots/tg-bot/src/health-monitor/health-monitor.service.ts
+++ b/bots/tg-bot/src/health-monitor/health-monitor.service.ts
@@ -5,7 +5,7 @@ import {
   OnModuleDestroy,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { TelegramService } from '../telegram/telegram.service';
+import { Bot } from 'grammy';
 
 const CHECK_INTERVAL_MS = 10 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10_000;
@@ -18,15 +18,20 @@ export class HealthMonitorService implements OnModuleInit, OnModuleDestroy {
   private isUp = true;
   private beUrl = '';
   private discordWebhook = '';
+  private dmChatId = '';
+  private bot!: Bot;
 
-  constructor(
-    private readonly config: ConfigService,
-    private readonly telegram: TelegramService,
-  ) {}
+  constructor(private readonly config: ConfigService) {}
 
   onModuleInit() {
     this.beUrl = this.config.get<string>('BE_URL') ?? '';
     this.discordWebhook = this.config.get<string>('DISCORD_WEBHOOK_URL') ?? '';
+    this.dmChatId = this.config.get<string>('TELEGRAM_DM_CHAT_ID') ?? '';
+
+    const token = this.config.get<string>('TELEGRAM_BOT_TOKEN');
+    if (token) {
+      this.bot = new Bot(token);
+    }
 
     if (!this.beUrl) {
       this.logger.warn('BE_URL not set, health monitoring disabled');
@@ -94,12 +99,15 @@ export class HealthMonitorService implements OnModuleInit, OnModuleDestroy {
 
   private async notify(message: string): Promise<void> {
     const timestamp = new Date().toISOString();
-    const full = `${message}\n<code>${timestamp}</code>`;
 
-    try {
-      await this.telegram.sendAlert(full);
-    } catch (err) {
-      this.logger.error(`Failed to send Telegram alert: ${err}`);
+    if (this.dmChatId && this.bot) {
+      try {
+        await this.bot.api.sendMessage(this.dmChatId, `${message}\n<code>${timestamp}</code>`, {
+          parse_mode: 'HTML',
+        });
+      } catch (err) {
+        this.logger.error(`Failed to send Telegram DM: ${err}`);
+      }
     }
 
     if (this.discordWebhook) {


### PR DESCRIPTION
## Summary
Health monitor alerts now go to Telegram DM instead of the group chat.

## Changes
- Health monitor creates its own Bot instance and sends to `TELEGRAM_DM_CHAT_ID`
- Removed TelegramModule dependency from HealthMonitorModule
- Added `TELEGRAM_DM_CHAT_ID` to `.env.example`

## Setup
Add to `bots/tg-bot/.env` on OCI:
```
TELEGRAM_DM_CHAT_ID=8366678267
```

Health alerts (backend online/down) will be sent to your personal Telegram DM and Discord (if configured).