### PR TITLE
fix(be): make sonar/radar free actions so bots can attack after using them

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
@@ -118,15 +118,16 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       expect(ok).toBe(false);
     });
 
-    it('advances turn after sonar', () => {
+    it('does not advance turn after sonar (free action)', () => {
       const s = battleState({ sonar: true });
+      const beforeIndex = s.currentTurnIndex;
       const result = engine.executeAction(s, 'useSonar', ctx('a'), {
         targetPlayerId: 'b',
         row: 0,
         col: 0,
       });
 
-      expect(result.state!.currentTurnIndex).not.toBe(s.currentTurnIndex);
+      expect(result.state!.currentTurnIndex).toBe(beforeIndex);
     });
 
     it('rejects sonar when not enabled', () => {
@@ -277,14 +278,15 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       expect(ok).toBe(false);
     });
 
-    it('advances turn after radar', () => {
+    it('does not advance turn after radar (free action)', () => {
       const s = battleState({ radar: true });
+      const beforeIndex = s.currentTurnIndex;
       const result = engine.executeAction(s, 'useRadar', ctx('a'), {
         targetPlayerId: 'b',
         row: 0,
       });
 
-      expect(result.state!.currentTurnIndex).not.toBe(s.currentTurnIndex);
+      expect(result.state!.currentTurnIndex).toBe(beforeIndex);
     });
 
     it('rejects radar when not enabled', () => {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
@@ -1,9 +1,4 @@
-import {
-  BOARD_SIZE,
-  CellState,
-  GAME_MODE_VARIANTS,
-  SPEED_TURN_BUDGET_MS,
-} from './sea-battle.constants';
+import { BOARD_SIZE, CellState } from './sea-battle.constants';
 import {
   SeaBattlePlayer,
   SeaBattleState,
@@ -11,10 +6,6 @@ import {
   RadarPayload,
 } from './sea-battle.types';
 import { GameActionResult } from '../base/game-engine.interface';
-import {
-  advanceTeamRotationOnMiss,
-  getActiveShooterId,
-} from './team-rotation.utils';
 
 const SONAR_RADIUS = 1;
 
@@ -68,8 +59,6 @@ export function executeSonar(
     kind: 'sb.sonar',
     scope: 'private',
   });
-
-  advanceTurn(state);
 
   return { success: true, state };
 }
@@ -131,48 +120,5 @@ export function executeRadar(
     scope: 'private',
   });
 
-  advanceTurn(state);
-
   return { success: true, state };
-}
-
-function advanceTurn(state: SeaBattleState): void {
-  if (state.teams) {
-    advanceTeamRotationOnMiss(state);
-    const shooter = getActiveShooterId(state);
-    if (shooter) {
-      state.currentTurnIndex = state.playerOrder.indexOf(shooter);
-    }
-  } else {
-    const alivePlayers = state.players.filter((p) => p.alive);
-    if (alivePlayers.length <= 1) return;
-
-    let nextIndex = state.currentTurnIndex;
-    do {
-      nextIndex = (nextIndex + 1) % state.playerOrder.length;
-      const nextPlayer = state.players.find(
-        (p) => p.playerId === state.playerOrder[nextIndex],
-      );
-      if (nextPlayer?.alive) {
-        state.currentTurnIndex = nextIndex;
-        return;
-      }
-    } while (nextIndex !== state.currentTurnIndex);
-  }
-
-  state.roundNumber = (state.roundNumber ?? 1) + 1;
-
-  if (state.mode === GAME_MODE_VARIANTS.SPEED) {
-    const activePlayerId = state.teams
-      ? getActiveShooterId(state)
-      : state.playerOrder[state.currentTurnIndex];
-    if (activePlayerId) {
-      const speedPlayer = state.players.find(
-        (p) => p.playerId === activePlayerId,
-      );
-      if (speedPlayer) {
-        speedPlayer.turnDeadline = Date.now() + SPEED_TURN_BUDGET_MS;
-      }
-    }
-  }
 }

--- a/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
@@ -256,10 +256,7 @@ export class SeaBattleBotService {
             Math.floor(Math.random() * eligibleOpponents.length)
           ];
 
-        // --- Special weapons: sonar / radar ---
-        // Weapons are available if state.specialWeapons has them enabled.
-        // Admin exclusion via stripDisabledRules already removes excluded
-        // weapons from gameOptions before engine init, so we just check state.
+        // --- Special weapons: sonar / radar (free action, no turn advancement) ---
         const myUsage = state.specialWeaponUsage?.[botId];
         const hasSonar = !!state.specialWeapons?.sonar && !myUsage?.sonarUsed;
         const hasRadar = !!state.specialWeapons?.radar && !myUsage?.radarUsed;
@@ -278,15 +275,6 @@ export class SeaBattleBotService {
           );
           if (!refreshed) break;
           currentSession = refreshed;
-          const postSonar = currentSession.state as unknown as SeaBattleState;
-          const nextAfterSonar =
-            postSonar.playerOrder[postSonar.currentTurnIndex];
-          if (
-            nextAfterSonar !== botId ||
-            postSonar.phase !== GAME_PHASE.BATTLE
-          ) {
-            break;
-          }
         } else if (hasRadar) {
           const row = Math.floor(Math.random() * gridSize);
           await this.seaBattleService.executeActionByRoom(
@@ -295,20 +283,11 @@ export class SeaBattleBotService {
             'useRadar',
             { targetPlayerId: target.playerId, row },
           );
-          const refreshedRadar = await this.seaBattleService.findSessionByRoom(
+          const refreshed = await this.seaBattleService.findSessionByRoom(
             currentSession.roomId,
           );
-          if (!refreshedRadar) break;
-          currentSession = refreshedRadar;
-          const postRadar = currentSession.state as unknown as SeaBattleState;
-          const nextAfterRadar =
-            postRadar.playerOrder[postRadar.currentTurnIndex];
-          if (
-            nextAfterRadar !== botId ||
-            postRadar.phase !== GAME_PHASE.BATTLE
-          ) {
-            break;
-          }
+          if (!refreshed) break;
+          currentSession = refreshed;
         }
 
         // Smart Target Logic: Finish off damaged ships


### PR DESCRIPTION
## What

Make sonar and radar free actions that don't consume the player's turn, allowing bots (and humans) to use a weapon and attack in the same turn.

## Why

Bots would get stuck after using sonar/radar because these weapons advanced the turn, breaking the bot's play loop. Since nothing re-triggers the bot after its turn ends (unlike placement which has re-trigger logic), the bot would never attack again.

## Changes

- `sea-battle.special-weapons.ts`: Remove `advanceTurn()` calls from `executeSonar` and `executeRadar` — weapons are now a free action
- `sea-battle-bot.service.ts`: Remove turn-advance checks after weapon use; bot continues its `while` loop to attack on the same turn
- `sea-battle.engine.special-weapons.spec.ts`: Update tests to assert turn does NOT advance