### PR TITLE
fix(be): add logging to silent catch blocks and track glimworm countdown timer

### DIFF
--- a/apps/be/src/games/critical/critical-bot.service.ts
+++ b/apps/be/src/games/critical/critical-bot.service.ts
@@ -223,8 +223,10 @@ export class CriticalBotService {
       // Fallback: try position 0 if random failed for some reason, or just retry random
       try {
         await this.criticalService.defuseByRoom(botId, session.roomId, 0); // Fallback to top if all else fails
-      } catch {
-        /* ignore */
+      } catch (fallbackErr) {
+        this.logger.error(
+          `Bot ${botId} fallback defuse also failed: ${fallbackErr}`,
+        );
       }
     }
   }

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -109,8 +109,10 @@ export class GamesService {
     if (session && userId) {
       try {
         session = this.sanitizeForPlayer(session, userId);
-      } catch {
-        // safely continue with unsanitized session state
+      } catch (err) {
+        this.logger.warn(
+          `Sanitization failed for user ${userId} in room ${roomId}: ${err}`,
+        );
       }
     }
 
@@ -432,8 +434,10 @@ export class GamesService {
       const room = await this.roomsService.getRoom(roomId);
       const ruleMap = await this.ruleVisibility.getRulesForGame(room.gameId);
       this.stripDisabledRules(options, ruleMap);
-    } catch {
-      // Room not found or inaccessible — proceed without stripping.
+    } catch (err) {
+      this.logger.warn(
+        `Rule stripping failed for room ${roomId}: ${err}. Proceeding without stripping.`,
+      );
     }
 
     const updated = await this.roomsService.updateRoomOptions(

--- a/apps/be/src/games/glimworm/glimworm.service.ts
+++ b/apps/be/src/games/glimworm/glimworm.service.ts
@@ -58,6 +58,7 @@ const INPUT_MIN_INTERVAL_MS = 1000 / GLIMWORM_INPUT_RATE_LIMIT_HZ;
 export class GlimwormService implements OnModuleDestroy {
   private readonly logger = new Logger(GlimwormService.name);
   private readonly tickIntervals = new Map<string, NodeJS.Timeout>();
+  private readonly countdownTimers = new Map<string, NodeJS.Timeout>();
   private readonly strategies = new Map<string, VariantStrategy>();
   private readonly growthTargets = new Map<string, Map<WormId, number>>();
   private readonly random: RandomFn;
@@ -79,6 +80,10 @@ export class GlimwormService implements OnModuleDestroy {
       clearInterval(timer);
     }
     this.tickIntervals.clear();
+    for (const [, timer] of this.countdownTimers) {
+      clearTimeout(timer);
+    }
+    this.countdownTimers.clear();
   }
 
   // ========== Lobby / lifecycle ==========
@@ -377,12 +382,14 @@ export class GlimwormService implements OnModuleDestroy {
     if (this.tickIntervals.has(roomId)) return;
     // Schedule the countdown→playing transition. Until then the tick loop
     // emits snapshots without running the simulation.
-    setTimeout(() => {
+    const countdownTimer = setTimeout(() => {
+      this.countdownTimers.delete(roomId);
       const session = this.stateStore.get(roomId);
       if (session && session.status === 'countdown') {
         session.status = 'playing';
       }
     }, GLIMWORM_COUNTDOWN_MS);
+    this.countdownTimers.set(roomId, countdownTimer);
 
     const timer = setInterval(() => {
       try {
@@ -401,6 +408,11 @@ export class GlimwormService implements OnModuleDestroy {
     if (timer) {
       clearInterval(timer);
       this.tickIntervals.delete(roomId);
+    }
+    const countdown = this.countdownTimers.get(roomId);
+    if (countdown) {
+      clearTimeout(countdown);
+      this.countdownTimers.delete(roomId);
     }
   }
 


### PR DESCRIPTION
## What
Replace 3 empty `catch {}` blocks with proper logging and fix an untracked countdown timer in Glimworm.

## Why
Silent catch blocks hide bugs — sanitization failures, rule-stripping errors, and bot defuse failures produce zero observability. The Glimworm countdown `setTimeout` could fire after module destruction.

## Changes
- `games.service.ts` — log sanitization and rule-stripping failures at warn level
- `critical-bot.service.ts` — log fallback defuse failure at error level
- `glimworm.service.ts` — track countdown `setTimeout` in a Map, clear in `stopTickLoop` and `onModuleDestroy`