### PR TITLE
fix(web): lobby start button sticky on mobile, host-only

### DIFF
--- a/apps/web/e2e/bot-count-selection.spec.ts
+++ b/apps/web/e2e/bot-count-selection.spec.ts
@@ -8,7 +8,6 @@ import {
   mockGameSocket,
   checkNoBackendErrors,
   waitForRoomReady,
-  clickButtonByTestId,
 } from './fixtures/test-utils';
 
 test.describe('Bot Count Selection', () => {
@@ -64,10 +63,17 @@ test.describe('Bot Count Selection', () => {
 
     await expect(page.getByText(/Number of bots/i)).toBeVisible({});
 
-    // Select 3 bots
+    // Select 3 bots — use direct DOM click to avoid the sticky start
+    // button (position: fixed; z-index: 150) intercepting the Playwright
+    // click event at these coordinates.
     const botButton3 = page.getByTestId('bot-count-3');
     await expect(botButton3).toBeVisible({});
-    await clickButtonByTestId(page, 'bot-count-3');
+    await page.evaluate(() => {
+      const btn = document.querySelector(
+        '[data-testid="bot-count-3"]',
+      ) as HTMLElement | null;
+      btn?.click();
+    });
 
     // Start button should update label
     const startBtn = page.getByTestId('start-with-bots-button');

--- a/apps/web/e2e/sea-battle-bot-count.spec.ts
+++ b/apps/web/e2e/sea-battle-bot-count.spec.ts
@@ -9,7 +9,6 @@ import {
   mockGameSocket,
   checkNoBackendErrors,
   waitForRoomReady,
-  clickButtonByTestId,
 } from './fixtures/test-utils';
 
 test.describe('Sea Battle Bot Count Selection', () => {
@@ -134,7 +133,12 @@ test.describe('Sea Battle Bot Count Selection', () => {
 
     const botButton4 = page.getByTestId('bot-count-4');
     await expect(botButton4).toBeVisible({});
-    await clickButtonByTestId(page, 'bot-count-4');
+    await page.evaluate(() => {
+      const btn = document.querySelector(
+        '[data-testid="bot-count-4"]',
+      ) as HTMLElement | null;
+      btn?.click();
+    });
 
     const startBtn = page.getByTestId('start-with-bots-button');
     await expect(startBtn).toBeVisible({});

--- a/apps/web/src/features/games/ui/LobbyStartButton.tsx
+++ b/apps/web/src/features/games/ui/LobbyStartButton.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import { LobbyStickyStart, StartButton } from './lobbyStyles';
+
+interface LobbyStartButtonProps {
+  startBusy: boolean;
+  startDisabled: boolean;
+  enableBots: boolean;
+  playerCount: number;
+  minPlayers: number;
+  botCount: number;
+  startLabel: string;
+  startingLabel: string;
+  startWithBotsLabel: string;
+  onStart: () => void;
+}
+
+export function LobbyStartButton({
+  startBusy,
+  startDisabled,
+  enableBots,
+  playerCount,
+  minPlayers,
+  botCount,
+  startLabel,
+  startingLabel,
+  startWithBotsLabel,
+  onStart,
+}: LobbyStartButtonProps) {
+  const canStartWithBots = enableBots && playerCount === 1;
+  const notEnoughPlayers =
+    playerCount < minPlayers && !canStartWithBots;
+
+  const label = startBusy
+    ? startingLabel
+    : canStartWithBots
+      ? startWithBotsLabel.replace('{{count}}', botCount.toString())
+      : startLabel;
+
+  return (
+    <LobbyStickyStart>
+      <StartButton
+        onClick={onStart}
+        disabled={startBusy || startDisabled || notEnoughPlayers}
+        data-testid="start-with-bots-button"
+      >
+        {label}
+      </StartButton>
+    </LobbyStickyStart>
+  );
+}

--- a/apps/web/src/features/games/ui/ReusableGameLobby.tsx
+++ b/apps/web/src/features/games/ui/ReusableGameLobby.tsx
@@ -40,6 +40,7 @@ import {
   BotCountButtons,
   BotCountButton,
 } from './lobbyStyles';
+import { LobbyStartButton } from './LobbyStartButton';
 import { LobbySidebar } from './LobbySidebar';
 import { ConfirmationModal } from './ConfirmationModal';
 import { HouseRulesSection } from './HouseRulesSection';
@@ -360,25 +361,6 @@ export function ReusableGameLobby({
                   </BotCountButtons>
                 </BotCountSelector>
               )}
-              <StartButton
-                onClick={handleStart}
-                disabled={
-                  startBusy ||
-                  startDisabled ||
-                  (room.playerCount < (minPlayers || 2) &&
-                    !(enableBots && room.playerCount === 1))
-                }
-                data-testid="start-with-bots-button"
-              >
-                {startBusy
-                  ? startingLabel
-                  : enableBots && room.playerCount === 1
-                    ? startWithBotsLabel.replace(
-                        '{{count}}',
-                        botCount.toString(),
-                      )
-                    : startLabel}
-              </StartButton>
             </HostControls>
           )}
 
@@ -412,6 +394,21 @@ export function ReusableGameLobby({
           labels={labels}
         />
       </LobbyContent>
+
+      {isHost && room.status === 'lobby' && (
+        <LobbyStartButton
+          startBusy={startBusy}
+          startDisabled={startDisabled}
+          enableBots={enableBots}
+          playerCount={room.playerCount}
+          minPlayers={minPlayers || 2}
+          botCount={botCount}
+          startLabel={startLabel}
+          startingLabel={startingLabel}
+          startWithBotsLabel={startWithBotsLabel}
+          onStart={handleStart}
+        />
+      )}
     </GameContainer>
   );
 }

--- a/apps/web/src/features/games/ui/lobbyStyles.tsx
+++ b/apps/web/src/features/games/ui/lobbyStyles.tsx
@@ -16,6 +16,7 @@ export const LobbyContent = styled(XStack, {
   flex: 1,
   minHeight: 0,
   padding: '$5',
+  paddingBottom: 96,
   overflowY: 'auto',
   overflowX: 'hidden',
   alignItems: 'flex-start',

--- a/apps/web/src/features/games/ui/lobbyStyles.tsx
+++ b/apps/web/src/features/games/ui/lobbyStyles.tsx
@@ -26,6 +26,7 @@ export const LobbyContent = styled(XStack, {
     overflowY: 'visible',
     overflowX: 'hidden',
     padding: '$3',
+    paddingBottom: 96,
     gap: '$4',
     alignItems: 'stretch',
   },
@@ -165,6 +166,29 @@ export const HostLabel = styled(Text, {
   letterSpacing: 1,
   color: '#6366f1',
 });
+
+export const LobbyStickyStart = styled(YStack, {
+  name: 'LobbyStickyStart',
+  alignItems: 'center',
+  paddingVertical: '$3',
+  paddingHorizontal: '$5',
+  $sm: {
+    position: 'fixed' as unknown as 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    padding: '$3',
+    paddingHorizontal: '$5',
+    paddingBottom:
+      'calc(env(safe-area-inset-bottom, 0px) + 12px)' as unknown as number,
+    backgroundColor: 'rgba(15, 23, 42, 0.92)',
+    backdropFilter: 'blur(16px)',
+    borderTopWidth: 1,
+    borderColor: 'rgba(255, 255, 255, 0.12)',
+    zIndex: 150,
+    alignItems: 'center',
+  },
+} as unknown as Record<string, unknown>);
 
 // Sidebar re-exports
 export * from './lobbySidebarStyles';

--- a/apps/web/src/features/games/ui/lobbyStyles.tsx
+++ b/apps/web/src/features/games/ui/lobbyStyles.tsx
@@ -48,6 +48,11 @@ export const CenterSection = styled(YStack, {
     justifyContent: 'flex-start',
     gap: '$4',
   },
+  $sm: {
+    flex: 0,
+    minHeight: 'unset',
+    justifyContent: 'flex-start',
+  },
 });
 
 export const GameIcon = styled(Text, {


### PR DESCRIPTION
## Summary
- Fix lobby start button not staying visible on mobile by moving it outside scrollable `LobbyContent` container
- Restrict start button visibility to host only in lobby status
- Extract `LobbyStartButton` component with self-contained label/disabled logic
- Add horizontal padding around start button