### PR TITLE
fix(chess): limit bots to 1 and fix chess960 castling

### DIFF
--- a/apps/be/src/games/engines/chess/chess.move-utils.ts
+++ b/apps/be/src/games/engines/chess/chess.move-utils.ts
@@ -90,8 +90,8 @@ export function simulateMove(state: ChessState, move: ChessMove): Board {
 
   if (move.isCastle) {
     if (tf === 6) {
-      let rookFrom = 7;
-      for (let f = 7; f > tf; f--) {
+      let rookFrom = ff + 1;
+      for (let f = ff + 1; f < 8; f++) {
         if (board[tr][f]?.type === 'rook') {
           rookFrom = f;
           break;
@@ -100,8 +100,8 @@ export function simulateMove(state: ChessState, move: ChessMove): Board {
       board[tr][5] = board[tr][rookFrom];
       board[tr][rookFrom] = null;
     } else if (tf === 2) {
-      let rookFrom = 0;
-      for (let f = 0; f < tf; f++) {
+      let rookFrom = ff - 1;
+      for (let f = ff - 1; f >= 0; f--) {
         if (board[tr][f]?.type === 'rook') {
           rookFrom = f;
           break;

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -87,6 +87,7 @@ export function ReusableGameLobby({
   variantName,
   roomIcon = '🎲',
   minPlayers = 2,
+  maxPlayers: maxPlayersProp,
   theme = {},
   isFastMode,
   labels = {},
@@ -149,7 +150,7 @@ export function ReusableGameLobby({
   const [botCount, setBotCount] = useState(1);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const members = room.members ?? [];
-  const maxPlayers = room.maxPlayers ?? 6;
+  const maxPlayers = maxPlayersProp ?? room.maxPlayers ?? 6;
   const cooldownRef = React.useRef(0);
   const handleStart = React.useCallback(() => {
     const now = Date.now();

--- a/apps/web/src/features/games/ui/ReusableGameLobby.types.ts
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.types.ts
@@ -33,6 +33,7 @@ export interface ReusableGameLobbyProps {
 
   // Player limits
   minPlayers?: number;
+  maxPlayers?: number;
 
   // Labels (with sensible defaults)
   labels?: {

--- a/apps/web/src/widgets/ChessGame/ui/ChessLobby.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessLobby.tsx
@@ -250,6 +250,7 @@ export function ChessLobby({
         gameIcon="♟"
         variantName={variantLabel}
         minPlayers={2}
+        maxPlayers={2}
         theme={LOBBY_THEME}
         enableBots
         labels={{


### PR DESCRIPTION
## Summary
- Limit chess lobby bot count to 1 (max 2 total players)
- Fix chess960 castling to work with non-standard rook positions

## Changes

### 1. Bot limit (web)
The `ReusableGameLobby` component defaulted to `maxPlayers=6` when `room.maxPlayers` was not set, allowing up to 5 bots. Added a `maxPlayers` prop to `ReusableGameLobby` and passed `maxPlayers={2}` from `ChessLobby` to cap the total player count (human + bots) at 2.

**Files:**
- `apps/web/src/features/games/ui/ReusableGameLobby.types.ts` — added `maxPlayers` prop
- `apps/web/src/features/games/ui/ReusableGameLobby.tsx` — use prop to override `room.maxPlayers`
- `apps/web/src/widgets/ChessGame/ui/ChessLobby.tsx` — pass `maxPlayers={2}`

### 2. Chess960 castling fix (backend)
`simulateMove` hardcoded the rook search to file 7 (king-side) and file 0 (queen-side), which fails when rooks are on non-standard files in chess960. Fixed to search from the king's starting position (`ff`) in the correct direction.

**File:** `apps/be/src/games/engines/chess/chess.move-utils.ts`

## Verification
- ✅ Web type-check passes
- ✅ Web lint passes (0 errors)
- ✅ Backend lint passes
- ✅ All 46 chess engine tests pass
- ✅ All 1139 web unit tests pass
- ✅ File length check passes
- ✅ i18n completeness passes