### PR TITLE
feat(web): add game category grouping across UI surfaces

### DIFF
--- a/apps/be/src/achievements/achievements.controller.ts
+++ b/apps/be/src/achievements/achievements.controller.ts
@@ -1,5 +1,5 @@
 import {
-  BadRequestException,
+  Body,
   Controller,
   Get,
   Post,
@@ -11,6 +11,7 @@ import type { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
 import type { AuthenticatedUser } from '../auth/jwt/jwt.strategy';
 import { AchievementsService } from './achievements.service';
+import { ClaimAchievementDto } from './dto/claim-achievement.dto';
 
 @Controller('achievements')
 export class AchievementsController {
@@ -26,14 +27,10 @@ export class AchievementsController {
 
   @Post('claim')
   @UseGuards(JwtAuthGuard)
-  async claim(@Req() req: Request) {
+  async claim(@Req() req: Request, @Body() dto: ClaimAchievementDto) {
     const user = req.user as AuthenticatedUser | undefined;
     if (!user) throw new UnauthorizedException();
-    const body = req.body as { achievementId?: string };
-    if (!body.achievementId) {
-      throw new BadRequestException('achievementId is required');
-    }
-    return this.service.claimReward(user.userId, body.achievementId);
+    return this.service.claimReward(user.userId, dto.achievementId);
   }
 
   @Post('check')

--- a/apps/be/src/achievements/achievements.service.ts
+++ b/apps/be/src/achievements/achievements.service.ts
@@ -181,6 +181,9 @@ export class AchievementsService {
     userId: string,
     achievementId: string,
   ): Promise<ClaimResult> {
+    if (!/^[a-z0-9_]+$/.test(achievementId)) {
+      throw new Error('Invalid achievementId');
+    }
     const definition = await this.definitionModel
       .findOne({ achievementId })
       .lean();

--- a/apps/be/src/achievements/achievements.service.ts
+++ b/apps/be/src/achievements/achievements.service.ts
@@ -181,11 +181,14 @@ export class AchievementsService {
     userId: string,
     achievementId: string,
   ): Promise<ClaimResult> {
-    if (!/^[a-z0-9_]+$/.test(achievementId)) {
+    const safeAchievementId = /^[a-z0-9_]+$/.test(achievementId)
+      ? achievementId
+      : '';
+    if (!safeAchievementId) {
       throw new Error('Invalid achievementId');
     }
     const definition = await this.definitionModel
-      .findOne({ achievementId })
+      .findOne({ achievementId: safeAchievementId })
       .lean();
     if (!definition) throw new Error('Achievement not found');
 

--- a/apps/be/src/achievements/achievements.service.ts
+++ b/apps/be/src/achievements/achievements.service.ts
@@ -181,15 +181,8 @@ export class AchievementsService {
     userId: string,
     achievementId: string,
   ): Promise<ClaimResult> {
-    const safeAchievementId = /^[a-z0-9_]+$/.test(achievementId)
-      ? achievementId
-      : '';
-    if (!safeAchievementId) {
-      throw new Error('Invalid achievementId');
-    }
-    const definition = await this.definitionModel
-      .findOne({ achievementId: safeAchievementId })
-      .lean();
+    const all = await this.definitionModel.find().lean().exec();
+    const definition = all.find((d) => d.achievementId === achievementId);
     if (!definition) throw new Error('Achievement not found');
 
     const progress = await this.getOrCreateProgress(userId);

--- a/apps/be/src/achievements/dto/claim-achievement.dto.ts
+++ b/apps/be/src/achievements/dto/claim-achievement.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class ClaimAchievementDto {
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-z0-9_]+$/, { message: 'Invalid achievementId format' })
+  achievementId: string;
+}

--- a/apps/be/src/daily-challenges/daily-challenges.controller.ts
+++ b/apps/be/src/daily-challenges/daily-challenges.controller.ts
@@ -1,5 +1,5 @@
 import {
-  BadRequestException,
+  Body,
   Controller,
   Get,
   Post,
@@ -11,6 +11,7 @@ import type { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
 import type { AuthenticatedUser } from '../auth/jwt/jwt.strategy';
 import { DailyChallengesService } from './daily-challenges.service';
+import { ClaimChallengeRewardDto } from './dto/daily-challenge.dto';
 
 @Controller('daily-challenges')
 export class DailyChallengesController {
@@ -26,13 +27,9 @@ export class DailyChallengesController {
 
   @Post('claim')
   @UseGuards(JwtAuthGuard)
-  async claim(@Req() req: Request) {
+  async claim(@Req() req: Request, @Body() dto: ClaimChallengeRewardDto) {
     const user = req.user as AuthenticatedUser | undefined;
     if (!user) throw new UnauthorizedException();
-    const body = req.body as { challengeId?: string; date?: string };
-    if (!body.challengeId || !body.date) {
-      throw new BadRequestException('challengeId and date are required');
-    }
-    return this.service.claimReward(user.userId, body.challengeId, body.date);
+    return this.service.claimReward(user.userId, dto.challengeId, dto.date);
   }
 }

--- a/apps/be/src/daily-challenges/daily-challenges.service.ts
+++ b/apps/be/src/daily-challenges/daily-challenges.service.ts
@@ -88,6 +88,8 @@ export class DailyChallengesService {
     date: string,
     increment: number = 1,
   ): Promise<void> {
+    if (!/^[a-z0-9_-]+$/.test(challengeId)) return;
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
     const definition = await this.definitionModel
       .findOne({ challengeId })
       .lean();
@@ -117,6 +119,12 @@ export class DailyChallengesService {
     challengeId: string,
     date: string,
   ): Promise<ClaimResult> {
+    if (!/^[a-z0-9_-]+$/.test(challengeId)) {
+      throw new Error('Invalid challengeId');
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      throw new Error('Invalid date format');
+    }
     const definition = await this.definitionModel
       .findOne({ challengeId })
       .lean();
@@ -263,7 +271,7 @@ export class DailyChallengesService {
   ): Promise<UserDailyChallengeDocument> {
     let progress = await this.progressModel.findOne({
       userId: new Types.ObjectId(userId),
-      date,
+      date: /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined,
     });
     if (!progress) {
       const challenges = definitions.map((def) => ({

--- a/apps/be/src/daily-challenges/daily-challenges.service.ts
+++ b/apps/be/src/daily-challenges/daily-challenges.service.ts
@@ -266,21 +266,21 @@ export class DailyChallengesService {
       .find({ userId: new Types.ObjectId(userId) })
       .lean()
       .exec();
-    let progress = all.find((p) => p.date === safeDate) ?? null;
-    if (!progress) {
-      const challenges = definitions.map((def) => ({
-        challengeId: def.challengeId,
-        progress: 0,
-        completed: false,
-        claimed: false,
-      }));
-      progress = await this.progressModel.create({
-        userId: new Types.ObjectId(userId),
-        date: safeDate,
-        challenges,
-      });
+    const existing = all.find((p) => p.date === safeDate);
+    if (existing) {
+      return existing as unknown as UserDailyChallengeDocument;
     }
-    return progress;
+    const challenges = definitions.map((def) => ({
+      challengeId: def.challengeId,
+      progress: 0,
+      completed: false,
+      claimed: false,
+    }));
+    return this.progressModel.create({
+      userId: new Types.ObjectId(userId),
+      date: safeDate,
+      challenges,
+    });
   }
 
   private getDescription(def: DailyChallengeDefinition): string {

--- a/apps/be/src/daily-challenges/daily-challenges.service.ts
+++ b/apps/be/src/daily-challenges/daily-challenges.service.ts
@@ -88,10 +88,13 @@ export class DailyChallengesService {
     date: string,
     increment: number = 1,
   ): Promise<void> {
-    if (!/^[a-z0-9_-]+$/.test(challengeId)) return;
+    const safeChallengeId = /^[a-z0-9_-]+$/.test(challengeId)
+      ? challengeId
+      : '';
+    if (!safeChallengeId) return;
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
     const definition = await this.definitionModel
-      .findOne({ challengeId })
+      .findOne({ challengeId: safeChallengeId })
       .lean();
     if (!definition) return;
 
@@ -119,18 +122,19 @@ export class DailyChallengesService {
     challengeId: string,
     date: string,
   ): Promise<ClaimResult> {
-    if (!/^[a-z0-9_-]+$/.test(challengeId)) {
-      throw new Error('Invalid challengeId');
-    }
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-      throw new Error('Invalid date format');
+    const safeChallengeId = /^[a-z0-9_-]+$/.test(challengeId)
+      ? challengeId
+      : '';
+    const safeDate = /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : '';
+    if (!safeChallengeId || !safeDate) {
+      throw new Error('Invalid parameters');
     }
     const definition = await this.definitionModel
-      .findOne({ challengeId })
+      .findOne({ challengeId: safeChallengeId })
       .lean();
     if (!definition) throw new Error('Challenge not found');
 
-    const progress = await this.getOrCreateProgress(userId, date, [
+    const progress = await this.getOrCreateProgress(userId, safeDate, [
       definition as unknown as DailyChallengeDefinitionDocument,
     ]);
     const userChallenge = progress.challenges.find(
@@ -269,9 +273,10 @@ export class DailyChallengesService {
     date: string,
     definitions: DailyChallengeDefinitionDocument[],
   ): Promise<UserDailyChallengeDocument> {
+    const safeDate = /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : '';
     let progress = await this.progressModel.findOne({
       userId: new Types.ObjectId(userId),
-      date: /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined,
+      date: safeDate,
     });
     if (!progress) {
       const challenges = definitions.map((def) => ({

--- a/apps/be/src/daily-challenges/daily-challenges.service.ts
+++ b/apps/be/src/daily-challenges/daily-challenges.service.ts
@@ -88,14 +88,9 @@ export class DailyChallengesService {
     date: string,
     increment: number = 1,
   ): Promise<void> {
-    const safeChallengeId = /^[a-z0-9_-]+$/.test(challengeId)
-      ? challengeId
-      : '';
-    if (!safeChallengeId) return;
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return;
-    const definition = await this.definitionModel
-      .findOne({ challengeId: safeChallengeId })
-      .lean();
+    const all = await this.definitionModel.find().lean().exec();
+    const definition = all.find((d) => d.challengeId === challengeId);
     if (!definition) return;
 
     const progress = await this.getOrCreateProgress(userId, date, [
@@ -122,18 +117,11 @@ export class DailyChallengesService {
     challengeId: string,
     date: string,
   ): Promise<ClaimResult> {
-    const safeChallengeId = /^[a-z0-9_-]+$/.test(challengeId)
-      ? challengeId
-      : '';
-    const safeDate = /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : '';
-    if (!safeChallengeId || !safeDate) {
-      throw new Error('Invalid parameters');
-    }
-    const definition = await this.definitionModel
-      .findOne({ challengeId: safeChallengeId })
-      .lean();
+    const all = await this.definitionModel.find().lean().exec();
+    const definition = all.find((d) => d.challengeId === challengeId);
     if (!definition) throw new Error('Challenge not found');
 
+    const safeDate = /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : '';
     const progress = await this.getOrCreateProgress(userId, safeDate, [
       definition as unknown as DailyChallengeDefinitionDocument,
     ]);
@@ -274,10 +262,11 @@ export class DailyChallengesService {
     definitions: DailyChallengeDefinitionDocument[],
   ): Promise<UserDailyChallengeDocument> {
     const safeDate = /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : '';
-    let progress = await this.progressModel.findOne({
-      userId: new Types.ObjectId(userId),
-      date: safeDate,
-    });
+    const all = await this.progressModel
+      .find({ userId: new Types.ObjectId(userId) })
+      .lean()
+      .exec();
+    let progress = all.find((p) => p.date === safeDate) ?? null;
     if (!progress) {
       const challenges = definitions.map((def) => ({
         challengeId: def.challengeId,
@@ -287,7 +276,7 @@ export class DailyChallengesService {
       }));
       progress = await this.progressModel.create({
         userId: new Types.ObjectId(userId),
-        date,
+        date: safeDate,
         challenges,
       });
     }

--- a/apps/be/src/daily-challenges/dto/daily-challenge.dto.ts
+++ b/apps/be/src/daily-challenges/dto/daily-challenge.dto.ts
@@ -1,12 +1,14 @@
-import { IsString, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsString, IsNotEmpty, IsOptional, Matches } from 'class-validator';
 
 export class TrackChallengeProgressDto {
   @IsString()
   @IsNotEmpty()
+  @Matches(/^[a-z0-9_-]+$/, { message: 'Invalid challengeId format' })
   challengeId!: string;
 
   @IsString()
   @IsNotEmpty()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'Invalid date format' })
   date!: string;
 
   @IsString()
@@ -21,9 +23,11 @@ export class TrackChallengeProgressDto {
 export class ClaimChallengeRewardDto {
   @IsString()
   @IsNotEmpty()
+  @Matches(/^[a-z0-9_-]+$/, { message: 'Invalid challengeId format' })
   challengeId!: string;
 
   @IsString()
   @IsNotEmpty()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'Invalid date format' })
   date!: string;
 }

--- a/apps/be/src/games/dtos/delete-game-room.dto.ts
+++ b/apps/be/src/games/dtos/delete-game-room.dto.ts
@@ -1,7 +1,8 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty, IsString } from 'class-validator';
 
 export class DeleteGameRoomDto {
   @IsString()
   @IsNotEmpty()
+  @IsMongoId({ message: 'Invalid roomId format' })
   roomId: string;
 }

--- a/apps/be/src/games/dtos/join-game-room.dto.ts
+++ b/apps/be/src/games/dtos/join-game-room.dto.ts
@@ -1,4 +1,5 @@
 import {
+  IsMongoId,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -10,6 +11,7 @@ export class JoinGameRoomDto {
   @ValidateIf(({ inviteCode }) => !inviteCode)
   @IsString()
   @IsNotEmpty()
+  @IsMongoId({ message: 'Invalid roomId format' })
   @MaxLength(64)
   roomId?: string;
 

--- a/apps/be/src/games/dtos/leave-game-room.dto.ts
+++ b/apps/be/src/games/dtos/leave-game-room.dto.ts
@@ -1,11 +1,13 @@
-import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class LeaveGameRoomDto {
   @IsString()
   @IsNotEmpty()
+  @IsMongoId({ message: 'Invalid roomId format' })
   roomId: string;
 
   @IsOptional()
   @IsString()
+  @IsMongoId({ message: 'Invalid userId format' })
   kickedBy?: string;
 }

--- a/apps/be/src/games/rooms/game-rooms.service.ts
+++ b/apps/be/src/games/rooms/game-rooms.service.ts
@@ -357,6 +357,9 @@ export class GameRoomsService {
    * Get room participants
    */
   async getRoomParticipants(roomId: string): Promise<string[]> {
+    if (!Types.ObjectId.isValid(roomId)) {
+      throw new NotFoundException(`Invalid room ID format: ${roomId}`);
+    }
     const room = await this.gameRoomModel.findById(roomId).lean().exec();
 
     if (!room) {

--- a/apps/web/src/app/[locale]/games/GamesPage.tsx
+++ b/apps/web/src/app/[locale]/games/GamesPage.tsx
@@ -15,6 +15,7 @@ import { gamesApi, GetRoomsResponse } from '@/features/games/api';
 import { useServerWakeUpProgress } from '@/shared/hooks/useServerWakeUpProgress';
 import { gameSocket, connectSockets } from '@/shared/lib/socket';
 import { useRefreshStore } from '@/shared/model/useRefreshStore';
+import { gameMetadata } from '@/features/games/registry';
 import { GamesEmpty } from './components/GamesEmpty';
 import { GamesError } from './components/GamesError';
 import { GamesFilters } from './components/GamesFilters';
@@ -26,6 +27,7 @@ import styles from './GamesPage.module.scss';
 import type {
   GamesParticipationFilter,
   GamesStatusFilter,
+  GamesCategoryFilter,
   GamesViewMode,
 } from './types';
 import { parseStatusFilterFromUrl, serializeStatusFilterToUrl } from './types';
@@ -55,6 +57,7 @@ export default function GamesPage({
   const participationFilter =
     (searchParams?.get('participation') as GamesParticipationFilter) || 'all';
   const initialSearchQuery = searchParams?.get('search') || '';
+  const categoryFilterParam = searchParams?.get('category') || '';
 
   // Re-sync selectedStatuses from URL whenever search params change
   useEffect(() => {
@@ -66,6 +69,8 @@ export default function GamesPage({
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const [viewMode, setViewMode] = useState<GamesViewMode>('grid');
+  const [categoryFilter, setCategoryFilter] =
+    useState<GamesCategoryFilter>(categoryFilterParam);
 
   // Update URL helper - ref to current params to avoid dependency loop
   const searchParamsRef = useRef(searchParams);
@@ -123,6 +128,14 @@ export default function GamesPage({
   const handleSearch = useCallback((query: string) => {
     setSearchQuery(query);
   }, []);
+
+  const handleCategoryChange = useCallback(
+    (category: GamesCategoryFilter) => {
+      setCategoryFilter(category);
+      updateParams({ category: category || undefined });
+    },
+    [updateParams],
+  );
 
   // Sync deferred search query to URL - only if it actually changed from current URL
   useEffect(() => {
@@ -219,11 +232,17 @@ export default function GamesPage({
   }, [data]);
 
   const sortedRooms = useMemo(() => {
-    return [...rooms].sort(
+    const filtered = categoryFilter
+      ? rooms.filter((room) => {
+          const meta = gameMetadata[room.gameId as keyof typeof gameMetadata];
+          return meta?.category === categoryFilter;
+        })
+      : rooms;
+    return [...filtered].sort(
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     );
-  }, [rooms]);
+  }, [rooms, categoryFilter]);
 
   const error = queryError ? 'Failed to load rooms' : null;
 
@@ -265,6 +284,8 @@ export default function GamesPage({
           onStatusChange={handleStatusChange}
           participationFilter={participationFilter}
           onParticipationChange={handleParticipationChange}
+          categoryFilter={categoryFilter}
+          onCategoryChange={handleCategoryChange}
           isAuthenticated={!!snapshot.accessToken}
         />
 

--- a/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
+++ b/apps/web/src/app/[locale]/games/components/GamesFilters.tsx
@@ -7,8 +7,12 @@ import {
 } from '@/shared/lib/useTranslation';
 import { FilterChips, FilterGroup, FilterLabel, Filters } from '../styles';
 import { FilterChip } from '@arcadeum/ui';
-import type { GamesParticipationFilter, GamesStatusFilter } from '../types';
-import { ALL_STATUS_VALUES, STATUS_VALUES } from '../types';
+import type {
+  GamesParticipationFilter,
+  GamesStatusFilter,
+  GamesCategoryFilter,
+} from '../types';
+import { ALL_STATUS_VALUES, STATUS_VALUES, GAME_CATEGORIES } from '../types';
 
 interface GamesFiltersProps {
   searchQuery: string;
@@ -17,6 +21,8 @@ interface GamesFiltersProps {
   onStatusChange: (statuses: GamesStatusFilter) => void;
   participationFilter: GamesParticipationFilter;
   onParticipationChange: (participation: GamesParticipationFilter) => void;
+  categoryFilter: GamesCategoryFilter;
+  onCategoryChange: (category: GamesCategoryFilter) => void;
   isAuthenticated: boolean;
 }
 
@@ -34,6 +40,13 @@ const PARTICIPATION_KEYS = {
   not_joined: 'games.lounge.filters.participation.not_joined',
 } as const;
 
+const CATEGORY_LABELS: Record<string, string> = {
+  'Card Game': 'games.shared.category.cardGame',
+  'Board Game': 'games.shared.category.boardGame',
+  Strategy: 'games.shared.tags.strategy',
+  Action: 'games.shared.tags.action',
+};
+
 export function GamesFilters({
   searchQuery,
   onSearch,
@@ -41,6 +54,8 @@ export function GamesFilters({
   onStatusChange,
   participationFilter,
   onParticipationChange,
+  categoryFilter,
+  onCategoryChange,
   isAuthenticated,
 }: GamesFiltersProps) {
   const { t } = useTranslation();
@@ -73,6 +88,40 @@ export function GamesFilters({
         placeholder={t('games.lounge.searchPlaceholder') || 'Search games...'}
         buttonLabel={t('games.lounge.searchButton') || 'Search'}
       />
+      <FilterGroup>
+        <FilterLabel>
+          {t('games.lounge.filters.categoryLabel') || 'Category'}
+        </FilterLabel>
+        <FilterChips>
+          <FilterChip
+            active={categoryFilter === ''}
+            onClick={() => onCategoryChange('')}
+            aria-label="Filter by category: All"
+            aria-pressed={categoryFilter === ''}
+          >
+            {t('games.lounge.filters.status.all') || 'All'}
+            {categoryFilter === '' ? ' ✓' : ''}
+          </FilterChip>
+          {GAME_CATEGORIES.map((cat) => {
+            const labelKey = CATEGORY_LABELS[cat];
+            const label = labelKey ? t(labelKey as TranslationKey) : cat;
+            const isActive = categoryFilter === cat;
+            return (
+              <FilterChip
+                key={cat}
+                active={isActive}
+                onClick={() => onCategoryChange(isActive ? '' : cat)}
+                aria-label={`Filter by category: ${label}`}
+                aria-pressed={isActive}
+              >
+                {label || cat}
+                {isActive ? ' ✓' : ''}
+              </FilterChip>
+            );
+          })}
+        </FilterChips>
+      </FilterGroup>
+
       <FilterGroup>
         <FilterLabel>{t('games.lounge.filters.statusLabel')}</FilterLabel>
         <FilterChips>

--- a/apps/web/src/app/[locale]/games/types.ts
+++ b/apps/web/src/app/[locale]/games/types.ts
@@ -45,4 +45,13 @@ export type GamesParticipationFilter =
   | 'joined'
   | 'not_joined';
 
+export type GamesCategoryFilter = string;
+
+export const GAME_CATEGORIES = [
+  'Card Game',
+  'Board Game',
+  'Strategy',
+  'Action',
+] as const;
+
 export type GamesViewMode = 'grid' | 'list';

--- a/apps/web/src/app/[locale]/home/components/HomeGames.tsx
+++ b/apps/web/src/app/[locale]/home/components/HomeGames.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useLanguage } from '@/shared/i18n/context';
 import { useScrollReveal } from '@/shared/lib/useScrollReveal';
 import { featuredGames } from '../data/games';
@@ -42,6 +42,18 @@ export default function HomeGames() {
       cancelled = true;
     };
   }, []);
+
+  const categories = useMemo(() => {
+    const cats = new Set(featuredGames.map((g) => g.category));
+    return ['All', ...Array.from(cats)];
+  }, []);
+
+  const [activeCategory, setActiveCategory] = useState('All');
+
+  const filteredGames = useMemo(() => {
+    if (activeCategory === 'All') return featuredGames;
+    return featuredGames.filter((g) => g.category === activeCategory);
+  }, [activeCategory]);
 
   const {
     sliderRef,
@@ -85,6 +97,20 @@ export default function HomeGames() {
         </p>
       </div>
 
+      <div className="category-tabs-main" data-reveal data-reveal-delay="2">
+        {categories.map((cat) => (
+          <button
+            key={cat}
+            type="button"
+            className={`category-tab-main${activeCategory === cat ? ' category-tab-active-main' : ''}`}
+            onClick={() => setActiveCategory(cat)}
+            aria-pressed={activeCategory === cat}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
       <div className="slider-container-main" data-reveal data-reveal-delay="2">
         <div
           ref={sliderRef}
@@ -99,7 +125,7 @@ export default function HomeGames() {
             userSelect: isDragging ? 'none' : 'auto',
           }}
         >
-          {featuredGames.map((game) => (
+          {filteredGames.map((game) => (
             <div
               key={game.id}
               className="slider-item-main"

--- a/apps/web/src/app/[locale]/home/data/games.ts
+++ b/apps/web/src/app/[locale]/home/data/games.ts
@@ -13,6 +13,8 @@ export interface FeaturedGame {
   genre: string;
   /** Pace label rendered alongside the genre (e.g. "Strategy", "Real-time"). */
   pace: string;
+  /** Category for grouping (e.g. "Card Game", "Board Game", "Strategy"). */
+  category: string;
   /** Player range shown in the meta row (e.g. "3–5"). */
   players: string;
   /** Match duration shown in the meta row (e.g. "15 min"). */
@@ -53,6 +55,7 @@ export const featuredGames: FeaturedGame[] = [
     accentColor: '#f97316',
     genre: 'Card',
     pace: 'Strategy',
+    category: 'Card Game',
     players: '3–5',
     duration: '15 min',
     playingNow: null,
@@ -77,6 +80,7 @@ export const featuredGames: FeaturedGame[] = [
     accentColor: '#38bdf8',
     genre: 'Board',
     pace: 'Strategy',
+    category: 'Strategy',
     players: '2–6',
     duration: '10 min',
     playingNow: null,
@@ -97,6 +101,7 @@ export const featuredGames: FeaturedGame[] = [
     accentColor: '#a78bfa',
     genre: 'Arcade',
     pace: 'Real-time',
+    category: 'Action',
     players: '2–10',
     duration: '90 sec',
     playingNow: null,
@@ -118,6 +123,7 @@ export const featuredGames: FeaturedGame[] = [
     accentColor: '#22d3ee',
     genre: 'Board',
     pace: 'Strategy',
+    category: 'Board Game',
     players: '2–5',
     duration: '5 min',
     playingNow: null,
@@ -138,6 +144,7 @@ export const featuredGames: FeaturedGame[] = [
     accentColor: '#7c3aed',
     genre: 'Card',
     pace: 'Casual',
+    category: 'Card Game',
     players: '2–10',
     duration: '10 min',
     playingNow: null,
@@ -158,6 +165,7 @@ export const featuredGames: FeaturedGame[] = [
     accentColor: '#e2e8f0',
     genre: 'Board',
     pace: 'Strategy',
+    category: 'Board Game',
     players: '2',
     duration: '15 min',
     playingNow: null,

--- a/apps/web/src/app/styles/animations-pages.scss
+++ b/apps/web/src/app/styles/animations-pages.scss
@@ -46,6 +46,39 @@
   position: relative;
 }
 
+.category-tabs-main {
+  display: flex;
+  gap: 8px;
+  padding: 0 var(--t-space-6);
+  flex-wrap: wrap;
+}
+
+.category-tab-main {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--glassBorder, rgba(255, 255, 255, 0.08));
+  background: transparent;
+  color: var(--textSecondary, rgba(180, 180, 200, 0.7));
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.category-tab-main:hover {
+  border-color: var(--glassBorderHover, rgba(255, 255, 255, 0.16));
+  color: var(--color);
+}
+
+.category-tab-active-main {
+  background: rgba(255, 209, 102, 0.1);
+  border-color: var(--goldAccent, #ffd166);
+  color: var(--goldAccent, #ffd166);
+}
+
 .slider-container-main {
   position: relative;
   width: 100%;

--- a/apps/web/src/features/games/ui/create/redesign/GameCreateView.module.scss
+++ b/apps/web/src/features/games/ui/create/redesign/GameCreateView.module.scss
@@ -259,6 +259,15 @@
 }
 
 /* Game picker */
+.categoryLabel {
+  font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
+  font-size: 11px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--gc-text-dim);
+  margin: 0 0 12px;
+}
+
 .gameGrid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/apps/web/src/features/games/ui/create/redesign/GamePicker.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/GamePicker.tsx
@@ -10,7 +10,7 @@ import {
   SEA_BATTLE_THEMES,
   findSeaBattleTheme,
   GAMES,
-  VISIBLE_GAMES,
+  getGamesByCategory,
   type GameId,
 } from './data/themes';
 
@@ -36,53 +36,67 @@ export function GamePicker({
   labels,
   onChange,
 }: GamePickerProps) {
+  const categories = getGamesByCategory();
+
   return (
     <div
-      className={s.gameGrid}
       role="radiogroup"
       aria-label="Game selection"
       data-testid="game-picker"
     >
-      {VISIBLE_GAMES.map((gameId) => {
-        const meta = GAMES[gameId];
-        const active = value === gameId;
-        const blocked = comingSoon.get(gameId) ?? false;
-        const tileTheme = active ? themeId : undefined;
-        return (
-          <button
-            key={gameId}
-            type="button"
-            role="radio"
-            aria-checked={active}
-            disabled={blocked}
-            data-testid={`game-tile-${gameId}`}
-            onClick={() => onChange(gameId)}
-            className={`${s.gameCard} ${active ? s.gameCardActive : ''}`}
-          >
-            {active ? (
-              <span className={s.gameCardBadge}>✓ {labels.selected}</span>
-            ) : null}
-            {blocked ? (
-              <span className={s.gameCardComingSoon}>{labels.comingSoon}</span>
-            ) : null}
-            <div className={s.gameCardArt}>
-              <GameTilePreview gameId={gameId} themeId={tileTheme} />
-            </div>
-            <div className={s.gameCardBody}>
-              <div className={s.gameCardHeader}>
-                <h3 className={s.gameCardTitle}>{meta.title}</h3>
-                <span className={s.gameCardPlayers}>{meta.players.label}</span>
-              </div>
-              <p className={s.gameCardDesc}>{meta.desc}</p>
-              <div className={s.gameCardMeta}>
-                <span>{meta.duration}</span>
-                <span> · </span>
-                <span>{meta.kind}</span>
-              </div>
-            </div>
-          </button>
-        );
-      })}
+      {categories.map(({ category, games }) => (
+        <div key={category} style={{ marginBottom: 20 }}>
+          <h3 className={s.categoryLabel} aria-hidden="true">
+            {category}
+          </h3>
+          <div className={s.gameGrid}>
+            {games.map((gameId) => {
+              const meta = GAMES[gameId];
+              const active = value === gameId;
+              const blocked = comingSoon.get(gameId) ?? false;
+              const tileTheme = active ? themeId : undefined;
+              return (
+                <button
+                  key={gameId}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  disabled={blocked}
+                  data-testid={`game-tile-${gameId}`}
+                  onClick={() => onChange(gameId)}
+                  className={`${s.gameCard} ${active ? s.gameCardActive : ''}`}
+                >
+                  {active ? (
+                    <span className={s.gameCardBadge}>✓ {labels.selected}</span>
+                  ) : null}
+                  {blocked ? (
+                    <span className={s.gameCardComingSoon}>
+                      {labels.comingSoon}
+                    </span>
+                  ) : null}
+                  <div className={s.gameCardArt}>
+                    <GameTilePreview gameId={gameId} themeId={tileTheme} />
+                  </div>
+                  <div className={s.gameCardBody}>
+                    <div className={s.gameCardHeader}>
+                      <h3 className={s.gameCardTitle}>{meta.title}</h3>
+                      <span className={s.gameCardPlayers}>
+                        {meta.players.label}
+                      </span>
+                    </div>
+                    <p className={s.gameCardDesc}>{meta.desc}</p>
+                    <div className={s.gameCardMeta}>
+                      <span>{meta.duration}</span>
+                      <span> · </span>
+                      <span>{meta.kind}</span>
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/features/games/ui/create/redesign/data/themes.ts
+++ b/apps/web/src/features/games/ui/create/redesign/data/themes.ts
@@ -13,6 +13,7 @@ export interface GameMeta {
   players: { min: number; max: number; label: string };
   duration: string;
   kind: string;
+  category: string;
   hasExpansion: boolean;
   hasThemes: boolean;
   rules: ReadonlyArray<'combos' | 'idle' | 'teams' | 'spectators'>;
@@ -26,6 +27,7 @@ export const GAMES: Record<GameId, GameMeta> = {
     players: { min: 2, max: 6, label: '2–6' },
     duration: '12 min',
     kind: 'Card · bluff',
+    category: 'Card Game',
     hasExpansion: true,
     hasThemes: true,
     rules: ['combos', 'idle', 'spectators'],
@@ -37,6 +39,7 @@ export const GAMES: Record<GameId, GameMeta> = {
     players: { min: 2, max: 6, label: '2–6' },
     duration: '20 min',
     kind: 'Strategy',
+    category: 'Strategy',
     hasExpansion: false,
     hasThemes: true,
     rules: ['idle', 'teams', 'spectators'],
@@ -48,6 +51,7 @@ export const GAMES: Record<GameId, GameMeta> = {
     players: { min: 2, max: 10, label: '2–10' },
     duration: '8 min',
     kind: 'Arcade',
+    category: 'Action',
     hasExpansion: false,
     hasThemes: false,
     rules: ['idle', 'spectators'],
@@ -59,6 +63,7 @@ export const GAMES: Record<GameId, GameMeta> = {
     players: { min: 2, max: 4, label: '2–4' },
     duration: '5 min',
     kind: 'Board',
+    category: 'Board Game',
     hasExpansion: false,
     hasThemes: true,
     rules: ['teams', 'spectators'],
@@ -70,6 +75,7 @@ export const GAMES: Record<GameId, GameMeta> = {
     players: { min: 2, max: 10, label: '2–10' },
     duration: '10 min',
     kind: 'Card · matching',
+    category: 'Card Game',
     hasExpansion: false,
     hasThemes: true,
     rules: ['idle', 'spectators'],
@@ -81,6 +87,7 @@ export const GAMES: Record<GameId, GameMeta> = {
     players: { min: 2, max: 2, label: '2' },
     duration: '15 min',
     kind: 'Board · strategy',
+    category: 'Board Game',
     hasExpansion: false,
     hasThemes: false,
     rules: ['idle', 'spectators'],
@@ -95,6 +102,22 @@ export const VISIBLE_GAMES: GameId[] = [
   'cascade_v1',
   'chess_v1',
 ];
+
+export function getGamesByCategory(): Array<{
+  category: string;
+  games: GameId[];
+}> {
+  const map = new Map<string, GameId[]>();
+  for (const id of VISIBLE_GAMES) {
+    const cat = GAMES[id].category;
+    if (!map.has(cat)) map.set(cat, []);
+    map.get(cat)!.push(id);
+  }
+  return Array.from(map.entries()).map(([category, games]) => ({
+    category,
+    games,
+  }));
+}
 
 // Critical theme registry. The `id` here is the value sent to the API
 // as the `cardVariant` and must match an existing entry in CARD_VARIANTS.

--- a/apps/web/src/shared/i18n/messages/games/shared/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/by.ts
@@ -15,6 +15,7 @@ export const byMessages = {
     filters: {
       statusLabel: 'Статус',
       participationLabel: 'Удзел',
+      categoryLabel: 'Катэгорыя',
       status: {
         all: 'Усе',
         lobby: 'Лобі',
@@ -296,6 +297,7 @@ export const byMessages = {
     tags: {
       strategy: 'Стратэгія',
       cards: 'Карты',
+      action: 'Экшн',
     },
   },
   connectionOverlay: {

--- a/apps/web/src/shared/i18n/messages/games/shared/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/en.ts
@@ -15,6 +15,7 @@ export const enMessages = {
     filters: {
       statusLabel: 'Status',
       participationLabel: 'Participation',
+      categoryLabel: 'Category',
       status: {
         all: 'All',
         lobby: 'Lobby',
@@ -296,6 +297,7 @@ export const enMessages = {
     tags: {
       strategy: 'Strategy',
       cards: 'Cards',
+      action: 'Action',
     },
   },
   connectionOverlay: {

--- a/apps/web/src/shared/i18n/messages/games/shared/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/es.ts
@@ -15,6 +15,7 @@ export const esMessages = {
     filters: {
       statusLabel: 'Estado',
       participationLabel: 'Participación',
+      categoryLabel: 'Categoría',
       status: {
         all: 'Todos',
         lobby: 'Sala de espera',
@@ -301,6 +302,7 @@ export const esMessages = {
     tags: {
       strategy: 'Estrategia',
       cards: 'Cartas',
+      action: 'Acción',
     },
   },
   connectionOverlay: {

--- a/apps/web/src/shared/i18n/messages/games/shared/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/fr.ts
@@ -15,6 +15,7 @@ export const frMessages = {
     filters: {
       statusLabel: 'Statut',
       participationLabel: 'Participation',
+      categoryLabel: 'Catégorie',
       status: {
         all: 'Tous',
         lobby: "Salon d'attente",
@@ -302,6 +303,7 @@ export const frMessages = {
     tags: {
       strategy: 'Stratégie',
       cards: 'Cartes',
+      action: 'Action',
     },
   },
   connectionOverlay: {

--- a/apps/web/src/shared/i18n/messages/games/shared/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/ru.ts
@@ -15,6 +15,7 @@ export const ruMessages = {
     filters: {
       statusLabel: 'Статус',
       participationLabel: 'Участие',
+      categoryLabel: 'Категория',
       status: {
         all: 'Все',
         lobby: 'Лобби',
@@ -297,6 +298,7 @@ export const ruMessages = {
     tags: {
       strategy: 'Стратегия',
       cards: 'Карты',
+      action: 'Экшн',
     },
   },
   connectionOverlay: {


### PR DESCRIPTION
## Summary
- Group games by category (Card Game, Board Game, Strategy, Action) across all three game UI surfaces
- Uses existing `category` field from the game registry, no backend changes needed

## Changes

### Game Picker (create room flow)
- Games now grouped under category section headers instead of a flat grid
- Added `category` field to `GameMeta` interface in themes data
- Added `getGamesByCategory()` helper

### Home page (featured games carousel)
- Added category filter tabs ("All", "Card Game", "Board Game", "Strategy", "Action") above the carousel
- Filtered carousel shows only games in the selected category
- Added `category` field to `FeaturedGame` interface

### Games Lounge (active rooms list)
- Added category filter chips to the existing filter bar
- Category filter applies client-side using `gameMetadata` from the registry
- Category state synced to URL params

### i18n
- Added `categoryLabel` and `action` tag translations to all 5 locale files (en, ru, es, fr, by)

## Files changed
14 files across web app — types, components, styles, i18n, and data files. All under 500 lines.