### PR TITLE
feat(task-bot): CI fix max attempts, CI polling, and rate limiting

### DIFF
--- a/.github/workflows/auto-fix-ci.yml
+++ b/.github/workflows/auto-fix-ci.yml
@@ -44,8 +44,24 @@ jobs:
             core.setOutput('branch', context.payload.workflow_run.head_branch);
             core.setOutput('failed_checks', JSON.stringify(failed));
 
-      - name: Notify task bot
+      - name: Check if PR is from task bot
+        id: check
         if: steps.pr.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(context.payload.workflow_run.head_branch.match(/task-(\d+)/)?.[1] || '0'),
+            }).catch(() => null);
+
+            const branch = context.payload.workflow_run.head_branch;
+            const isTaskBot = branch.startsWith('task-');
+            core.setOutput('is_task_bot', isTaskBot);
+
+      - name: Notify task bot
+        if: steps.pr.outputs.pr_number != '' && steps.check.outputs.is_task_bot == 'true'
         run: |
           curl -s -X POST "https://$TASK_BOT_HOST/ci/fix" \
             -H "Content-Type: application/json" \

--- a/bots/task-bot/src/ci/ci-fix-tracker.service.ts
+++ b/bots/task-bot/src/ci/ci-fix-tracker.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+const PREFIX = 'task-bot:ci-fix:';
+const DEFAULT_MAX_ATTEMPTS = 3;
+const TTL_SECONDS = 3600;
+
+@Injectable()
+export class CIFixTrackerService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(CIFixTrackerService.name);
+  private redis!: Redis;
+  private readonly maxAttempts: number;
+
+  constructor(private readonly config: ConfigService) {
+    this.maxAttempts = parseInt(
+      this.config.get<string>('CI_FIX_MAX_ATTEMPTS') ?? String(DEFAULT_MAX_ATTEMPTS),
+      10,
+    );
+  }
+
+  async onModuleInit() {
+    const host = this.config.get<string>('REDIS_HOST') ?? '127.0.0.1';
+    const port = parseInt(this.config.get<string>('REDIS_PORT') ?? '6379', 10);
+    const password = this.config.get<string>('REDIS_PASSWORD');
+    this.redis = new Redis({ host, port, password });
+    this.logger.log(`CIFixTracker initialized (maxAttempts=${this.maxAttempts})`);
+  }
+
+  async onModuleDestroy() {
+    await this.redis.quit();
+  }
+
+  async incrementAttempts(prNumber: string): Promise<number> {
+    const key = `${PREFIX}${prNumber}`;
+    const count = await this.redis.incr(key);
+    await this.redis.expire(key, TTL_SECONDS);
+    this.logger.log(`CI fix attempt ${count}/${this.maxAttempts} for PR #${prNumber}`);
+    return count;
+  }
+
+  async getAttempts(prNumber: string): Promise<number> {
+    const key = `${PREFIX}${prNumber}`;
+    const val = await this.redis.get(key);
+    return val ? parseInt(val, 10) : 0;
+  }
+
+  async canRetry(prNumber: string): Promise<boolean> {
+    const attempts = await this.getAttempts(prNumber);
+    return attempts < this.maxAttempts;
+  }
+
+  async resetAttempts(prNumber: string): Promise<void> {
+    const key = `${PREFIX}${prNumber}`;
+    await this.redis.del(key);
+  }
+
+  getMaxAttempts(): number {
+    return this.maxAttempts;
+  }
+}

--- a/bots/task-bot/src/ci/ci-poll.service.ts
+++ b/bots/task-bot/src/ci/ci-poll.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { NotificationService } from '../notification/notification.service';
+import { execFileSync } from 'child_process';
+import { ConfigService } from '@nestjs/config';
+
+interface PollEntry {
+  timer: NodeJS.Timeout;
+  prNumber: string;
+  issueNum: string;
+  engine: string;
+  startTime: number;
+}
+
+@Injectable()
+export class CIFollService implements OnModuleDestroy {
+  private readonly logger = new Logger(CIFollService.name);
+  private readonly activePolls = new Map<string, PollEntry>();
+  private readonly pollIntervalMs = 30_000;
+  private readonly maxPollTimeMs = 15 * 60 * 1000;
+
+  constructor(
+    private readonly notificationService: NotificationService,
+    private readonly config: ConfigService,
+  ) {}
+
+  onModuleDestroy() {
+    for (const [key, entry] of this.activePolls) {
+      clearTimeout(entry.timer);
+      this.activePolls.delete(key);
+    }
+  }
+
+  startPolling(
+    prNumber: string,
+    issueNum: string,
+    engine: string,
+  ): void {
+    if (this.activePolls.has(prNumber)) {
+      this.logger.log(`Already polling PR #${prNumber}`);
+      return;
+    }
+
+    this.logger.log(`Starting CI poll for PR #${prNumber}`);
+    this.scheduleNext(prNumber, issueNum, engine, Date.now());
+  }
+
+  stopPolling(prNumber: string): void {
+    const entry = this.activePolls.get(prNumber);
+    if (entry) {
+      clearTimeout(entry.timer);
+      this.activePolls.delete(prNumber);
+      this.logger.log(`Stopped CI poll for PR #${prNumber}`);
+    }
+  }
+
+  private scheduleNext(
+    prNumber: string,
+    issueNum: string,
+    engine: string,
+    startTime: number,
+  ): void {
+    const timer = setTimeout(() => {
+      this.activePolls.delete(prNumber);
+      this.checkCIStatus(prNumber, issueNum, engine, startTime);
+    }, this.pollIntervalMs);
+
+    this.activePolls.set(prNumber, { timer, prNumber, issueNum, engine, startTime });
+  }
+
+  private checkCIStatus(
+    prNumber: string,
+    issueNum: string,
+    engine: string,
+    startTime: number,
+  ): void {
+    const elapsed = Date.now() - startTime;
+    if (elapsed > this.maxPollTimeMs) {
+      this.logger.log(`CI poll timeout for PR #${prNumber} after ${Math.round(elapsed / 1000)}s`);
+      return;
+    }
+
+    try {
+      const repoPath = this.config.get<string>('REPO_PATH') ?? process.cwd();
+      const result = execFileSync(
+        'gh',
+        ['pr', 'checks', prNumber, '--json', 'name,state,conclusion'],
+        { encoding: 'utf-8', cwd: repoPath, timeout: 15_000 },
+      );
+
+      const checks = JSON.parse(result) as Array<{
+        name: string;
+        state: string;
+        conclusion: string | null;
+      }>;
+
+      if (checks.length === 0) {
+        this.logger.log(`No checks found for PR #${prNumber} yet, retrying...`);
+        this.scheduleNext(prNumber, issueNum, engine, startTime);
+        return;
+      }
+
+      const pending = checks.filter(
+        (c) => c.state === 'pending' || c.conclusion === null,
+      );
+      const failed = checks.filter(
+        (c) => c.conclusion === 'failure' || c.conclusion === 'action_required',
+      );
+      const passed = checks.filter(
+        (c) => c.conclusion === 'success',
+      );
+
+      this.logger.log(
+        `PR #${prNumber} CI: ${passed.length} passed, ${failed.length} failed, ${pending.length} pending`,
+      );
+
+      if (failed.length > 0) {
+        this.logger.log(`CI has failures on PR #${prNumber}, webhook will handle auto-fix`);
+        return;
+      }
+
+      if (pending.length > 0) {
+        this.scheduleNext(prNumber, issueNum, engine, startTime);
+        return;
+      }
+
+      if (passed.length > 0 && pending.length === 0 && failed.length === 0) {
+        this.logger.log(`CI all green for PR #${prNumber}!`);
+        this.notificationService.publish({
+          jobId: `ci-green-${prNumber}`,
+          issueNum,
+          engine,
+          success: true,
+          message: `All ${passed.length} CI checks passed for PR #${prNumber}`,
+          timestamp: Date.now(),
+          type: 'ci-fixed',
+        });
+        return;
+      }
+    } catch (err) {
+      this.logger.warn(`CI poll error for PR #${prNumber}: ${(err as Error).message}`);
+      this.scheduleNext(prNumber, issueNum, engine, startTime);
+    }
+  }
+}

--- a/bots/task-bot/src/ci/ci.controller.ts
+++ b/bots/task-bot/src/ci/ci.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body, Logger, HttpCode } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NotificationService } from '../notification/notification.service';
 import { ImplementQueueService } from '../queue/implement-queue.service';
+import { CIFixTrackerService } from './ci-fix-tracker.service';
 
 interface CIFailurePayload {
   prNumber: string;
@@ -20,6 +21,7 @@ export class CIController {
     private readonly queueService: ImplementQueueService,
     private readonly notificationService: NotificationService,
     private readonly config: ConfigService,
+    private readonly ciFixTracker: CIFixTrackerService,
   ) {}
 
   @Post('fix')
@@ -31,16 +33,39 @@ export class CIController {
       return { status: 'rejected' };
     }
 
+    const maxAttempts = this.ciFixTracker.getMaxAttempts();
+    const currentAttempts = await this.ciFixTracker.getAttempts(payload.prNumber);
+
+    if (currentAttempts >= maxAttempts) {
+      this.logger.warn(
+        `CI fix max attempts (${maxAttempts}) reached for PR #${payload.prNumber}. Giving up.`,
+      );
+
+      await this.notificationService.publish({
+        jobId: `ci-fix-max-${payload.prNumber}`,
+        issueNum: payload.issueNum ?? payload.prNumber,
+        engine: 'mimo',
+        success: false,
+        message: `CI fix failed after ${maxAttempts} attempts. Manual intervention needed.\nFailed checks: ${payload.failedChecks.join(', ')}`,
+        timestamp: Date.now(),
+        type: 'ci-fixed',
+      });
+
+      return { status: 'max_attempts_reached', attempts: currentAttempts };
+    }
+
     this.logger.log(
-      `CI failure received for PR #${payload.prNumber} (${payload.branchName}): ${payload.failedChecks.join(', ')}`,
+      `CI failure received for PR #${payload.prNumber} (${payload.branchName}): ${payload.failedChecks.join(', ')} [attempt ${currentAttempts + 1}/${maxAttempts}]`,
     );
+
+    await this.ciFixTracker.incrementAttempts(payload.prNumber);
 
     await this.notificationService.publish({
       jobId: `ci-fail-${payload.prNumber}`,
       issueNum: payload.issueNum ?? payload.prNumber,
       engine: 'mimo',
       success: false,
-      message: `CI failed: ${payload.failedChecks.join(', ')}`,
+      message: `CI failed (attempt ${currentAttempts + 1}/${maxAttempts}): ${payload.failedChecks.join(', ')}`,
       timestamp: Date.now(),
       type: 'ci-failed',
       failedChecks: payload.failedChecks,
@@ -63,9 +88,9 @@ export class CIController {
         },
       );
 
-      this.logger.log(`CI fix queued: job ${jobId} for PR #${payload.prNumber}`);
+      this.logger.log(`CI fix queued: job ${jobId} for PR #${payload.prNumber} (attempt ${currentAttempts + 1}/${maxAttempts})`);
 
-      return { status: 'queued', jobId };
+      return { status: 'queued', jobId, attempt: currentAttempts + 1, maxAttempts };
     } catch (err) {
       this.logger.error(`Failed to queue CI fix: ${(err as Error).message}`);
 
@@ -81,5 +106,16 @@ export class CIController {
 
       return { status: 'error', message: (err as Error).message };
     }
+  }
+
+  @Post('reset')
+  @HttpCode(200)
+  async resetAttempts(@Body() body: { prNumber: string; secret?: string }) {
+    const secret = this.config.get<string>('CI_WEBHOOK_SECRET');
+    if (secret && body.secret !== secret) {
+      return { status: 'rejected' };
+    }
+    await this.ciFixTracker.resetAttempts(body.prNumber);
+    return { status: 'reset' };
   }
 }

--- a/bots/task-bot/src/ci/ci.module.ts
+++ b/bots/task-bot/src/ci/ci.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { CIController } from './ci.controller';
+import { CIFixTrackerService } from './ci-fix-tracker.service';
+import { CIFollService } from './ci-poll.service';
 import { QueueModule } from '../queue/queue.module';
 import { NotificationModule } from '../notification/notification.module';
 
 @Module({
   imports: [QueueModule, NotificationModule],
   controllers: [CIController],
+  providers: [CIFixTrackerService, CIFollService],
+  exports: [CIFixTrackerService, CIFollService],
 })
 export class CIModule {}

--- a/bots/task-bot/src/github/github.service.ts
+++ b/bots/task-bot/src/github/github.service.ts
@@ -12,11 +12,27 @@ interface GitHubIssue {
   scope: string[];
 }
 
+const GITHUB_RATE_LIMIT_DELAY_MS = 500;
+
 @Injectable()
 export class GitHubService {
   private readonly logger = new Logger(GitHubService.name);
+  private lastGhCallTime = 0;
 
   constructor(private readonly config: ConfigService) {}
+
+  private throttleGitHub(): void {
+    const now = Date.now();
+    const elapsed = now - this.lastGhCallTime;
+    if (elapsed < GITHUB_RATE_LIMIT_DELAY_MS) {
+      const waitMs = GITHUB_RATE_LIMIT_DELAY_MS - elapsed;
+      const start = Date.now();
+      while (Date.now() - start < waitMs) {
+        // busy wait for rate limit
+      }
+    }
+    this.lastGhCallTime = Date.now();
+  }
 
   private getCwd(): string {
     return this.config.get<string>('REPO_PATH') ?? process.cwd();
@@ -209,6 +225,7 @@ export class GitHubService {
     ];
 
     try {
+      this.throttleGitHub();
       const result = execFileSync('gh', args, {
         encoding: 'utf-8',
         cwd: this.getCwd(),
@@ -250,6 +267,7 @@ export class GitHubService {
     labels: Array<{ name: string }>;
   } | null {
     try {
+      this.throttleGitHub();
       const result = execFileSync(
         'gh',
         ['issue', 'view', issueNum, '--json', 'state,title,body,comments,labels'],
@@ -285,6 +303,7 @@ export class GitHubService {
     statusCheckRollup: Array<{ name: string; conclusion: string | null }>;
   } | null {
     try {
+      this.throttleGitHub();
       const result = execFileSync(
         'gh',
         ['pr', 'view', prNum, '--json', 'state,headRefName,statusCheckRollup'],
@@ -304,6 +323,7 @@ export class GitHubService {
     prNumber: string,
   ): Array<{ name: string; state: string; link: string }> {
     try {
+      this.throttleGitHub();
       const result = execFileSync(
         'gh',
         ['pr', 'checks', prNumber, '--json', 'name,state,link'],
@@ -347,6 +367,7 @@ export class GitHubService {
     prNumber: string,
   ): Array<{ body: string; state: string }> {
     try {
+      this.throttleGitHub();
       const result = execFileSync(
         'gh',
         ['pr', 'view', prNumber, '--json', 'reviews'],
@@ -440,6 +461,7 @@ export class GitHubService {
       if (!issue) {
         return { success: false, message: `Issue #${issueNum} not found` };
       }
+      this.throttleGitHub();
       const prUrl = execFileSync(
         'gh',
         [

--- a/bots/task-bot/src/task-bot/task-bot.service.ts
+++ b/bots/task-bot/src/task-bot/task-bot.service.ts
@@ -784,7 +784,7 @@ export class TaskBotService implements OnApplicationBootstrap {
 
       case 'ci-fixed':
         text = notification.success
-          ? `*CI Fixed* ✅\n${notification.message}`
+          ? `*CI Passed* ✅\n${notification.message}`
           : `*CI Fix Failed* ❌\n${notification.message}`;
         break;
 

--- a/bots/task-bot/src/worker/implement.processor.spec.ts
+++ b/bots/task-bot/src/worker/implement.processor.spec.ts
@@ -5,12 +5,14 @@ import { ImplementJobData } from '../queue/implement-queue.service';
 import { ReviewQueueService } from '../queue/review-queue.service';
 import { GitHubService } from '../github/github.service';
 import { NotificationService } from '../notification/notification.service';
+import { CIFollService } from '../ci/ci-poll.service';
 
 describe('ImplementProcessor', () => {
   let processor: ImplementProcessor;
   let mockGitHubService: jest.Mocked<GitHubService>;
   let mockReviewQueue: jest.Mocked<ReviewQueueService>;
   let mockNotificationService: jest.Mocked<NotificationService>;
+  let mockCIPollService: jest.Mocked<CIFollService>;
 
   beforeEach(async () => {
     mockGitHubService = {
@@ -31,12 +33,18 @@ describe('ImplementProcessor', () => {
       publish: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<NotificationService>;
 
+    mockCIPollService = {
+      startPolling: jest.fn(),
+      stopPolling: jest.fn(),
+    } as unknown as jest.Mocked<CIFollService>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ImplementProcessor,
         { provide: GitHubService, useValue: mockGitHubService },
         { provide: ReviewQueueService, useValue: mockReviewQueue },
         { provide: NotificationService, useValue: mockNotificationService },
+        { provide: CIFollService, useValue: mockCIPollService },
       ],
     }).compile();
 
@@ -181,6 +189,30 @@ describe('ImplementProcessor', () => {
         123456,
         789,
         'https://github.com/test/pr/1',
+      );
+    });
+
+    it('should start CI polling after PR creation', async () => {
+      const job = {
+        id: '6',
+        data: {
+          issueNum: '222',
+          engine: 'mimo',
+          chatId: 123456,
+          userId: 789,
+          type: 'implement' as const,
+          issueTitle: 'CI Poll Test',
+          issueBody: 'body',
+        },
+        progress: jest.fn().mockResolvedValue(undefined),
+      } as unknown as Job<ImplementJobData>;
+
+      await processor.handleJob(job);
+
+      expect(mockCIPollService.startPolling).toHaveBeenCalledWith(
+        '1',
+        '222',
+        'mimo',
       );
     });
   });

--- a/bots/task-bot/src/worker/implement.processor.ts
+++ b/bots/task-bot/src/worker/implement.processor.ts
@@ -5,6 +5,7 @@ import { GitHubService } from '../github/github.service';
 import { ImplementJobData } from '../queue/implement-queue.service';
 import { ReviewQueueService } from '../queue/review-queue.service';
 import { NotificationService } from '../notification/notification.service';
+import { CIFollService } from '../ci/ci-poll.service';
 
 const concurrency = parseInt(process.env.WORKER_CONCURRENCY ?? '5', 10);
 
@@ -17,6 +18,7 @@ export class ImplementProcessor {
     private readonly githubService: GitHubService,
     private readonly reviewQueue: ReviewQueueService,
     private readonly notificationService: NotificationService,
+    private readonly ciPollService: CIFollService,
   ) {}
 
   @Process({ concurrency })
@@ -245,6 +247,12 @@ export class ImplementProcessor {
         );
       } catch (err) {
         this.logger.error(`Failed to queue review: ${(err as Error).message}`);
+      }
+
+      const prNum = prUrl.match(/\/(\d+)$/)?.[1];
+      if (prNum) {
+        this.logger.log(`Starting CI poll for PR #${prNum}`);
+        this.ciPollService.startPolling(prNum, issueNum, job.data.engine);
       }
     }
 

--- a/bots/task-bot/src/worker/worker.module.ts
+++ b/bots/task-bot/src/worker/worker.module.ts
@@ -6,6 +6,7 @@ import { ReviewProcessor } from './review.processor';
 import { ReviewQueueService } from '../queue/review-queue.service';
 import { GitHubModule } from '../github/github.module';
 import { NotificationModule } from '../notification/notification.module';
+import { CIModule } from '../ci/ci.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { NotificationModule } from '../notification/notification.module';
     ),
     GitHubModule,
     NotificationModule,
+    CIModule,
   ],
   providers: [
     { provide: ImplementProcessor, useClass: ImplementProcessor },

--- a/docs/TASK-BOT-FLOW.md
+++ b/docs/TASK-BOT-FLOW.md
@@ -29,6 +29,7 @@ Worker Process (concurrency: 3)
     ├─ 5. git commit + push
     ├─ 6. gh pr create --base develop
     ├─ 7. Queue review job
+    ├─ 8. Start CI polling (background, 30s interval, 15min timeout)
     │
     ▼
 Review Worker
@@ -42,14 +43,17 @@ CI Pipeline (GitHub Actions)
     ├─ ci.yml runs lint/typecheck/test
     ├─ If failed → auto-fix-ci.yml
     │   └─ POST to task bot /ci/fix endpoint
-    │       └─ Worker fixes + pushes
+    │       ├─ Check max attempts (default 3, Redis-tracked)
+    │       ├─ If under limit → queue fix job
+    │       └─ If over limit → notify "manual intervention needed"
+    ├─ CI Poller detects all checks passed → notify "CI Green ✅"
     │
     ▼
 Notifications (Redis pub/sub → Telegram)
     │
     ├─ "PR Opened 🔗 ..."
-    ├─ "CI Failed ❌ Auto-fixing..."
-    ├─ "CI Fixed ✅"
+    ├─ "CI Failed ❌ Auto-fixing... (attempt 1/3)"
+    ├─ "CI Fixed ✅" / "CI Passed ✅"
     └─ "Task Completed ✅"
 ```
 
@@ -235,6 +239,7 @@ REDIS_PORT=6379
 TASK_BOT_PORT=4002
 WORKER_CONCURRENCY=3
 CI_WEBHOOK_SECRET=...
+CI_FIX_MAX_ATTEMPTS=3
 
 # AI Engines
 MIMO_API_KEY=...
@@ -286,6 +291,23 @@ When PR merges → auto-closes linked issue.
 | `in-review`       | Task bot worker     | PR created, ready for review                         |
 | `priority`        | Task bot (TG)       | High/urgent priority                                 |
 | `ARC-XXX`         | Task bot (TG)       | Links to roadmap ticket                              |
+
+## CI Fix Max Attempts
+
+The CI auto-fix loop is bounded by `CI_FIX_MAX_ATTEMPTS` (default: 3). Tracked per PR in Redis with 1-hour TTL.
+
+- Each CI failure webhook increments the counter
+- When max reached, the bot stops auto-fixing and notifies "manual intervention needed"
+- Counter resets when CI passes (via `/ci/reset` endpoint or Redis TTL)
+- Configurable via `CI_FIX_MAX_ATTEMPTS` env var
+
+## CI Polling
+
+After PR creation, the worker starts a background CI poller:
+- Checks `gh pr checks` every 30 seconds
+- Notifies "CI Passed ✅" when all checks pass
+- Stops polling on failure (webhook handles auto-fix) or after 15 minutes timeout
+- Non-blocking — doesn't hold the worker process
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary

- **CI fix max attempts guard**: Tracks CI fix attempts per PR in Redis (default max: 3, configurable via `CI_FIX_MAX_ATTEMPTS`). When max reached, stops auto-fixing and notifies "manual intervention needed".
- **CI polling after PR creation**: Background poller checks `gh pr checks` every 30s, notifies "CI Passed ✅" when all checks green. Times out after 15 minutes.
- **GitHub API rate limiting**: Adds 500ms minimum delay between `gh` CLI calls to prevent API throttling.
- **Auto-fix workflow guard**: `auto-fix-ci.yml` only fires for `task-*` branches (won't loop on non-bot PRs).
- **Reset endpoint**: `POST /ci/reset` to clear attempt counter for a PR.

## Changes

| File | Change |
|------|--------|
| `bots/task-bot/src/ci/ci-fix-tracker.service.ts` | **New** — Redis-based CI fix attempt counter |
| `bots/task-bot/src/ci/ci-poll.service.ts` | **New** — Background CI status poller |
| `bots/task-bot/src/ci/ci.controller.ts` | Max attempts guard + reset endpoint |
| `bots/task-bot/src/ci/ci.module.ts` | Export new services |
| `bots/task-bot/src/worker/implement.processor.ts` | Start CI polling after PR creation |
| `bots/task-bot/src/worker/worker.module.ts` | Import CIModule |
| `bots/task-bot/src/github/github.service.ts` | Rate limiting on gh CLI calls |
| `bots/task-bot/src/task-bot/task-bot.service.ts` | Updated notification text |
| `.github/workflows/auto-fix-ci.yml` | Task-bot branch check |
| `docs/TASK-BOT-FLOW.md` | Updated flow diagram + docs |