### PR TITLE
fix(web): sea battle ship placement and ships remaining fixes

### DIFF
--- a/apps/web/src/widgets/SeaBattleGame/hooks/usePlacementOptimistic.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/usePlacementOptimistic.ts
@@ -38,40 +38,38 @@ export function usePlacementOptimistic({
     return changed ? cleaned : rawPendingPlacements;
   }, [serverShips, rawPendingPlacements]);
 
-  const [pendingMove, setPendingMove] = useState<{
-    shipId: string;
-    originalCells: ShipCell[];
-    newCells: ShipCell[];
-  } | null>(null);
+  const [pendingMoves, setPendingMoves] = useState<
+    Map<string, { originalCells: ShipCell[]; newCells: ShipCell[] }>
+  >(new Map());
 
-  const effectivePendingMove = useMemo(() => {
-    if (!pendingMove) return null;
-    const ship = serverShips.find((s) => s.id === pendingMove.shipId);
-    if (!ship) return pendingMove;
-    const matchesNew =
-      ship.cells.length === pendingMove.newCells.length &&
-      ship.cells.every(
-        (c, i) =>
-          c.row === pendingMove.newCells[i].row &&
-          c.col === pendingMove.newCells[i].col,
-      );
-    return matchesNew ? null : pendingMove;
-  }, [serverShips, pendingMove]);
-
-  useEffect(() => {
-    if (!pendingMove) return;
-    const timer = setTimeout(() => setPendingMove(null), 2000);
-    return () => clearTimeout(timer);
-  }, [pendingMove]);
+  const effectivePendingMoves = useMemo(() => {
+    if (pendingMoves.size === 0) return pendingMoves;
+    const cleaned = new Map(pendingMoves);
+    let changed = false;
+    for (const [shipId, move] of cleaned) {
+      const ship = serverShips.find((s) => s.id === shipId);
+      if (!ship) continue;
+      const matchesNew =
+        ship.cells.length === move.newCells.length &&
+        ship.cells.every(
+          (c, i) =>
+            c.row === move.newCells[i].row && c.col === move.newCells[i].col,
+        );
+      if (matchesNew) {
+        cleaned.delete(shipId);
+        changed = true;
+      }
+    }
+    return changed ? cleaned : pendingMoves;
+  }, [serverShips, pendingMoves]);
 
   const ships = useMemo<Ship[]>(() => {
     let result = serverShips;
-    if (effectivePendingMove) {
-      result = result.map((s) =>
-        s.id === effectivePendingMove.shipId
-          ? { ...s, cells: effectivePendingMove.newCells }
-          : s,
-      );
+    if (effectivePendingMoves.size > 0) {
+      result = result.map((s) => {
+        const move = effectivePendingMoves.get(s.id);
+        return move ? { ...s, cells: move.newCells } : s;
+      });
     }
     for (const [, entry] of pendingPlacements) {
       if (!result.some((s) => s.id === entry.ship.id)) {
@@ -79,15 +77,15 @@ export function usePlacementOptimistic({
       }
     }
     return result;
-  }, [serverShips, effectivePendingMove, pendingPlacements]);
+  }, [serverShips, effectivePendingMoves, pendingPlacements]);
 
   const board = useMemo<CellState[][]>(() => {
     const next = serverBoard.map((row) => row.slice());
-    if (effectivePendingMove) {
-      for (const c of effectivePendingMove.originalCells) {
+    for (const [, move] of effectivePendingMoves) {
+      for (const c of move.originalCells) {
         next[c.row][c.col] = CELL_STATE.EMPTY;
       }
-      for (const c of effectivePendingMove.newCells) {
+      for (const c of move.newCells) {
         next[c.row][c.col] = CELL_STATE.SHIP;
       }
     }
@@ -97,7 +95,7 @@ export function usePlacementOptimistic({
       }
     }
     return next;
-  }, [serverBoard, effectivePendingMove, pendingPlacements]);
+  }, [serverBoard, effectivePendingMoves, pendingPlacements]);
 
   const registerPlacement = useCallback(
     (shipId: string, name: string, size: number, cells: ShipCell[]) => {
@@ -115,15 +113,24 @@ export function usePlacementOptimistic({
 
   const registerMove = useCallback(
     (shipId: string, originalCells: ShipCell[], newCells: ShipCell[]) => {
-      setPendingMove({ shipId, originalCells, newCells });
+      setPendingMoves((prev) => {
+        const next = new Map(prev);
+        next.set(shipId, { originalCells, newCells });
+        return next;
+      });
     },
     [],
   );
+
+  const clearPendingMoves = useCallback(() => {
+    setPendingMoves(new Map());
+  }, []);
 
   return {
     ships,
     board,
     registerPlacement,
     registerMove,
+    clearPendingMoves,
   };
 }

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -36,6 +36,7 @@ interface AttackPlayerBoardProps {
   isTeammate?: boolean;
   team?: SeaBattleTeam;
   sunkCellSet: Set<string>;
+  shipCount?: number;
   sonarHighlightCells?: Set<string> | null;
   sonarCellStates?: Map<string, number> | null;
   radarHighlightCells?: Set<string> | null;
@@ -61,6 +62,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   isTeammate = false,
   team,
   sunkCellSet,
+  shipCount,
   sonarHighlightCells,
   sonarCellStates,
   radarHighlightCells,
@@ -101,9 +103,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
     (e: React.MouseEvent) => {
       if (!isMyTurn || isAttackDisabled || !onAttack) return;
       const cell = (e.target as HTMLElement).closest(
-        weaponMode
-          ? '.sb-cell[data-row]'
-          : '.sb-cell.sb-attackable',
+        weaponMode ? '.sb-cell[data-row]' : '.sb-cell.sb-attackable',
       );
       if (!cell) return;
       const row = cell.getAttribute('data-row');
@@ -157,16 +157,18 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
           const cellKey = `${player.playerId}-${rIndex}-${cIndex}`;
           const isSonarCell = !isMe && sonarHighlightCells?.has(cellKey);
           const isRadarCell = !isMe && radarHighlightCells?.has(cellKey);
-          const highlight: 'sonar' | 'radar' | null =
-            isSonarCell ? 'sonar' : isRadarCell ? 'radar' : null;
+          const highlight: 'sonar' | 'radar' | null = isSonarCell
+            ? 'sonar'
+            : isRadarCell
+              ? 'radar'
+              : null;
           const highlightCellState =
             isSonarCell && sonarCellStates
               ? sonarCellStates.get(cellKey)
               : isRadarCell && radarCellStates
                 ? radarCellStates.get(cellKey)
                 : undefined;
-          const isWeaponPreview =
-            !isMe && weaponPreviewCells?.has(cellKey);
+          const isWeaponPreview = !isMe && weaponPreviewCells?.has(cellKey);
 
           return (
             <AttackBoardCell
@@ -190,7 +192,9 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
                   ? () => onCellHover(player.playerId, rIndex, cIndex)
                   : undefined
               }
-              onMouseLeave={!isMe && onCellHoverEnd ? onCellHoverEnd : undefined}
+              onMouseLeave={
+                !isMe && onCellHoverEnd ? onCellHoverEnd : undefined
+              }
             />
           );
         }),
@@ -288,7 +292,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
             {idlePlayers.includes(player.playerId) && <IdleBadge />}
           </PlayerName>
           <PlayerStats>
-            <ShipsLeft ships={player.ships} isMe={true} />
+            <ShipsLeft ships={player.ships} isMe={true} shipCount={shipCount} />
           </PlayerStats>
           <BoardWithLabels>
             <div />
@@ -382,7 +386,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
           {idlePlayers.includes(player.playerId) && <IdleBadge />}
         </PlayerName>
         <PlayerStats>
-          <ShipsLeft ships={player.ships} isMe={false} />
+          <ShipsLeft ships={player.ships} isMe={false} shipCount={shipCount} />
         </PlayerStats>
         <BoardWithLabels>
           <div />

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -23,6 +23,7 @@ export interface AttackBoardProps {
   teammateIds?: string[];
   teams?: SeaBattleTeam[];
   gridSize?: number;
+  shipCount?: number;
   snapshot?: SeaBattleSnapshot | null;
   weaponPreviewCells?: Set<string> | null;
   weaponPreviewType?: 'sonar' | 'radar' | null;
@@ -42,6 +43,7 @@ export const AttackBoard = memo(function AttackBoard({
   teammateIds,
   teams,
   snapshot,
+  shipCount,
   weaponPreviewCells,
   weaponPreviewType,
   onCellHover,
@@ -154,6 +156,7 @@ export const AttackBoard = memo(function AttackBoard({
               tt.playerIds.includes(currentPlayer.playerId),
             )}
             sunkCellSet={sunkCellSet}
+            shipCount={shipCount}
             t={t}
           />
         )}
@@ -181,6 +184,7 @@ export const AttackBoard = memo(function AttackBoard({
               isTeammate={isTeammate}
               team={team}
               sunkCellSet={sunkCellSet}
+              shipCount={shipCount}
               onAttack={isTeammate ? undefined : onAttack}
               sonarHighlightCells={isSonarTarget ? sonarHighlightSet : null}
               sonarCellStates={isSonarTarget ? sonarCellStates : null}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -379,6 +379,7 @@ export function SeaBattleBoards({
             teammateIds={teammateIds}
             teams={teams}
             gridSize={snapshot.gridSize}
+            shipCount={snapshot.shipCount}
             snapshot={snapshot}
             weaponPreviewCells={
               weaponMode?.weapon === 'sonar'

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleTable.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleTable.tsx
@@ -26,6 +26,7 @@ interface SeaBattleTableProps {
   resolveDisplayName: (id: string, fb: string) => string;
   teams?: SeaBattleTeam[];
   activeShooterId?: string;
+  shipCount?: number;
 }
 
 interface PlayerRowProps {
@@ -35,6 +36,7 @@ interface PlayerRowProps {
   teamColor?: string;
   resolveDisplayName: (id: string, fb: string) => string;
   idlePlayers: string[];
+  shipCount?: number;
   t: (key: TranslationKey) => string;
 }
 
@@ -45,6 +47,7 @@ function PlayerRow({
   teamColor,
   resolveDisplayName,
   idlePlayers,
+  shipCount,
   t,
 }: PlayerRowProps) {
   return (
@@ -120,7 +123,7 @@ function PlayerRow({
           )),
         )}
       </YStack>
-      <ShipsLeft ships={player.ships} isMe={isMe} />
+      <ShipsLeft ships={player.ships} isMe={isMe} shipCount={shipCount} />
     </YStack>
   );
 }
@@ -133,6 +136,7 @@ export function SeaBattleTable({
   resolveDisplayName,
   teams,
   activeShooterId,
+  shipCount,
 }: SeaBattleTableProps) {
   const { t } = useTranslation();
   const idlePlayers = useGameStore((s: GameState) => s.idlePlayers);
@@ -242,6 +246,7 @@ export function SeaBattleTable({
                       teamColor={team.color}
                       resolveDisplayName={resolveDisplayName}
                       idlePlayers={idlePlayers}
+                      shipCount={shipCount}
                       t={t}
                     />
                   ))}
@@ -260,6 +265,7 @@ export function SeaBattleTable({
               isActive={activePlayerId === player.playerId}
               resolveDisplayName={resolveDisplayName}
               idlePlayers={idlePlayers}
+              shipCount={shipCount}
               t={t}
             />
           ))}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -63,7 +63,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     [currentPlayer?.board],
   );
 
-  const { ships, board, registerPlacement, registerMove } =
+  const { ships, board, registerPlacement, registerMove, clearPendingMoves } =
     usePlacementOptimistic({ serverShips, serverBoard });
 
   const handleMoveShip = useCallback(
@@ -311,6 +311,11 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     onConfirmPlacement(shipsData);
   }, [ships, onConfirmPlacement]);
 
+  const handleReset = useCallback(() => {
+    clearPendingMoves();
+    onResetPlacement();
+  }, [clearPendingMoves, onResetPlacement]);
+
   const isAllShipsPlaced = unplacedShips.length === 0;
   const pendingCells: ShipCell[] = [];
 
@@ -381,7 +386,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
           placedShipIdsSize={placedShipIds.size}
           onRotate={handleRotate}
           onConfirm={handleConfirm}
-          onReset={onResetPlacement}
+          onReset={handleReset}
           onAutoPlace={onAutoPlace}
           onCancelMove={clearMovingState}
           isMovingShip={!!movingShipId}
@@ -430,7 +435,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
         placedShipIdsSize={placedShipIds.size}
         onRotate={handleRotate}
         onConfirm={handleConfirm}
-        onReset={onResetPlacement}
+        onReset={handleReset}
         onAutoPlace={onAutoPlace}
         onCancelMove={clearMovingState}
         isMovingShip={!!movingShipId}

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipsLeft.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipsLeft.tsx
@@ -1,11 +1,12 @@
 import { styled, YStack, XStack, Text, useMedia } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
-import { Ship, SHIPS } from '../types';
+import { Ship, getActiveShips } from '../types';
 import { useSeaBattleTheme } from '../lib/SeaBattleThemeContext';
 
 interface ShipsLeftProps {
   ships: Ship[];
   isMe: boolean;
+  shipCount?: number;
 }
 
 const ShipsContainer = styled(YStack, {
@@ -28,12 +29,14 @@ const ShipsContainer = styled(YStack, {
   },
 });
 
-export function ShipsLeft({ ships, isMe }: ShipsLeftProps) {
+export function ShipsLeft({ ships, isMe, shipCount }: ShipsLeftProps) {
   const { t } = useTranslation();
   const theme = useSeaBattleTheme();
   const media = useMedia();
   const isMobile = !media.gtSm;
-  const sortedConfig = [...SHIPS].sort((a, b) => b.size - a.size);
+  const sortedConfig = [...getActiveShips(shipCount)].sort(
+    (a, b) => b.size - a.size,
+  );
   const totalShips = sortedConfig.length;
   const sunkCount = ships?.filter((s) => s.sunk).length ?? 0;
   const aliveCount = totalShips - sunkCount;


### PR DESCRIPTION
## Summary
- **Ship placement moves persist until confirm** — moving ship A then ship B no longer reverts ship A
- **Ships remaining shows correct count** — was hardcoded to 14 ships regardless of game config

## Changes

### Ship placement moves (`usePlacementOptimistic.ts`)
- Changed `pendingMove` from single object to `Map<shipId, move>` for multiple concurrent moves
- Removed 2s auto-clear timer that was wiping all pending moves
- Added `clearPendingMoves()` for reset; confirm lets server response handle cleanup via `effectivePendingMoves`

### Ships remaining (`ShipsLeft.tsx` + prop threading)
- `ShipsLeft` was always using the full `SHIPS` array (14 ships) instead of `getActiveShips(shipCount)`
- Threaded `shipCount` through `AttackBoard` → `AttackPlayerBoard` → `ShipsLeft` and `SeaBattleBoards` → `AttackBoard`