### PR TITLE
fix(ci): auto-increment version when tag already exists

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -39,6 +39,12 @@ jobs:
             COMMIT_MSG="chore: bump version to v${NEW_VERSION} and update changelog"
           fi
           
+          # If tag already exists on remote, auto-increment patch until we find a free version
+          while git ls-remote --tags origin "refs/tags/v$NEW_VERSION" | grep -q "refs/tags/v$NEW_VERSION"; do
+            echo "Tag v$NEW_VERSION already exists on remote, bumping patch"
+            NEW_VERSION=$(node -p "const v = '$NEW_VERSION'.split('.'); v[2]++; v.join('.')")
+          done
+          
           echo "New Version: $NEW_VERSION"
           echo "Commit Message: $COMMIT_MSG"
           
@@ -70,13 +76,8 @@ jobs:
           git add CHANGELOG.md
           
           git commit -m "$COMMIT_MSG"
-          git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           
-          if [[ "$BRANCH_NAME" == "main" ]]; then
-            echo "Pushing minor bump to develop"
-            git push origin HEAD:develop --follow-tags
-          else
-            echo "Pushing patch bump to develop"
-            git push origin HEAD:develop --follow-tags
-          fi
+          git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+          git push origin HEAD:develop
+          git push origin "v$NEW_VERSION"
 


### PR DESCRIPTION
## What
The version bump CI workflow (`version-bump.yml`) failed with `fatal: tag 'v1.23.32' already exists` when a remote tag already existed for the calculated version.

## Why
The workflow read the version from `package.json`, calculated the next version, and tried to create a tag without checking if it already existed on the remote. This happens when a previous CI run or manual action already created the tag.

## Changes
- Added a `while` loop that checks `git ls-remote --tags` before creating the tag
- If the tag already exists on remote, the patch version is auto-incremented until a free version is found
- Separated commit push and tag push (was using `--follow-tags` which fails atomically)

No tags are deleted — only new unique tags are created.