### PR TITLE
fix(be): prevent memory leaks in emote rate limits and sea-bot lock maps

### DIFF
--- a/apps/be/src/games/games.gateway.emote.ts
+++ b/apps/be/src/games/games.gateway.emote.ts
@@ -9,6 +9,8 @@ import { extractString } from './games.gateway.utils';
 
 const emoteRateLimits = new Map<string, number>();
 const EMOTE_RATE_LIMIT_MS = 2000;
+const EMOTE_ENTRY_TTL_MS = 60_000;
+let lastEviction = 0;
 
 export function handleEmote(
   logger: Logger,
@@ -31,6 +33,14 @@ export function handleEmote(
 
   if (!roomId || !userId || !emoteId) return;
 
+  const now = Date.now();
+  if (now - lastEviction > EMOTE_ENTRY_TTL_MS) {
+    lastEviction = now;
+    for (const [key, ts] of emoteRateLimits) {
+      if (now - ts > EMOTE_ENTRY_TTL_MS) emoteRateLimits.delete(key);
+    }
+  }
+
   if (!(EMOTE_IDS as readonly string[]).includes(emoteId)) {
     logger.warn(
       `Invalid emoteId "${emoteId}" from user ${userId} in room ${roomId}`,
@@ -39,7 +49,6 @@ export function handleEmote(
   }
 
   const rateKey = `${roomId}:${userId}`;
-  const now = Date.now();
   const lastEmote = emoteRateLimits.get(rateKey);
   if (lastEmote && now - lastEmote < EMOTE_RATE_LIMIT_MS) return;
   emoteRateLimits.set(rateKey, now);

--- a/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
@@ -14,6 +14,7 @@ import {
 import { getTeamForPlayer } from '../engines/sea-battle/team-rotation.utils';
 
 const LOCK_TIMEOUT_MS = 30000;
+const PROCESSING_ENTRY_TTL_MS = 120_000;
 
 // Randomised bot delays make matches feel human without dragging on.
 const PLACEMENT_DELAY_MS = { min: 500, max: 1500 };
@@ -37,10 +38,13 @@ export class SeaBattleBotService {
   ): Promise<T> {
     const prev = this.placementChain.get(roomId) ?? Promise.resolve();
     const next = prev.catch(() => undefined).then(task);
-    this.placementChain.set(
-      roomId,
-      next.catch(() => undefined),
-    );
+    const settled = next.catch(() => undefined);
+    this.placementChain.set(roomId, settled);
+    void settled.finally(() => {
+      if (this.placementChain.get(roomId) === settled) {
+        this.placementChain.delete(roomId);
+      }
+    });
     return next;
   }
 
@@ -57,6 +61,11 @@ export class SeaBattleBotService {
       await Promise.resolve(); // Satisfy async requirement
       if (session.status !== 'active') {
         return;
+      }
+
+      const now = Date.now();
+      for (const [key, ts] of this.processing) {
+        if (now - ts > PROCESSING_ENTRY_TTL_MS) this.processing.delete(key);
       }
 
       const state = session.state as unknown as SeaBattleState;


### PR DESCRIPTION
## What
Fix three unbounded in-memory Maps that grow without cleanup in the games backend.

## Why
- `emoteRateLimits` — module-level Map keyed by `roomId:userId`, entries never deleted. Every unique user who sends an emote adds a permanent entry.
- `sea-battle-bot processing` — per-bot lock Map with timestamp-based expiry but no eviction. Stale entries accumulate after rooms close.
- `sea-battle-bot placementChain` — per-room promise chain Map, entries persist after placement completes.

## Changes
- `games.gateway.emote.ts` — add 60s TTL eviction sweep on each emote call
- `sea-battle-bot.service.ts` — evict `processing` entries older than 120s; auto-delete `placementChain` entries after the chain settles