### PR TITLE
fix(tic-tac-toe): correct expandBoard() oversized growth in infinity mode

### DIFF
--- a/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.spec.ts
+++ b/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.spec.ts
@@ -196,27 +196,27 @@ describe('tic-tac-toe utils', () => {
       expect(cells).toContain('o');
     });
 
-    it('rounds expansion to even numbers to prevent origin drift', () => {
+    it('guarantees mark is at least margin cells from the expanded edge', () => {
       const board = createEmptyBoard(9);
       board[0][4] = 'x';
       const result = expandBoard(board, 0, 4, 3);
-      const addedRows = result.board.length - 9;
-      expect(addedRows % 2).toBe(0);
+      const markRow = 0 + result.originDelta.row;
+      expect(markRow).toBeGreaterThanOrEqual(3);
     });
 
-    it('rounds column expansion to even numbers', () => {
+    it('guarantees column mark is at least margin cells from the expanded edge', () => {
       const board = createEmptyBoard(9);
       board[4][0] = 'x';
       const result = expandBoard(board, 4, 0, 3);
-      const addedCols = result.board[0].length - 9;
-      expect(addedCols % 2).toBe(0);
+      const markCol = 0 + result.originDelta.col;
+      expect(markCol).toBeGreaterThanOrEqual(3);
     });
 
     it('expands correctly with margin=1', () => {
       const board = createEmptyBoard(9);
       board[0][4] = 'x';
       const result = expandBoard(board, 0, 4, 1);
-      expect(result.board.length).toBe(11);
+      expect(result.board.length).toBe(10);
       expect(result.originDelta.row).toBe(1);
     });
 
@@ -225,7 +225,19 @@ describe('tic-tac-toe utils', () => {
       board[0][4] = 'x';
       const result = expandBoard(board, 0, 4, 2);
       expect(result.board.length).toBe(11);
-      expect(result.originDelta.row).toBe(1);
+      expect(result.originDelta.row).toBe(2);
+    });
+
+    it('does not double-expand when both axes need rows (corner case)', () => {
+      const board = createEmptyBoard(9);
+      board[0][0] = 'x';
+      const result = expandBoard(board, 0, 0, 3);
+      const addedRows = result.board.length - 9;
+      const addedCols = result.board[0].length - 9;
+      expect(addedRows).toBeLessThanOrEqual(6);
+      expect(addedCols).toBeLessThanOrEqual(6);
+      expect(result.originDelta.row).toBeGreaterThanOrEqual(3);
+      expect(result.originDelta.col).toBeGreaterThanOrEqual(3);
     });
   });
 

--- a/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.ts
+++ b/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.ts
@@ -37,18 +37,19 @@ export function expandBoard(
     return { board, originDelta: { row: 0, col: 0 } };
   }
 
-  const totalNewRows =
-    neededTop + neededBottom === 0
-      ? 0
-      : neededTop + neededBottom + ((neededTop + neededBottom) % 2);
-  const totalNewCols =
-    neededLeft + neededRight === 0
-      ? 0
-      : neededLeft + neededRight + ((neededLeft + neededRight) % 2);
-  const newRowsTop = totalNewRows / 2;
-  const newColsLeft = totalNewCols / 2;
+  const totalNewRows = neededTop + neededBottom;
+  const totalNewCols = neededLeft + neededRight;
+  const expansion = Math.max(totalNewRows, totalNewCols);
+  const newSize = size + expansion;
 
-  const newSize = size + totalNewRows + totalNewCols;
+  const newRowsTop = Math.min(
+    Math.max(neededTop, Math.ceil(expansion / 2)),
+    expansion - neededBottom,
+  );
+  const newColsLeft = Math.min(
+    Math.max(neededLeft, Math.ceil(expansion / 2)),
+    expansion - neededRight,
+  );
   const newBoard = createEmptyBoard(newSize);
 
   for (let r = 0; r < size; r++) {


### PR DESCRIPTION
## What
Fix `expandBoard()` in TicTacToe infinity mode which was growing the board ~2x faster than intended, producing oversized MongoDB documents.

## Why
The formula `size + totalNewRows + totalNewCols` added both row and column padding to each dimension of the square board. A corner placement with margin=3 produced a 17×17 board instead of the correct 13×13. This caused the 100×100 hard cap (`INFINITY_MAX_BOARD_SIZE`) to be reached in ~12 moves instead of ~22, inflating `stateHistory` snapshots and increasing MongoDB document sizes and write latency.

## Changes
- `tic-tac-toe.utils.ts` — Fixed expansion formula to `size + Math.max(totalNewRows, totalNewCols)` and ensured mark lands at least `margin` cells from every expanded edge
- `tic-tac-toe.utils.spec.ts` — Updated tests to verify correct margin guarantees and added corner-case test