### PR TITLE
fix(auth): resolve periodic re-login by fixing token refresh and session recovery

### DIFF
--- a/apps/be/src/auth/auth.controller.ts
+++ b/apps/be/src/auth/auth.controller.ts
@@ -74,9 +74,12 @@ function setTokenCookies(
   });
 }
 
-function clearTokenCookies(res: Response): void {
-  res.clearCookie('access_token', { path: '/' });
-  res.clearCookie('refresh_token', { path: '/' });
+function clearTokenCookies(res: Response, req: Request): void {
+  const secure = isSecureOrigin(req);
+  const sameSite: 'strict' | 'none' | 'lax' = secure ? 'none' : 'lax';
+  const options = { path: '/', httpOnly: true, secure, sameSite };
+  res.clearCookie('access_token', options);
+  res.clearCookie('refresh_token', options);
 }
 
 @Controller('auth')
@@ -199,8 +202,8 @@ export class AuthController {
 
   @Post('logout')
   @HttpCode(204)
-  logout(@Res({ passthrough: true }) res: Response): void {
-    clearTokenCookies(res);
+  logout(@Req() req: Request, @Res({ passthrough: true }) res: Response): void {
+    clearTokenCookies(res, req);
   }
 
   // Account-enumeration defense: always 204, never reveal whether the email

--- a/apps/web/src/app/BrowserRegistry.tsx
+++ b/apps/web/src/app/BrowserRegistry.tsx
@@ -67,6 +67,27 @@ export default function BrowserRegistry({ children }: BrowserRegistryProps) {
   }, []);
 
   useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return;
+      const state = useSessionStore.getState();
+      if (!state.hydrated || !state.snapshot.accessToken) return;
+      const expiresAt = state.snapshot.accessTokenExpiresAt;
+      if (!expiresAt) return;
+      const expiresAtMs = Date.parse(expiresAt);
+      if (!Number.isFinite(expiresAtMs)) return;
+      const msUntilExpiry = expiresAtMs - Date.now();
+      if (msUntilExpiry < 2 * 60 * 1000) {
+        state.refreshTokens().catch(() => {});
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  useEffect(() => {
     useSessionStore.getState().setHydrated(true);
   }, []);
 

--- a/apps/web/src/entities/session/model/SessionRoleSync.tsx
+++ b/apps/web/src/entities/session/model/SessionRoleSync.tsx
@@ -29,10 +29,6 @@ export function SessionRoleSync(): null {
       if (!stateBefore.hydrated) return;
 
       if (!stateBefore.snapshot.accessToken) {
-        const hasRefreshCookie = document.cookie
-          .split(';')
-          .some((c) => c.trim().startsWith('refresh_token='));
-        if (!hasRefreshCookie) return;
         try {
           const refreshed = await refreshSessionFromCookie();
           if (refreshed.accessToken) {
@@ -124,11 +120,16 @@ export function SessionRoleSync(): null {
     const onFocus = (): void => {
       void sync();
     };
+    const onVisibilityChange = (): void => {
+      if (document.visibilityState === 'visible') void sync();
+    };
     window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
       clearTimeout(timer);
       window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
       unsubscribe();
     };
   }, []);

--- a/apps/web/src/entities/session/store/sessionStore.ts
+++ b/apps/web/src/entities/session/store/sessionStore.ts
@@ -235,6 +235,18 @@ export const useSessionStore = create<SessionState>()(
           mode: s.mode,
         };
       },
+      onRehydrateStorage: () => () => {
+        if (typeof window === 'undefined') return;
+        const handleStorage = (e: StorageEvent) => {
+          if (e.key !== 'web_session_tokens_v1') return;
+          if (e.newValue) return;
+          const current = useSessionStore.getState();
+          if (current.snapshot.userId) {
+            current.clearTokens();
+          }
+        };
+        window.addEventListener('storage', handleStorage);
+      },
     },
   ),
 );


### PR DESCRIPTION
## What
Fixes authentication session persistence so users no longer need to periodically sign in.

## Why
Multiple issues caused sessions to expire and require re-login:
1. SessionRoleSync checked for refresh_token via document.cookie, but the cookie is httpOnly — JavaScript can never read it, making the session recovery path dead code
2. Token refresh relied solely on setTimeout, which browsers throttle/pause in background tabs — after 15+ minutes of inactivity, the refresh timer never fires
3. No cross-tab logout sync — logging out in one tab left other tabs with stale UI
4. Backend clearTokenCookies didn't match setTokenCookies options (httpOnly, secure, sameSite), potentially leaving stale cookies

## Changes
- SessionRoleSync.tsx: Removed broken httpOnly cookie check — now always attempts refreshSessionFromCookie() when no access token is present. Added visibilitychange listener for reliable sync when tab regains focus
- BrowserRegistry.tsx: Added visibilitychange handler to proactively refresh tokens when tab becomes visible and token is near expiry (less than 2 min)
- sessionStore.ts: Added storage event listener via onRehydrateStorage to detect logout in other tabs and clear local state
- auth.controller.ts: Fixed clearTokenCookies to include httpOnly, secure, and sameSite options matching setTokenCookies
