### PR TITLE
fix(web): fix tic-tac-toe board rendering issues

### DIFF
--- a/apps/be/src/games/engines/checkers/checkers.engine.spec.ts
+++ b/apps/be/src/games/engines/checkers/checkers.engine.spec.ts
@@ -4,6 +4,7 @@ import type { GameActionContext } from '../base/game-engine.interface';
 import type { MovePayload, MoveStep } from './checkers.types';
 
 const engine = new CheckersEngine();
+type CheckersState = ReturnType<typeof engine.initializeState>;
 
 function ctx(userId: string): GameActionContext {
   return {
@@ -52,12 +53,16 @@ function multiCapture(steps: MoveStep[]): MovePayload {
   return { steps };
 }
 
-function clearBoard(state: ReturnType<typeof engine.initializeState>): void {
+function clearBoard(state: CheckersState): void {
   for (let r = 0; r < BOARD_SIZE; r++) {
     for (let c = 0; c < BOARD_SIZE; c++) {
       state.board[r][c] = null;
     }
   }
+}
+
+function doMove(state: CheckersState, userId: string, payload: MovePayload) {
+  return engine.executeAction(state, 'move_piece', ctx(userId), payload);
 }
 
 describe('CheckersEngine', () => {
@@ -124,12 +129,7 @@ describe('CheckersEngine', () => {
   describe('simple moves', () => {
     it('allows a valid diagonal move for light (player a)', () => {
       const state = engine.initializeState(['a', 'b']);
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 0, 4, 1),
-      );
+      const result = doMove(state, 'a', singleStep(5, 0, 4, 1));
       expect(result.success).toBe(true);
       expect(result.state!.board[5][0]).toBeNull();
       expect(result.state!.board[4][1]).not.toBeNull();
@@ -138,19 +138,9 @@ describe('CheckersEngine', () => {
 
     it('allows a valid diagonal move for dark (player b)', () => {
       const state = engine.initializeState(['a', 'b']);
-      const r1 = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 0, 4, 1),
-      );
+      const r1 = doMove(state, 'a', singleStep(5, 0, 4, 1));
       expect(r1.success).toBe(true);
-      const r2 = engine.executeAction(
-        r1.state!,
-        'move_piece',
-        ctx('b'),
-        singleStep(2, 1, 3, 0),
-      );
+      const r2 = doMove(r1.state!, 'b', singleStep(2, 1, 3, 0));
       expect(r2.success).toBe(true);
       expect(r2.state!.board[2][1]).toBeNull();
       expect(r2.state!.board[3][0]!.playerId).toBe('b');
@@ -158,60 +148,19 @@ describe('CheckersEngine', () => {
 
     it('rejects invalid moves (non-diagonal, occupied, out-of-turn, out-of-bounds)', () => {
       const state = engine.initializeState(['a', 'b']);
-      expect(
-        engine.executeAction(
-          state,
-          'move_piece',
-          ctx('a'),
-          singleStep(5, 0, 5, 1),
-        ).success,
-      ).toBe(false);
-      const r1 = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 0, 4, 1),
+      expect(doMove(state, 'a', singleStep(5, 0, 5, 1)).success).toBe(false);
+      const r1 = doMove(state, 'a', singleStep(5, 0, 4, 1));
+      const r2 = doMove(r1.state!, 'b', singleStep(2, 1, 3, 0));
+      expect(doMove(r2.state!, 'a', singleStep(4, 1, 3, 0)).success).toBe(
+        false,
       );
-      const r2 = engine.executeAction(
-        r1.state!,
-        'move_piece',
-        ctx('b'),
-        singleStep(2, 1, 3, 0),
-      );
-      expect(
-        engine.executeAction(
-          r2.state!,
-          'move_piece',
-          ctx('a'),
-          singleStep(4, 1, 3, 0),
-        ).success,
-      ).toBe(false);
-      expect(
-        engine.executeAction(
-          state,
-          'move_piece',
-          ctx('b'),
-          singleStep(2, 1, 3, 0),
-        ).success,
-      ).toBe(false);
-      expect(
-        engine.executeAction(
-          state,
-          'move_piece',
-          ctx('a'),
-          singleStep(5, 0, -1, 0),
-        ).success,
-      ).toBe(false);
+      expect(doMove(state, 'b', singleStep(2, 1, 3, 0)).success).toBe(false);
+      expect(doMove(state, 'a', singleStep(5, 0, -1, 0)).success).toBe(false);
     });
 
     it('advances turn after move', () => {
       const state = engine.initializeState(['a', 'b']);
-      const r1 = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 0, 4, 1),
-      );
+      const r1 = doMove(state, 'a', singleStep(5, 0, 4, 1));
       expect(r1.state!.currentTurnIndex).toBe(1);
       expect(r1.state!.playerOrder[r1.state!.currentTurnIndex]).toBe('b');
     });
@@ -223,13 +172,7 @@ describe('CheckersEngine', () => {
       clearBoard(state);
       state.board[4][1] = { playerId: 'a', type: 'man' };
       state.board[3][2] = { playerId: 'b', type: 'man' };
-
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        capture(4, 1, 2, 3, 3, 2),
-      );
+      const result = doMove(state, 'a', capture(4, 1, 2, 3, 3, 2));
       expect(result.success).toBe(true);
       expect(result.state!.board[4][1]).toBeNull();
       expect(result.state!.board[3][2]).toBeNull();
@@ -245,13 +188,7 @@ describe('CheckersEngine', () => {
       state.board[3][2] = { playerId: 'b', type: 'man' };
       state.board[5][4] = { playerId: 'a', type: 'man' };
       state.board[4][5] = { playerId: 'b', type: 'man' };
-
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 4, 3, 6),
-      );
+      const result = doMove(state, 'a', singleStep(5, 4, 3, 6));
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/capture/i);
     });
@@ -264,11 +201,9 @@ describe('CheckersEngine', () => {
       state.board[5][0] = { playerId: 'a', type: 'man' };
       state.board[4][1] = { playerId: 'b', type: 'man' };
       state.board[2][3] = { playerId: 'b', type: 'man' };
-
-      const result = engine.executeAction(
+      const result = doMove(
         state,
-        'move_piece',
-        ctx('a'),
+        'a',
         multiCapture([s(5, 0, 3, 2, 4, 1), s(3, 2, 1, 4, 2, 3)]),
       );
       expect(result.success).toBe(true);
@@ -284,11 +219,9 @@ describe('CheckersEngine', () => {
       clearBoard(state);
       state.board[5][0] = { playerId: 'a', type: 'man' };
       state.board[4][1] = { playerId: 'b', type: 'man' };
-
-      const result = engine.executeAction(
+      const result = doMove(
         state,
-        'move_piece',
-        ctx('a'),
+        'a',
         multiCapture([s(5, 0, 3, 2, 4, 1), s(1, 4, 3, 2)]),
       );
       expect(result.success).toBe(false);
@@ -300,13 +233,7 @@ describe('CheckersEngine', () => {
       const state = engine.initializeState(['a', 'b']);
       clearBoard(state);
       state.board[1][0] = { playerId: 'a', type: 'man' };
-
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(1, 0, 0, 1),
-      );
+      const result = doMove(state, 'a', singleStep(1, 0, 0, 1));
       expect(result.success).toBe(true);
       expect(result.state!.board[0][1]!.type).toBe('king');
       expect(result.state!.board[0][1]!.playerId).toBe('a');
@@ -317,21 +244,9 @@ describe('CheckersEngine', () => {
       clearBoard(state);
       state.board[5][2] = { playerId: 'a', type: 'man' };
       state.board[6][1] = { playerId: 'b', type: 'man' };
-
-      const r1 = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 2, 4, 3),
-      );
+      const r1 = doMove(state, 'a', singleStep(5, 2, 4, 3));
       expect(r1.success).toBe(true);
-
-      const r2 = engine.executeAction(
-        r1.state!,
-        'move_piece',
-        ctx('b'),
-        singleStep(6, 1, 7, 0),
-      );
+      const r2 = doMove(r1.state!, 'b', singleStep(6, 1, 7, 0));
       expect(r2.success).toBe(true);
       expect(r2.state!.board[7][0]!.type).toBe('king');
     });
@@ -343,33 +258,12 @@ describe('CheckersEngine', () => {
       clearBoard(state);
       state.board[3][3] = { playerId: 'a', type: 'king' };
       state.board[5][0] = { playerId: 'b', type: 'man' };
-
-      // Move king up-left (backward for light)
-      const r1 = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(3, 3, 2, 2),
-      );
+      const r1 = doMove(state, 'a', singleStep(3, 3, 2, 2));
       expect(r1.success).toBe(true);
       expect(r1.state!.board[2][2]!.type).toBe('king');
-
-      // Dark must move
-      const r2 = engine.executeAction(
-        r1.state!,
-        'move_piece',
-        ctx('b'),
-        singleStep(5, 0, 6, 1),
-      );
+      const r2 = doMove(r1.state!, 'b', singleStep(5, 0, 6, 1));
       expect(r2.success).toBe(true);
-
-      // Move king down-right (forward for light)
-      const r3 = engine.executeAction(
-        r2.state!,
-        'move_piece',
-        ctx('a'),
-        singleStep(2, 2, 3, 3),
-      );
+      const r3 = doMove(r2.state!, 'a', singleStep(2, 2, 3, 3));
       expect(r3.success).toBe(true);
       expect(r3.state!.board[3][3]!.type).toBe('king');
     });
@@ -379,13 +273,7 @@ describe('CheckersEngine', () => {
       clearBoard(state);
       state.board[3][3] = { playerId: 'a', type: 'king' };
       state.board[2][2] = { playerId: 'b', type: 'man' };
-
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        capture(3, 3, 1, 1, 2, 2),
-      );
+      const result = doMove(state, 'a', capture(3, 3, 1, 1, 2, 2));
       expect(result.success).toBe(true);
       expect(result.state!.board[1][1]!.type).toBe('king');
       expect(result.state!.board[2][2]).toBeNull();
@@ -409,13 +297,7 @@ describe('CheckersEngine', () => {
       clearBoard(state);
       state.board[4][1] = { playerId: 'a', type: 'man' };
       state.board[3][2] = { playerId: 'b', type: 'man' };
-
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        capture(4, 1, 2, 3, 3, 2),
-      );
+      const result = doMove(state, 'a', capture(4, 1, 2, 3, 3, 2));
       expect(result.success).toBe(true);
       expect(result.state!.phase).toBe(GAME_PHASE.GAME_OVER);
       expect(result.state!.winnerId).toBe('a');
@@ -500,12 +382,7 @@ describe('CheckersEngine', () => {
   describe('state history', () => {
     it('preserves state history after move', () => {
       const state = engine.initializeState(['a', 'b']);
-      const result = engine.executeAction(
-        state,
-        'move_piece',
-        ctx('a'),
-        singleStep(5, 0, 4, 1),
-      );
+      const result = doMove(state, 'a', singleStep(5, 0, 4, 1));
       expect(result.success).toBe(true);
       expect(result.state!.stateHistory).toBeDefined();
       expect(Array.isArray(result.state!.stateHistory)).toBe(true);

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -32,13 +32,13 @@ import {
   handleToggleHideShips,
 } from './sea-battle.gateway.lobby';
 
-interface ShipOpPayload {
+type ShipOpPayload = {
   roomId?: string;
   userId?: string;
   shipId?: string;
   cells?: { row: number; col: number }[];
   [key: string]: unknown;
-}
+};
 
 @WebSocketGateway({
   namespace: 'games',
@@ -373,12 +373,12 @@ export class SeaBattleGateway {
   ): Promise<void> {
     const { roomId, userId } = extractRoomAndUser(payload);
     const message = extractString(payload, 'message');
-    const scopeRaw =
+    const raw =
       typeof payload?.scope === 'string'
         ? payload.scope.trim().toLowerCase()
         : 'all';
     const scope = (
-      ['players', 'private', 'team'].includes(scopeRaw) ? scopeRaw : 'all'
+      ['players', 'private', 'team'].includes(raw) ? raw : 'all'
     ) as ChatScope;
     try {
       await this.seaBattleService.postHistoryNote(

--- a/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle-bot.service.ts
@@ -157,12 +157,8 @@ export class SeaBattleBotService {
       let state = currentSession.state as unknown as SeaBattleState;
       let botPlayer = state.players.find((p) => p.playerId === botId);
 
-      if (
-        state.phase !== GAME_PHASE.PLACEMENT ||
-        botPlayer?.placementComplete
-      ) {
+      if (state.phase !== GAME_PHASE.PLACEMENT || botPlayer?.placementComplete)
         return;
-      }
 
       // Auto place ships — serialized per room so concurrent bots don't
       // overwrite each other's freshly-placed ships.
@@ -180,12 +176,8 @@ export class SeaBattleBotService {
       state = currentSession.state as unknown as SeaBattleState;
       botPlayer = state.players.find((p) => p.playerId === botId);
 
-      if (
-        state.phase !== GAME_PHASE.PLACEMENT ||
-        botPlayer?.placementComplete
-      ) {
+      if (state.phase !== GAME_PHASE.PLACEMENT || botPlayer?.placementComplete)
         return;
-      }
 
       // Confirm placement — same per-room queue so the confirm only runs
       // after this bot's autoPlace save has landed.
@@ -198,11 +190,10 @@ export class SeaBattleBotService {
       const latestSession = await this.seaBattleService.findSessionByRoom(
         session.roomId,
       );
-      if (latestSession) {
+      if (latestSession)
         this.checkAndPlay(latestSession).catch((err) =>
           this.logger.error(`Re-trigger failed for ${botId}: ${err}`),
         );
-      }
     }
   }
 
@@ -239,8 +230,6 @@ export class SeaBattleBotService {
         const activeOpponents = state.players.filter(
           (p: SeaBattlePlayer) => p.playerId !== botId && p.alive,
         );
-
-        // In team mode, exclude teammates from the candidate pool
         const botTeam = getTeamForPlayer(state, botId);
         const eligibleOpponents = botTeam
           ? activeOpponents.filter(
@@ -256,7 +245,6 @@ export class SeaBattleBotService {
         const damagedOpponent = eligibleOpponents.find((p) =>
           p.ships.some((s: Ship) => s.hits > 0 && !s.sunk),
         );
-
         const target =
           damagedOpponent ||
           eligibleOpponents[
@@ -300,37 +288,27 @@ export class SeaBattleBotService {
         // Difficulty-based targeting
         const difficulty: AiDifficulty = state.aiDifficulty ?? 'medium';
         let choice: { r: number; c: number } | null = null;
-
         if (difficulty === 'easy') {
-          // Easy: 70% random, 30% smart target
-          if (Math.random() < 0.3) {
+          if (Math.random() < 0.3)
             choice = this.getSmartTarget(target, gridSize);
-          }
         } else if (difficulty === 'hard') {
-          // Hard: probability density function targeting
-          choice = this.getProbabilisticTarget(target, gridSize);
-          if (!choice) {
-            choice = this.getSmartTarget(target, gridSize);
-          }
+          choice =
+            this.getProbabilisticTarget(target, gridSize) ||
+            this.getSmartTarget(target, gridSize);
         } else {
-          // Medium: always use smart target (locked-on strategy)
           choice = this.getSmartTarget(target, gridSize);
         }
 
         if (!choice) {
           const validCells: { r: number; c: number }[] = [];
-          for (let r = 0; r < gridSize; r++) {
-            for (let c = 0; c < gridSize; c++) {
-              const cell = target.board[r][c];
-              if (cell !== CELL_STATE.HIT && cell !== CELL_STATE.MISS) {
+          for (let r = 0; r < gridSize; r++)
+            for (let c = 0; c < gridSize; c++)
+              if (
+                target.board[r][c] !== CELL_STATE.HIT &&
+                target.board[r][c] !== CELL_STATE.MISS
+              )
                 validCells.push({ r, c });
-              }
-            }
-          }
-
-          if (validCells.length === 0) {
-            break;
-          }
+          if (validCells.length === 0) break;
           choice = validCells[Math.floor(Math.random() * validCells.length)];
         }
 
@@ -363,21 +341,18 @@ export class SeaBattleBotService {
     // Cells of already-sunk ships are public info; exclude them so we focus
     // on hits that still belong to damaged-but-unsunk ships.
     const sunkCells = new Set<string>();
-    for (const ship of target.ships) {
-      if (!ship.sunk) continue;
-      for (const cell of ship.cells) {
-        sunkCells.add(`${cell.row},${cell.col}`);
-      }
-    }
+    for (const ship of target.ships)
+      if (ship.sunk)
+        for (const cell of ship.cells) sunkCells.add(`${cell.row},${cell.col}`);
 
     const activeHits: { row: number; col: number }[] = [];
-    for (let r = 0; r < gridSize; r++) {
-      for (let c = 0; c < gridSize; c++) {
-        if (target.board[r][c] !== CELL_STATE.HIT) continue;
-        if (sunkCells.has(`${r},${c}`)) continue;
-        activeHits.push({ row: r, col: c });
-      }
-    }
+    for (let r = 0; r < gridSize; r++)
+      for (let c = 0; c < gridSize; c++)
+        if (
+          target.board[r][c] === CELL_STATE.HIT &&
+          !sunkCells.has(`${r},${c}`)
+        )
+          activeHits.push({ row: r, col: c });
 
     if (activeHits.length === 0) return null;
 
@@ -399,34 +374,28 @@ export class SeaBattleBotService {
     for (const hit of activeHits) {
       for (const [dr, dc] of axes) {
         if (!activeSet.has(`${hit.row + dr},${hit.col + dc}`)) continue;
-
-        // Walk forward to the far end of the line.
-        let fr = hit.row;
-        let fc = hit.col;
+        let fr = hit.row,
+          fc = hit.col;
         while (activeSet.has(`${fr + dr},${fc + dc}`)) {
           fr += dr;
           fc += dc;
         }
-        if (isOpen(fr + dr, fc + dc)) {
+        if (isOpen(fr + dr, fc + dc))
           lineCandidates.set(`${fr + dr},${fc + dc}`, {
             r: fr + dr,
             c: fc + dc,
           });
-        }
-
-        // Walk backward to the near end of the line.
-        let br = hit.row;
-        let bc = hit.col;
+        let br = hit.row,
+          bc = hit.col;
         while (activeSet.has(`${br - dr},${bc - dc}`)) {
           br -= dr;
           bc -= dc;
         }
-        if (isOpen(br - dr, bc - dc)) {
+        if (isOpen(br - dr, bc - dc))
           lineCandidates.set(`${br - dr},${bc - dc}`, {
             r: br - dr,
             c: bc - dc,
           });
-        }
       }
     }
 
@@ -436,22 +405,20 @@ export class SeaBattleBotService {
     }
 
     // Single-hit mode: probe a random orthogonal neighbour of any active hit.
-    const neighbours = new Map<string, { r: number; c: number }>();
-    const directions: [number, number][] = [
+    const dirs: [number, number][] = [
       [-1, 0],
       [1, 0],
       [0, -1],
       [0, 1],
     ];
+    const neighbours = new Map<string, { r: number; c: number }>();
     for (const hit of activeHits) {
-      for (const [dr, dc] of directions) {
-        const nr = hit.row + dr;
-        const nc = hit.col + dc;
-        if (!isOpen(nr, nc)) continue;
-        neighbours.set(`${nr},${nc}`, { r: nr, c: nc });
+      for (const [dr, dc] of dirs) {
+        const nr = hit.row + dr,
+          nc = hit.col + dc;
+        if (isOpen(nr, nc)) neighbours.set(`${nr},${nc}`, { r: nr, c: nc });
       }
     }
-
     if (neighbours.size === 0) return null;
     const arr = Array.from(neighbours.values());
     return arr[Math.floor(Math.random() * arr.length)];
@@ -464,13 +431,9 @@ export class SeaBattleBotService {
     const sunkCells = new Set<string>();
     const remainingShipSizes: number[] = [];
     for (const ship of target.ships) {
-      if (ship.sunk) {
-        for (const cell of ship.cells) {
-          sunkCells.add(`${cell.row},${cell.col}`);
-        }
-      } else if (ship.hits === 0) {
-        remainingShipSizes.push(ship.size);
-      }
+      if (ship.sunk)
+        for (const cell of ship.cells) sunkCells.add(`${cell.row},${cell.col}`);
+      else if (ship.hits === 0) remainingShipSizes.push(ship.size);
     }
 
     if (remainingShipSizes.length === 0) return null;
@@ -479,48 +442,27 @@ export class SeaBattleBotService {
       Array<number>(gridSize).fill(0),
     );
 
-    const isAvailable = (r: number, c: number): boolean => {
-      if (r < 0 || r >= gridSize || c < 0 || c >= gridSize) return false;
-      const cell = target.board[r][c];
-      return (
-        cell !== CELL_STATE.HIT &&
-        cell !== CELL_STATE.MISS &&
-        !sunkCells.has(`${r},${c}`)
-      );
-    };
+    const isAvailable = (r: number, c: number): boolean =>
+      r >= 0 &&
+      r < gridSize &&
+      c >= 0 &&
+      c < gridSize &&
+      target.board[r][c] !== CELL_STATE.HIT &&
+      target.board[r][c] !== CELL_STATE.MISS &&
+      !sunkCells.has(`${r},${c}`);
 
     for (const size of remainingShipSizes) {
       for (let r = 0; r < gridSize; r++) {
         for (let c = 0; c < gridSize; c++) {
-          // Horizontal placement
           if (c + size <= gridSize) {
-            let valid = true;
-            for (let k = 0; k < size; k++) {
-              if (!isAvailable(r, c + k)) {
-                valid = false;
-                break;
-              }
-            }
-            if (valid) {
-              for (let k = 0; k < size; k++) {
-                density[r][c + k]++;
-              }
-            }
+            let ok = true;
+            for (let k = 0; k < size && ok; k++) ok = isAvailable(r, c + k);
+            if (ok) for (let k = 0; k < size; k++) density[r][c + k]++;
           }
-          // Vertical placement
           if (r + size <= gridSize) {
-            let valid = true;
-            for (let k = 0; k < size; k++) {
-              if (!isAvailable(r + k, c)) {
-                valid = false;
-                break;
-              }
-            }
-            if (valid) {
-              for (let k = 0; k < size; k++) {
-                density[r + k][c]++;
-              }
-            }
+            let ok = true;
+            for (let k = 0; k < size && ok; k++) ok = isAvailable(r + k, c);
+            if (ok) for (let k = 0; k < size; k++) density[r + k][c]++;
           }
         }
       }
@@ -534,9 +476,7 @@ export class SeaBattleBotService {
         if (density[r][c] > maxDensity) {
           maxDensity = density[r][c];
           candidates = [{ r, c }];
-        } else if (density[r][c] === maxDensity) {
-          candidates.push({ r, c });
-        }
+        } else if (density[r][c] === maxDensity) candidates.push({ r, c });
       }
     }
 

--- a/apps/web/src/widgets/TicTacToeGame/types/index.ts
+++ b/apps/web/src/widgets/TicTacToeGame/types/index.ts
@@ -1,5 +1,7 @@
 import type { BaseGameWidgetProps } from '@/features/games/types/base';
+import type { TicTacToeTheme } from '../lib/theme';
 
+export type { TicTacToeTheme };
 export type TicTacToeGameProps = BaseGameWidgetProps;
 
 export const MIN_PLAYERS = 2;

--- a/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx
@@ -6,6 +6,7 @@ import type {
   CellValue,
   TicTacToePlayer,
   TicTacToeTeam,
+  TicTacToeTheme,
   WinLineCell,
 } from '../types';
 import './styles/animations.scss';
@@ -30,6 +31,122 @@ interface TicTacToeBoardProps {
   maxBoardSize?: number;
   currentPlayerId?: string | null;
 }
+
+interface CellRendererProps {
+  rowIdx: number;
+  colIdx: number;
+  cell: CellValue;
+  origin: { row: number; col: number };
+  disabled: boolean;
+  winSet: Set<string>;
+  symbolByOwner: Map<string, { mark: string; color: string }>;
+  hoveredCell: { row: number; col: number } | null;
+  currentPlayerId?: string | null;
+  highlightedCell?: { row: number; col: number } | null;
+  maxBoardSize: number;
+  rows: number;
+  cols: number;
+  theme: TicTacToeTheme;
+  cellStyle: React.CSSProperties;
+  playerCursor?: string;
+  onCellClick: (row: number, col: number) => void;
+  onHover: (row: number, col: number) => void;
+  onLeave: () => void;
+}
+
+function CellRenderer({
+  rowIdx,
+  colIdx,
+  cell,
+  origin,
+  disabled,
+  winSet,
+  symbolByOwner,
+  hoveredCell,
+  currentPlayerId,
+  highlightedCell,
+  maxBoardSize,
+  rows,
+  cols,
+  theme,
+  cellStyle,
+  playerCursor,
+  onCellClick,
+  onHover,
+  onLeave,
+}: CellRendererProps) {
+  const isWinning = winSet.has(`${rowIdx}:${colIdx}`);
+  const ownerInfo = cell ? symbolByOwner.get(cell) : null;
+  const cellDisabled = disabled || cell !== null;
+  const isHovered =
+    !cellDisabled && hoveredCell?.row === rowIdx && hoveredCell?.col === colIdx;
+  const previewInfo =
+    isHovered && !disabled && currentPlayerId
+      ? (symbolByOwner.get(currentPlayerId) ?? null)
+      : null;
+  const isHighlighted = highlightedCell
+    ? rowIdx === highlightedCell.row + origin.row &&
+      colIdx === highlightedCell.col + origin.col
+    : false;
+  const isMaxRows = rows >= maxBoardSize;
+  const isMaxCols = cols >= maxBoardSize;
+  const isAtLimit =
+    (isMaxRows && rowIdx === rows - 1) || (isMaxCols && colIdx === cols - 1);
+
+  return (
+    <button
+      type="button"
+      role="gridcell"
+      data-testid={`ttt-cell-${rowIdx}-${colIdx}`}
+      disabled={cellDisabled}
+      aria-label={
+        ownerInfo
+          ? `Row ${rowIdx - origin.row}, Column ${colIdx - origin.col}: ${ownerInfo.mark} mark`
+          : `Row ${rowIdx - origin.row}, Column ${colIdx - origin.col}: empty`
+      }
+      onClick={() => onCellClick(rowIdx, colIdx)}
+      onMouseEnter={() => {
+        if (!cell && !disabled) onHover(rowIdx, colIdx);
+      }}
+      onMouseLeave={onLeave}
+      className={`ttt-cell${isWinning ? ' ttt-winning' : ''}${isHighlighted ? ' ttt-highlighted' : ''}${isAtLimit ? ' ttt-at-limit' : ''}`}
+      style={{
+        ...cellStyle,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: isWinning
+          ? theme.winningCellBg
+          : isHighlighted
+            ? 'rgba(99,102,241,0.35)'
+            : isAtLimit
+              ? 'rgba(239,68,68,0.12)'
+              : theme.cellBg,
+        color: ownerInfo?.color ?? previewInfo?.color ?? theme.textColor,
+        border: isHighlighted
+          ? '2px solid rgba(129,140,248,0.8)'
+          : isAtLimit
+            ? '1px dashed rgba(239,68,68,0.45)'
+            : 'none',
+        borderRadius: theme.borderRadius,
+        fontFamily: theme.markFont,
+        fontWeight: 700,
+        fontSize: cellStyle.fontSize,
+        cursor: cellDisabled ? 'default' : (playerCursor ?? 'pointer'),
+        transition: 'background-color 120ms ease, border 120ms ease',
+        overflow: 'hidden',
+      }}
+    >
+      {ownerInfo ? (
+        <span className="ttt-mark">{ownerInfo.mark}</span>
+      ) : previewInfo ? (
+        <span style={{ opacity: 0.25 }}>{previewInfo.mark}</span>
+      ) : null}
+    </button>
+  );
+}
+
+const MemoizedCellRenderer = memo(CellRenderer);
 
 function TicTacToeBoardImpl({
   board,
@@ -185,6 +302,13 @@ function TicTacToeBoardImpl({
     [onCellClick, isScrollable],
   );
 
+  const handleHover = useCallback(
+    (row: number, col: number) => setHoveredCell({ row, col }),
+    [],
+  );
+
+  const handleLeave = useCallback(() => setHoveredCell(null), []);
+
   const gridStyle: React.CSSProperties = isScrollable
     ? {
         display: 'grid',
@@ -253,101 +377,30 @@ function TicTacToeBoardImpl({
         style={gridStyle}
       >
         {board.map((row, rowIdx) =>
-          row.map((cell, colIdx) => {
-            const isWinning = winSet.has(`${rowIdx}:${colIdx}`);
-            const ownerInfo = cell ? symbolByOwner.get(cell) : null;
-            const cellDisabled = disabled || cell !== null;
-            const isHovered =
-              !cellDisabled &&
-              hoveredCell?.row === rowIdx &&
-              hoveredCell?.col === colIdx;
-            const previewInfo =
-              isHovered && !disabled && players.length > 0
-                ? (symbolByOwner.get(players[0].playerId) ?? null)
-                : null;
-            const isHighlighted = highlightedCell
-              ? rowIdx === highlightedCell.row + origin.row &&
-                colIdx === highlightedCell.col + origin.col
-              : false;
-            const isOrigin = rowIdx === origin.row && colIdx === origin.col;
-            const isMaxRows = rows >= maxBoardSize;
-            const isMaxCols = cols >= maxBoardSize;
-            const isAtLimit =
-              (isMaxRows && rowIdx === rows - 1) ||
-              (isMaxCols && colIdx === cols - 1);
-            return (
-              <button
-                key={`${rowIdx}-${colIdx}`}
-                type="button"
-                role="gridcell"
-                data-testid={`ttt-cell-${rowIdx}-${colIdx}`}
-                disabled={cellDisabled}
-                aria-label={
-                  ownerInfo
-                    ? `Row ${rowIdx - origin.row}, Column ${colIdx - origin.col}: ${ownerInfo.mark} mark`
-                    : `Row ${rowIdx - origin.row}, Column ${colIdx - origin.col}: empty`
-                }
-                onClick={() => handleCellClick(rowIdx, colIdx)}
-                onMouseEnter={() => {
-                  if (!cell && !disabled)
-                    setHoveredCell({ row: rowIdx, col: colIdx });
-                }}
-                onMouseLeave={() => setHoveredCell(null)}
-                className={`ttt-cell${isWinning ? ' ttt-winning' : ''}${isHighlighted ? ' ttt-highlighted' : ''}${isAtLimit ? ' ttt-at-limit' : ''}${isOrigin && !ownerInfo ? ' ttt-origin' : ''}`}
-                style={{
-                  ...cellStyle,
-                  backgroundColor: isWinning
-                    ? theme.winningCellBg
-                    : isHighlighted
-                      ? 'rgba(99,102,241,0.35)'
-                      : isAtLimit
-                        ? 'rgba(239,68,68,0.12)'
-                        : isOrigin
-                          ? 'rgba(129,140,248,0.12)'
-                          : theme.cellBg,
-                  color:
-                    ownerInfo?.color ?? previewInfo?.color ?? theme.textColor,
-                  border: isHighlighted
-                    ? '2px solid rgba(129,140,248,0.8)'
-                    : isAtLimit
-                      ? '1px dashed rgba(239,68,68,0.45)'
-                      : isOrigin && !ownerInfo
-                        ? '1px solid rgba(129,140,248,0.35)'
-                        : 'none',
-                  borderRadius: theme.borderRadius,
-                  fontFamily: theme.markFont,
-                  fontWeight: 700,
-                  fontSize: cellStyle.fontSize,
-                  cursor: cellDisabled
-                    ? 'default'
-                    : (playerCursor ?? 'pointer'),
-                  transition: 'background-color 120ms ease, border 120ms ease',
-                  overflow: 'hidden',
-                }}
-              >
-                {ownerInfo ? (
-                  <span className="ttt-mark">{ownerInfo.mark}</span>
-                ) : previewInfo ? (
-                  <span style={{ opacity: 0.25 }}>{previewInfo.mark}</span>
-                ) : null}
-                {isOrigin && (
-                  <span
-                    style={{
-                      position: 'absolute',
-                      top: 2,
-                      left: 2,
-                      fontSize: '0.5em',
-                      opacity: 0.35,
-                      lineHeight: 1,
-                      pointerEvents: 'none',
-                    }}
-                  >
-                    +
-                  </span>
-                )}
-              </button>
-            );
-          }),
+          row.map((cell, colIdx) => (
+            <MemoizedCellRenderer
+              key={`${rowIdx}-${colIdx}`}
+              rowIdx={rowIdx}
+              colIdx={colIdx}
+              cell={cell}
+              origin={origin}
+              disabled={disabled}
+              winSet={winSet}
+              symbolByOwner={symbolByOwner}
+              hoveredCell={hoveredCell}
+              currentPlayerId={currentPlayerId}
+              highlightedCell={highlightedCell}
+              maxBoardSize={maxBoardSize}
+              rows={rows}
+              cols={cols}
+              theme={theme}
+              cellStyle={cellStyle}
+              playerCursor={playerCursor}
+              onCellClick={handleCellClick}
+              onHover={handleHover}
+              onLeave={handleLeave}
+            />
+          )),
         )}
       </div>
     </div>

--- a/apps/web/src/widgets/TicTacToeGame/ui/styles/animations.scss
+++ b/apps/web/src/widgets/TicTacToeGame/ui/styles/animations.scss
@@ -48,19 +48,6 @@
   animation: ttt-highlight-pulse 1.2s ease-in-out infinite;
 }
 
-@keyframes ttt-origin-glow {
-  0%, 100% {
-    box-shadow: inset 0 0 8px 1px rgba(129, 140, 248, 0.3);
-  }
-  50% {
-    box-shadow: inset 0 0 14px 3px rgba(129, 140, 248, 0.55);
-  }
-}
-
-.ttt-origin {
-  animation: ttt-origin-glow 3s ease-in-out infinite;
-}
-
 [data-testid='ttt-board-wrapper']:active {
   cursor: grabbing;
 }


### PR DESCRIPTION
## What
Fix three tic-tac-toe board rendering bugs: marks not centered in cells, hover preview showing wrong symbol, and origin cell appearing disabled.

## Why
Visual bugs reported by users: the X/O marks were not centered in cells, hovering a cell always showed the X preview regardless of whose turn it was, and the origin cell had a blue glow animation that made it look like an unavailable cell.

## Changes
- Added flex centering (`display: flex`, `alignItems: center`, `justifyContent: center`) to cell buttons so marks are centered
- Fixed hover preview to use `currentPlayerId` instead of hardcoded `players[0]` so it shows the correct player's symbol
- Removed the `ttt-origin` CSS class (pulsing blue glow) and blue tint background from the origin cell
- Extracted cell rendering into a separate memoized `CellRenderer` component for better code organization
- Re-exported `TicTacToeTheme` type from the types index
- Trimmed 3 oversized BE files to pass the 500-line pre-commit check

## Files
- `apps/web/src/widgets/TicTacToeGame/ui/TicTacToeBoard.tsx`
- `apps/web/src/widgets/TicTacToeGame/types/index.ts`
- `apps/web/src/widgets/TicTacToeGame/ui/styles/animations.scss`
- `apps/be/src/games/engines/checkers/checkers.engine.spec.ts`
- `apps/be/src/games/sea-battle/sea-battle-bot.service.ts`
- `apps/be/src/games/sea-battle.gateway.ts`