### PR TITLE
fix(tic-tac-toe): use separate row/col bounds in infinity board validator

### DIFF
--- a/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.validators.ts
+++ b/apps/be/src/games/engines/tic-tac-toe/tic-tac-toe.validators.ts
@@ -11,14 +11,15 @@ export function validatePlaceMark(
   }
 
   const { row, col } = payload ?? { row: -1, col: -1 };
-  const size = state.board.length;
+  const rows = state.board.length;
+  const cols = state.board[0]?.length ?? rows;
   if (
     !Number.isInteger(row) ||
     !Number.isInteger(col) ||
     row < 0 ||
-    row >= size ||
+    row >= rows ||
     col < 0 ||
-    col >= size
+    col >= cols
   ) {
     return { ok: false, error: 'Move out of bounds' };
   }


### PR DESCRIPTION
## Summary
- Fix "Move out of bounds" error in Tic-Tac-Toe Infinity mode when placing marks on valid but asymmetrically-expanded positions

## Root cause
The `validatePlaceMark` function used `state.board.length` (row count) for **both** row and column bounds checks. In infinity mode, the board expands asymmetrically — moves near one edge keep adding rows/columns in that direction only, creating non-square boards (e.g., 9 rows × 34 columns). When a player tried to place at `col: 33`, the validator checked `33 >= 9` (the row count) and rejected the valid move.

## Changes
- `tic-tac-toe.validators.ts`: Use `board[0]?.length` for column bound check instead of `board.length`

## Testing
- All 1262 backend unit tests pass
- All 1139 web unit tests pass