### PR TITLE
fix(ci): daily changelog poster runs on schedule only

### DIFF
--- a/.github/workflows/social-posts.yml
+++ b/.github/workflows/social-posts.yml
@@ -17,8 +17,7 @@ jobs:
     name: Daily Develop Changelog Poster
     if: >
       (github.event_name == 'schedule') ||
-      (github.event_name == 'workflow_dispatch' && !inputs.tag) ||
-      (github.event_name == 'push' && github.ref_name == 'develop')
+      (github.event_name == 'workflow_dispatch' && !inputs.tag)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout develop branch


### PR DESCRIPTION
## Summary
- Removed `push` trigger condition from the `daily-post` job in the Social Posts workflow
- The Daily Develop Changelog Poster was firing on every push to develop (including PR merges), causing duplicate posts

## Changes
- `.github/workflows/social-posts.yml`: removed `github.event_name == 'push' && github.ref_name == 'develop'` from the daily-post job condition

The daily-post job now only triggers on:
- **Schedule**: daily cron at 08:00 UTC
- **workflow_dispatch**: manual trigger without a tag input