### PR TITLE
perf(be): optimize queries and fix CI version-bump workflow

### DIFF
--- a/apps/be/src/games/history/game-history.service.ts
+++ b/apps/be/src/games/history/game-history.service.ts
@@ -98,9 +98,13 @@ export class GameHistoryService {
 
     const rooms = await this.gameRoomModel
       .find(query)
+      .select(
+        'hostId gameId name status visibility participants updatedAt gameOptions',
+      )
       .sort({ updatedAt: -1 })
       .skip(skip)
       .limit(limit)
+      .lean()
       .exec();
 
     const roomIds = rooms.map((r) => r._id.toString());
@@ -108,14 +112,22 @@ export class GameHistoryService {
     // Find sessions for these rooms
     const sessions = await this.gameSessionModel
       .find({ roomId: { $in: roomIds } })
+      .select('roomId gameId status state createdAt updatedAt')
       .sort({ createdAt: -1 })
+      .lean()
       .exec();
 
     let entries: GameHistorySummary[] | GroupedHistorySummary[];
     if (options.grouped) {
-      entries = await this.builder.buildGroupedHistory(rooms, sessions);
+      entries = await this.builder.buildGroupedHistory(
+        rooms as unknown as GameRoom[],
+        sessions as unknown as GameSession[],
+      );
     } else {
-      entries = await this.builder.buildHistoryList(rooms, sessions);
+      entries = await this.builder.buildHistoryList(
+        rooms as unknown as GameRoom[],
+        sessions as unknown as GameSession[],
+      );
     }
 
     return {
@@ -158,7 +170,7 @@ export class GameHistoryService {
       sender?: HistoryParticipantSummary;
     }>;
   }> {
-    const room = await this.gameRoomModel.findById(roomId).exec();
+    const room = await this.gameRoomModel.findById(roomId).lean().exec();
 
     if (!room) {
       throw new NotFoundException(`Room not found: ${roomId}`);
@@ -176,11 +188,15 @@ export class GameHistoryService {
     // Get all sessions for this room
     const sessions = await this.gameSessionModel
       .find({ roomId })
+      .select('roomId gameId status state createdAt updatedAt')
       .sort({ createdAt: -1 })
+      .lean()
       .exec();
 
     // Get participant summaries
-    const participants = await this.builder.getParticipantSummaries(room);
+    const participants = await this.builder.getParticipantSummaries(
+      room as unknown as GameRoom,
+    );
 
     // Find the latest session for this room
     const latestSession = sessions[0] || null;
@@ -220,23 +236,22 @@ export class GameHistoryService {
       }
     }
 
-    // Build summary
     const host = participants.find((p) => p.isHost) || participants[0];
-    const summary = {
-      roomId: room._id.toString(),
-      sessionId: latestSession ? latestSession._id.toString() : null,
-      gameId: room.gameId,
-      roomName: room.name,
-      status: room.status,
-      startedAt: latestSession ? latestSession.createdAt.toISOString() : null,
-      completedAt: latestSession ? latestSession.updatedAt.toISOString() : null,
-      lastActivityAt: room.updatedAt.toISOString(),
-      host,
-      participants,
-    };
-
     return {
-      summary,
+      summary: {
+        roomId: room._id.toString(),
+        sessionId: latestSession ? latestSession._id.toString() : null,
+        gameId: room.gameId,
+        roomName: room.name,
+        status: room.status,
+        startedAt: latestSession ? latestSession.createdAt.toISOString() : null,
+        completedAt: latestSession
+          ? latestSession.updatedAt.toISOString()
+          : null,
+        lastActivityAt: room.updatedAt.toISOString(),
+        host,
+        participants,
+      },
       logs,
     };
   }
@@ -245,31 +260,21 @@ export class GameHistoryService {
    * Hide a history entry for a user
    */
   async hideHistoryEntry(userId: string, roomId: string): Promise<void> {
-    const room = await this.gameRoomModel.findById(roomId).exec();
+    const room = await this.gameRoomModel.findById(roomId).lean().exec();
+    if (!room) throw new NotFoundException(`Room not found: ${roomId}`);
 
-    if (!room) {
-      throw new NotFoundException(`Room not found: ${roomId}`);
-    }
-
-    // Check if user was a participant
     const isParticipant =
       room.hostId === userId ||
       room.participants.some((p) => p.userId === userId);
-
-    if (!isParticipant) {
+    if (!isParticipant)
       throw new BadRequestException('You were not a participant in this game');
-    }
 
-    // Check if already hidden
     const existing = await this.historyHiddenModel
       .findOne({ userId, roomId })
+      .lean()
       .exec();
+    if (existing) return;
 
-    if (existing) {
-      return; // Already hidden
-    }
-
-    // Create hidden entry
     await this.historyHiddenModel.create({
       userId,
       roomId,

--- a/apps/be/src/games/rooms/game-rooms.service.ts
+++ b/apps/be/src/games/rooms/game-rooms.service.ts
@@ -141,7 +141,11 @@ export class GameRoomsService {
     if (!Types.ObjectId.isValid(roomId)) {
       throw new NotFoundException(`Invalid room ID format: ${roomId}`);
     }
-    const room = await this.gameRoomModel.findById(roomId).lean().exec();
+    const room = await this.gameRoomModel
+      .findById(roomId)
+      .select('-password')
+      .lean()
+      .exec();
 
     if (!room) {
       throw new NotFoundException(`Room not found: ${roomId}`);
@@ -444,14 +448,13 @@ export class GameRoomsService {
     return this.gameRoomsMapper.prepareRoomSummary(room, userId);
   }
 
-  // ========== Private Helper Methods ==========
-
   private canViewRoom(room: GameRoom, userId?: string | null): boolean {
     if (room.visibility === 'public') return true;
     if (!userId) return false;
-    if (room.hostId === userId) return true;
-    if (room.participants.some((p) => p.userId === userId)) return true;
-    return false;
+    return (
+      room.hostId === userId ||
+      room.participants.some((p) => p.userId === userId)
+    );
   }
 
   async declineRematchInvitation(

--- a/apps/be/src/main.ts
+++ b/apps/be/src/main.ts
@@ -39,8 +39,14 @@ async function bootstrap() {
     }),
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   app.use(compression());
   app.use(cookieParser());
+
+  // Trust proxy: required for correct client IP resolution behind reverse proxies (nginx, Cloudflare).
+  // Without this, req.ip always returns 127.0.0.1, breaking per-IP rate limiting.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+  app.getHttpAdapter().getInstance().set('trust proxy', 1);
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## What
- Add [skip ci] to version-bump commit to prevent re-triggering workflow
- Use MongoDB aggregation for last-messages-per-chat (N+1 → 1 query)
- Add .lean() to read-heavy queries for reduced memory usage
- Select only needed fields in listChatsForUser
- Enable trust proxy in NestJS for correct client IP behind reverse proxies
- Fix pre-existing ESLint error on compression() call
- Remove stale 'latest' tag from remote