### PR TITLE
fix(be,web): fix ship placement race condition and add more ships for bigger fields

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -3,8 +3,8 @@ import { Logger } from '@nestjs/common';
 import {
   BOARD_SIZE,
   CELL_STATE,
-  SHIPS,
   GAME_PHASE,
+  getActiveShips,
   type ShipConfig,
 } from './sea-battle.constants';
 import {
@@ -43,7 +43,10 @@ export function runPlaceShip(
   player: SeaBattlePlayer,
   payload: PlaceShipPayload,
 ): GameActionResult<SeaBattleState> {
-  const shipConfig = SHIPS.find((s) => s.id === payload.shipId) as ShipConfig;
+  const activeShips = getActiveShips(state.shipCount);
+  const shipConfig = activeShips.find(
+    (s) => s.id === payload.shipId,
+  ) as ShipConfig;
   const ship: Ship = {
     id: payload.shipId,
     name: shipConfig.name,
@@ -80,7 +83,10 @@ export function runMoveShip(
   }
   player.ships = player.ships.filter((s) => s.id !== payload.shipId);
 
-  const shipConfig = SHIPS.find((s) => s.id === payload.shipId) as ShipConfig;
+  const activeShips = getActiveShips(state.shipCount);
+  const shipConfig = activeShips.find(
+    (s) => s.id === payload.shipId,
+  ) as ShipConfig;
   const ship: Ship = {
     id: payload.shipId,
     name: shipConfig.name,
@@ -108,6 +114,7 @@ export function runAutoPlace(
   player: SeaBattlePlayer,
 ): GameActionResult<SeaBattleState> {
   const gridSize = state.gridSize ?? BOARD_SIZE;
+  const activeShips = getActiveShips(state.shipCount);
   for (let r = 0; r < gridSize; r++) {
     for (let c = 0; c < gridSize; c++) {
       if (player.board[r][c] === CELL_STATE.SHIP) {
@@ -117,13 +124,13 @@ export function runAutoPlace(
   }
   player.ships = [];
   player.placementComplete = false;
-  const placements = randomlyPlaceShips(gridSize);
+  const placements = randomlyPlaceShips(gridSize, state.shipCount);
   if (Object.keys(placements).length === 0) {
     return { success: false, error: 'Failed to generate ship placement' };
   }
   for (const shipId of Object.keys(placements)) {
     const cells = placements[shipId];
-    const shipConfig = SHIPS.find((s) => s.id === shipId);
+    const shipConfig = activeShips.find((s) => s.id === shipId);
     if (shipConfig) {
       const ship: Ship = {
         id: shipId,

--- a/apps/be/src/games/engines/sea-battle/sea-battle.constants.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.constants.ts
@@ -27,6 +27,7 @@ export interface ShipConfig {
 }
 
 export const SHIPS: ShipConfig[] = [
+  { id: 'carrier-1', name: 'Carrier', size: 5 },
   { id: 'battleship-1', name: 'Battleship', size: 4 },
   { id: 'cruiser-1', name: 'Cruiser', size: 3 },
   { id: 'cruiser-2', name: 'Cruiser', size: 3 },
@@ -37,7 +38,16 @@ export const SHIPS: ShipConfig[] = [
   { id: 'submarine-2', name: 'Submarine', size: 1 },
   { id: 'submarine-3', name: 'Submarine', size: 1 },
   { id: 'submarine-4', name: 'Submarine', size: 1 },
+  { id: 'patrol-1', name: 'Patrol', size: 2 },
+  { id: 'patrol-2', name: 'Patrol', size: 2 },
+  { id: 'frigate-1', name: 'Frigate', size: 3 },
+  { id: 'frigate-2', name: 'Frigate', size: 3 },
 ];
+
+export function getActiveShips(shipCount?: number): ShipConfig[] {
+  const count = shipCount ?? 10;
+  return SHIPS.slice(0, Math.min(count, SHIPS.length));
+}
 
 export const GAME_PHASE = {
   LOBBY: 'lobby',

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -8,8 +8,8 @@ import {
 import {
   BOARD_SIZE,
   CELL_STATE,
-  SHIPS,
   GAME_PHASE,
+  getActiveShips,
   ATTACK_RESULT,
   ROW_LABELS,
   COL_LABELS,
@@ -87,12 +87,14 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
     const orderedIds = shouldRandomize
       ? [...playerIds].sort(() => Math.random() - 0.5)
       : [...playerIds];
+    const shipCount = config?.shipCount;
+    const activeShipCount = getActiveShips(shipCount).length;
     const players: SeaBattlePlayer[] = orderedIds.map((id) => ({
       playerId: id,
       alive: true,
       board: createEmptyBoard(gridSize),
       ships: [],
-      shipsRemaining: SHIPS.length,
+      shipsRemaining: activeShipCount,
       placementComplete: false,
     }));
     const baseState: SeaBattleState = {
@@ -100,7 +102,12 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
       players,
       playerOrder: orderedIds,
       currentTurnIndex: 0,
-      logs: [this.createLogEntry('system', `Game started! Mode: ${mode}. Place your ships.`)],
+      logs: [
+        this.createLogEntry(
+          'system',
+          `Game started! Mode: ${mode}. Place your ships.`,
+        ),
+      ],
       mode,
       roundNumber: 1,
       gridSize,
@@ -150,7 +157,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
         const isValid = validateConfirmPlacement(state, player);
         if (!isValid) {
           this.logger.error(
-            `[SeaBattleEngine] confirmPlacement validation failed for ${userId}. Phase: ${state.phase}, Ships: ${player.ships.length}/${SHIPS.length}, Ready: ${player.placementComplete}`,
+            `[SeaBattleEngine] confirmPlacement validation failed for ${userId}. Phase: ${state.phase}, Ships: ${player.ships.length}/${getActiveShips(state.shipCount).length}, Ready: ${player.placementComplete}`,
           );
         }
         return isValid;
@@ -262,9 +269,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
             senderId: target.playerId,
           }),
         );
-        // In team mode, make sure the eliminated player isn't left as their
-        // team's active shooter — otherwise their team's next turn deadlocks
-        // on a dead player.
+        // Ensure eliminated player isn't left as team's active shooter
         normalizeTeamShooterAfterDeath(state, target.playerId);
         this.checkAndSetWinner(state);
       }
@@ -311,11 +316,9 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
         this.advanceToNextPlayer(state);
       }
 
-      // Increment round number on miss (turn passes)
       state.roundNumber = (state.roundNumber ?? 1) + 1;
     }
 
-    // Set turn deadline for speed mode
     if (state.mode === GAME_MODE_VARIANTS.SPEED) {
       this.setTurnDeadline(state);
     }
@@ -432,12 +435,8 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
       const wasActiveShooter = getActiveShooterId(newState) === playerId;
 
       if (wasActiveShooter) {
-        // Active shooter forfeits the turn — advance like a miss so the
-        // next team plays and the leaver's team rotates to the next teammate.
         advanceTeamRotationOnMiss(newState);
       } else {
-        // Otherwise, only patch up the leaver's own team shooter pointer so
-        // a live teammate is queued up when their team plays again.
         const team = newState.teams.find((t) => t.playerIds.includes(playerId));
         if (team && team.playerIds[team.currentShooterIndex] === playerId) {
           const n = team.playerIds.length;
@@ -455,8 +454,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
         }
       }
 
-      // Keep currentTurnIndex in sync with the active shooter so consumers
-      // that read playerOrder[currentTurnIndex] (e.g. the bot service) match.
+      // Keep currentTurnIndex in sync with the active shooter
       const activeTeam = getActiveTeam(newState);
       if (activeTeam) {
         const shooter = getActiveShooterId(newState);

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -3,7 +3,7 @@ import {
   CELL_STATE,
   CellState,
   GAME_PHASE,
-  SHIPS,
+  getActiveShips,
 } from './sea-battle.constants';
 import {
   ShipCell,
@@ -156,13 +156,14 @@ export function getSeaBattleAvailableActions(
   if (!player || !player.alive) return [];
 
   const actions: string[] = ['chat'];
+  const activeShips = getActiveShips(state.shipCount);
 
   if (state.phase === GAME_PHASE.PLACEMENT) {
     if (!player.placementComplete) {
-      if (player.ships.length < SHIPS.length) {
+      if (player.ships.length < activeShips.length) {
         actions.push('placeShip');
       }
-      if (player.ships.length === SHIPS.length) {
+      if (player.ships.length === activeShips.length) {
         actions.push('confirmPlacement');
       }
       if (player.ships.length > 0) {
@@ -255,12 +256,14 @@ function canPlaceShip(
 
 export function randomlyPlaceShips(
   gridSize: number = BOARD_SIZE,
+  shipCount?: number,
 ): Record<string, ShipCell[]> {
   const board = createEmptyBoard(gridSize);
   const placements: Record<string, ShipCell[]> = {};
+  const activeShips = getActiveShips(shipCount);
 
   // Sort ships by size descending to make placement easier
-  const sortedShips = [...SHIPS].sort((a, b) => b.size - a.size);
+  const sortedShips = [...activeShips].sort((a, b) => b.size - a.size);
 
   for (const ship of sortedShips) {
     let placed = false;

--- a/apps/be/src/games/engines/sea-battle/sea-battle.validators.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.validators.ts
@@ -1,8 +1,8 @@
 import {
   BOARD_SIZE,
   CELL_STATE,
-  SHIPS,
   GAME_PHASE,
+  getActiveShips,
 } from './sea-battle.constants';
 import {
   SeaBattlePlayer,
@@ -28,7 +28,8 @@ export function validatePlaceShip(
   if (player.placementComplete) return false;
   if (!payload?.shipId || !payload?.cells) return false;
 
-  const shipConfig = SHIPS.find((s) => s.id === payload.shipId);
+  const activeShips = getActiveShips(state.shipCount);
+  const shipConfig = activeShips.find((s) => s.id === payload.shipId);
   if (!shipConfig) return false;
   if (payload.cells.length !== shipConfig.size) return false;
 
@@ -81,7 +82,8 @@ export function validateMoveShip(
   if (player.placementComplete) return false;
   if (!payload?.shipId || !payload?.cells) return false;
 
-  const shipConfig = SHIPS.find((s) => s.id === payload.shipId);
+  const activeShips = getActiveShips(state.shipCount);
+  const shipConfig = activeShips.find((s) => s.id === payload.shipId);
   if (!shipConfig) return false;
   if (payload.cells.length !== shipConfig.size) return false;
 
@@ -137,7 +139,7 @@ export function validateConfirmPlacement(
 ): boolean {
   if (state.phase !== GAME_PHASE.PLACEMENT) return false;
   if (player.placementComplete) return false;
-  return player.ships.length === SHIPS.length;
+  return player.ships.length === getActiveShips(state.shipCount).length;
 }
 
 export function validateAutoPlace(state: SeaBattleState): boolean {

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -58,12 +58,27 @@ const STRIP_DOC_SIZE_BYTES = 500 * 1024;
 @Injectable()
 export class GameSessionsService {
   private readonly logger = new Logger(GameSessionsService.name);
+  private readonly sessionLocks = new Map<string, Promise<void>>();
 
   constructor(
     @InjectModel(GameSession.name)
     private readonly gameSessionModel: Model<GameSession>,
     private readonly engineRegistry: GameEngineRegistry,
   ) {}
+
+  private async acquireSessionLock(sessionId: string): Promise<() => void> {
+    let release: () => void;
+    const prev = this.sessionLocks.get(sessionId) ?? Promise.resolve();
+    const next = new Promise<void>((resolve) => {
+      release = () => {
+        resolve();
+        this.sessionLocks.delete(sessionId);
+      };
+    });
+    this.sessionLocks.set(sessionId, next);
+    await prev;
+    return release!;
+  }
 
   /**
    * Create a new game session
@@ -202,87 +217,91 @@ export class GameSessionsService {
   ): Promise<GameSessionSummary> {
     const { sessionId, action, userId, payload } = options;
 
-    const session = await this.gameSessionModel.findById(sessionId).exec();
+    const release = await this.acquireSessionLock(sessionId);
+    try {
+      const session = await this.gameSessionModel.findById(sessionId).exec();
 
-    if (!session) {
-      throw new NotFoundException(`Session not found: ${sessionId}`);
-    }
+      if (!session) {
+        throw new NotFoundException(`Session not found: ${sessionId}`);
+      }
 
-    if (session.status !== 'active') {
-      throw new BadRequestException('Session is not active');
-    }
+      if (session.status !== 'active') {
+        throw new BadRequestException('Session is not active');
+      }
 
-    // Get the game engine
-    const engine = this.engineRegistry.getEngine(session.gameId);
+      // Get the game engine
+      const engine = this.engineRegistry.getEngine(session.gameId);
 
-    // Self-heal any drifted state before validation/execution. Engines opt in
-    // via the optional normalizeState hook; must be idempotent.
-    if (engine.normalizeState) {
-      session.state = engine.normalizeState(
+      // Self-heal any drifted state before validation/execution. Engines opt in
+      // via the optional normalizeState hook; must be idempotent.
+      if (engine.normalizeState) {
+        session.state = engine.normalizeState(
+          session.state as unknown as BaseGameState,
+        ) as unknown as Record<string, unknown>;
+        session.markModified('state');
+      }
+
+      // Create action context
+      const context: GameActionContext = {
+        userId,
+        roomId: session.roomId,
+        sessionId: session._id.toString(),
+        timestamp: new Date(),
+      };
+
+      // Execute the action (engines validate internally and return errorResult
+      // with the actual error message on failure).
+      const result = engine.executeAction(
         session.state as unknown as BaseGameState,
-      ) as unknown as Record<string, unknown>;
-      session.markModified('state');
-    }
-
-    // Create action context
-    const context: GameActionContext = {
-      userId,
-      roomId: session.roomId,
-      sessionId: session._id.toString(),
-      timestamp: new Date(),
-    };
-
-    // Execute the action (engines validate internally and return errorResult
-    // with the actual error message on failure).
-    const result = engine.executeAction(
-      session.state as unknown as BaseGameState,
-      action,
-      context,
-      payload,
-    );
-
-    if (!result.success) {
-      throw new BadRequestException(result.error || 'Invalid action');
-    }
-
-    // Update session with new state
-    if (result.state) {
-      session.state = result.state as unknown as Record<string, unknown>;
-      session.markModified('state');
-    }
-
-    // Check if game is over
-    if (engine.isGameOver(result.state as unknown as BaseGameState)) {
-      session.status = 'completed';
-      (result.state as unknown as BaseGameState).gameResult = engine.getResult(
-        result.state as unknown as BaseGameState,
+        action,
+        context,
+        payload,
       );
-    }
 
-    // Safety valve: strip stateHistory if document is approaching BSON limit
-    const approxSize = Buffer.byteLength(
-      JSON.stringify(session.state),
-      'utf-8',
-    );
-    if (approxSize > STRIP_DOC_SIZE_BYTES) {
-      this.logger.warn(
-        `Session ${sessionId} state is ${Math.round(approxSize / 1024)}KB — stripping stateHistory and logs.`,
+      if (!result.success) {
+        throw new BadRequestException(result.error || 'Invalid action');
+      }
+
+      // Update session with new state
+      if (result.state) {
+        session.state = result.state as unknown as Record<string, unknown>;
+        session.markModified('state');
+      }
+
+      // Check if game is over
+      if (engine.isGameOver(result.state as unknown as BaseGameState)) {
+        session.status = 'completed';
+        (result.state as unknown as BaseGameState).gameResult =
+          engine.getResult(result.state as unknown as BaseGameState);
+      }
+
+      // Safety valve: strip stateHistory if document is approaching BSON limit
+      const approxSize = Buffer.byteLength(
+        JSON.stringify(session.state),
+        'utf-8',
       );
-      const s = session.state;
-      if (Array.isArray(s.stateHistory)) s.stateHistory = [];
-      if (Array.isArray(s.logs)) s.logs = s.logs.slice(-20);
-      session.markModified('state');
-    } else if (approxSize > WARN_DOC_SIZE_BYTES) {
-      this.logger.warn(
-        `Session ${sessionId} state is ${Math.round(approxSize / 1024)}KB — approaching size limit.`,
-      );
+      if (approxSize > STRIP_DOC_SIZE_BYTES) {
+        this.logger.warn(
+          `Session ${sessionId} state is ${Math.round(approxSize / 1024)}KB — stripping stateHistory and logs.`,
+        );
+        const s = session.state;
+        if (Array.isArray(s.stateHistory)) s.stateHistory = [];
+        if (Array.isArray(s.logs)) s.logs = s.logs.slice(-20);
+        session.markModified('state');
+      } else if (approxSize > WARN_DOC_SIZE_BYTES) {
+        this.logger.warn(
+          `Session ${sessionId} state is ${Math.round(approxSize / 1024)}KB — approaching size limit.`,
+        );
+      }
+
+      session.updatedAt = new Date();
+
+      await session.save();
+
+      return this.toSessionSummary(session);
+    } finally {
+      release();
     }
-
-    session.updatedAt = new Date();
-
-    await session.save();
-
-    return this.toSessionSummary(session);
   }
 
   /**

--- a/apps/web/e2e/sea-battle-single-player.spec.ts
+++ b/apps/web/e2e/sea-battle-single-player.spec.ts
@@ -118,6 +118,7 @@ test.describe('Sea Battle Single Player Mode', () => {
                           ...p,
                           placementComplete: false,
                           ships: [
+                            { id: 'carrier-1', size: 5 },
                             { id: 'battleship-1', size: 4 },
                             { id: 'cruiser-1', size: 3 },
                             { id: 'cruiser-2', size: 3 },
@@ -127,7 +128,6 @@ test.describe('Sea Battle Single Player Mode', () => {
                             { id: 'submarine-1', size: 1 },
                             { id: 'submarine-2', size: 1 },
                             { id: 'submarine-3', size: 1 },
-                            { id: 'submarine-4', size: 1 },
                           ].map((config, i) => ({
                             ...config,
                             name: 'Ship',

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.test.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.test.ts
@@ -1,7 +1,13 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useDragPlacement } from './useDragPlacement';
-import { BOARD_SIZE, CELL_STATE, type CellState, type Ship } from '../types';
+import {
+  BOARD_SIZE,
+  CELL_STATE,
+  SHIPS,
+  type CellState,
+  type Ship,
+} from '../types';
 
 function emptyBoard(): CellState[][] {
   return Array.from({ length: BOARD_SIZE }, () =>
@@ -58,6 +64,7 @@ function setup(
       isVertical: false,
       placedShipIds: new Set([battleship.id]),
       ships: [battleship],
+      activeShips: SHIPS,
       placementComplete: false,
       onPlaceShip,
       onMoveShip,

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
@@ -2,8 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DragEvent } from 'react';
-import type { ShipCell, CellState, Ship } from '../types';
-import { CELL_STATE, SHIPS } from '../types';
+import type { ShipCell, CellState, Ship, ShipConfig } from '../types';
+import { CELL_STATE } from '../types';
 import { getCells, canPlace, cellsEqual } from './drag-helpers';
 
 interface UseDragPlacementArgs {
@@ -11,6 +11,7 @@ interface UseDragPlacementArgs {
   isVertical: boolean;
   placedShipIds: Set<string>;
   ships: Ship[];
+  activeShips: ShipConfig[];
   placementComplete: boolean;
   onPlaceShip: (shipId: string, cells: ShipCell[]) => void;
   onMoveShip: (shipId: string, cells: ShipCell[]) => void;
@@ -76,6 +77,7 @@ export function useDragPlacement({
   isVertical,
   placedShipIds,
   ships,
+  activeShips,
   placementComplete,
   onPlaceShip,
   onMoveShip,
@@ -183,7 +185,7 @@ export function useDragPlacement({
       e.preventDefault();
       const shipId = draggingShipId.current;
       if (!shipId) return;
-      const ship = SHIPS.find((s) => s.id === shipId);
+      const ship = activeShips.find((s) => s.id === shipId);
       if (!ship) return;
 
       if (dragMode.current === 'board') {
@@ -214,7 +216,7 @@ export function useDragPlacement({
         setIsInvalidHover?.(true);
       }
     },
-    [board, isVertical, setHoveredCells, setIsInvalidHover],
+    [board, isVertical, activeShips, setHoveredCells, setIsInvalidHover],
   );
 
   const clearDragState = useCallback(() => {
@@ -235,7 +237,7 @@ export function useDragPlacement({
         clearDragState();
         return;
       }
-      const ship = SHIPS.find((s) => s.id === shipId);
+      const ship = activeShips.find((s) => s.id === shipId);
       if (!ship) {
         clearDragState();
         return;
@@ -268,7 +270,7 @@ export function useDragPlacement({
       }
       clearDragState();
     },
-    [board, isVertical, onPlaceShip, onMoveShip, clearDragState],
+    [board, isVertical, activeShips, onPlaceShip, onMoveShip, clearDragState],
   );
 
   const onDragLeave = useCallback(() => {
@@ -332,7 +334,7 @@ export function useDragPlacement({
 
         const cell = findCellFromPoint(me.clientX, me.clientY);
         if (cell && t.origin) {
-          const shipDef = SHIPS.find((s) => s.id === t.shipId);
+          const shipDef = activeShips.find((s) => s.id === t.shipId);
           if (!shipDef) return;
           const vertical = t.origin.orientation === 'v';
           const startRow = vertical
@@ -364,7 +366,7 @@ export function useDragPlacement({
         if (t.started && t.shipId && t.origin) {
           const cell = findCellFromPoint(ue.clientX, ue.clientY);
           if (cell) {
-            const shipDef = SHIPS.find((s) => s.id === t.shipId);
+            const shipDef = activeShips.find((s) => s.id === t.shipId);
             if (shipDef) {
               const vertical = t.origin.orientation === 'v';
               const startRow = vertical
@@ -414,6 +416,7 @@ export function useDragPlacement({
     },
     [
       ships,
+      activeShips,
       placementComplete,
       setSelectedShipId,
       setHoveredCells,

--- a/apps/web/src/widgets/SeaBattleGame/hooks/usePlacementOptimistic.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/usePlacementOptimistic.ts
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import type { ShipCell, CellState, Ship } from '../types';
+import { CELL_STATE } from '../types';
+
+interface UsePlacementOptimisticArgs {
+  serverShips: Ship[];
+  serverBoard: CellState[][];
+}
+
+export function usePlacementOptimistic({
+  serverShips,
+  serverBoard,
+}: UsePlacementOptimisticArgs) {
+  const [rawPendingPlacements, setRawPendingPlacements] = useState<
+    Map<string, { ship: Ship; cells: ShipCell[] }>
+  >(new Map());
+
+  // Auto-clear stale pending placements after 3s
+  useEffect(() => {
+    if (rawPendingPlacements.size === 0) return;
+    const timer = setTimeout(() => setRawPendingPlacements(new Map()), 3000);
+    return () => clearTimeout(timer);
+  }, [rawPendingPlacements]);
+
+  const pendingPlacements = useMemo(() => {
+    if (rawPendingPlacements.size === 0) return rawPendingPlacements;
+    const serverIds = new Set(serverShips.map((s) => s.id));
+    let changed = false;
+    const cleaned = new Map(rawPendingPlacements);
+    for (const [id] of cleaned) {
+      if (serverIds.has(id)) {
+        cleaned.delete(id);
+        changed = true;
+      }
+    }
+    return changed ? cleaned : rawPendingPlacements;
+  }, [serverShips, rawPendingPlacements]);
+
+  const [pendingMove, setPendingMove] = useState<{
+    shipId: string;
+    originalCells: ShipCell[];
+    newCells: ShipCell[];
+  } | null>(null);
+
+  const effectivePendingMove = useMemo(() => {
+    if (!pendingMove) return null;
+    const ship = serverShips.find((s) => s.id === pendingMove.shipId);
+    if (!ship) return pendingMove;
+    const matchesNew =
+      ship.cells.length === pendingMove.newCells.length &&
+      ship.cells.every(
+        (c, i) =>
+          c.row === pendingMove.newCells[i].row &&
+          c.col === pendingMove.newCells[i].col,
+      );
+    return matchesNew ? null : pendingMove;
+  }, [serverShips, pendingMove]);
+
+  useEffect(() => {
+    if (!pendingMove) return;
+    const timer = setTimeout(() => setPendingMove(null), 2000);
+    return () => clearTimeout(timer);
+  }, [pendingMove]);
+
+  const ships = useMemo<Ship[]>(() => {
+    let result = serverShips;
+    if (effectivePendingMove) {
+      result = result.map((s) =>
+        s.id === effectivePendingMove.shipId
+          ? { ...s, cells: effectivePendingMove.newCells }
+          : s,
+      );
+    }
+    for (const [, entry] of pendingPlacements) {
+      if (!result.some((s) => s.id === entry.ship.id)) {
+        result = [...result, entry.ship];
+      }
+    }
+    return result;
+  }, [serverShips, effectivePendingMove, pendingPlacements]);
+
+  const board = useMemo<CellState[][]>(() => {
+    const next = serverBoard.map((row) => row.slice());
+    if (effectivePendingMove) {
+      for (const c of effectivePendingMove.originalCells) {
+        next[c.row][c.col] = CELL_STATE.EMPTY;
+      }
+      for (const c of effectivePendingMove.newCells) {
+        next[c.row][c.col] = CELL_STATE.SHIP;
+      }
+    }
+    for (const [, entry] of pendingPlacements) {
+      for (const c of entry.cells) {
+        next[c.row][c.col] = CELL_STATE.SHIP;
+      }
+    }
+    return next;
+  }, [serverBoard, effectivePendingMove, pendingPlacements]);
+
+  const registerPlacement = useCallback(
+    (shipId: string, name: string, size: number, cells: ShipCell[]) => {
+      setRawPendingPlacements((prev) => {
+        const next = new Map(prev);
+        next.set(shipId, {
+          ship: { id: shipId, name, size, cells, hits: 0, sunk: false },
+          cells,
+        });
+        return next;
+      });
+    },
+    [],
+  );
+
+  const registerMove = useCallback(
+    (shipId: string, originalCells: ShipCell[], newCells: ShipCell[]) => {
+      setPendingMove({ shipId, originalCells, newCells });
+    },
+    [],
+  );
+
+  return {
+    ships,
+    board,
+    registerPlacement,
+    registerMove,
+  };
+}

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -49,6 +49,7 @@ export interface ShipConfig {
 }
 
 export const SHIPS: ShipConfig[] = [
+  { id: 'carrier-1', name: 'Carrier', size: 5 },
   { id: 'battleship-1', name: 'Battleship', size: 4 },
   { id: 'cruiser-1', name: 'Cruiser', size: 3 },
   { id: 'cruiser-2', name: 'Cruiser', size: 3 },
@@ -59,7 +60,16 @@ export const SHIPS: ShipConfig[] = [
   { id: 'submarine-2', name: 'Submarine', size: 1 },
   { id: 'submarine-3', name: 'Submarine', size: 1 },
   { id: 'submarine-4', name: 'Submarine', size: 1 },
+  { id: 'patrol-1', name: 'Patrol', size: 2 },
+  { id: 'patrol-2', name: 'Patrol', size: 2 },
+  { id: 'frigate-1', name: 'Frigate', size: 3 },
+  { id: 'frigate-2', name: 'Frigate', size: 3 },
 ];
+
+export function getActiveShips(shipCount?: number): ShipConfig[] {
+  const count = shipCount ?? 10;
+  return SHIPS.slice(0, Math.min(count, SHIPS.length));
+}
 
 export interface ShipCell {
   row: number;
@@ -119,6 +129,7 @@ export interface SeaBattleSnapshot {
   winnerId?: string;
   logs: GameLogEntry[];
   gridSize?: number;
+  shipCount?: number;
   lastAttack?: LastAttack;
   teams?: SeaBattleTeam[];
   teamOrder?: string[];

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -15,7 +15,11 @@ import type {
   ShipCell,
 } from '../types';
 
-type WeaponMode = null | { weapon: 'sonar' | 'radar'; targetPlayerId: string; radarAxis?: 'row' | 'col' };
+type WeaponMode = null | {
+  weapon: 'sonar' | 'radar';
+  targetPlayerId: string;
+  radarAxis?: 'row' | 'col';
+};
 
 interface SeaBattleBoardsProps {
   isPlacementPhase: boolean;
@@ -176,6 +180,7 @@ export function SeaBattleBoards({
           isPlacementComplete={isPlacementComplete}
           onAutoPlace={handleAutoPlace}
           gridSize={snapshot?.gridSize}
+          shipCount={snapshot?.shipCount}
         />
       )}
 
@@ -302,16 +307,15 @@ export function SeaBattleBoards({
                       setWeaponMode({
                         weapon: 'radar',
                         targetPlayerId: targetId,
-                        radarAxis: weaponMode?.radarAxis === 'col' ? 'row' : 'col',
+                        radarAxis:
+                          weaponMode?.radarAxis === 'col' ? 'row' : 'col',
                       });
                     }}
                     style={{
                       ...buttonBase,
                       padding: '8px 10px',
                       color:
-                        weaponMode?.weapon === 'radar'
-                          ? '#c084fc'
-                          : '#a0a0a0',
+                        weaponMode?.weapon === 'radar' ? '#c084fc' : '#a0a0a0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
                       borderBottom: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
                       borderLeft: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
@@ -350,7 +354,8 @@ export function SeaBattleBoards({
                 <span
                   style={{
                     fontSize: 12,
-                    color: weaponMode.weapon === 'sonar' ? '#06b6d4' : '#a855f7',
+                    color:
+                      weaponMode.weapon === 'sonar' ? '#06b6d4' : '#a855f7',
                     fontWeight: 600,
                   }}
                 >
@@ -389,7 +394,9 @@ export function SeaBattleBoards({
                   }
                 : undefined
             }
-            onCellHoverEnd={isWeaponMode ? () => setHoveredCell(null) : undefined}
+            onCellHoverEnd={
+              isWeaponMode ? () => setHoveredCell(null) : undefined
+            }
             weaponMode={isWeaponMode}
           />
         </>

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/ShipPaletteSection.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/ShipPaletteSection.tsx
@@ -2,7 +2,7 @@
 
 import { memo } from 'react';
 import { Text } from 'tamagui';
-import { SHIPS } from '../../types';
+import type { ShipConfig } from '../../types';
 import {
   ShipPalette,
   ShipItem,
@@ -23,6 +23,7 @@ interface ShipPaletteSectionProps {
     draggable: boolean;
     onDragStart: (e: React.DragEvent<HTMLElement>) => void;
   };
+  activeShips: ShipConfig[];
   t: (key: TranslationKey, params?: Record<string, string | number>) => string;
 }
 
@@ -34,9 +35,10 @@ export const ShipPaletteSection = memo(
     selectedShipId,
     setSelectedShipId,
     getDragProps,
+    activeShips,
     t,
   }: ShipPaletteSectionProps) => {
-    const shipItems = SHIPS.map((ship) => {
+    const shipItems = activeShips.map((ship) => {
       const isPlaced = placedShipIds.has(ship.id);
       const isSelected = selectedShipId === ship.id;
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -1,24 +1,23 @@
 'use client';
 
-import { useState, useCallback, useMemo, useEffect, memo } from 'react';
+import { useState, useCallback, useMemo, memo } from 'react';
 import { Text, YStack, useMedia } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
-import type {
-  ShipCell,
-  ShipConfig,
-  SeaBattlePlayerState,
-  CellState,
-  Ship,
-} from '../types';
-import { SHIPS, CELL_STATE } from '../types';
+import type { ShipCell, ShipConfig, SeaBattlePlayerState } from '../types';
+import { CELL_STATE, getActiveShips } from '../types';
 import { PlacementHeader, GameBoardWrapper, BoardContainer } from './styles';
 import { useSeaBattleTheme } from '../lib/SeaBattleThemeContext';
 import { useDragPlacement } from '../hooks/useDragPlacement';
 import { useMobileShipMove } from '../hooks/useMobileShipMove';
+import { usePlacementOptimistic } from '../hooks/usePlacementOptimistic';
 import {
   createEmptyBoard,
   getCellsForPlacement,
 } from './ShipPlacement/placement-utils';
+
+import { ShipPaletteSection } from './ShipPlacement/ShipPaletteSection';
+import { PlacementActionsSection } from './ShipPlacement/PlacementActionsSection';
+import { PlacementBoardGrid } from './ShipPlacement/PlacementBoardGrid';
 
 interface ShipPlacementBoardProps {
   currentPlayer: SeaBattlePlayerState | null;
@@ -29,11 +28,8 @@ interface ShipPlacementBoardProps {
   isPlacementComplete: boolean;
   onAutoPlace?: () => void;
   gridSize?: number;
+  shipCount?: number;
 }
-
-import { ShipPaletteSection } from './ShipPlacement/ShipPaletteSection';
-import { PlacementActionsSection } from './ShipPlacement/PlacementActionsSection';
-import { PlacementBoardGrid } from './ShipPlacement/PlacementBoardGrid';
 
 export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   currentPlayer,
@@ -44,6 +40,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   isPlacementComplete,
   onAutoPlace,
   gridSize,
+  shipCount,
 }: ShipPlacementBoardProps) {
   const boardSize = gridSize ?? currentPlayer?.board.length ?? 10;
   const [selectedShipId, setSelectedShipId] = useState<string | null>(null);
@@ -55,80 +52,25 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   const media = useMedia();
   const isMobile = !media.gtMd;
 
-  const serverShips = useMemo<Ship[]>(
+  const serverShips = useMemo(
     () => currentPlayer?.ships ?? [],
     [currentPlayer?.ships],
   );
-  const serverBoard = useMemo<CellState[][]>(
+  const serverBoard = useMemo(
     () => currentPlayer?.board || createEmptyBoard(),
     [currentPlayer?.board],
   );
 
-  // Optimistic move: when the player drops a ship, render it at the new spot
-  // immediately while the server round-trip is in flight. The pending state
-  // is treated as "effective" only while the server hasn't yet reflected the
-  // move — derived in render so we never call setState from an effect.
-  // A 2s safety timer clears the underlying state if no server update arrives
-  // (e.g. dropped socket, server-side rejection that produces no broadcast).
-  const [pendingMove, setPendingMove] = useState<{
-    shipId: string;
-    originalCells: ShipCell[];
-    newCells: ShipCell[];
-  } | null>(null);
+  const { ships, board, registerPlacement, registerMove } =
+    usePlacementOptimistic({ serverShips, serverBoard });
 
-  const effectivePendingMove = useMemo(() => {
-    if (!pendingMove) return null;
-    const ship = serverShips.find((s) => s.id === pendingMove.shipId);
-    if (!ship) return pendingMove;
-    const matchesNew =
-      ship.cells.length === pendingMove.newCells.length &&
-      ship.cells.every(
-        (c, i) =>
-          c.row === pendingMove.newCells[i].row &&
-          c.col === pendingMove.newCells[i].col,
-      );
-    return matchesNew ? null : pendingMove;
-  }, [serverShips, pendingMove]);
-
-  const ships = useMemo<Ship[]>(() => {
-    if (!effectivePendingMove) return serverShips;
-    return serverShips.map((s) =>
-      s.id === effectivePendingMove.shipId
-        ? { ...s, cells: effectivePendingMove.newCells }
-        : s,
-    );
-  }, [serverShips, effectivePendingMove]);
-
-  const board = useMemo<CellState[][]>(() => {
-    if (!effectivePendingMove) return serverBoard;
-    const next = serverBoard.map((row) => row.slice());
-    for (const c of effectivePendingMove.originalCells) {
-      next[c.row][c.col] = CELL_STATE.EMPTY;
-    }
-    for (const c of effectivePendingMove.newCells) {
-      next[c.row][c.col] = CELL_STATE.SHIP;
-    }
-    return next;
-  }, [serverBoard, effectivePendingMove]);
-
-  useEffect(() => {
-    if (!pendingMove) return;
-    const timer = setTimeout(() => setPendingMove(null), 2000);
-    return () => clearTimeout(timer);
-  }, [pendingMove]);
   const handleMoveShip = useCallback(
     (shipId: string, cells: ShipCell[]) => {
       const ship = serverShips.find((s) => s.id === shipId);
-      if (ship) {
-        setPendingMove({
-          shipId,
-          originalCells: ship.cells,
-          newCells: cells,
-        });
-      }
+      if (ship) registerMove(shipId, ship.cells, cells);
       onMoveShip(shipId, cells);
     },
-    [serverShips, onMoveShip],
+    [serverShips, onMoveShip, registerMove],
   );
 
   const {
@@ -145,17 +87,25 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     setIsInvalidHover,
   });
 
-  const placedShipIds = useMemo(() => {
-    return new Set(ships.map((s) => s.id));
-  }, [ships]);
+  const placedShipIds = useMemo(() => new Set(ships.map((s) => s.id)), [ships]);
+  const activeShips = useMemo(() => getActiveShips(shipCount), [shipCount]);
+  const unplacedShips = useMemo(
+    () => activeShips.filter((s) => !placedShipIds.has(s.id)),
+    [activeShips, placedShipIds],
+  );
+  const selectedShip = useMemo(
+    () => activeShips.find((s) => s.id === selectedShipId) || null,
+    [activeShips, selectedShipId],
+  );
 
-  const unplacedShips = useMemo(() => {
-    return SHIPS.filter((s) => !placedShipIds.has(s.id));
-  }, [placedShipIds]);
-
-  const selectedShip = useMemo(() => {
-    return SHIPS.find((s) => s.id === selectedShipId) || null;
-  }, [selectedShipId]);
+  const handlePlaceShip = useCallback(
+    (shipId: string, cells: ShipCell[]) => {
+      const cfg = activeShips.find((s) => s.id === shipId);
+      if (cfg) registerPlacement(shipId, cfg.name, cfg.size, cells);
+      onPlaceShip(shipId, cells);
+    },
+    [activeShips, onPlaceShip, registerPlacement],
+  );
 
   const {
     getDragProps,
@@ -173,17 +123,15 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     isVertical,
     placedShipIds,
     ships,
+    activeShips,
     placementComplete: isPlacementComplete,
-    onPlaceShip,
+    onPlaceShip: handlePlaceShip,
     onMoveShip: handleMoveShip,
     setSelectedShipId,
     setHoveredCells,
     setIsInvalidHover,
   });
 
-  // Rotate a placed ship in place around the clicked cell. Keeps the clicked
-  // cell as the anchor and flips orientation; falls back silently if the
-  // rotated layout would be invalid (out of bounds, overlap, or adjacency).
   const handleRotateInPlace = useCallback(
     (row: number, col: number) => {
       if (isPlacementComplete) return;
@@ -215,7 +163,6 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
         newCells.push(cell);
       }
 
-      // Validate against a board with the rotating ship's own cells cleared.
       const virtual = board.map((r) => r.slice());
       for (const c of ship.cells) {
         virtual[c.row][c.col] = CELL_STATE.EMPTY;
@@ -249,7 +196,6 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
   const canPlaceAt = useCallback(
     (row: number, col: number, ship: ShipConfig): boolean => {
       if (!ship) return false;
-
       const cells = getCellsForPlacement(
         row,
         col,
@@ -260,11 +206,8 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       if (!cells) return false;
 
       for (const cell of cells) {
-        if (board[cell.row]?.[cell.col] !== CELL_STATE.EMPTY) {
-          return false;
-        }
-
-        const directions = [
+        if (board[cell.row]?.[cell.col] !== CELL_STATE.EMPTY) return false;
+        const dirs = [
           [-1, -1],
           [-1, 0],
           [-1, 1],
@@ -274,18 +217,14 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
           [1, 0],
           [1, 1],
         ];
-
-        for (const [dr, dc] of directions) {
+        for (const [dr, dc] of dirs) {
           const r = cell.row + (dr ?? 0);
           const c = cell.col + (dc ?? 0);
           if (r >= 0 && r < boardSize && c >= 0 && c < boardSize) {
-            if (board[r][c] === CELL_STATE.SHIP) {
-              return false;
-            }
+            if (board[r][c] === CELL_STATE.SHIP) return false;
           }
         }
       }
-
       return true;
     },
     [board, boardSize, isVertical],
@@ -298,27 +237,19 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
         setIsInvalidHover(false);
         return;
       }
-
       const cells = getCellsForPlacement(
         row,
         col,
         selectedShip.size,
         isVertical,
       );
-
       if (!cells) {
         setHoveredCells([]);
         setIsInvalidHover(false);
         return;
       }
-
-      if (canPlaceAt(row, col, selectedShip)) {
-        setHoveredCells(cells);
-        setIsInvalidHover(false);
-      } else {
-        setHoveredCells(cells);
-        setIsInvalidHover(true);
-      }
+      setHoveredCells(cells);
+      setIsInvalidHover(!canPlaceAt(row, col, selectedShip));
     },
     [selectedShip, isVertical, canPlaceAt],
   );
@@ -330,15 +261,11 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
 
   const handleCellClickInner = useCallback(
     (row: number, col: number) => {
-      // Mobile tap-to-move: handled by hook; returns true if consumed
       if (handleMobileCellClick(row, col)) {
         setSelectedShipId(null);
         return;
       }
-
-      // Desktop: existing palette → board placement flow
       if (!selectedShip || !canPlaceAt(row, col, selectedShip)) return;
-
       const cells = getCellsForPlacement(
         row,
         col,
@@ -347,10 +274,9 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       );
       if (!cells) return;
 
-      onPlaceShip(selectedShip.id, cells);
+      handlePlaceShip(selectedShip.id, cells);
 
-      // Auto-select next unplaced ship so mobile users don't need to scroll back
-      const nextShip = SHIPS.find(
+      const nextShip = activeShips.find(
         (s) => s.id !== selectedShip.id && !placedShipIds.has(s.id),
       );
       setSelectedShipId(nextShip?.id ?? null);
@@ -361,9 +287,10 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
       selectedShip,
       isVertical,
       canPlaceAt,
-      onPlaceShip,
+      handlePlaceShip,
       placedShipIds,
       handleMobileCellClick,
+      activeShips,
     ],
   );
 
@@ -374,47 +301,11 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     }
     handleCellClickInner(row, col);
   };
-  const handleRotate = useCallback(() => {
-    setIsVertical((prev) => !prev);
-  }, []);
 
+  const handleRotate = useCallback(() => setIsVertical((p) => !p), []);
   const isAllShipsPlaced = unplacedShips.length === 0;
+  const pendingCells: ShipCell[] = [];
 
-  const shipPaletteEl = (
-    <ShipPaletteSection
-      theme={theme}
-      isMobile={isMobile}
-      placedShipIds={placedShipIds}
-      selectedShipId={selectedShipId}
-      setSelectedShipId={setSelectedShipId}
-      getDragProps={getDragProps}
-      t={t}
-    />
-  );
-
-  const actionsEl = (
-    <PlacementActionsSection
-      isMobile={isMobile}
-      selectedShip={selectedShip}
-      isVertical={isVertical}
-      isAllShipsPlaced={isAllShipsPlaced}
-      isPlacementComplete={isPlacementComplete}
-      placedShipIdsSize={placedShipIds.size}
-      onRotate={handleRotate}
-      onConfirm={onConfirmPlacement}
-      onReset={onResetPlacement}
-      onAutoPlace={onAutoPlace}
-      onCancelMove={clearMovingState}
-      isMovingShip={!!movingShipId}
-      t={t}
-    />
-  );
-
-  const pendingCells = effectivePendingMove?.newCells ?? [];
-
-  // First cell of each multi-cell placed ship — gets a small ↻ rotate button
-  // so the interaction is discoverable. 1-cell submarines are excluded since
-  // their orientation is meaningless and rotating them is a no-op.
   const shipHeadKeys = useMemo(() => {
     const keys = new Set<string>();
     for (const ship of ships) {
@@ -455,8 +346,6 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     />
   );
 
-  // Mobile: compact palette + actions above board so buttons don't overlap the grid
-  // Desktop: palette beside board, actions below
   if (isMobile) {
     return (
       <YStack
@@ -465,8 +354,31 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
         onDragEnd={handleDragEnd}
         paddingHorizontal="$1"
       >
-        {shipPaletteEl}
-        {actionsEl}
+        <ShipPaletteSection
+          theme={theme}
+          isMobile={isMobile}
+          placedShipIds={placedShipIds}
+          selectedShipId={selectedShipId}
+          setSelectedShipId={setSelectedShipId}
+          getDragProps={getDragProps}
+          activeShips={activeShips}
+          t={t}
+        />
+        <PlacementActionsSection
+          isMobile={isMobile}
+          selectedShip={selectedShip}
+          isVertical={isVertical}
+          isAllShipsPlaced={isAllShipsPlaced}
+          isPlacementComplete={isPlacementComplete}
+          placedShipIdsSize={placedShipIds.size}
+          onRotate={handleRotate}
+          onConfirm={onConfirmPlacement}
+          onReset={onResetPlacement}
+          onAutoPlace={onAutoPlace}
+          onCancelMove={clearMovingState}
+          isMovingShip={!!movingShipId}
+          t={t}
+        />
         <BoardContainer alignSelf="center">{boardEl}</BoardContainer>
       </YStack>
     );
@@ -490,9 +402,32 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
           </PlacementHeader>
           {boardEl}
         </BoardContainer>
-        {shipPaletteEl}
+        <ShipPaletteSection
+          theme={theme}
+          isMobile={isMobile}
+          placedShipIds={placedShipIds}
+          selectedShipId={selectedShipId}
+          setSelectedShipId={setSelectedShipId}
+          getDragProps={getDragProps}
+          activeShips={activeShips}
+          t={t}
+        />
       </GameBoardWrapper>
-      {actionsEl}
+      <PlacementActionsSection
+        isMobile={isMobile}
+        selectedShip={selectedShip}
+        isVertical={isVertical}
+        isAllShipsPlaced={isAllShipsPlaced}
+        isPlacementComplete={isPlacementComplete}
+        placedShipIdsSize={placedShipIds.size}
+        onRotate={handleRotate}
+        onConfirm={onConfirmPlacement}
+        onReset={onResetPlacement}
+        onAutoPlace={onAutoPlace}
+        onCancelMove={clearMovingState}
+        isMovingShip={!!movingShipId}
+        t={t}
+      />
     </YStack>
   );
 });


### PR DESCRIPTION
## Summary
- Fix race condition in ship placement where concurrent actions from different players would overwrite each other's ship placements
- Add optimistic placement tracking so newly placed ships stay visible when other players' state broadcasts arrive before server confirmation
- Extend ship roster from 10 to 15 ships (add Carrier, Patrol, Frigate) for bigger field sizes
- Wire `shipCount` config through validators, utils, engine, and frontend

## Changes
- **Backend**: Added per-session mutex lock to `executeAction` to serialize concurrent actions
- **Backend**: Added `getActiveShips(shipCount)` helper and updated all validators/utils to use it instead of hardcoded `SHIPS.length`
- **Frontend**: Added `usePlacementOptimistic` hook with pending placement tracking
- **Frontend**: Updated `useDragPlacement` to accept `activeShips` instead of importing hardcoded `SHIPS`
- **Frontend**: `ShipPlacementBoard` now accepts `shipCount` prop and passes `activeShips` to palette and drag hooks

## Testing
- All 96 backend sea-battle tests pass
- All 157 web test files (1139 tests) pass
- TypeScript compiles cleanly for both BE and web