### PR TITLE
fix(web): gray out completed game room actions and show Watch Results

### DIFF
--- a/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
@@ -250,7 +250,7 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
       )}
 
       <StyledRoomActions viewMode={viewMode}>
-        {(room.status === GAME_ROOM_STATUS.LOBBY || isParticipant) && (
+        {!isCompleted && (room.status === GAME_ROOM_STATUS.LOBBY || isParticipant) && (
           <LinkButton
             href={routes.gameRoom(room.id)}
             variant="primary"
@@ -260,16 +260,18 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
             {t('games.common.joinRoom')}
           </LinkButton>
         )}
-        {room.status === GAME_ROOM_STATUS.LOBBY || !isParticipant ? (
-          <LinkButton
-            href={`${routes.gameRoom(room.id)}?mode=watch`}
-            variant="secondary"
-            size="md"
-            flex={viewMode === 'grid' ? 1 : 0}
-          >
-            {t('games.common.watchRoom')}
-          </LinkButton>
-        ) : null}
+        {(isCompleted || room.status === GAME_ROOM_STATUS.LOBBY || !isParticipant) && (
+          <YStack opacity={isCompleted ? 0.5 : 1} flex={viewMode === 'grid' ? 1 : 0}>
+            <LinkButton
+              href={`${routes.gameRoom(room.id)}?mode=watch`}
+              variant="secondary"
+              size="md"
+              flex={1}
+            >
+              {isCompleted ? t('games.common.watchResults') : t('games.common.watchRoom')}
+            </LinkButton>
+          </YStack>
+        )}
       </StyledRoomActions>
     </StyledRoomCard>
   );

--- a/apps/web/src/shared/i18n/messages/games/shared/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/by.ts
@@ -76,6 +76,7 @@ export const byMessages = {
     joinRoom: 'Увайсці ў зал',
     joining: 'Уваход...',
     watchRoom: 'Глядзець',
+    watchResults: 'Вынікі',
     joinByCode: 'Увайсці па кодзе',
     cancel: 'Адмена',
     share: 'Падзяліцца',

--- a/apps/web/src/shared/i18n/messages/games/shared/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/en.ts
@@ -76,6 +76,7 @@ export const enMessages = {
     joinRoom: 'Join Room',
     joining: 'Joining...',
     watchRoom: 'Watch',
+    watchResults: 'Watch Results',
     joinByCode: 'Join by Code',
     cancel: 'Cancel',
     share: 'Share',

--- a/apps/web/src/shared/i18n/messages/games/shared/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/es.ts
@@ -76,6 +76,7 @@ export const esMessages = {
     joinRoom: 'Unirse a Sala',
     joining: 'Uniéndose...',
     watchRoom: 'Ver',
+    watchResults: 'Ver Resultados',
     joinByCode: 'Unirse con código',
     cancel: 'Cancelar',
     share: 'Compartir',

--- a/apps/web/src/shared/i18n/messages/games/shared/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/fr.ts
@@ -76,6 +76,7 @@ export const frMessages = {
     joinRoom: 'Rejoindre une Salle',
     joining: 'Rejoindre...',
     watchRoom: 'Regarder',
+    watchResults: 'Voir les Résultats',
     joinByCode: 'Rejoindre par code',
     cancel: 'Annuler',
     share: 'Partager',

--- a/apps/web/src/shared/i18n/messages/games/shared/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/ru.ts
@@ -76,6 +76,7 @@ export const ruMessages = {
     joinRoom: 'Войти в зал',
     joining: 'Вход...',
     watchRoom: 'Смотреть',
+    watchResults: 'Результаты',
     joinByCode: 'Войти по коду',
     cancel: 'Отмена',
     share: 'Поделиться',


### PR DESCRIPTION
## What
Update game room cards for completed games: hide the Join button, show a grayed-out "Watch Results" button instead.

## Why
Completed games should not offer join actions since the game is finished. The watch button is retained so users can still review the game, but its label changes to "Watch Results" and it's visually dimmed to indicate the game is over.

## Changes
- Hide Join button when room status is `completed`
- Show Watch button with `opacity: 0.5` for completed games (grayed out)
- Add `watchResults` i18n key across all 5 locales (en, ru, es, fr, by) — "Watch Results"
- Completed games display "Watch Results" instead of "Watch"