### PR TITLE
ci: rename guard-main workflow to match check-pr-title ruleset

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,4 +1,4 @@
-name: Guard main branch
+name: check-pr-title
 
 on:
   pull_request:


### PR DESCRIPTION
## What
Rename the `guard-main` workflow to `check-pr-title` so the required status check context matches the GitHub ruleset expectation.

## Why
The staging branch ruleset requires a status check named `check-pr-title`, but GitHub Actions reports the check as `Guard main branch / check-pr-title` (workflow name / job name). This mismatch causes the check to stay stuck at "Expected — Waiting for status to be reported".

## Changes
- Renamed workflow in `.github/workflows/guard-main.yml` from `Guard main branch` to `check-pr-title`