### PR TITLE
fix(web): suppress result modal when entering an already-completed game

### DIFF
--- a/apps/web/e2e/game-over.spec.ts
+++ b/apps/web/e2e/game-over.spec.ts
@@ -70,18 +70,9 @@ test.describe('Game Over Screen', () => {
     await navigateTo(page, `/games/rooms/${roomId}`);
     await waitForRoomReady(page);
 
+    // Entering an already-completed game should NOT auto-show the result modal.
     const victoryHeading = page.getByTestId('game-result-title');
-    await expect(victoryHeading).toBeVisible({});
-    await expect(victoryHeading).toContainText(/Victory|🏆|won|победа/i);
-
-    const rematchBtn = page.getByRole('button', {
-      name: /Play Again|Rematch/i,
-    });
-    await expect(rematchBtn.first()).toBeVisible({});
-
-    const homeBtn = page.getByRole('link', { name: /Back to Home/i }).first();
-    await expect(homeBtn).toBeVisible();
-    await homeBtn.click({ force: true });
+    await expect(victoryHeading).not.toBeVisible({ timeout: 3000 });
   });
 
   test('should display defeat modal when player loses', async ({ page }) => {
@@ -142,16 +133,8 @@ test.describe('Game Over Screen', () => {
     await navigateTo(page, `/games/rooms/${roomId}`);
     await waitForRoomReady(page);
 
+    // Entering an already-completed game should NOT auto-show the result modal.
     const defeatHeading = page.getByTestId('game-result-title');
-    await expect(defeatHeading).toBeVisible({});
-    await expect(defeatHeading).toContainText(/Game Over|💀|lost|поражение/i);
-
-    const homeBtn = page.getByRole('link', { name: /Back to Home/i }).first();
-    await expect(homeBtn).toBeVisible();
-    await homeBtn.click({ force: true });
-
-    await expect(
-      page.getByRole('button', { name: /Play Again/i }),
-    ).not.toBeVisible();
+    await expect(defeatHeading).not.toBeVisible({ timeout: 3000 });
   });
 });

--- a/apps/web/e2e/victory-celebration.spec.ts
+++ b/apps/web/e2e/victory-celebration.spec.ts
@@ -62,11 +62,9 @@ test.describe('Victory celebration', () => {
     await navigateTo(page, `/games/rooms/${roomId}`);
     await waitForRoomReady(page);
 
-    // Result modal shows victory…
-    await expect(page.getByTestId('game-result-title')).toContainText(
-      /Victory|🏆|won|победа/i,
-    );
-    // …and the celebration FX layer is mounted.
-    await expect(page.getByTestId('victory-celebration')).toBeVisible();
+    // Entering an already-completed game should NOT auto-show the result modal.
+    await expect(page.getByTestId('game-result-title')).not.toBeVisible({
+      timeout: 3000,
+    });
   });
 });

--- a/apps/web/src/features/games/hooks/useGameResultModal.ts
+++ b/apps/web/src/features/games/hooks/useGameResultModal.ts
@@ -18,13 +18,24 @@ export function useGameResultModal(
   session: GameSessionSummary | null | undefined,
   result: GameResult,
   resultMessages: ResultMessages | undefined,
+  isGameOver?: boolean,
 ) {
   const [dismissedSessionId, setDismissedSessionId] = useState<string | null>(
     null,
   );
+  const [wasAlreadyOver] = useState(
+    () => isGameOver === true && result !== null,
+  );
+  const [hasSeenActiveGame, setHasSeenActiveGame] = useState(false);
+
+  if (!wasAlreadyOver && isGameOver && !hasSeenActiveGame) {
+    setHasSeenActiveGame(true);
+  }
 
   const showResultModal =
-    !!result && dismissedSessionId !== (session?.id ?? null);
+    !!result &&
+    dismissedSessionId !== (session?.id ?? null) &&
+    hasSeenActiveGame;
 
   const sharedResult: SharedResult = useMemo(() => {
     if (result === 'won') return 'victory';

--- a/apps/web/src/widgets/CascadeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CascadeGame/ui/Game.tsx
@@ -142,6 +142,7 @@ function CascadeGameImpl({
             ),
           }
         : undefined,
+      isGameOver,
     );
 
   const options = useMemo(

--- a/apps/web/src/widgets/ChessGame/ui/Game.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/Game.tsx
@@ -178,6 +178,7 @@ function ChessGameImpl({
             ),
           }
         : undefined,
+      isGameOver,
     );
 
   const isFlipped = myColor === 'black';

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -111,6 +111,13 @@ export function ActiveGameView({
   // Sync modal dismissal state with game over state
   const [modalDismissed, setModalDismissed] = useState(false);
 
+  const [wasAlreadyOverOnMount] = useState(() => isGameOver === true);
+  const [hasSeenActiveGame, setHasSeenActiveGame] = useState(false);
+
+  if (!wasAlreadyOverOnMount && isGameOver && !hasSeenActiveGame) {
+    setHasSeenActiveGame(true);
+  }
+
   // Reset modal dismissal when game over state changes (e.g. new game starts or current game ends)
   const [prevIsGameOver, setPrevIsGameOver] = useState(isGameOver);
 
@@ -120,7 +127,7 @@ export function ActiveGameView({
     setModalDismissed(false);
   }
 
-  const showResultModal = isGameOver && !modalDismissed;
+  const showResultModal = isGameOver && !modalDismissed && hasSeenActiveGame;
   useWebGameHaptics(isMyTurn);
 
   // Record game result to local stats

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -120,6 +120,13 @@ export const SeaBattleGame = memo(function SeaBattleGame({
     room: room ?? undefined,
   });
 
+  const [wasAlreadyOverOnMount] = useState(() => isGameOver === true);
+  const [hasSeenActiveGame, setHasSeenActiveGame] = useState(false);
+
+  if (!wasAlreadyOverOnMount && isGameOver && !hasSeenActiveGame) {
+    setHasSeenActiveGame(true);
+  }
+
   const teammateIds = useMemo(() => {
     if (!viewerTeam || !currentUserId) return undefined;
     return viewerTeam.playerIds.filter((id) => id !== currentUserId);
@@ -435,6 +442,7 @@ export const SeaBattleGame = memo(function SeaBattleGame({
             setShowRules={setShowRules}
             isGameOver={isGameOver}
             resultModalDismissed={resultModalDismissed}
+            hasSeenActiveGame={hasSeenActiveGame}
             gameResult={gameResult}
             handleRematchClick={handleRematchClick}
             session={session}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleModals.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleModals.tsx
@@ -17,6 +17,7 @@ interface SeaBattleModalsProps {
   setShowRules: (val: boolean) => void;
   isGameOver: boolean;
   resultModalDismissed: boolean;
+  hasSeenActiveGame: boolean;
   gameResult: 'victory' | 'defeat' | null;
   handleRematchClick: () => void;
   session: GameSessionSummary | null;
@@ -44,6 +45,7 @@ export function SeaBattleModals({
   setShowRules,
   isGameOver,
   resultModalDismissed,
+  hasSeenActiveGame,
   gameResult,
   handleRematchClick,
   session,
@@ -73,7 +75,7 @@ export function SeaBattleModals({
         t={t}
       />
       <GameResultModal
-        isOpen={isGameOver && !resultModalDismissed}
+        isOpen={isGameOver && hasSeenActiveGame && !resultModalDismissed}
         result={gameResult}
         onRematch={handleRematchClick}
         onClose={() => {

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -150,6 +150,7 @@ function TicTacToeGameImpl({
             ),
           }
         : undefined,
+      isGameOver,
     );
 
   const options = useMemo(


### PR DESCRIPTION
## What
Prevents the win/loss GameResultModal from auto-popping when a user enters an already-completed game via the "show results" button.

## Why
When navigating into a completed game (e.g. from history), the result modal was immediately displayed because `isGameOver` was true on mount. The modal should only appear when the game transitions to `game_over` during the current session — not for games that were already finished before the user arrived.

## Changes
- `useGameResultModal` hook: added `isGameOver` parameter and `hasSeenActiveGame` state that only becomes true when the game transitions from active to over during the current mount. The modal is suppressed if the game was already complete on first render.
- TicTacToe, Chess, Cascade game widgets: pass `isGameOver` to `useGameResultModal`.
- SeaBattle: added `hasSeenActiveGame` tracking via state, passed to `SeaBattleModals` as a new prop.
- CriticalGame: added inline `hasSeenActiveGame` state, gating `showResultModal` on it.