### PR TITLE
feat(web,be): improve Tic Tac Toe Infinity UX

### DIFF
--- a/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.engine.spec.ts
+++ b/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.engine.spec.ts
@@ -286,7 +286,7 @@ describe('TicTacToeEngine', () => {
         col: 4,
       }).state!;
       expect(state.board.length).toBeGreaterThan(9);
-      expect(state.board[0].length).toBeGreaterThan(9);
+      expect(state.board[0].length).toBe(9);
     });
 
     it('does not expand when mark is placed away from edges', () => {

--- a/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.spec.ts
+++ b/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.spec.ts
@@ -145,45 +145,59 @@ describe('tic-tac-toe utils', () => {
       expect(result.originDelta).toEqual({ row: 0, col: 0 });
     });
 
-    it('expands when mark is placed near the top edge', () => {
+    it('expands only at the top when mark is placed near the top edge', () => {
       const board = createEmptyBoard(9);
       board[0][4] = 'x';
       const result = expandBoard(board, 0, 4, 3);
-      expect(result.board.length).toBeGreaterThan(9);
-      expect(result.originDelta.row).toBeGreaterThan(0);
-      expect(
-        result.board[0 + result.originDelta.row][4 + result.originDelta.col],
-      ).toBe('x');
+      expect(result.board.length).toBe(12);
+      expect(result.board[0].length).toBe(9);
+      expect(result.originDelta.row).toBe(3);
+      expect(result.originDelta.col).toBe(0);
+      expect(result.board[3][4]).toBe('x');
     });
 
-    it('expands when mark is placed near the bottom edge', () => {
+    it('expands only at the bottom when mark is placed near the bottom edge', () => {
       const board = createEmptyBoard(9);
       board[8][4] = 'x';
       const result = expandBoard(board, 8, 4, 3);
-      expect(result.board.length).toBeGreaterThan(9);
+      expect(result.board.length).toBe(12);
+      expect(result.board[0].length).toBe(9);
+      expect(result.originDelta.row).toBe(0);
+      expect(result.originDelta.col).toBe(0);
+      expect(result.board[8][4]).toBe('x');
     });
 
-    it('expands when mark is placed near the left edge', () => {
+    it('expands only at the left when mark is placed near the left edge', () => {
       const board = createEmptyBoard(9);
       board[4][0] = 'x';
       const result = expandBoard(board, 4, 0, 3);
-      expect(result.board[0].length).toBeGreaterThan(9);
-      expect(result.originDelta.col).toBeGreaterThan(0);
+      expect(result.board.length).toBe(9);
+      expect(result.board[0].length).toBe(12);
+      expect(result.originDelta.row).toBe(0);
+      expect(result.originDelta.col).toBe(3);
+      expect(result.board[4][3]).toBe('x');
     });
 
-    it('expands when mark is placed near the right edge', () => {
+    it('expands only at the right when mark is placed near the right edge', () => {
       const board = createEmptyBoard(9);
       board[4][8] = 'x';
       const result = expandBoard(board, 4, 8, 3);
-      expect(result.board[0].length).toBeGreaterThan(9);
+      expect(result.board.length).toBe(9);
+      expect(result.board[0].length).toBe(12);
+      expect(result.originDelta.row).toBe(0);
+      expect(result.originDelta.col).toBe(0);
+      expect(result.board[4][8]).toBe('x');
     });
 
-    it('expands in both axes when placed in a corner', () => {
+    it('expands both axes when placed in a corner', () => {
       const board = createEmptyBoard(9);
       board[0][0] = 'x';
       const result = expandBoard(board, 0, 0, 3);
-      expect(result.board.length).toBeGreaterThan(9);
-      expect(result.board[0].length).toBeGreaterThan(9);
+      expect(result.board.length).toBe(12);
+      expect(result.board[0].length).toBe(12);
+      expect(result.originDelta.row).toBe(3);
+      expect(result.originDelta.col).toBe(3);
+      expect(result.board[3][3]).toBe('x');
     });
 
     it('preserves existing marks after expansion', () => {
@@ -217,6 +231,7 @@ describe('tic-tac-toe utils', () => {
       board[0][4] = 'x';
       const result = expandBoard(board, 0, 4, 1);
       expect(result.board.length).toBe(10);
+      expect(result.board[0].length).toBe(9);
       expect(result.originDelta.row).toBe(1);
     });
 
@@ -225,19 +240,20 @@ describe('tic-tac-toe utils', () => {
       board[0][4] = 'x';
       const result = expandBoard(board, 0, 4, 2);
       expect(result.board.length).toBe(11);
+      expect(result.board[0].length).toBe(9);
       expect(result.originDelta.row).toBe(2);
     });
 
-    it('does not double-expand when both axes need rows (corner case)', () => {
+    it('expands only on needed sides for corner placement', () => {
       const board = createEmptyBoard(9);
       board[0][0] = 'x';
       const result = expandBoard(board, 0, 0, 3);
       const addedRows = result.board.length - 9;
       const addedCols = result.board[0].length - 9;
-      expect(addedRows).toBeLessThanOrEqual(6);
-      expect(addedCols).toBeLessThanOrEqual(6);
-      expect(result.originDelta.row).toBeGreaterThanOrEqual(3);
-      expect(result.originDelta.col).toBeGreaterThanOrEqual(3);
+      expect(addedRows).toBe(3);
+      expect(addedCols).toBe(3);
+      expect(result.originDelta.row).toBe(3);
+      expect(result.originDelta.col).toBe(3);
     });
   });
 

--- a/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.ts
+++ b/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.utils.ts
@@ -1,8 +1,9 @@
 import type { CellValue, WinLineCell } from './tic-tac-toe.types';
 
-export function createEmptyBoard(size: number): CellValue[][] {
-  return Array.from({ length: size }, () =>
-    Array.from({ length: size }, () => null as CellValue),
+export function createEmptyBoard(rows: number, cols?: number): CellValue[][] {
+  const c = cols ?? rows;
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: c }, () => null as CellValue),
   );
 }
 
@@ -17,16 +18,17 @@ export function expandBoard(
   col: number,
   margin: number,
 ): ExpandResult {
-  const size = board.length;
+  const rows = board.length;
+  const cols = board[0]?.length ?? rows;
   let neededTop = 0;
   let neededBottom = 0;
   let neededLeft = 0;
   let neededRight = 0;
 
   if (row < margin) neededTop = margin - row;
-  if (row >= size - margin) neededBottom = margin - (size - 1 - row);
+  if (row >= rows - margin) neededBottom = margin - (rows - 1 - row);
   if (col < margin) neededLeft = margin - col;
-  if (col >= size - margin) neededRight = margin - (size - 1 - col);
+  if (col >= cols - margin) neededRight = margin - (cols - 1 - col);
 
   if (
     neededTop === 0 &&
@@ -37,30 +39,19 @@ export function expandBoard(
     return { board, originDelta: { row: 0, col: 0 } };
   }
 
-  const totalNewRows = neededTop + neededBottom;
-  const totalNewCols = neededLeft + neededRight;
-  const expansion = Math.max(totalNewRows, totalNewCols);
-  const newSize = size + expansion;
+  const newRows = rows + neededTop + neededBottom;
+  const newCols = cols + neededLeft + neededRight;
+  const newBoard = createEmptyBoard(newRows, newCols);
 
-  const newRowsTop = Math.min(
-    Math.max(neededTop, Math.ceil(expansion / 2)),
-    expansion - neededBottom,
-  );
-  const newColsLeft = Math.min(
-    Math.max(neededLeft, Math.ceil(expansion / 2)),
-    expansion - neededRight,
-  );
-  const newBoard = createEmptyBoard(newSize);
-
-  for (let r = 0; r < size; r++) {
-    for (let c = 0; c < size; c++) {
-      newBoard[r + newRowsTop][c + newColsLeft] = board[r][c];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      newBoard[r + neededTop][c + neededLeft] = board[r][c];
     }
   }
 
   return {
     board: newBoard,
-    originDelta: { row: newRowsTop, col: newColsLeft },
+    originDelta: { row: neededTop, col: neededLeft },
   };
 }
 
@@ -97,13 +88,15 @@ export function findWinningLine(
   winLength: number,
   owner: string,
 ): WinLineCell[] | null {
-  for (let row = 0; row < size; row++) {
-    for (let col = 0; col < size; col++) {
+  const rows = board.length;
+  const cols = board[0]?.length ?? rows;
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
       if (board[row][col] !== owner) continue;
       for (const [dRow, dCol] of DIRECTIONS) {
         const endRow = row + dRow * (winLength - 1);
         const endCol = col + dCol * (winLength - 1);
-        if (endRow < 0 || endRow >= size || endCol < 0 || endCol >= size) {
+        if (endRow < 0 || endRow >= rows || endCol < 0 || endCol >= cols) {
           continue;
         }
         let matched = true;

--- a/apps/web/src/widgets/TicTacToeGame/lib/constants.ts
+++ b/apps/web/src/widgets/TicTacToeGame/lib/constants.ts
@@ -2,6 +2,8 @@ import type { TranslationKey } from '@/shared/lib/useTranslation';
 import type { GameVariantOption } from '@/features/games/ui/GameVariantSelector';
 import type { TicTacToeVariant } from '../types';
 
+export const INFINITY_MAX_BOARD_SIZE = 100;
+
 export interface TicTacToeVariantOption extends GameVariantOption {
   id: TicTacToeVariant;
   name: TranslationKey;

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -25,7 +25,10 @@ import { TicTacToeBoard } from './TicTacToeBoard';
 import { TurnBadge } from './TurnBadge';
 import { RulesModal } from './RulesModal';
 import { WIN_LENGTHS } from '../types';
-import { TIC_TAC_TOE_VARIANTS } from '../lib/constants';
+import {
+  TIC_TAC_TOE_VARIANTS,
+  INFINITY_MAX_BOARD_SIZE,
+} from '../lib/constants';
 import {
   type BoardSize,
   type TicTacToeOptions,
@@ -210,6 +213,8 @@ function TicTacToeGameImpl({
             origin={snapshot.origin}
             disabled={!myTurn || isGameOver}
             highlightedCell={effectiveHighlight}
+            maxBoardSize={INFINITY_MAX_BOARD_SIZE}
+            currentPlayerId={currentShooterId}
             ariaLabel={
               snapshot.options.boardSize === 'infinity'
                 ? 'Tic-Tac-Toe Infinity board'

--- a/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
@@ -118,7 +118,10 @@ function TicTacToeBoardImpl({
       /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([^)]+\)|[a-zA-Z]+)$/.test(info.color)
         ? info.color
         : '#000000';
-    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><text x='16' y='23' font-size='22' font-weight='bold' fill='${safeColor}' text-anchor='middle' font-family='system-ui,sans-serif'>${info.mark}</text></svg>`;
+    const safeMark = /^[A-Za-z0-9△□▲■○●◆◇★☆♡]+$/.test(info.mark)
+      ? info.mark
+      : '?';
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><text x='16' y='23' font-size='22' font-weight='bold' fill='${safeColor}' text-anchor='middle' font-family='system-ui,sans-serif'>${safeMark}</text></svg>`;
     return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 16 16, pointer` as const;
   }, [disabled, currentPlayerId, symbolByOwner]);
 

--- a/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
@@ -27,6 +27,8 @@ interface TicTacToeBoardProps {
   ariaLabel?: string;
   onCellClick: (row: number, col: number) => void;
   highlightedCell?: { row: number; col: number } | null;
+  maxBoardSize?: number;
+  currentPlayerId?: string | null;
 }
 
 function TicTacToeBoardImpl({
@@ -40,10 +42,13 @@ function TicTacToeBoardImpl({
   ariaLabel,
   onCellClick,
   highlightedCell,
+  maxBoardSize = 100,
+  currentPlayerId,
 }: TicTacToeBoardProps) {
   const theme = useTicTacToeTheme();
-  const size = board.length;
-  const isScrollable = size > SCROLL_THRESHOLD;
+  const rows = board.length;
+  const cols = board[0]?.length ?? rows;
+  const isScrollable = rows > SCROLL_THRESHOLD || cols > SCROLL_THRESHOLD;
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const dragState = useRef({
@@ -104,6 +109,15 @@ function TicTacToeBoardImpl({
     }
     return map;
   }, [players, teams, teamMode, theme]);
+
+  const playerCursor = useMemo(() => {
+    if (disabled || !currentPlayerId) return undefined;
+    const info = symbolByOwner.get(currentPlayerId);
+    if (!info) return undefined;
+    const color = info.color.replace(/'/g, "\\'");
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><text x='16' y='23' font-size='22' font-weight='bold' fill='${color}' text-anchor='middle' font-family='system-ui,sans-serif'>${info.mark}</text></svg>`;
+    return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 16 16, pointer` as const;
+  }, [disabled, currentPlayerId, symbolByOwner]);
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
@@ -168,8 +182,8 @@ function TicTacToeBoardImpl({
   const gridStyle: React.CSSProperties = isScrollable
     ? {
         display: 'grid',
-        gridTemplateColumns: `repeat(${size}, ${CELL_PX}px)`,
-        gridTemplateRows: `repeat(${size}, ${CELL_PX}px)`,
+        gridTemplateColumns: `repeat(${cols}, ${CELL_PX}px)`,
+        gridTemplateRows: `repeat(${rows}, ${CELL_PX}px)`,
         gap: `${GAP_PX}px`,
         padding: `${BOARD_PADDING_PX}px`,
         backgroundColor: theme.gridLine,
@@ -180,15 +194,15 @@ function TicTacToeBoardImpl({
       }
     : {
         display: 'grid',
-        gridTemplateColumns: `repeat(${size}, 1fr)`,
-        gridTemplateRows: `repeat(${size}, 1fr)`,
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        gridTemplateRows: `repeat(${rows}, 1fr)`,
         gap: '4px',
         padding: '12px',
         backgroundColor: theme.gridLine,
         borderRadius: theme.borderRadius,
         width: '100%',
         maxWidth: 'min(80vmin, 480px)',
-        aspectRatio: '1 / 1',
+        aspectRatio: `${cols} / ${rows}`,
         margin: '0 auto',
         boxSizing: 'border-box',
       };
@@ -200,7 +214,7 @@ function TicTacToeBoardImpl({
         fontSize: '1.1rem',
       }
     : {
-        fontSize: `clamp(0.85rem, ${(55 / size).toFixed(1)}cqw, 3rem)`,
+        fontSize: `clamp(0.85rem, ${(55 / Math.max(rows, cols)).toFixed(1)}cqw, 3rem)`,
       };
 
   return (
@@ -250,6 +264,11 @@ function TicTacToeBoardImpl({
                 colIdx === highlightedCell.col + origin.col
               : false;
             const isOrigin = rowIdx === origin.row && colIdx === origin.col;
+            const isMaxRows = rows >= maxBoardSize;
+            const isMaxCols = cols >= maxBoardSize;
+            const isAtLimit =
+              (isMaxRows && rowIdx === rows - 1) ||
+              (isMaxCols && colIdx === cols - 1);
             return (
               <button
                 key={`${rowIdx}-${colIdx}`}
@@ -268,28 +287,34 @@ function TicTacToeBoardImpl({
                     setHoveredCell({ row: rowIdx, col: colIdx });
                 }}
                 onMouseLeave={() => setHoveredCell(null)}
-                className={`ttt-cell${isWinning ? ' ttt-winning' : ''}${isHighlighted ? ' ttt-highlighted' : ''}`}
+                className={`ttt-cell${isWinning ? ' ttt-winning' : ''}${isHighlighted ? ' ttt-highlighted' : ''}${isAtLimit ? ' ttt-at-limit' : ''}${isOrigin && !ownerInfo ? ' ttt-origin' : ''}`}
                 style={{
                   ...cellStyle,
                   backgroundColor: isWinning
                     ? theme.winningCellBg
                     : isHighlighted
                       ? 'rgba(99,102,241,0.35)'
-                      : isOrigin
-                        ? 'rgba(255,255,255,0.08)'
-                        : theme.cellBg,
+                      : isAtLimit
+                        ? 'rgba(239,68,68,0.12)'
+                        : isOrigin
+                          ? 'rgba(129,140,248,0.12)'
+                          : theme.cellBg,
                   color:
                     ownerInfo?.color ?? previewInfo?.color ?? theme.textColor,
                   border: isHighlighted
                     ? '2px solid rgba(129,140,248,0.8)'
-                    : isOrigin && !ownerInfo
-                      ? '1px dashed rgba(255,255,255,0.25)'
-                      : 'none',
+                    : isAtLimit
+                      ? '1px dashed rgba(239,68,68,0.45)'
+                      : isOrigin && !ownerInfo
+                        ? '1px solid rgba(129,140,248,0.35)'
+                        : 'none',
                   borderRadius: theme.borderRadius,
                   fontFamily: theme.markFont,
                   fontWeight: 700,
                   fontSize: cellStyle.fontSize,
-                  cursor: cellDisabled ? 'default' : 'pointer',
+                  cursor: cellDisabled
+                    ? 'default'
+                    : (playerCursor ?? 'pointer'),
                   transition: 'background-color 120ms ease, border 120ms ease',
                   overflow: 'hidden',
                 }}

--- a/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
@@ -114,8 +114,11 @@ function TicTacToeBoardImpl({
     if (disabled || !currentPlayerId) return undefined;
     const info = symbolByOwner.get(currentPlayerId);
     if (!info) return undefined;
-    const color = info.color.replace(/'/g, "\\'");
-    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><text x='16' y='23' font-size='22' font-weight='bold' fill='${color}' text-anchor='middle' font-family='system-ui,sans-serif'>${info.mark}</text></svg>`;
+    const safeColor =
+      /^(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\([^)]+\)|[a-zA-Z]+)$/.test(info.color)
+        ? info.color
+        : '#000000';
+    const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'><text x='16' y='23' font-size='22' font-weight='bold' fill='${safeColor}' text-anchor='middle' font-family='system-ui,sans-serif'>${info.mark}</text></svg>`;
     return `url("data:image/svg+xml,${encodeURIComponent(svg)}") 16 16, pointer` as const;
   }, [disabled, currentPlayerId, symbolByOwner]);
 

--- a/apps/web/src/widgets/TicTacToeGame/ui/styles/animations.scss
+++ b/apps/web/src/widgets/TicTacToeGame/ui/styles/animations.scss
@@ -48,6 +48,19 @@
   animation: ttt-highlight-pulse 1.2s ease-in-out infinite;
 }
 
+@keyframes ttt-origin-glow {
+  0%, 100% {
+    box-shadow: inset 0 0 8px 1px rgba(129, 140, 248, 0.3);
+  }
+  50% {
+    box-shadow: inset 0 0 14px 3px rgba(129, 140, 248, 0.55);
+  }
+}
+
+.ttt-origin {
+  animation: ttt-origin-glow 3s ease-in-out infinite;
+}
+
 [data-testid='ttt-board-wrapper']:active {
   cursor: grabbing;
 }


### PR DESCRIPTION
## What
- Expand board only on the side near the last click instead of symmetrically on all sides
- Highlight last row/column with dashed red border when board reaches max size (100×100)
- Add glowing origin cell marker with breathing animation
- Show player-specific cursor with actual symbol (X/O/△/□) and color

## Why
The infinity mode board previously expanded equally on all sides (keeping it square), which was unintuitive — players expected growth only where they were playing. Additionally, there was no visual indication when the board hit its size limit, and the cursor was a generic cross regardless of which player was placing.

## Changes
### BE
- `expandBoard()` now adds rows/columns only on the side(s) where the mark was placed, allowing rectangular boards
- `findWinningLine()` and `createEmptyBoard()` updated to support rectangular boards (rows ≠ cols)

### Web
- `TicTacToeBoard` — rectangular grid support, max-size boundary highlight, origin glow animation, player-specific SVG cursor
- `Game.tsx` — passes `maxBoardSize` and `currentPlayerId` props