### PR TITLE
ci(implement-task): add in-progress label guard to prevent duplicate work

### DIFF
--- a/.github/workflows/implement-task.yml
+++ b/.github/workflows/implement-task.yml
@@ -60,6 +60,17 @@ jobs:
           npm install -g @anthropic-ai/mimo
           echo "$(npm root -g)/.bin" >> $GITHUB_PATH
 
+      - name: Check if issue is already in progress
+        run: |
+          LABELS=$(gh issue view ${{ inputs.issue_number }} --json labels -q '.labels[].name')
+          if echo "$LABELS" | grep -q "^in-progress$"; then
+            echo "::warning::Issue #${{ inputs.issue_number }} is already in-progress (possibly by a local agent). Skipping."
+            exit 1
+          fi
+
+      - name: Mark issue as in progress
+        run: gh issue edit ${{ inputs.issue_number }} --add-label "in-progress"
+
       - name: Fetch issue details
         id: issue
         run: |
@@ -128,12 +139,17 @@ jobs:
             --head ${{ steps.branch.outputs.branch }})
           echo "url=${PR_URL}" >> $GITHUB_OUTPUT
           echo "number=$(echo ${PR_URL} | grep -oE '[0-9]+$')" >> $GITHUB_OUTPUT
+          gh issue edit ${{ inputs.issue_number }} --remove-label "in-progress" 2>/dev/null || true
 
       - name: Comment on issue
         if: success() && steps.pr.outputs.url
         run: |
           gh issue comment ${{ inputs.issue_number }} --body \
             "Implementation complete (${ENGINE:-opencode}). PR: ${{ steps.pr.outputs.url }}"
+
+      - name: Remove in-progress label on failure
+        if: failure()
+        run: gh issue edit ${{ inputs.issue_number }} --remove-label "in-progress" 2>/dev/null || true
 
       - name: Notify on failure
         if: failure()


### PR DESCRIPTION
## Summary
- Add `in-progress` label guard to the implement-task workflow to prevent CI from working on issues already being handled locally
- CI now checks for the label before starting and skips with a warning if present
- Label is auto-removed on success (PR created) or failure

## Why
When running agents locally, there was no way to signal to CI that an issue is already being worked on. This could lead to duplicate PRs for the same issue.

## Changes
- **Check label**: Added step to check if issue has `in-progress` label before proceeding
- **Mark as in-progress**: CI adds the label when it starts working
- **Cleanup on success**: Label removed when PR is created
- **Cleanup on failure**: Label removed if workflow fails

## Usage
To claim an issue locally:
```bash
gh issue edit <number> --add-label "in-progress"
```

CI will skip issues with this label. Remove it when done or let the PR close the issue.