### PR TITLE
ci: add PR title conventions for staging and main branches

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-**PR Title:** Use `<type>(<scope>): <description>` for `develop`, `demo: ...` for `staging`, `release: ...` for `main`. See [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-title-convention).
+**PR Title:** Use `<type>(<scope>): <description>` for `develop`, `demo: ... v1.23.~` for `staging`, `release: v1.23.~` for `main`. See [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-title-convention).
 
 ## Description
 Provide a brief summary of the changes and the motivation behind them.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+**PR Title:** Use `<type>(<scope>): <description>` for `develop`, `demo: ...` for `staging`, `release: ...` for `main`. See [CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-title-convention).
+
 ## Description
 Provide a brief summary of the changes and the motivation behind them.
 

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -10,12 +10,22 @@ jobs:
   check-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR title starts with 'release'
+      - name: Check PR title prefix matches target branch
         run: |
           TITLE="${{ github.event.pull_request.title }}"
-          if [[ ! "$TITLE" =~ ^release ]]; then
-            echo "❌ PR title must start with 'release' to merge to main."
-            echo "   Got: $TITLE"
-            exit 1
+          BASE="${{ github.event.pull_request.base.ref }}"
+
+          if [[ "$BASE" == "staging" ]]; then
+            if [[ ! "$TITLE" =~ ^demo ]]; then
+              echo "❌ PR title must start with 'demo' to merge to staging."
+              echo "   Got: $TITLE"
+              exit 1
+            fi
+          elif [[ "$BASE" == "main" ]]; then
+            if [[ ! "$TITLE" =~ ^release ]]; then
+              echo "❌ PR title must start with 'release' to merge to main."
+              echo "   Got: $TITLE"
+              exit 1
+            fi
           fi
           echo "✅ PR title OK: $TITLE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,28 @@ Before submitting a Pull Request, please ensure:
 4.  **One Feature Per PR**: Keep PRs focused. If you have multiple unrelated changes, split them into separate PRs.
 5.  **Clear PR Description**: Use our PR template to explain what your changes do and why.
 
+### Pull Request Title Convention
+
+PR titles must follow **Conventional Commits** format:
+
+```
+<type>(<scope>): <description>
+```
+
+| Target branch | Required prefix      | Example                                    |
+| ------------- | -------------------- | ------------------------------------------ |
+| `develop`     | `<type>(scope): ...` | `feat(web): add leaderboard page`          |
+| `staging`     | `demo:`              | `demo: merge develop into staging v1.24.~` |
+| `main`        | `release:`           | `release: v1.24.~`                         |
+
+**Rules:**
+
+- PRs targeting `staging` **must** start with `demo:` — enforced by CI.
+- PRs targeting `main` **must** start with `release:` — enforced by CI.
+- PRs targeting `develop` use the same types as commits: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`, `ci`, `revert`.
+- Scope is optional but recommended (e.g., `web`, `mobile`, `be`, `ci`, `task-bot`).
+- Use lowercase; keep it under 72 characters.
+
 ---
 
 ## Pull Request Description Template

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,8 @@ PR titles must follow **Conventional Commits** format:
 | Target branch | Required prefix      | Example                                    |
 | ------------- | -------------------- | ------------------------------------------ |
 | `develop`     | `<type>(scope): ...` | `feat(web): add leaderboard page`          |
-| `staging`     | `demo:`              | `demo: merge develop into staging v1.24.~` |
-| `main`        | `release:`           | `release: v1.24.~`                         |
+| `staging`     | `demo:`              | `demo: merge develop into staging v1.23.~` |
+| `main`        | `release:`           | `release: v1.23.~`                         |
 
 **Rules:**
 


### PR DESCRIPTION
## What
Add PR title convention rules and enforce them via CI.

## Why
Previously PRs to staging/main had no title format enforcement, leading to inconsistent naming.

## Changes
- `guard-main.yml`: check `demo:` prefix for staging, `release:` prefix for main
- `CONTRIBUTING.md`: document PR title conventions with examples
- `.github/pull_request_template.md`: add title reminder at top