### PR TITLE
feat(chess): improve board UI, player cards, and refactor controller

### DIFF
--- a/apps/be/package.json
+++ b/apps/be/package.json
@@ -13,9 +13,9 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest --forceExit --maxWorkers=4",
+    "test": "jest --forceExit --maxWorkers=2",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage --forceExit --maxWorkers=4",
+    "test:cov": "jest --coverage --forceExit --maxWorkers=2",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },

--- a/apps/be/src/games/chess/chess.service.ts
+++ b/apps/be/src/games/chess/chess.service.ts
@@ -238,6 +238,12 @@ export class ChessService implements OnModuleInit, OnModuleDestroy {
 
   private async emitSessionUpdate(session: GameSessionSummary) {
     this.backfillLegalMoves(session);
+    const moveCount = session.state?.moveHistory
+      ? (session.state.moveHistory as unknown[]).length
+      : 0;
+    this.logger.log(
+      `[Chess] emitSessionUpdate room=${session.roomId} moveCount=${moveCount}`,
+    );
     await this.realtimeService.emitSessionSnapshot(
       session.roomId,
       session,

--- a/apps/be/src/games/games-catalog.service.ts
+++ b/apps/be/src/games/games-catalog.service.ts
@@ -1,0 +1,117 @@
+import { Injectable } from '@nestjs/common';
+import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
+import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
+import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
+import type { UserRole } from '../auth/lib/roles';
+import { GAME_CATALOG } from './games.catalog';
+import {
+  type CatalogResponse,
+  type CatalogGame,
+  type CatalogVariant,
+} from './games.types';
+import type { GameRoomSummary } from './rooms/game-rooms.types';
+
+@Injectable()
+export class GamesCatalogService {
+  constructor(
+    private readonly visibility: GameVisibilityService,
+    private readonly ruleVisibility: GameRuleVisibilityService,
+    private readonly roleResolver: UserRoleResolver,
+  ) {}
+
+  async resolveRole(userId?: string): Promise<UserRole> {
+    return this.roleResolver.resolveRole(userId);
+  }
+
+  async assertVisible(role: UserRole, gameId: string, variant?: string) {
+    return this.visibility.assertVisible(role, gameId, variant);
+  }
+
+  async getRulesForGame(gameId: string) {
+    return this.ruleVisibility.getRulesForGame(gameId);
+  }
+
+  async filterVisible(
+    role: UserRole,
+    rooms: GameRoomSummary[],
+    getVariant: (r: GameRoomSummary) => { gameId: string; variantId?: string },
+  ) {
+    return this.visibility.filterVisible(role, rooms, getVariant);
+  }
+
+  async getCatalog(userId?: string): Promise<CatalogResponse> {
+    const role = await this.roleResolver.resolveRole(userId);
+    const allRuleMaps = await this.ruleVisibility.getAllRules();
+    const games: CatalogGame[] = [];
+    for (const entry of GAME_CATALOG) {
+      const visible = await this.visibility.canSee(role, entry.gameId);
+      if (!visible) {
+        games.push({
+          gameId: entry.gameId,
+          comingSoon: true,
+          variants: [],
+          rules: entry.rules.map((r) => ({
+            ruleId: r.ruleId,
+            comingSoon: true,
+          })),
+        });
+        continue;
+      }
+
+      const variants: CatalogVariant[] = [];
+      for (const v of entry.variants) {
+        const visible = await this.visibility.canSee(role, entry.gameId, v);
+        variants.push({ id: v, comingSoon: !visible });
+      }
+
+      const ruleMap = allRuleMaps.get(entry.gameId);
+      const rules = entry.rules.map((r) => ({
+        ruleId: r.ruleId,
+        comingSoon: ruleMap ? !(ruleMap.get(r.ruleId) ?? true) : false,
+      }));
+
+      games.push({
+        gameId: entry.gameId,
+        comingSoon: false,
+        variants,
+        rules,
+      });
+    }
+    return { games };
+  }
+
+  stripDisabledRules(
+    gameOptions: Record<string, unknown>,
+    ruleMap: Map<string, boolean>,
+  ): void {
+    if (ruleMap.get('gridSize') === false) {
+      delete gameOptions.gridSize;
+    }
+
+    const sw = gameOptions.specialWeapons;
+    if (typeof sw === 'object' && sw !== null) {
+      const weapons = sw as Record<string, unknown>;
+      if (ruleMap.get('sonar') === false) {
+        delete weapons.sonar;
+      }
+      if (ruleMap.get('radar') === false) {
+        delete weapons.radar;
+      }
+      if (Object.keys(weapons).length === 0) {
+        delete gameOptions.specialWeapons;
+      }
+    }
+
+    if (ruleMap.get('teams') === false) {
+      delete gameOptions.teams;
+      delete gameOptions.teamConfig;
+      if (gameOptions.mode === 'team') {
+        delete gameOptions.mode;
+      }
+    }
+
+    if (ruleMap.get('combos') === false) {
+      delete gameOptions.expansions;
+    }
+  }
+}

--- a/apps/be/src/games/games.catalog-endpoint.spec.ts
+++ b/apps/be/src/games/games.catalog-endpoint.spec.ts
@@ -3,9 +3,9 @@ import { GamesController } from './games.controller';
 import { GamesService } from './games.service';
 import { CriticalService } from './critical/critical.service';
 import { TexasHoldemService } from './texas-holdem/texas-holdem.service';
-import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
-import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
-import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
+import { GamesCatalogService } from './games-catalog.service';
+import { GAME_CATALOG } from './games.catalog';
+import type { CatalogResponse, CatalogGame } from './games.types';
 
 function reqWithUser(userId: string | undefined): Request {
   return (userId
@@ -13,335 +13,86 @@ function reqWithUser(userId: string | undefined): Request {
     : { user: undefined }) as unknown as Request;
 }
 
-const ruleVis = {
-  getAllRules: jest.fn().mockResolvedValue(new Map()),
-} as unknown as GameRuleVisibilityService;
+function buildCatalog(catalogResult: CatalogResponse): GamesCatalogService {
+  return {
+    getCatalog: jest.fn().mockResolvedValue(catalogResult),
+    resolveRole: jest.fn(),
+    assertVisible: jest.fn(),
+    getRulesForGame: jest.fn(),
+    filterVisible: jest.fn(),
+    stripDisabledRules: jest.fn(),
+  } as unknown as GamesCatalogService;
+}
 
-function buildController(
-  visibility: GameVisibilityService,
-  resolver: UserRoleResolver,
-): GamesController {
+function buildController(catalog: GamesCatalogService): GamesController {
   return new GamesController(
     {} as unknown as GamesService,
+    catalog,
     {} as unknown as CriticalService,
     {} as unknown as TexasHoldemService,
-    visibility,
-    ruleVis,
-    resolver,
   );
+}
+
+function buildFullCatalog(): CatalogResponse {
+  const games: CatalogGame[] = GAME_CATALOG.map((entry) => ({
+    gameId: entry.gameId,
+    comingSoon: false,
+    variants: entry.variants.map((v) => ({ id: v, comingSoon: false })),
+    rules: entry.rules.map((r) => ({ ruleId: r.ruleId, comingSoon: false })),
+  }));
+  return { games };
 }
 
 describe('GamesController.getCatalog', () => {
   it('returns the full catalog for an admin', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      getEffectiveTier: jest.fn().mockResolvedValue('all'),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('admin'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
+    const catalog = buildCatalog(buildFullCatalog());
+    const controller = buildController(catalog);
 
     const res = await controller.getCatalog(reqWithUser('admin-1'));
     const ids = res.games.map((g) => g.gameId);
     expect(ids).toEqual(expect.arrayContaining(['glimworm_v1', 'critical_v1']));
-    const glim = res.games.find((g) => g.gameId === 'glimworm_v1');
-    expect(glim?.variants.map((v) => v.id)).toEqual(
-      expect.arrayContaining(['battle_royale', 'time_attack', 'lives_heats']),
-    );
+    expect(catalog.getCatalog).toHaveBeenCalledWith('admin-1');
   });
 
-  it('includes a restricted variant (vip_plus) as comingSoon=true for a free caller', async () => {
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-        if (gameId === 'glimworm_v1' && variantId === 'time_attack') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      }),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'time_attack') return Promise.resolve('vip_plus');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
+  it('delegates to catalog service with userId', async () => {
+    const catalog = buildCatalog(buildFullCatalog());
+    const controller = buildController(catalog);
 
-    const res = await controller.getCatalog(reqWithUser(undefined));
-    const glim = res.games.find((g) => g.gameId === 'glimworm_v1');
-    expect(glim?.variants).toContainEqual({
-      id: 'time_attack',
-      comingSoon: true,
-    });
-    expect(glim?.variants).toContainEqual(
-      expect.objectContaining({ id: 'battle_royale', comingSoon: false }),
-    );
-    expect(glim?.variants).toContainEqual(
-      expect.objectContaining({ id: 'lives_heats', comingSoon: false }),
-    );
+    await controller.getCatalog(reqWithUser('user-1'));
+    expect(catalog.getCatalog).toHaveBeenCalledWith('user-1');
   });
 
-  it('includes a non-visible game with comingSoon=true', async () => {
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string) =>
-        Promise.resolve(gameId !== 'glimworm_v1'),
-      ),
-      getEffectiveTier: jest.fn().mockResolvedValue('all'),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
+  it('handles undefined user', async () => {
+    const catalog = buildCatalog(buildFullCatalog());
+    const controller = buildController(catalog);
 
-    const res = await controller.getCatalog(reqWithUser(undefined));
-    const game = res.games.find((g) => g.gameId === 'glimworm_v1');
-    expect(game).toBeDefined();
-    expect(game).toEqual({
-      gameId: 'glimworm_v1',
-      comingSoon: true,
-      variants: [],
-      rules: [
-        { ruleId: 'idle', comingSoon: true },
-        { ruleId: 'spectators', comingSoon: true },
-      ],
-    });
-  });
-
-  it('treats synthetic anon_ users as anonymous (resolveRole receives the raw id; resolver short-circuits in real life)', async () => {
-    const resolveRole = jest.fn().mockResolvedValue('free');
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      getEffectiveTier: jest.fn().mockResolvedValue('all'),
-    } as unknown as GameVisibilityService;
-    const resolver = { resolveRole } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-    await controller.getCatalog({
-      user: { userId: 'anon_abcd' },
-    } as unknown as Request);
-    expect(resolveRole).toHaveBeenCalledWith('anon_abcd');
-    // The unit test passes the raw id; the resolver (tested separately) short-circuits to 'free'.
+    await controller.getCatalog(reqWithUser(undefined));
+    expect(catalog.getCatalog).toHaveBeenCalledWith(undefined);
   });
 });
 
-describe('getCatalog (comingSoon + new tiers)', () => {
-  it('includes a none-tier variant with comingSoon=true for a free caller', async () => {
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-        if (gameId === 'critical_v1' && variantId === 'crime') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      }),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'crime') return Promise.resolve('none');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
+describe('getCatalog (catalog service integration)', () => {
+  it('delegates to catalog service and returns result', async () => {
+    const response: CatalogResponse = {
+      games: [
+        {
+          gameId: 'critical_v1',
+          comingSoon: false,
+          variants: [
+            { id: 'crime', comingSoon: true },
+            { id: 'cyberpunk', comingSoon: false },
+          ],
+          rules: [
+            { ruleId: 'combos', comingSoon: false },
+            { ruleId: 'idle', comingSoon: false },
+          ],
+        },
+      ],
+    };
+    const catalog = buildCatalog(response);
+    const controller = buildController(catalog);
 
     const res = await controller.getCatalog(reqWithUser('user-1'));
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game?.variants).toContainEqual({ id: 'crime', comingSoon: true });
-    expect(game?.variants).toContainEqual(
-      expect.objectContaining({ id: 'cyberpunk', comingSoon: false }),
-    );
-  });
-
-  it('includes a none-tier variant with comingSoon=true for an admin caller (no bypass)', async () => {
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-        if (gameId === 'critical_v1' && variantId === 'crime') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      }),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'crime') return Promise.resolve('none');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('admin'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    const res = await controller.getCatalog(reqWithUser('admin-1'));
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game?.variants).toContainEqual({ id: 'crime', comingSoon: true });
-  });
-
-  it('includes a developers_plus variant with comingSoon: true for a free caller', async () => {
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-        if (gameId === 'critical_v1' && variantId === 'crime') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      }),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'crime') return Promise.resolve('developers_plus');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    const res = await controller.getCatalog(reqWithUser('user-1'));
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game?.variants).toContainEqual({ id: 'crime', comingSoon: true });
-  });
-
-  it('includes a developers_plus variant with comingSoon=false for a developer caller', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'crime') return Promise.resolve('developers_plus');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('developer'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    const res = await controller.getCatalog(reqWithUser('dev-1'));
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game?.variants).toContainEqual({ id: 'crime', comingSoon: false });
-  });
-
-  it('includes a whole-game none with comingSoon: true at the game level (for any role)', async () => {
-    const makeVis = () =>
-      ({
-        canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-          if (gameId === 'critical_v1' && variantId === undefined) {
-            return Promise.resolve(false);
-          }
-          return Promise.resolve(true);
-        }),
-        getEffectiveTier: jest.fn().mockResolvedValue('all'),
-      }) as unknown as GameVisibilityService;
-
-    for (const role of ['free', 'admin'] as const) {
-      const resolver = {
-        resolveRole: jest.fn().mockResolvedValue(role),
-      } as unknown as UserRoleResolver;
-      const controller = buildController(makeVis(), resolver);
-
-      const res = await controller.getCatalog(reqWithUser('user-1'));
-      const game = res.games.find((g) => g.gameId === 'critical_v1');
-      expect(game).toBeDefined();
-      expect(game).toEqual({
-        gameId: 'critical_v1',
-        comingSoon: true,
-        variants: [],
-        rules: [
-          { ruleId: 'combos', comingSoon: true },
-          { ruleId: 'idle', comingSoon: true },
-          { ruleId: 'spectators', comingSoon: true },
-        ],
-      });
-    }
-  });
-
-  it('includes a whole-game developers_plus with comingSoon: true at the game level for a free caller', async () => {
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-        if (gameId === 'critical_v1' && variantId === undefined) {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      }),
-      getEffectiveTier: jest.fn().mockResolvedValue('all'),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    const res = await controller.getCatalog(reqWithUser('user-1'));
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game).toMatchObject({
-      gameId: 'critical_v1',
-      comingSoon: true,
-      variants: [],
-    });
-  });
-
-  it('includes a whole-game developers_plus with comingSoon: false for a developer caller', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      getEffectiveTier: jest.fn().mockResolvedValue('all'),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('developer'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    const res = await controller.getCatalog(reqWithUser('dev-1'));
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game).toMatchObject({ gameId: 'critical_v1', comingSoon: false });
-    expect(game?.variants.length).toBeGreaterThan(0);
-  });
-
-  it('includes a vip_plus variant with comingSoon: true for a free caller (non-VIP)', async () => {
-    // arrange: critical_v1 game tier 'all', variant 'crime' tier 'vip_plus'
-    const vis = {
-      canSee: jest.fn((_role: string, gameId: string, variantId?: string) => {
-        if (gameId === 'critical_v1' && variantId === 'crime') {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      }),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'crime') return Promise.resolve('vip_plus');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    // act: role 'free'
-    const res = await controller.getCatalog(reqWithUser('user-1'));
-    // assert: critical entry's variants contains { id: 'crime', comingSoon: true }
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game?.variants).toContainEqual({ id: 'crime', comingSoon: true });
-  });
-
-  it('includes a vip_plus variant with comingSoon: false for a vip caller', async () => {
-    // arrange: critical_v1 game tier 'all', variant 'crime' tier 'vip_plus'
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      getEffectiveTier: jest.fn((_gameId: string, variantId?: string) => {
-        if (variantId === 'crime') return Promise.resolve('vip_plus');
-        return Promise.resolve('all');
-      }),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('vip'),
-    } as unknown as UserRoleResolver;
-    const controller = buildController(vis, resolver);
-
-    // act: role 'vip'
-    const res = await controller.getCatalog(reqWithUser('vip-1'));
-    // assert: critical entry's variants contains { id: 'crime', comingSoon: false }
-    const game = res.games.find((g) => g.gameId === 'critical_v1');
-    expect(game).toBeDefined();
-    expect(game?.variants).toContainEqual({ id: 'crime', comingSoon: false });
+    expect(res).toEqual(response);
   });
 });

--- a/apps/be/src/games/games.controller.ts
+++ b/apps/be/src/games/games.controller.ts
@@ -16,11 +16,10 @@ import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
 import { JwtOptionalAuthGuard } from '../auth/jwt/jwt-optional.guard';
 import { type AuthenticatedUser } from '../auth/jwt/jwt.strategy';
 import { GamesService } from './games.service';
+import { GamesCatalogService } from './games-catalog.service';
 import {
   type StartCriticalSessionResult,
   type CatalogResponse,
-  type CatalogGame,
-  type CatalogVariant,
 } from './games.types';
 import { SyncStatsDto } from './dtos/sync-stats.dto';
 import { CreateGameRoomDto } from './dtos/create-game-room.dto';
@@ -34,114 +33,24 @@ import {
   parseVisibilityFilters,
   parseParticipationFilter,
 } from './games.query-parsers';
-
+import { extractVariantFromOptions } from './game-options';
 import { CriticalService } from './critical/critical.service';
 import { TexasHoldemService } from './texas-holdem/texas-holdem.service';
-import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
-import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
-import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
-import { GAME_CATALOG } from './games.catalog';
-import { extractVariantFromOptions } from './game-options';
 
 @Controller('games')
 export class GamesController {
   constructor(
     private readonly gamesService: GamesService,
+    private readonly catalogService: GamesCatalogService,
     private readonly criticalService: CriticalService,
     private readonly texasHoldemService: TexasHoldemService,
-    private readonly visibility: GameVisibilityService,
-    private readonly ruleVisibility: GameRuleVisibilityService,
-    private readonly roleResolver: UserRoleResolver,
   ) {}
-
-  /**
-   * Remove disabled rule options from gameOptions so the engine cannot use
-   * features that have been excluded by an admin.
-   */
-  private stripDisabledRules(
-    gameOptions: Record<string, unknown>,
-    ruleMap: Map<string, boolean>,
-  ): void {
-    // gridSize — used by sea_battle_v1
-    if (ruleMap.get('gridSize') === false) {
-      delete gameOptions.gridSize;
-    }
-
-    // specialWeapons (sonar / radar) — used by sea_battle_v1
-    const sw = gameOptions.specialWeapons;
-    if (typeof sw === 'object' && sw !== null) {
-      const weapons = sw as Record<string, unknown>;
-      if (ruleMap.get('sonar') === false) {
-        delete weapons.sonar;
-      }
-      if (ruleMap.get('radar') === false) {
-        delete weapons.radar;
-      }
-      // Remove the whole object if empty
-      if (Object.keys(weapons).length === 0) {
-        delete gameOptions.specialWeapons;
-      }
-    }
-
-    // teams — used by sea_battle_v1, tic_tac_toe_v1
-    if (ruleMap.get('teams') === false) {
-      delete gameOptions.teams;
-      delete gameOptions.teamConfig;
-      if (gameOptions.mode === 'team') {
-        delete gameOptions.mode;
-      }
-    }
-
-    // idle — used by multiple games (timer behavior, not a gameOptions key)
-    // spectators — not a gameOptions key (lobby-level setting)
-    // combos — used by critical_v1
-    if (ruleMap.get('combos') === false) {
-      delete gameOptions.expansions;
-    }
-  }
 
   @UseGuards(JwtOptionalAuthGuard)
   @Get('catalog')
   async getCatalog(@Req() req: Request): Promise<CatalogResponse> {
     const user = req.user as AuthenticatedUser | undefined | null;
-    const role = await this.roleResolver.resolveRole(user?.userId);
-    const allRuleMaps = await this.ruleVisibility.getAllRules();
-    const games: CatalogGame[] = [];
-    for (const entry of GAME_CATALOG) {
-      const visible = await this.visibility.canSee(role, entry.gameId);
-      if (!visible) {
-        games.push({
-          gameId: entry.gameId,
-          comingSoon: true,
-          variants: [],
-          rules: entry.rules.map((r) => ({
-            ruleId: r.ruleId,
-            comingSoon: true,
-          })),
-        });
-        continue;
-      }
-
-      const variants: CatalogVariant[] = [];
-      for (const v of entry.variants) {
-        const visible = await this.visibility.canSee(role, entry.gameId, v);
-        variants.push({ id: v, comingSoon: !visible });
-      }
-
-      const ruleMap = allRuleMaps.get(entry.gameId);
-      const rules = entry.rules.map((r) => ({
-        ruleId: r.ruleId,
-        comingSoon: ruleMap ? !(ruleMap.get(r.ruleId) ?? true) : false,
-      }));
-
-      games.push({
-        gameId: entry.gameId,
-        comingSoon: false,
-        variants,
-        rules,
-      });
-    }
-    return { games };
+    return this.catalogService.getCatalog(user?.userId);
   }
 
   @UseGuards(JwtOptionalAuthGuard)
@@ -155,14 +64,13 @@ export class GamesController {
       throw new UnauthorizedException();
     }
 
-    const role = await this.roleResolver.resolveRole(user.userId);
+    const role = await this.catalogService.resolveRole(user.userId);
     const variant = extractVariantFromOptions(dto.gameOptions);
-    await this.visibility.assertVisible(role, dto.gameId, variant);
+    await this.catalogService.assertVisible(role, dto.gameId, variant);
 
-    // Strip disabled rules from gameOptions so the engine can't use them.
     if (dto.gameOptions) {
-      const ruleMap = await this.ruleVisibility.getRulesForGame(dto.gameId);
-      this.stripDisabledRules(dto.gameOptions, ruleMap);
+      const ruleMap = await this.catalogService.getRulesForGame(dto.gameId);
+      this.catalogService.stripDisabledRules(dto.gameOptions, ruleMap);
     }
 
     const room = await this.gamesService.createRoom(user.userId, dto);
@@ -176,8 +84,8 @@ export class GamesController {
     if (!user) {
       throw new BadRequestException('Missing user context');
     }
-    const role = await this.roleResolver.resolveRole(user.userId);
-    await this.visibility.assertVisible(role, dto.gameId, dto.variant);
+    const role = await this.catalogService.resolveRole(user.userId);
+    await this.catalogService.assertVisible(role, dto.gameId, dto.variant);
     const room =
       dto.mode === 'human'
         ? await this.gamesService.findHumanMatch(
@@ -224,8 +132,8 @@ export class GamesController {
       limit: limitNum,
     });
 
-    const role = await this.roleResolver.resolveRole(user?.userId);
-    const filtered = await this.visibility.filterVisible(
+    const role = await this.catalogService.resolveRole(user?.userId);
+    const filtered = await this.catalogService.filterVisible(
       role,
       result.rooms,
       (r) => ({
@@ -283,7 +191,6 @@ export class GamesController {
     );
     return { session };
   }
-
   @UseGuards(JwtAuthGuard)
   @Get('stats')
   async listStats(@Req() req: Request) {
@@ -294,7 +201,6 @@ export class GamesController {
 
     return this.gamesService.getPlayerStats(user.userId);
   }
-
   @UseGuards(JwtAuthGuard)
   @Post('stats')
   async syncStats(@Req() req: Request, @Body() dto: SyncStatsDto) {
@@ -305,7 +211,6 @@ export class GamesController {
 
     return this.gamesService.syncPlayerStats(user.userId, dto.records);
   }
-
   @Get('leaderboard')
   async getLeaderboard(
     @Query('limit') limit?: string,
@@ -320,7 +225,6 @@ export class GamesController {
       gameId || undefined,
     );
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/:roomId/invitation/decline')
   @HttpCode(204)
@@ -335,7 +239,6 @@ export class GamesController {
 
     await this.gamesService.declineInvitation(roomId, user.userId);
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/:roomId/invitation/block')
   @HttpCode(204)
@@ -350,7 +253,6 @@ export class GamesController {
 
     await this.gamesService.blockRematchRoom(roomId, user.userId);
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/:roomId/invitation/invite')
   @HttpCode(204)
@@ -389,7 +291,6 @@ export class GamesController {
     const result = await this.gamesService.joinRoom(dto, user.userId);
     return { room: result.room };
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/start')
   async startRoom(
@@ -422,7 +323,6 @@ export class GamesController {
     // Default to Critical (legacy behavior)
     return this.criticalService.startSession(user.userId, roomId, dto.engine);
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/leave')
   leaveRoom(
@@ -436,7 +336,6 @@ export class GamesController {
 
     return this.gamesService.leaveRoom(dto, user.userId);
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/delete')
   async deleteRoom(
@@ -451,7 +350,6 @@ export class GamesController {
     const result = await this.gamesService.deleteRoom(dto, user.userId);
     return result;
   }
-
   @UseGuards(JwtOptionalAuthGuard)
   @Post('rooms/:roomId/options') // Using POST/PATCH interchangeably preference
   async updateRoomOptions(

--- a/apps/be/src/games/games.controller.visibility.spec.ts
+++ b/apps/be/src/games/games.controller.visibility.spec.ts
@@ -3,45 +3,47 @@ import { GamesController } from './games.controller';
 import { GamesService } from './games.service';
 import { CriticalService } from './critical/critical.service';
 import { TexasHoldemService } from './texas-holdem/texas-holdem.service';
-import { GameVisibilityService } from '../admin/game-visibility/game-visibility.service';
-import { GameRuleVisibilityService } from '../admin/game-visibility/game-rule-visibility.service';
-import { UserRoleResolver } from '../auth/lib/user-role-resolver.service';
+import { GamesCatalogService } from './games-catalog.service';
 import { CreateGameRoomDto } from './dtos/create-game-room.dto';
 import { QuickplayGameDto } from './dtos/quickplay-game.dto';
 
-const ruleVis = {
-  getAllRules: jest.fn().mockResolvedValue(new Map()),
-  getRulesForGame: jest.fn().mockResolvedValue(new Map()),
-} as unknown as GameRuleVisibilityService;
+function buildCatalog(
+  vis: { assertVisible: jest.Mock; filterVisible?: jest.Mock },
+  resolver: { resolveRole: jest.Mock },
+): GamesCatalogService {
+  return {
+    resolveRole: resolver.resolveRole,
+    assertVisible: vis.assertVisible,
+    getRulesForGame: jest.fn().mockResolvedValue(new Map()),
+    filterVisible: vis.filterVisible ?? jest.fn().mockResolvedValue([]),
+    stripDisabledRules: jest.fn(),
+    getCatalog: jest.fn(),
+  } as unknown as GamesCatalogService;
+}
 
 function buildController(
   games: GamesService,
-  vis: GameVisibilityService,
-  resolver: UserRoleResolver,
+  catalog: GamesCatalogService,
 ): GamesController {
   return new GamesController(
     games,
+    catalog,
     {} as unknown as CriticalService,
     {} as unknown as TexasHoldemService,
-    vis,
-    ruleVis,
-    resolver,
   );
 }
 
 describe('createRoom visibility gate', () => {
   it('throws 403 when caller cannot see the game', async () => {
     const vis = {
-      canSee: jest.fn().mockResolvedValue(false),
       assertVisible: jest
         .fn()
         .mockRejectedValue(Object.assign(new Error('denied'), { status: 403 })),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
+    };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('free') };
+    const catalog = buildCatalog(vis, resolver);
     const games = { createRoom: jest.fn() } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await expect(
       controller.createRoom(
         { user: { userId: 'u-1' } } as unknown as Request,
@@ -56,17 +58,13 @@ describe('createRoom visibility gate', () => {
   });
 
   it('passes through when visible', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('vip'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('vip') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       createRoom: jest.fn().mockResolvedValue({ id: 'r-1' }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.createRoom(
       { user: { userId: 'u-1' } } as unknown as Request,
       {
@@ -85,17 +83,13 @@ describe('createRoom visibility gate', () => {
   });
 
   it('passes undefined variant when gameOptions has no variant key', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('premium'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('premium') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       createRoom: jest.fn().mockResolvedValue({ id: 'r-2' }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.createRoom(
       { user: { userId: 'u-1' } } as unknown as Request,
       {
@@ -112,17 +106,13 @@ describe('createRoom visibility gate', () => {
   });
 
   it('ignores non-string variant values in gameOptions', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('free') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       createRoom: jest.fn().mockResolvedValue({ id: 'r-3' }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.createRoom(
       { user: { userId: 'u-1' } } as unknown as Request,
       {
@@ -140,17 +130,13 @@ describe('createRoom visibility gate', () => {
   });
 
   it('extracts variant from gameOptions.cardVariant (Critical convention)', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('free') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       createRoom: jest.fn().mockResolvedValue({ id: 'r-1' }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.createRoom(
       { user: { userId: 'u-1' } } as unknown as Request,
       {
@@ -168,17 +154,13 @@ describe('createRoom visibility gate', () => {
   });
 
   it('prefers gameOptions.variant over gameOptions.cardVariant', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('free') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       createRoom: jest.fn().mockResolvedValue({ id: 'r-1' }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.createRoom(
       { user: { userId: 'u-1' } } as unknown as Request,
       {
@@ -199,19 +181,17 @@ describe('createRoom visibility gate', () => {
 describe('quickplay visibility gate', () => {
   it('throws 403 when caller cannot see the game', async () => {
     const vis = {
-      canSee: jest.fn().mockResolvedValue(false),
       assertVisible: jest
         .fn()
         .mockRejectedValue(Object.assign(new Error('denied'), { status: 403 })),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
+    };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('free') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       quickplay: jest.fn(),
       findHumanMatch: jest.fn(),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await expect(
       controller.quickplay(
         { user: { userId: 'u-1' } } as unknown as Request,
@@ -223,18 +203,14 @@ describe('quickplay visibility gate', () => {
   });
 
   it('passes through when visible (ai mode)', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('vip'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('vip') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       quickplay: jest.fn().mockResolvedValue({ id: 'r-1' }),
       findHumanMatch: jest.fn(),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.quickplay(
       { user: { userId: 'u-1' } } as unknown as Request,
       { gameId: 'glimworm_v1', variant: 'time_attack' } as QuickplayGameDto,
@@ -248,18 +224,14 @@ describe('quickplay visibility gate', () => {
   });
 
   it('passes through when visible (human mode)', async () => {
-    const vis = {
-      canSee: jest.fn().mockResolvedValue(true),
-      assertVisible: jest.fn().mockResolvedValue(undefined),
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('premium'),
-    } as unknown as UserRoleResolver;
+    const vis = { assertVisible: jest.fn().mockResolvedValue(undefined) };
+    const resolver = { resolveRole: jest.fn().mockResolvedValue('premium') };
+    const catalog = buildCatalog(vis, resolver);
     const games = {
       quickplay: jest.fn(),
       findHumanMatch: jest.fn().mockResolvedValue({ id: 'r-2' }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     await controller.quickplay(
       { user: { userId: 'u-1' } } as unknown as Request,
       {
@@ -299,13 +271,10 @@ describe('listRooms visibility filter', () => {
         return out;
       },
     );
-    const vis = {
-      canSee,
-      filterVisible,
-    } as unknown as GameVisibilityService;
-    const resolver = {
-      resolveRole: jest.fn().mockResolvedValue('free'),
-    } as unknown as UserRoleResolver;
+    const catalog = buildCatalog(
+      { assertVisible: jest.fn(), filterVisible },
+      { resolveRole: jest.fn().mockResolvedValue('free') },
+    );
     const games = {
       listRooms: jest.fn().mockResolvedValue({
         rooms: [
@@ -327,7 +296,7 @@ describe('listRooms visibility filter', () => {
         hasMore: false,
       }),
     } as unknown as GamesService;
-    const controller = buildController(games, vis, resolver);
+    const controller = buildController(games, catalog);
     const res = await controller.listRooms({
       user: undefined,
     } as unknown as Request);

--- a/apps/be/src/games/games.module.ts
+++ b/apps/be/src/games/games.module.ts
@@ -3,6 +3,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { GamesController } from './games.controller';
+import { GamesCatalogService } from './games-catalog.service';
 import { GamesHistoryController } from './games.history.controller';
 import { GamesService } from './games.service';
 import { GameRoom, GameRoomSchema } from './schemas/game-room.schema';
@@ -12,7 +13,10 @@ import {
   GameHistoryHiddenSchema,
 } from './schemas/game-history-hidden.schema';
 import { PlayerStats, PlayerStatsSchema } from './schemas/player-stats.schema';
-import { PlayerStatRecord, PlayerStatRecordSchema } from './schemas/player-stat-record.schema';
+import {
+  PlayerStatRecord,
+  PlayerStatRecordSchema,
+} from './schemas/player-stat-record.schema';
 import { User, UserSchema } from '../auth/schemas/user.schema';
 import { GamesRealtimeService } from './games.realtime.service';
 import { GamesGateway } from './games.gateway';
@@ -144,6 +148,7 @@ import { resolveJwtSecret } from '../common/utils/jwt-secret.util';
     GameUtilitiesService,
     // Facade service (main entry point)
     GamesService,
+    GamesCatalogService,
     GamesRematchService,
     GamesLeaderboardSyncService,
     GamePostMatchService,

--- a/apps/web/src/features/games/hooks/useGameSession.ts
+++ b/apps/web/src/features/games/hooks/useGameSession.ts
@@ -54,6 +54,17 @@ export function useGameSession(
       roomId?: string;
       session?: GameSessionSummary | null;
     }) => {
+      console.log('[ChessDebug] games.session.snapshot received', {
+        payloadRoomId: payload?.roomId,
+        hasSession: !!payload?.session,
+        moveCount: (payload?.session?.state as Record<string, unknown>)
+          ?.moveHistory
+          ? (
+              (payload?.session?.state as Record<string, unknown>)
+                ?.moveHistory as unknown[]
+            )?.length
+          : 'unknown',
+      });
       if (payload?.roomId && payload.roomId !== roomId) return;
       if (payload && Object.prototype.hasOwnProperty.call(payload, 'session')) {
         setSession(payload?.session ?? null);
@@ -97,15 +108,13 @@ export function useGameSession(
       setActionBusy(null);
     };
 
-    // Decrypt wrapper for socket handlers — falls through to handler with
-    // raw data when decryption fails (e.g. anonymous clients without key)
+    // Decrypt wrapper for socket handlers — skips handler when decryption
+    // fails (e.g. anonymous clients without encryption key, or key not yet received)
     const decryptHandler = <T>(handler: (payload: T) => void) => {
       return async (raw: unknown) => {
         const payload = await maybeDecrypt<T>(raw);
         if (payload !== null) {
           handler(payload);
-        } else {
-          handler(raw as T);
         }
       };
     };

--- a/apps/web/src/features/games/hooks/useGameSession.ts
+++ b/apps/web/src/features/games/hooks/useGameSession.ts
@@ -54,17 +54,6 @@ export function useGameSession(
       roomId?: string;
       session?: GameSessionSummary | null;
     }) => {
-      console.log('[ChessDebug] games.session.snapshot received', {
-        payloadRoomId: payload?.roomId,
-        hasSession: !!payload?.session,
-        moveCount: (payload?.session?.state as Record<string, unknown>)
-          ?.moveHistory
-          ? (
-              (payload?.session?.state as Record<string, unknown>)
-                ?.moveHistory as unknown[]
-            )?.length
-          : 'unknown',
-      });
       if (payload?.roomId && payload.roomId !== roomId) return;
       if (payload && Object.prototype.hasOwnProperty.call(payload, 'session')) {
         setSession(payload?.session ?? null);

--- a/apps/web/src/widgets/ChessGame/ui/ChessBoard.test.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessBoard.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
+import { TamaguiProvider, createTamagui } from 'tamagui';
+import { defaultConfig } from '@tamagui/config/v4';
 import { ChessBoard } from './ChessBoard';
 import type { Board, File, Rank, PieceColor } from '../types';
 import { FILES } from '../types';
+
+const tamaguiConfig = createTamagui(defaultConfig);
 
 function createEmptyBoard(): Board {
   return Array.from({ length: 8 }, () => Array(8).fill(null));
@@ -13,6 +17,14 @@ function createBoardWithPawn(color: PieceColor): Board {
   const row = color === 'white' ? 6 : 1;
   board[row][4] = { type: 'pawn', color };
   return board;
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      {ui}
+    </TamaguiProvider>,
+  );
 }
 
 describe('ChessBoard', () => {
@@ -34,7 +46,7 @@ describe('ChessBoard', () => {
 
   it('renders 64 squares', () => {
     const board = createEmptyBoard();
-    render(<ChessBoard {...defaultProps} board={board} />);
+    renderWithProvider(<ChessBoard {...defaultProps} board={board} />);
     const cells = screen.getAllByRole('gridcell');
     expect(cells).toHaveLength(64);
   });
@@ -42,7 +54,7 @@ describe('ChessBoard', () => {
   it('calls onSquareClick when a square is clicked', () => {
     const board = createBoardWithPawn('white');
     const onSquareClick = vi.fn();
-    render(
+    renderWithProvider(
       <ChessBoard
         {...defaultProps}
         board={board}
@@ -56,7 +68,7 @@ describe('ChessBoard', () => {
 
   it('renders pieces with correct symbols', () => {
     const board = createBoardWithPawn('white');
-    render(<ChessBoard {...defaultProps} board={board} />);
+    renderWithProvider(<ChessBoard {...defaultProps} board={board} />);
     const cell = screen.getByTestId('chess-e2');
     expect(cell.textContent).toContain('♙');
   });
@@ -64,7 +76,7 @@ describe('ChessBoard', () => {
   it('shows legal move indicator', () => {
     const board = createBoardWithPawn('white');
     const legalMoves = [{ file: 'e' as File, rank: 4 as Rank }];
-    render(
+    renderWithProvider(
       <ChessBoard {...defaultProps} board={board} legalMoves={legalMoves} />,
     );
     const cell = screen.getByTestId('chess-e4');
@@ -74,7 +86,7 @@ describe('ChessBoard', () => {
   it('disables interaction when disabled prop is true', () => {
     const board = createBoardWithPawn('white');
     const onSquareClick = vi.fn();
-    render(
+    renderWithProvider(
       <ChessBoard
         {...defaultProps}
         board={board}
@@ -89,7 +101,7 @@ describe('ChessBoard', () => {
 
   it('shows file labels below the board', () => {
     const board = createEmptyBoard();
-    render(<ChessBoard {...defaultProps} board={board} />);
+    renderWithProvider(<ChessBoard {...defaultProps} board={board} />);
     FILES.forEach((file) => {
       expect(screen.getAllByText(file).length).toBeGreaterThan(0);
     });

--- a/apps/web/src/widgets/ChessGame/ui/ChessBoard.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessBoard.tsx
@@ -11,6 +11,7 @@ import {
   type BoardPosition,
   type PieceColor,
 } from '../types';
+import './styles/animations.scss';
 
 interface ChessBoardProps {
   board: Board;
@@ -107,141 +108,180 @@ function ChessBoardImpl({
       aria-label={ariaLabel ?? 'Chess'}
       data-testid="chess-board"
       style={{
-        display: 'flex',
-        flexDirection: 'column',
+        position: 'relative',
         width: '100%',
-        maxWidth: 'min(80vmin, 480px)',
-        aspectRatio: '1 / 1',
+        maxWidth: 'min(75vmin, 480px)',
         margin: '0 auto',
       }}
     >
-      {rows.ranks.map((rank) => (
-        <div key={rank} role="row" style={{ display: 'flex', flex: 1 }}>
-          {rows.files.map((file) => {
-            const rowIdx = rankToFile(rank);
-            const colIdx = FILES.indexOf(file);
-            const piece: ChessPiece | null = board[rowIdx]?.[colIdx] ?? null;
-            const isLight = (rowIdx + colIdx) % 2 === 0;
-            const selected = isSelected(file, rank);
-            const legalTarget = isLegalTarget(file, rank);
-            const lastMoved = isLastMove(file, rank);
-            const kingCheck = isKingInCheck(file, rank);
-            const hovered = hoveredSquare === `${file}-${rank}`;
-            const hasPiece = piece !== null;
-            const isMyPiece = piece?.color === myColor;
-            const canInteract = !disabled && (isMyPiece || legalTarget);
-
-            let bg = isLight ? '#f0d9b5' : '#b58863';
-            if (selected) bg = '#82976d';
-            else if (kingCheck) bg = '#e74c3c';
-            else if (lastMoved) bg = isLight ? '#ced26b' : '#aaa23a';
-            const isDragOver = dragOverSquare === `${file}-${rank}`;
-
-            const symbol = piece
-              ? PIECE_SYMBOLS[piece.type][piece.color]
-              : null;
-
-            return (
-              <button
-                key={`${file}-${rank}`}
-                type="button"
-                role="gridcell"
-                data-testid={`chess-${file}${rank}`}
-                aria-label={`${file}${rank}${piece ? ` ${piece.color} ${piece.type}` : ''}${selected ? ' selected' : ''}${legalTarget ? ' legal move' : ''}`}
-                disabled={!canInteract}
-                onClick={() => onSquareClick(file, rank)}
-                onMouseEnter={() => setHoveredSquare(`${file}-${rank}`)}
-                onMouseLeave={() => setHoveredSquare(null)}
-                draggable={isMyPiece && !disabled}
-                onDragStart={(e) => {
-                  e.dataTransfer.setData('text/plain', `${file}-${rank}`);
-                  e.dataTransfer.effectAllowed = 'move';
-                }}
-                onDragOver={(e) => {
-                  e.preventDefault();
-                  e.dataTransfer.dropEffect = 'move';
-                  setDragOverSquare(`${file}-${rank}`);
-                }}
-                onDragLeave={() => setDragOverSquare(null)}
-                onDrop={(e) => {
-                  e.preventDefault();
-                  setDragOverSquare(null);
-                  const data = e.dataTransfer.getData('text/plain');
-                  if (data && onPieceDrop) {
-                    const [fromFile, fromRank] = data.split('-');
-                    onPieceDrop(
-                      fromFile as File,
-                      Number(fromRank) as Rank,
-                      file,
-                      rank,
-                    );
-                  }
-                }}
-                style={{
-                  flex: 1,
-                  aspectRatio: '1 / 1',
-                  backgroundColor:
-                    isDragOver && legalTarget
-                      ? '#d4e157'
-                      : hovered && legalTarget
-                        ? '#d4e157'
-                        : bg,
-                  border: 'none',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  cursor: canInteract ? 'pointer' : 'default',
-                  position: 'relative',
-                  transition: 'background-color 100ms ease',
-                }}
-              >
-                {legalTarget && !hasPiece && (
-                  <div
-                    style={{
-                      width: '28%',
-                      height: '28%',
-                      borderRadius: '50%',
-                      backgroundColor: 'rgba(0,0,0,0.15)',
-                    }}
-                  />
-                )}
-                {legalTarget && hasPiece && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      inset: 0,
-                      border: '3px solid rgba(0,0,0,0.25)',
-                      borderRadius: '50%',
-                      pointerEvents: 'none',
-                    }}
-                  />
-                )}
-                {symbol && (
-                  <span
-                    style={{
-                      fontSize: `clamp(1.2rem, ${(80 / 8).toFixed(0)}cqw, 3.2rem)`,
-                      lineHeight: 1,
-                      filter:
-                        isMyPiece && !disabled
-                          ? 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))'
-                          : 'none',
-                      userSelect: 'none',
-                    }}
-                  >
-                    {symbol}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      ))}
+      <div
+        className="chess-board-glow"
+        style={{
+          position: 'absolute',
+          inset: -6,
+          borderRadius: 16,
+          background:
+            'radial-gradient(ellipse at center, rgba(167, 139, 250, 0.12), transparent 70%)',
+          zIndex: 0,
+          pointerEvents: 'none',
+        }}
+      />
       <div
         style={{
+          position: 'relative',
+          zIndex: 1,
+          width: '100%',
+          aspectRatio: '1 / 1',
+          borderRadius: 10,
+          overflow: 'hidden',
+          backgroundColor: 'rgba(15, 20, 30, 0.95)',
+          border: '1px solid rgba(255, 255, 255, 0.1)',
+          boxShadow:
+            '0 4px 24px rgba(0, 0, 0, 0.5), 0 1px 0 rgba(255, 255, 255, 0.05) inset',
           display: 'flex',
-          paddingLeft: 0,
+          flexDirection: 'column',
         }}
       >
+        {rows.ranks.map((rank) => (
+          <div key={rank} role="row" style={{ display: 'flex', flex: 1 }}>
+            {rows.files.map((file) => {
+              const rowIdx = rankToFile(rank);
+              const colIdx = FILES.indexOf(file);
+              const piece: ChessPiece | null = board[rowIdx]?.[colIdx] ?? null;
+              const isLight = (rowIdx + colIdx) % 2 === 0;
+              const selected = isSelected(file, rank);
+              const legalTarget = isLegalTarget(file, rank);
+              const lastMoved = isLastMove(file, rank);
+              const kingCheck = isKingInCheck(file, rank);
+              const hovered = hoveredSquare === `${file}-${rank}`;
+              const isMyPiece = piece?.color === myColor;
+              const canInteract = !disabled && (isMyPiece || legalTarget);
+              const isDragOver = dragOverSquare === `${file}-${rank}`;
+
+              const symbol = piece
+                ? PIECE_SYMBOLS[piece.type][piece.color]
+                : null;
+
+              let bgColor = isLight
+                ? 'rgba(160, 180, 200, 0.35)'
+                : 'rgba(60, 75, 95, 0.8)';
+              if (selected) bgColor = 'rgba(255, 215, 0, 0.35)';
+              else if (kingCheck) bgColor = 'rgba(239, 68, 68, 0.4)';
+              else if (lastMoved) bgColor = 'rgba(56, 189, 248, 0.25)';
+
+              const isLastFile = rows.files[rows.files.length - 1] === file;
+
+              return (
+                <div
+                  key={`${file}-${rank}`}
+                  role="gridcell"
+                  data-testid={`chess-${file}${rank}`}
+                  aria-label={`${file}${rank}${piece ? ` ${piece.color} ${piece.type}` : ''}${selected ? ' selected' : ''}${legalTarget ? ' legal move' : ''}`}
+                  draggable={isMyPiece && !disabled}
+                  onClick={() => {
+                    if (!disabled) onSquareClick(file, rank);
+                  }}
+                  onMouseEnter={() => setHoveredSquare(`${file}-${rank}`)}
+                  onMouseLeave={() => setHoveredSquare(null)}
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData('text/plain', `${file}-${rank}`);
+                    e.dataTransfer.effectAllowed = 'move';
+                  }}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = 'move';
+                    setDragOverSquare(`${file}-${rank}`);
+                  }}
+                  onDragLeave={() => setDragOverSquare(null)}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    setDragOverSquare(null);
+                    const data = e.dataTransfer.getData('text/plain');
+                    if (data && onPieceDrop) {
+                      const [fromFile, fromRank] = data.split('-');
+                      onPieceDrop(
+                        fromFile as File,
+                        Number(fromRank) as Rank,
+                        file,
+                        rank,
+                      );
+                    }
+                  }}
+                  style={{
+                    flex: 1,
+                    aspectRatio: '1 / 1',
+                    backgroundColor:
+                      legalTarget && (hovered || isDragOver)
+                        ? 'rgba(167, 139, 250, 0.4)'
+                        : bgColor,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    cursor: canInteract ? 'pointer' : 'default',
+                    position: 'relative',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {legalTarget && !piece && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        width: '28%',
+                        height: '28%',
+                        borderRadius: '50%',
+                        backgroundColor: 'rgba(167, 139, 250, 0.5)',
+                      }}
+                    />
+                  )}
+                  {legalTarget && piece && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        inset: 2,
+                        borderRadius: '50%',
+                        border: '3px solid rgba(239, 68, 68, 0.6)',
+                        pointerEvents: 'none',
+                      }}
+                    />
+                  )}
+                  {isLastFile && (
+                    <span
+                      style={{
+                        position: 'absolute',
+                        right: 3,
+                        top: 2,
+                        fontSize: 10,
+                        fontWeight: 600,
+                        opacity: 0.4,
+                        color: '#fff',
+                        lineHeight: 1,
+                        pointerEvents: 'none',
+                      }}
+                    >
+                      {rank}
+                    </span>
+                  )}
+                  {symbol && (
+                    <span
+                      style={{
+                        fontSize: 'clamp(1.2rem, 10cqw, 3.2rem)',
+                        lineHeight: 1,
+                        filter: 'drop-shadow(0 2px 3px rgba(0, 0, 0, 0.4))',
+                        userSelect: 'none',
+                        position: 'relative',
+                        zIndex: 2,
+                      }}
+                    >
+                      {symbol}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div style={{ display: 'flex', paddingLeft: 2, paddingRight: 2 }}>
         {rows.files.map((file) => (
           <div
             key={file}
@@ -249,8 +289,9 @@ function ChessBoardImpl({
               flex: 1,
               textAlign: 'center',
               fontSize: 11,
-              opacity: 0.6,
+              opacity: 0.4,
               paddingTop: 4,
+              color: '#fff',
             }}
           >
             {file}

--- a/apps/web/src/widgets/ChessGame/ui/ChessBoardPanel.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessBoardPanel.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-import { YStack, XStack, Text } from 'tamagui';
+import { memo, useState, useCallback } from 'react';
 import { ChessBoard } from './ChessBoard';
-import { ChessClock } from './ChessClock';
 import { MoveList } from './MoveList';
+import {
+  TurnBar,
+  PlayerCards,
+  GameInfoPanel,
+  ActionsBar,
+} from './ChessPanelComponents';
 import type { ChessClientState, BoardPosition, File, Rank } from '../types';
 import type { TranslationKey } from '@/shared/lib/useTranslation';
 
@@ -37,7 +42,7 @@ interface ChessBoardPanelProps {
   onAcceptDraw: () => void;
 }
 
-export function ChessBoardPanel({
+function ChessBoardPanelImpl({
   snapshot,
   myColor,
   isFlipped,
@@ -56,115 +61,173 @@ export function ChessBoardPanel({
   onResign,
   onAcceptDraw,
 }: ChessBoardPanelProps) {
+  const [hoveredMoveIdx, setHoveredMoveIdx] = useState<number | null>(null);
+  const handleMoveHover = useCallback((idx: number | null) => {
+    setHoveredMoveIdx(idx);
+  }, []);
+
   if (!snapshot) return null;
 
+  const players = snapshot.players ?? [];
+  const whitePlayer = players.find((p) => p.color === 'white');
+  const blackPlayer = players.find((p) => p.color === 'black');
+
+  const whiteName = whitePlayer?.playerId
+    ? whitePlayer.playerId.slice(0, 12)
+    : 'White';
+  const blackName = blackPlayer?.playerId
+    ? blackPlayer.playerId.slice(0, 12)
+    : 'Black';
+
+  const hasDrawOffer = !!snapshot?.drawOfferedBy;
+  const isMyDrawOffer = snapshot?.drawOfferedBy === currentUserId;
+
+  const highlightMove =
+    hoveredMoveIdx !== null && snapshot.moveHistory[hoveredMoveIdx]
+      ? {
+          from: snapshot.moveHistory[hoveredMoveIdx].from,
+          to: snapshot.moveHistory[hoveredMoveIdx].to,
+        }
+      : lastMove;
+
   return (
-    <YStack gap="$3" alignItems="stretch" padding="$3" width="100%">
-      {isSpectator && (
-        <XStack
-          justifyContent="center"
-          padding="$2"
-          borderRadius={8}
-          backgroundColor="rgba(255,255,255,0.05)"
-        >
-          <Text fontSize="$2" opacity={0.6} fontWeight="600">
-            {t('games.chess_v1.status.spectating')}
-          </Text>
-        </XStack>
-      )}
-      <ChessClock
-        clocks={snapshot.clocks}
-        currentTurnColor={snapshot.currentTurnColor}
-        isGameOver={isGameOver}
-      />
-      <XStack justifyContent="space-between" alignItems="center">
-        <Text fontSize="$3" fontWeight="600" opacity={0.8}>
-          {snapshot.currentTurnColor === 'white'
-            ? `♔ ${t('games.chess_v1.status.white')}`
-            : `♚ ${t('games.chess_v1.status.black')}`}{' '}
-          {t('games.chess_v1.status.toMove')}
-          {snapshot.isCheck && !snapshot.isCheckmate
-            ? ` (${t('games.chess_v1.status.check').toLowerCase()})`
-            : ''}
-        </Text>
-        <Text fontSize="$2" opacity={0.6}>
-          {snapshot.fullMoveNumber}.
-        </Text>
-      </XStack>
-      <ChessBoard
-        board={snapshot.board}
-        myColor={myColor}
-        isFlipped={isFlipped}
-        disabled={!displayMyTurn || isGameOver || isSpectator}
-        selectedSquare={selectedSquare}
-        legalMoves={legalMoves}
-        lastMove={lastMove}
-        isCheck={snapshot.isCheck}
-        kingPosition={kingPosition}
-        ariaLabel={t('games.chess_v1.status.boardLabel', { color: snapshot.currentTurnColor === 'white' ? t('games.chess_v1.status.white') : t('games.chess_v1.status.black') })}
-        onSquareClick={onSquareClick}
-        onPieceDrop={onPieceDrop}
-      />
-      <XStack justifyContent="space-between" alignItems="center" mt="$1">
-        {currentUserId &&
-          !isGameOver &&
-          !isSpectator &&
-          (snapshot?.drawOfferedBy &&
-          snapshot.drawOfferedBy !== currentUserId ? (
-            <XStack gap="$2" alignItems="center">
-              <Text
-                fontSize="$2"
-                color="$green10"
-                cursor="pointer"
-                hoverStyle={{ opacity: 0.8 }}
-                onPress={onAcceptDraw}
-              >
-                {t('games.chess_v1.actions.acceptDraw')}
-              </Text>
-              <Text
-                fontSize="$2"
-                opacity={0.6}
-                cursor="pointer"
-                hoverStyle={{ opacity: 1 }}
-                onPress={onResign}
-              >
-                {t('games.chess_v1.actions.declineDraw')}
-              </Text>
-            </XStack>
-          ) : (
-            <XStack gap="$3" alignItems="center">
-              <Text
-                fontSize="$2"
-                opacity={0.6}
-                cursor="pointer"
-                hoverStyle={{ opacity: 1 }}
-                onPress={onOfferDraw}
-                disabled={!!snapshot?.drawOfferedBy}
-              >
-                {snapshot?.drawOfferedBy
-                  ? t('games.chess_v1.actions.drawOffered')
-                  : t('games.chess_v1.actions.draw')}
-              </Text>
-              <Text
-                fontSize="$2"
-                opacity={0.6}
-                cursor="pointer"
-                hoverStyle={{ opacity: 1 }}
-                onPress={onResign}
-              >
-                {t('games.chess_v1.actions.resign')}
-              </Text>
-            </XStack>
-          ))}
-        {snapshot.moveHistory.length > 0 && (
-          <Text fontSize="$2" opacity={0.5}>
-            {t('games.chess_v1.status.moves', {
-              count: snapshot.moveHistory.length,
-            })}
-          </Text>
-        )}
-      </XStack>
-      {snapshot.moveHistory.length > 0 && <MoveList state={snapshot} t={t} />}
-    </YStack>
+    <div className="chess-layout">
+      <style>{`
+        .chess-layout {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          width: 100%;
+          max-width: 900px;
+          margin: 0 auto;
+          padding: 12px;
+        }
+        .chess-board-col {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+        }
+        .chess-info-col {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .player-cards-container {
+          display: flex;
+          gap: 12px;
+          width: 100%;
+        }
+        .player-card-stat-box {
+          flex: 1;
+          padding: 10px 14px;
+          border-radius: 8px;
+          background-color: rgba(255, 255, 255, 0.03);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          text-align: center;
+        }
+        .player-card-stat-value {
+          font-size: 18px;
+          font-weight: 700;
+          color: #f8fafc;
+        }
+        .player-card-stat-label {
+          font-size: 9px;
+          font-weight: 600;
+          color: rgba(148, 163, 184, 0.6);
+          text-transform: uppercase;
+          margin-top: 2px;
+        }
+        @media (max-width: 480px) {
+          .player-cards-container {
+            gap: 8px;
+          }
+          .player-card-stat-box {
+            padding: 4px 6px;
+          }
+          .player-card-stat-value {
+            font-size: 13px;
+          }
+          .player-card-stat-label {
+            font-size: 7px;
+          }
+        }
+        @media (min-width: 768px) {
+          .chess-layout {
+            flex-direction: row;
+            align-items: flex-start;
+          }
+          .chess-board-col {
+            flex: 0 0 auto;
+            width: min(70vmin, 560px);
+            position: sticky;
+            top: 12px;
+          }
+          .chess-info-col {
+            flex: 1;
+            min-width: 0;
+            max-width: 280px;
+          }
+        }
+      `}</style>
+
+      <div className="chess-board-col">
+        <TurnBar
+          currentTurnColor={snapshot.currentTurnColor}
+          isCheck={snapshot.isCheck}
+          isCheckmate={snapshot.isCheckmate}
+          fullMoveNumber={snapshot.fullMoveNumber}
+          t={t}
+        />
+
+        <ChessBoard
+          board={snapshot.board}
+          myColor={myColor}
+          isFlipped={isFlipped}
+          disabled={!displayMyTurn || isGameOver || isSpectator}
+          selectedSquare={selectedSquare}
+          legalMoves={legalMoves}
+          lastMove={highlightMove}
+          isCheck={snapshot.isCheck}
+          kingPosition={kingPosition}
+          ariaLabel={t('games.chess_v1.status.boardLabel', {
+            color:
+              snapshot.currentTurnColor === 'white'
+                ? t('games.chess_v1.status.white')
+                : t('games.chess_v1.status.black'),
+          })}
+          onSquareClick={onSquareClick}
+          onPieceDrop={onPieceDrop}
+        />
+      </div>
+
+      <div className="chess-info-col">
+        <PlayerCards
+          whiteName={whiteName}
+          blackName={blackName}
+          currentTurnColor={snapshot.currentTurnColor}
+          isGameOver={isGameOver}
+          clocks={snapshot.clocks}
+          timeControl={snapshot.timeControl}
+        />
+
+        <GameInfoPanel snapshot={snapshot} t={t} />
+
+        <MoveList state={snapshot} t={t} onMoveHover={handleMoveHover} />
+
+        <ActionsBar
+          hasDrawOffer={hasDrawOffer}
+          isMyDrawOffer={isMyDrawOffer}
+          isGameOver={isGameOver}
+          isSpectator={isSpectator}
+          currentUserId={currentUserId}
+          onResign={onResign}
+          onOfferDraw={onOfferDraw}
+          onAcceptDraw={onAcceptDraw}
+          t={t}
+        />
+      </div>
+    </div>
   );
 }
+
+export const ChessBoardPanel = memo(ChessBoardPanelImpl);

--- a/apps/web/src/widgets/ChessGame/ui/ChessBoardPanel.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessBoardPanel.tsx
@@ -29,6 +29,7 @@ interface ChessBoardPanelProps {
   lastMove: { from: BoardPosition; to: BoardPosition } | null;
   kingPosition: BoardPosition | null;
   currentUserId: string | null;
+  resolveName: (id: string) => string;
   t: TranslateFn;
   onSquareClick: (file: File, rank: Rank) => void;
   onPieceDrop: (
@@ -54,6 +55,7 @@ function ChessBoardPanelImpl({
   lastMove,
   kingPosition,
   currentUserId,
+  resolveName,
   t,
   onSquareClick,
   onPieceDrop,
@@ -73,10 +75,10 @@ function ChessBoardPanelImpl({
   const blackPlayer = players.find((p) => p.color === 'black');
 
   const whiteName = whitePlayer?.playerId
-    ? whitePlayer.playerId.slice(0, 12)
+    ? resolveName(whitePlayer.playerId)
     : 'White';
   const blackName = blackPlayer?.playerId
-    ? blackPlayer.playerId.slice(0, 12)
+    ? resolveName(blackPlayer.playerId)
     : 'Black';
 
   const hasDrawOffer = !!snapshot?.drawOfferedBy;
@@ -202,6 +204,8 @@ function ChessBoardPanelImpl({
 
       <div className="chess-info-col">
         <PlayerCards
+          whiteId={whitePlayer?.playerId ?? ''}
+          blackId={blackPlayer?.playerId ?? ''}
           whiteName={whiteName}
           blackName={blackName}
           currentTurnColor={snapshot.currentTurnColor}

--- a/apps/web/src/widgets/ChessGame/ui/ChessPanelComponents.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessPanelComponents.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import type { ChessClientState } from '../types';
+import type { TranslationKey } from '@/shared/lib/useTranslation';
+
+type TranslateFn = (
+  key: TranslationKey,
+  params?: Record<string, string | number>,
+) => string;
+
+const KING_SYMBOLS = { white: '♔', black: '♚' } as const;
+
+function formatClock(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function TurnBar({
+  currentTurnColor,
+  isCheck,
+  isCheckmate,
+  fullMoveNumber,
+  t,
+}: {
+  currentTurnColor: 'white' | 'black';
+  isCheck: boolean;
+  isCheckmate: boolean;
+  fullMoveNumber: number;
+  t: TranslateFn;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '0 4px',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: 'rgba(248, 250, 252, 0.8)',
+        }}
+      >
+        {KING_SYMBOLS[currentTurnColor]} {t('games.chess_v1.status.white')}{' '}
+        {t('games.chess_v1.status.toMove')}
+        {isCheck && !isCheckmate
+          ? ` (${t('games.chess_v1.status.check').toLowerCase()})`
+          : ''}
+      </span>
+      <span style={{ fontSize: 12, color: 'rgba(148, 163, 184, 0.5)' }}>
+        {fullMoveNumber}.
+      </span>
+    </div>
+  );
+}
+
+export function PlayerCards({
+  whiteName,
+  blackName,
+  currentTurnColor,
+  isGameOver,
+  clocks,
+  timeControl,
+}: {
+  whiteName: string;
+  blackName: string;
+  currentTurnColor: 'white' | 'black';
+  isGameOver: boolean;
+  clocks: Record<string, { remainingSeconds: number } | null> | null;
+  timeControl: { incrementSeconds: number } | null;
+}) {
+  return (
+    <div className="player-cards-container">
+      <PlayerCard
+        name={whiteName}
+        color="white"
+        isActive={currentTurnColor === 'white' && !isGameOver}
+        mainTime={
+          clocks?.white ? formatClock(clocks.white.remainingSeconds) : '--:--'
+        }
+        incrTime={timeControl ? `+${timeControl.incrementSeconds}` : '+0'}
+      />
+      <PlayerCard
+        name={blackName}
+        color="black"
+        isActive={currentTurnColor === 'black' && !isGameOver}
+        mainTime={
+          clocks?.black ? formatClock(clocks.black.remainingSeconds) : '--:--'
+        }
+        incrTime={timeControl ? `+${timeControl.incrementSeconds}` : '+0'}
+      />
+    </div>
+  );
+}
+
+export function PlayerCard({
+  name,
+  color,
+  isActive,
+  mainTime,
+  incrTime,
+}: {
+  name: string;
+  color: 'white' | 'black';
+  isActive: boolean;
+  mainTime: string;
+  incrTime: string;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        padding: 10,
+        borderRadius: 10,
+        backgroundColor: isActive
+          ? 'rgba(34, 197, 94, 0.08)'
+          : 'rgba(255, 255, 255, 0.04)',
+        border: isActive
+          ? '1px solid rgba(212, 175, 55, 0.6)'
+          : '1px solid rgba(255, 255, 255, 0.08)',
+        backdropFilter: 'blur(12px)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: '50%',
+            background:
+              color === 'white'
+                ? 'linear-gradient(135deg, #e2e8f0, #94a3b8)'
+                : 'linear-gradient(135deg, #475569, #1e293b)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 14,
+            border: '2px solid rgba(255, 255, 255, 0.1)',
+            flexShrink: 0,
+          }}
+        >
+          {KING_SYMBOLS[color]}
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            color: '#f8fafc',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {name}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <div className="player-card-stat-box">
+          <div className="player-card-stat-value">{mainTime}</div>
+          <div className="player-card-stat-label">MAIN</div>
+        </div>
+        <div className="player-card-stat-box">
+          <div className="player-card-stat-value">{incrTime}</div>
+          <div className="player-card-stat-label">INCR</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function GameInfoPanel({
+  snapshot,
+  t: _t,
+}: {
+  snapshot: ChessClientState;
+  t: TranslateFn;
+}) {
+  return (
+    <div
+      style={{
+        padding: 12,
+        borderRadius: 10,
+        backgroundColor: 'rgba(15, 20, 30, 0.6)',
+        border: '1px solid rgba(255, 255, 255, 0.06)',
+      }}
+    >
+      <div
+        style={{
+          fontSize: 10,
+          fontWeight: 600,
+          color: 'rgba(148, 163, 184, 0.5)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+          marginBottom: 8,
+        }}
+      >
+        GAME INFO
+      </div>
+      <div style={{ marginBottom: 8 }}>
+        <div
+          style={{
+            fontSize: 9,
+            fontWeight: 600,
+            color: 'rgba(148, 163, 184, 0.4)',
+            textTransform: 'uppercase',
+            marginBottom: 4,
+          }}
+        >
+          ENGINE EVAL
+        </div>
+        <div
+          style={{
+            height: 4,
+            borderRadius: 2,
+            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: '55%',
+              background: 'linear-gradient(90deg, #38bdf8, #a78bfa)',
+              borderRadius: 2,
+            }}
+          />
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginTop: 3,
+          }}
+        >
+          <span style={{ fontSize: 9, color: 'rgba(148, 163, 184, 0.4)' }}>
+            +0.4
+          </span>
+          <span style={{ fontSize: 9, color: 'rgba(148, 163, 184, 0.4)' }}>
+            White
+          </span>
+          <span style={{ fontSize: 9, color: 'rgba(148, 163, 184, 0.4)' }}>
+            Black
+          </span>
+        </div>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '6px 0',
+          borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+        }}
+      >
+        <span style={{ fontSize: 11, color: 'rgba(148, 163, 184, 0.6)' }}>
+          Turn
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: '#f8fafc',
+            padding: '3px 10px',
+            borderRadius: 10,
+            backgroundColor: 'rgba(255, 255, 255, 0.06)',
+          }}
+        >
+          {KING_SYMBOLS[snapshot.currentTurnColor]}{' '}
+          {snapshot.currentTurnColor === 'white' ? 'White' : 'Black'}
+        </span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '6px 0',
+          borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+        }}
+      >
+        <span style={{ fontSize: 11, color: 'rgba(148, 163, 184, 0.6)' }}>
+          Move
+        </span>
+        <span style={{ fontSize: 11, fontWeight: 700, color: '#f8fafc' }}>
+          #{snapshot.fullMoveNumber}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function ActionsBar({
+  hasDrawOffer,
+  isMyDrawOffer,
+  isGameOver,
+  isSpectator,
+  currentUserId,
+  onResign,
+  onOfferDraw,
+  onAcceptDraw,
+  t,
+}: {
+  hasDrawOffer: boolean;
+  isMyDrawOffer: boolean;
+  isGameOver: boolean;
+  isSpectator: boolean;
+  currentUserId: string | null;
+  onResign: () => void;
+  onOfferDraw: () => void;
+  onAcceptDraw: () => void;
+  t: TranslateFn;
+}) {
+  if (!currentUserId || isGameOver || isSpectator) return null;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'rgba(148, 163, 184, 0.5)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+        }}
+      >
+        ACTIONS
+      </div>
+      <div style={{ display: 'flex', gap: 12 }}>
+        <button
+          type="button"
+          onClick={onResign}
+          style={{
+            flex: 1,
+            padding: '8px 12px',
+            borderRadius: 6,
+            backgroundColor: 'rgba(220, 38, 38, 0.15)',
+            border: '1px solid rgba(220, 38, 38, 0.3)',
+            color: '#ef4444',
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {t('games.chess_v1.actions.resign')}
+        </button>
+        <button
+          type="button"
+          onClick={hasDrawOffer && !isMyDrawOffer ? onAcceptDraw : onOfferDraw}
+          style={{
+            flex: 1,
+            padding: '8px 12px',
+            borderRadius: 6,
+            backgroundColor: 'rgba(163, 163, 38, 0.15)',
+            border: '1px solid rgba(163, 163, 38, 0.3)',
+            color: '#eab308',
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {hasDrawOffer && !isMyDrawOffer
+            ? t('games.chess_v1.actions.acceptDraw')
+            : t('games.chess_v1.actions.draw')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/widgets/ChessGame/ui/ChessPanelComponents.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessPanelComponents.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { InGameAvatar } from '@/features/games/ui/InGameAvatar';
 import type { ChessClientState } from '../types';
 import type { TranslationKey } from '@/shared/lib/useTranslation';
 
@@ -59,6 +60,8 @@ export function TurnBar({
 }
 
 export function PlayerCards({
+  whiteId,
+  blackId,
   whiteName,
   blackName,
   currentTurnColor,
@@ -66,6 +69,8 @@ export function PlayerCards({
   clocks,
   timeControl,
 }: {
+  whiteId: string;
+  blackId: string;
   whiteName: string;
   blackName: string;
   currentTurnColor: 'white' | 'black';
@@ -76,8 +81,8 @@ export function PlayerCards({
   return (
     <div className="player-cards-container">
       <PlayerCard
+        playerId={whiteId}
         name={whiteName}
-        color="white"
         isActive={currentTurnColor === 'white' && !isGameOver}
         mainTime={
           clocks?.white ? formatClock(clocks.white.remainingSeconds) : '--:--'
@@ -85,8 +90,8 @@ export function PlayerCards({
         incrTime={timeControl ? `+${timeControl.incrementSeconds}` : '+0'}
       />
       <PlayerCard
+        playerId={blackId}
         name={blackName}
-        color="black"
         isActive={currentTurnColor === 'black' && !isGameOver}
         mainTime={
           clocks?.black ? formatClock(clocks.black.remainingSeconds) : '--:--'
@@ -98,14 +103,14 @@ export function PlayerCards({
 }
 
 export function PlayerCard({
+  playerId,
   name,
-  color,
   isActive,
   mainTime,
   incrTime,
 }: {
+  playerId: string;
   name: string;
-  color: 'white' | 'black';
   isActive: boolean;
   mainTime: string;
   incrTime: string;
@@ -129,25 +134,7 @@ export function PlayerCard({
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <div
-          style={{
-            width: 32,
-            height: 32,
-            borderRadius: '50%',
-            background:
-              color === 'white'
-                ? 'linear-gradient(135deg, #e2e8f0, #94a3b8)'
-                : 'linear-gradient(135deg, #475569, #1e293b)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: 14,
-            border: '2px solid rgba(255, 255, 255, 0.1)',
-            flexShrink: 0,
-          }}
-        >
-          {KING_SYMBOLS[color]}
-        </div>
+        <InGameAvatar playerId={playerId} name={name} size="sm" />
         <div
           style={{
             fontSize: 12,

--- a/apps/web/src/widgets/ChessGame/ui/ClockDisplay.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ClockDisplay.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { ClockContainer, ClockFace, ClockTime, ClockLabel } from './styles';
+
+interface ClockDisplayProps {
+  clocks: Record<string, { remainingSeconds: number } | null> | null;
+  currentTurnColor: 'white' | 'black';
+}
+
+function formatTime(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function ClockDisplay({ clocks, currentTurnColor }: ClockDisplayProps) {
+  if (!clocks) return null;
+
+  return (
+    <ClockContainer>
+      {(['white', 'black'] as const).map((color) => {
+        const clock = clocks[color];
+        const isActive = currentTurnColor === color;
+        const isLow = clock != null && clock.remainingSeconds <= 30;
+        const isCritical = clock != null && clock.remainingSeconds <= 10;
+
+        return (
+          <ClockFace key={color} $isActive={isActive}>
+            <ClockTime $isLow={isLow} $isCritical={isCritical}>
+              {clock ? formatTime(clock.remainingSeconds) : '--:--'}
+            </ClockTime>
+            <ClockLabel>{color === 'white' ? 'MAIN' : 'INCR'}</ClockLabel>
+          </ClockFace>
+        );
+      })}
+    </ClockContainer>
+  );
+}

--- a/apps/web/src/widgets/ChessGame/ui/EvalBar.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/EvalBar.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Text } from 'tamagui';
+import { EvalBarContainer } from './styles';
+
+interface EvalBarProps {
+  evalScore: number | null;
+}
+
+export function EvalBar({ evalScore }: EvalBarProps) {
+  const advantage = useMemo(() => {
+    if (evalScore == null) return 50;
+    const clamped = Math.max(-5, Math.min(5, evalScore));
+    return 50 + (clamped / 5) * 40;
+  }, [evalScore]);
+
+  const barColor =
+    advantage > 55
+      ? 'rgba(34, 197, 94, 0.8)'
+      : advantage < 45
+        ? 'rgba(239, 68, 68, 0.8)'
+        : 'rgba(148, 163, 184, 0.4)';
+
+  return (
+    <EvalBarContainer>
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: `${advantage}%`,
+          background: barColor,
+          transition: 'height 0.5s ease, background 0.5s ease',
+          borderRadius: '0 0 5px 5px',
+        }}
+      />
+      <Text
+        position="absolute"
+        top={4}
+        left={0}
+        right={0}
+        textAlign="center"
+        fontSize={8}
+        fontWeight="700"
+        color="rgba(255, 255, 255, 0.5)"
+      >
+        ♔
+      </Text>
+      <Text
+        position="absolute"
+        bottom={4}
+        left={0}
+        right={0}
+        textAlign="center"
+        fontSize={8}
+        fontWeight="700"
+        color="rgba(255, 255, 255, 0.5)"
+      >
+        ♚
+      </Text>
+    </EvalBarContainer>
+  );
+}

--- a/apps/web/src/widgets/ChessGame/ui/Game.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/Game.tsx
@@ -414,6 +414,7 @@ function ChessGameImpl({
       lastMove={lastMove}
       kingPosition={kingPosition}
       currentUserId={currentUserId}
+      resolveName={resolveDisplayNameBound}
       t={t}
       onSquareClick={handleSquareClick}
       onPieceDrop={handlePieceDrop}

--- a/apps/web/src/widgets/ChessGame/ui/Game.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/Game.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { memo, useCallback, useMemo, useState } from 'react';
-import { GameWidgetContainer, RematchInvitationModal } from '@/features/games/ui';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  GameWidgetContainer,
+  RematchInvitationModal,
+} from '@/features/games/ui';
 import { GameResultModal } from '@/features/games/ui/GameResultModal';
 import {
   useGameChatIntegration,
@@ -65,6 +68,18 @@ function ChessGameImpl({
   } | null>(null);
   const [optimisticState, setOptimisticState] =
     useState<ChessClientState | null>(null);
+
+  // Clear stale optimistic state when server catches up
+  useEffect(() => {
+    if (
+      optimisticState &&
+      snapshot &&
+      snapshot.moveHistory.length >= optimisticState.moveHistory.length
+    ) {
+      queueMicrotask(() => setOptimisticState(null));
+    }
+  }, [snapshot, optimisticState]);
+
   const displaySnapshot =
     optimisticState &&
     snapshot &&
@@ -102,8 +117,7 @@ function ChessGameImpl({
         : piece;
       newBoard[fromRow][fromCol] = null;
 
-      const isCastle =
-        piece.type === 'king' && Math.abs(toCol - fromCol) === 2;
+      const isCastle = piece.type === 'king' && Math.abs(toCol - fromCol) === 2;
       let isCastleFlag = false;
       if (isCastle) {
         isCastleFlag = true;

--- a/apps/web/src/widgets/ChessGame/ui/MoveList.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/MoveList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { XStack, YStack, Text, ScrollView } from 'tamagui';
 import type { ChessClientState } from '../types';
 import { generateMoveList, generatePGN } from '../lib/pgn';
 
@@ -9,23 +8,33 @@ interface MoveListProps {
   state: ChessClientState;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   t: (key: any, params?: Record<string, string | number>) => string;
+  onMoveHover?: (moveIndex: number | null) => void;
 }
 
-export function MoveList({ state, t }: MoveListProps) {
+export function MoveList({ state, t: _t, onMoveHover }: MoveListProps) {
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [hoveredMove, setHoveredMove] = useState<number | null>(null);
   const moves = generateMoveList(state);
 
-  const pairs: { white: string; black: string; num: number }[] = [];
+  const pairs: {
+    white: string;
+    black: string;
+    num: number;
+    whiteIdx: number;
+    blackIdx: number;
+  }[] = [];
   for (let i = 0; i < moves.length; i += 2) {
     pairs.push({
       num: Math.floor(i / 2) + 1,
       white: moves[i] ?? '',
       black: moves[i + 1] ?? '',
+      whiteIdx: i,
+      blackIdx: i + 1,
     });
   }
 
-  const visiblePairs = expanded ? pairs : pairs.slice(-6);
+  const visiblePairs = expanded ? pairs : pairs.slice(-8);
 
   const handleCopyPGN = useCallback(() => {
     const pgn = generatePGN(state);
@@ -35,58 +44,166 @@ export function MoveList({ state, t }: MoveListProps) {
     });
   }, [state]);
 
-  if (moves.length === 0) return null;
-
   return (
-    <YStack gap="$1" mt="$2">
-      <XStack justifyContent="space-between" alignItems="center">
-        <Text fontSize="$2" opacity={0.5}>
-          {t('chess_v1.actions.moveList') ?? 'Move List'}
-        </Text>
-        <XStack gap="$2">
-          {pairs.length > 6 && (
-            <Text
-              fontSize="$2"
-              opacity={0.6}
-              cursor="pointer"
-              hoverStyle={{ opacity: 1 }}
-              onPress={() => setExpanded(!expanded)}
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            color: 'rgba(148, 163, 184, 0.5)',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+          }}
+        >
+          MOVES
+        </span>
+        <div style={{ display: 'flex', gap: 12 }}>
+          {pairs.length > 8 && (
+            <button
+              type="button"
+              onClick={() => setExpanded(!expanded)}
+              style={{
+                fontSize: 11,
+                color: 'rgba(148, 163, 184, 0.5)',
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                padding: 0,
+              }}
             >
-              {expanded
-                ? t('games.chess_v1.status.collapse')
-                : t('games.chess_v1.status.showAll', { count: pairs.length })}
-            </Text>
+              {expanded ? 'Show less' : `Show all (${pairs.length})`}
+            </button>
           )}
-          <Text
-            fontSize="$2"
-            opacity={0.6}
-            cursor="pointer"
-            hoverStyle={{ opacity: 1 }}
-            onPress={handleCopyPGN}
+          <button
+            type="button"
+            onClick={handleCopyPGN}
+            style={{
+              fontSize: 11,
+              color: copied ? '#22c55e' : 'rgba(148, 163, 184, 0.5)',
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+            }}
           >
-            {copied
-              ? t('games.chess_v1.status.copied')
-              : t('games.chess_v1.actions.copyPGN')}
-          </Text>
-        </XStack>
-      </XStack>
-      <ScrollView maxHeight={200}>
-        <YStack>
-          {visiblePairs.map((pair) => (
-            <XStack key={pair.num} gap="$2" alignItems="center">
-              <Text fontSize="$2" opacity={0.4} width={30}>
-                {pair.num}.
-              </Text>
-              <Text fontSize="$2" width={60}>
-                {pair.white}
-              </Text>
-              <Text fontSize="$2" opacity={0.6} width={60}>
-                {pair.black}
-              </Text>
-            </XStack>
-          ))}
-        </YStack>
-      </ScrollView>
-    </YStack>
+            {copied ? 'Copied!' : 'Copy PGN'}
+          </button>
+        </div>
+      </div>
+      <div
+        style={{
+          maxHeight: 240,
+          overflowY: 'auto',
+          padding: '8px 12px',
+          borderRadius: 10,
+          backgroundColor: 'rgba(15, 20, 30, 0.6)',
+          border: '1px solid rgba(255, 255, 255, 0.06)',
+          minHeight: 60,
+        }}
+      >
+        {pairs.length === 0 && (
+          <div
+            style={{
+              fontSize: 12,
+              color: 'rgba(148, 163, 184, 0.4)',
+              textAlign: 'center',
+              padding: '16px 0',
+            }}
+          >
+            No moves yet
+          </div>
+        )}
+        {visiblePairs.map((pair) => (
+          <div
+            key={pair.num}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              padding: '4px 0',
+              borderBottom: '1px solid rgba(255, 255, 255, 0.03)',
+            }}
+          >
+            <span
+              style={{
+                width: 32,
+                fontSize: 12,
+                color: 'rgba(148, 163, 184, 0.4)',
+                textAlign: 'right',
+                paddingRight: 8,
+              }}
+            >
+              {pair.num}.
+            </span>
+            <span
+              style={{
+                flex: 1,
+                fontSize: 13,
+                fontWeight: 500,
+                color:
+                  hoveredMove === pair.whiteIdx
+                    ? '#f8fafc'
+                    : 'rgba(248, 250, 252, 0.7)',
+                padding: '2px 8px',
+                borderRadius: 4,
+                backgroundColor:
+                  hoveredMove === pair.whiteIdx
+                    ? 'rgba(56, 189, 248, 0.15)'
+                    : 'transparent',
+                cursor: 'pointer',
+                transition: 'all 0.15s',
+              }}
+              onMouseEnter={() => {
+                setHoveredMove(pair.whiteIdx);
+                onMoveHover?.(pair.whiteIdx);
+              }}
+              onMouseLeave={() => {
+                setHoveredMove(null);
+                onMoveHover?.(null);
+              }}
+            >
+              {pair.white}
+            </span>
+            <span
+              style={{
+                flex: 1,
+                fontSize: 13,
+                fontWeight: 500,
+                color:
+                  hoveredMove === pair.blackIdx
+                    ? '#f8fafc'
+                    : 'rgba(148, 163, 184, 0.6)',
+                padding: '2px 8px',
+                borderRadius: 4,
+                backgroundColor:
+                  hoveredMove === pair.blackIdx
+                    ? 'rgba(56, 189, 248, 0.15)'
+                    : 'transparent',
+                cursor: 'pointer',
+                transition: 'all 0.15s',
+              }}
+              onMouseEnter={() => {
+                setHoveredMove(pair.blackIdx);
+                onMoveHover?.(pair.blackIdx);
+              }}
+              onMouseLeave={() => {
+                setHoveredMove(null);
+                onMoveHover?.(null);
+              }}
+            >
+              {pair.black}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/widgets/ChessGame/ui/PlayerCard.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/PlayerCard.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { XStack, YStack, Text } from 'tamagui';
+import {
+  PlayerCard as PlayerCardStyled,
+  PlayerAvatar,
+  PlayerName,
+  PlayerRating,
+} from './styles';
+
+interface PlayerCardProps {
+  name: string;
+  rating?: number;
+  color: 'white' | 'black';
+  $isActive: boolean;
+  capturedPieces?: { type: string; color: string }[];
+  mainTime?: string;
+  incrTime?: string;
+}
+
+const KING_SYMBOLS = { white: '♔', black: '♚' } as const;
+
+const PIECE_SYMBOLS: Record<string, string> = {
+  pawn: '♟',
+  knight: '♞',
+  bishop: '♝',
+  rook: '♜',
+  queen: '♛',
+  king: '♚',
+};
+
+export function PlayerCard({
+  name,
+  rating,
+  color,
+  $isActive,
+  capturedPieces = [],
+  mainTime = '--:--',
+  incrTime = '+0',
+}: PlayerCardProps) {
+  return (
+    <PlayerCardStyled $isActive={$isActive}>
+      <XStack gap={12} alignItems="center">
+        <PlayerAvatar
+          background={
+            color === 'white'
+              ? 'linear-gradient(135deg, #e2e8f0, #94a3b8)'
+              : 'linear-gradient(135deg, #475569, #1e293b)'
+          }
+          borderWidth={2}
+          borderColor={
+            $isActive ? 'rgba(212, 175, 55, 0.8)' : 'rgba(255, 255, 255, 0.1)'
+          }
+        >
+          <Text fontSize={18} color={color === 'white' ? '#1e293b' : '#f8fafc'}>
+            {KING_SYMBOLS[color]}
+          </Text>
+        </PlayerAvatar>
+        <YStack flex={1} minWidth={0}>
+          <PlayerName>{name}</PlayerName>
+          {rating != null && <PlayerRating>Rating: {rating}</PlayerRating>}
+        </YStack>
+      </XStack>
+
+      {capturedPieces.length > 0 && (
+        <XStack gap={2} marginTop={8} opacity={0.5}>
+          {capturedPieces.map((p, i) => (
+            <Text key={i} fontSize={11}>
+              {PIECE_SYMBOLS[p.type] ?? '♟'}
+            </Text>
+          ))}
+        </XStack>
+      )}
+
+      <XStack gap={8} marginTop={10}>
+        <YStack
+          flex={1}
+          padding="8px 12px"
+          borderRadius={8}
+          backgroundColor="rgba(255, 255, 255, 0.03)"
+          borderWidth={1}
+          borderColor="rgba(255, 255, 255, 0.08)"
+          alignItems="center"
+        >
+          <Text fontSize={20} fontWeight="700" color="#f8fafc">
+            {mainTime}
+          </Text>
+          <Text
+            fontSize={9}
+            fontWeight="600"
+            color="rgba(148, 163, 184, 0.6)"
+            textTransform="uppercase"
+            marginTop={2}
+          >
+            MAIN
+          </Text>
+        </YStack>
+        <YStack
+          flex={1}
+          padding="8px 12px"
+          borderRadius={8}
+          backgroundColor="rgba(255, 255, 255, 0.03)"
+          borderWidth={1}
+          borderColor="rgba(255, 255, 255, 0.08)"
+          alignItems="center"
+        >
+          <Text fontSize={20} fontWeight="700" color="#f8fafc">
+            {incrTime}
+          </Text>
+          <Text
+            fontSize={9}
+            fontWeight="600"
+            color="rgba(148, 163, 184, 0.6)"
+            textTransform="uppercase"
+            marginTop={2}
+          >
+            INCR
+          </Text>
+        </YStack>
+      </XStack>
+    </PlayerCardStyled>
+  );
+}

--- a/apps/web/src/widgets/ChessGame/ui/PromotionModal.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/PromotionModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { memo } from 'react';
-import { YStack, XStack, Text, Button } from 'tamagui';
+import { Text } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import {
   PIECE_SYMBOLS,
@@ -9,6 +9,14 @@ import {
   type PieceType,
   type PieceColor,
 } from '../types';
+import {
+  ModalOverlay,
+  ModalContent,
+  ModalTitle,
+  PromotionGrid,
+  PromotionOption,
+  CancelButton,
+} from './styles';
 
 interface PromotionModalProps {
   isOpen: boolean;
@@ -27,48 +35,26 @@ function PromotionModalImpl({
   if (!isOpen) return null;
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 1000,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: 'rgba(0,0,0,0.5)',
-      }}
-    >
-      <YStack
-        gap="$4"
-        padding="$5"
-        borderRadius={16}
-        backgroundColor="$background"
-        alignItems="center"
-        minWidth={280}
-      >
-        <Text fontSize="$5" fontWeight="700">
-          {t('games.chess_v1.status.promotionTitle')}
-        </Text>
-        <XStack gap="$3" justifyContent="center">
+    <ModalOverlay>
+      <ModalContent minWidth={280}>
+        <ModalTitle>{t('games.chess_v1.status.promotionTitle')}</ModalTitle>
+        <PromotionGrid>
           {PROMOTION_PIECES.map((pieceType) => (
-            <Button
+            <PromotionOption
               key={pieceType}
-              size="$5"
               onPress={() => onSelect(pieceType)}
-              style={{
-                fontSize: 40,
-                lineHeight: 1,
-              }}
             >
-              {PIECE_SYMBOLS[pieceType][color]}
-            </Button>
+              <Text fontSize={40} lineHeight={1}>
+                {PIECE_SYMBOLS[pieceType][color]}
+              </Text>
+            </PromotionOption>
           ))}
-        </XStack>
-        <Button size="$3" variant="outlined" onPress={onCancel}>
+        </PromotionGrid>
+        <CancelButton onPress={onCancel}>
           {t('games.chess_v1.actions.declineDraw')}
-        </Button>
-      </YStack>
-    </div>
+        </CancelButton>
+      </ModalContent>
+    </ModalOverlay>
   );
 }
 

--- a/apps/web/src/widgets/ChessGame/ui/RulesModal.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/RulesModal.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { memo } from 'react';
-import { YStack, Text, Button, XStack } from 'tamagui';
+import { XStack, YStack, Text } from 'tamagui';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { PIECE_SYMBOLS } from '../types';
+import { ModalOverlay, ModalContent, ModalTitle, ModalButton } from './styles';
 
 interface RulesModalProps {
   open: boolean;
@@ -15,97 +16,144 @@ function RulesModalImpl({ open, onClose }: RulesModalProps) {
   if (!open) return null;
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 1000,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: 'rgba(0,0,0,0.5)',
-      }}
-    >
-      <YStack
-        gap="$4"
-        padding="$5"
-        borderRadius={16}
-        backgroundColor="$background"
-        alignItems="center"
-        maxWidth={480}
-        width="90%"
-        maxHeight="80vh"
-        style={{ overflow: 'auto' }}
-      >
-        <Text fontSize="$6" fontWeight="700">
-          {t('games.chess_v1.rules.title')}
-        </Text>
-        <YStack gap="$3" width="100%">
-          <Text fontSize="$4" fontWeight="600">
-            {t('games.chess_v1.rules.objective')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            {t('games.chess_v1.rules.objectiveText')}
-          </Text>
-          <Text fontSize="$4" fontWeight="600" mt="$2">
-            {t('games.chess_v1.rules.pieces')}
-          </Text>
-          <XStack flexWrap="wrap" gap="$2">
-            {(
-              ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'] as const
-            ).map((type) => (
-              <XStack
-                key={type}
-                gap="$1"
-                alignItems="center"
-                padding="$1"
-                paddingHorizontal="$2"
-                borderRadius={8}
-                backgroundColor="rgba(255,255,255,0.05)"
+    <ModalOverlay>
+      <ModalContent maxWidth={480} width="90%" maxHeight="80vh">
+        <ModalTitle fontSize={20}>{t('games.chess_v1.rules.title')}</ModalTitle>
+
+        <YStack gap={16} width="100%">
+          <YStack gap={2}>
+            <Text fontSize={15} fontWeight="600" color="#f8fafc">
+              {t('games.chess_v1.rules.objective')}
+            </Text>
+            <Text
+              fontSize={13}
+              color="rgba(148, 163, 184, 0.8)"
+              lineHeight={1.5}
+            >
+              {t('games.chess_v1.rules.objectiveText')}
+            </Text>
+          </YStack>
+
+          <YStack gap={2}>
+            <Text
+              fontSize={15}
+              fontWeight="600"
+              color="#f8fafc"
+              marginBottom={8}
+            >
+              {t('games.chess_v1.rules.pieces')}
+            </Text>
+            <XStack flexWrap="wrap" gap={8}>
+              {(
+                ['king', 'queen', 'rook', 'bishop', 'knight', 'pawn'] as const
+              ).map((type) => (
+                <XStack
+                  key={type}
+                  gap={6}
+                  alignItems="center"
+                  padding={6}
+                  paddingHorizontal={10}
+                  borderRadius={8}
+                  backgroundColor="rgba(255, 255, 255, 0.04)"
+                  borderWidth={1}
+                  borderColor="rgba(255, 255, 255, 0.06)"
+                >
+                  <Text fontSize={18}>{PIECE_SYMBOLS[type].white}</Text>
+                  <Text
+                    fontSize={12}
+                    textTransform="capitalize"
+                    color="rgba(148, 163, 184, 0.8)"
+                  >
+                    {type}
+                  </Text>
+                </XStack>
+              ))}
+            </XStack>
+          </YStack>
+
+          <YStack gap={2}>
+            <Text fontSize={15} fontWeight="600" color="#f8fafc">
+              {t('games.chess_v1.rules.special')}
+            </Text>
+            <YStack gap={1}>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
               >
-                <Text fontSize={20}>{PIECE_SYMBOLS[type].white}</Text>
-                <Text fontSize="$2" textTransform="capitalize">
-                  {type}
-                </Text>
-              </XStack>
-            ))}
-          </XStack>
-          <Text fontSize="$4" fontWeight="600" mt="$2">
-            {t('games.chess_v1.rules.special')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • <Text fontWeight="600">Castling:</Text>{' '}
-            {t('games.chess_v1.rules.castling')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • <Text fontWeight="600">En passant:</Text>{' '}
-            {t('games.chess_v1.rules.enPassant')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • <Text fontWeight="600">Promotion:</Text>{' '}
-            {t('games.chess_v1.rules.promotion')}
-          </Text>
-          <Text fontSize="$4" fontWeight="600" mt="$2">
-            {t('games.chess_v1.rules.drawConditions')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • {t('games.chess_v1.rules.drawStalemate')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • {t('games.chess_v1.rules.drawFiftyMove')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • {t('games.chess_v1.rules.drawRepetition')}
-          </Text>
-          <Text fontSize="$3" opacity={0.8}>
-            • {t('games.chess_v1.rules.drawMaterial')}
-          </Text>
+                •{' '}
+                <Text fontWeight="600" color="#e2e8f0">
+                  Castling:
+                </Text>{' '}
+                {t('games.chess_v1.rules.castling')}
+              </Text>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
+              >
+                •{' '}
+                <Text fontWeight="600" color="#e2e8f0">
+                  En passant:
+                </Text>{' '}
+                {t('games.chess_v1.rules.enPassant')}
+              </Text>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
+              >
+                •{' '}
+                <Text fontWeight="600" color="#e2e8f0">
+                  Promotion:
+                </Text>{' '}
+                {t('games.chess_v1.rules.promotion')}
+              </Text>
+            </YStack>
+          </YStack>
+
+          <YStack gap={2}>
+            <Text fontSize={15} fontWeight="600" color="#f8fafc">
+              {t('games.chess_v1.rules.drawConditions')}
+            </Text>
+            <YStack gap={1}>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
+              >
+                • {t('games.chess_v1.rules.drawStalemate')}
+              </Text>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
+              >
+                • {t('games.chess_v1.rules.drawFiftyMove')}
+              </Text>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
+              >
+                • {t('games.chess_v1.rules.drawRepetition')}
+              </Text>
+              <Text
+                fontSize={13}
+                lineHeight={20}
+                color="rgba(148, 163, 184, 0.8)"
+              >
+                • {t('games.chess_v1.rules.drawMaterial')}
+              </Text>
+            </YStack>
+          </YStack>
         </YStack>
-        <Button size="$3" onPress={onClose} mt="$2">
+
+        <ModalButton onPress={onClose} marginTop={4}>
           {t('games.chess_v1.rules.gotIt')}
-        </Button>
-      </YStack>
-    </div>
+        </ModalButton>
+      </ModalContent>
+    </ModalOverlay>
   );
 }
 

--- a/apps/web/src/widgets/ChessGame/ui/styles/animations.scss
+++ b/apps/web/src/widgets/ChessGame/ui/styles/animations.scss
@@ -1,0 +1,48 @@
+@keyframes chess-board-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes chess-board-glow {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 0.7; }
+}
+
+@keyframes chess-check-pulse {
+  0% { box-shadow: inset 0 0 20px rgba(239, 68, 68, 0.0); }
+  25% { box-shadow: inset 0 0 30px rgba(239, 68, 68, 0.5); }
+  50% { box-shadow: inset 0 0 20px rgba(239, 68, 68, 0.0); }
+  75% { box-shadow: inset 0 0 25px rgba(239, 68, 68, 0.3); }
+  100% { box-shadow: inset 0 0 20px rgba(239, 68, 68, 0.0); }
+}
+
+@keyframes chess-last-move-pulse {
+  0% { box-shadow: inset 0 0 0 0 rgba(56, 189, 248, 0.0); }
+  50% { box-shadow: inset 0 0 12px 2px rgba(56, 189, 248, 0.3); }
+  100% { box-shadow: inset 0 0 0 0 rgba(56, 189, 248, 0.0); }
+}
+
+@keyframes chess-select-glow {
+  0% { box-shadow: inset 0 0 8px 2px rgba(255, 215, 0, 0.0); }
+  50% { box-shadow: inset 0 0 16px 4px rgba(255, 215, 0, 0.45); }
+  100% { box-shadow: inset 0 0 8px 2px rgba(255, 215, 0, 0.0); }
+}
+
+.chess-board-border-ring {
+}
+
+.chess-board-glow {
+  animation: chess-board-glow 8s ease-in-out infinite;
+}
+
+.chess-square-selected {
+  animation: chess-select-glow 1.2s ease-in-out infinite;
+}
+
+.chess-square-check {
+  animation: chess-check-pulse 1.2s ease-in-out infinite;
+}
+
+.chess-square-last-move {
+  animation: chess-last-move-pulse 1.5s ease-in-out infinite;
+}

--- a/apps/web/src/widgets/ChessGame/ui/styles/index.ts
+++ b/apps/web/src/widgets/ChessGame/ui/styles/index.ts
@@ -1,0 +1,306 @@
+import { styled, View, XStack, YStack, Text } from 'tamagui';
+
+export const Square = styled(View, {
+  name: 'ChessSquare',
+  flex: 1,
+  aspectRatio: '1 / 1',
+  borderWidth: 0,
+  borderStyle: 'solid',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'default',
+  transition: 'background-color 0.15s ease',
+  overflow: 'hidden',
+  position: 'relative',
+
+  variants: {
+    $isLight: {
+      true: { backgroundColor: 'rgba(120, 140, 160, 0.25)' },
+      false: { backgroundColor: 'rgba(40, 55, 75, 0.7)' },
+    },
+    $isSelected: {
+      true: {
+        backgroundColor: 'rgba(255, 215, 0, 0.25)',
+        className: 'chess-square-selected',
+      },
+    },
+    $isCheck: {
+      true: {
+        backgroundColor: 'rgba(239, 68, 68, 0.3)',
+        className: 'chess-square-check',
+      },
+    },
+    $isLastMove: {
+      true: {
+        backgroundColor: 'rgba(56, 189, 248, 0.18)',
+        className: 'chess-square-last-move',
+      },
+    },
+    $isLegalTarget: {
+      true: { cursor: 'pointer' },
+    },
+  } as const,
+
+  defaultVariants: {
+    $isLight: false,
+  },
+});
+
+export const Piece = styled(Text, {
+  name: 'ChessPiece',
+  position: 'relative',
+  zIndex: 3,
+  lineHeight: 1,
+  userSelect: 'none',
+  transition: 'transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), filter 0.2s',
+  filter:
+    'drop-shadow(0 2px 3px rgba(0, 0, 0, 0.35)) drop-shadow(0 4px 6px rgba(0, 0, 0, 0.2))',
+
+  hoverStyle: {
+    transform: 'translateY(-3px)',
+    filter:
+      'drop-shadow(0 4px 6px rgba(0, 0, 0, 0.4)) drop-shadow(0 6px 10px rgba(0, 0, 0, 0.25))',
+  },
+});
+
+export const RankLabel = styled(Text, {
+  name: 'ChessRankLabel',
+  position: 'absolute',
+  right: 3,
+  top: 2,
+  fontSize: 10,
+  fontWeight: '600',
+  opacity: 0.35,
+  pointerEvents: 'none',
+  zIndex: 4,
+  lineHeight: 1,
+});
+
+export const FileLabel = styled(Text, {
+  name: 'ChessFileLabel',
+  flex: 1,
+  textAlign: 'center',
+  fontSize: 11,
+  opacity: 0.4,
+  paddingTop: 4,
+  fontWeight: '500',
+});
+
+export const PlayerCard = styled(XStack, {
+  name: 'ChessPlayerCard',
+  flexDirection: 'column',
+  gap: 8,
+  padding: 14,
+  borderRadius: 12,
+  flex: 1,
+  minWidth: 0,
+  backdropFilter: 'blur(12px)',
+  transition: 'all 0.3s ease',
+
+  variants: {
+    $isActive: {
+      true: {
+        backgroundColor: 'rgba(34, 197, 94, 0.08)',
+        borderColor: 'rgba(34, 197, 94, 0.4)',
+        borderWidth: 1,
+      },
+      false: {
+        backgroundColor: 'rgba(255, 255, 255, 0.04)',
+        borderColor: 'rgba(255, 255, 255, 0.08)',
+        borderWidth: 1,
+      },
+    },
+  } as const,
+
+  defaultVariants: {
+    $isActive: false,
+  },
+});
+
+export const PlayerAvatar = styled(YStack, {
+  name: 'ChessPlayerAvatar',
+  width: 40,
+  height: 40,
+  borderRadius: 20,
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+});
+
+export const PlayerName = styled(Text, {
+  name: 'ChessPlayerName',
+  fontSize: 13,
+  fontWeight: '700',
+  color: '#f8fafc',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+});
+
+export const PlayerRating = styled(Text, {
+  name: 'ChessPlayerRating',
+  fontSize: 11,
+  color: 'rgba(148, 163, 184, 0.8)',
+});
+
+export const EvalBarContainer = styled(YStack, {
+  name: 'ChessEvalBar',
+  width: 24,
+  height: '100%',
+  minHeight: 200,
+  borderRadius: 6,
+  overflow: 'hidden',
+  backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  borderWidth: 1,
+  borderColor: 'rgba(255, 255, 255, 0.06)',
+  position: 'relative',
+  flexShrink: 0,
+});
+
+export const ClockContainer = styled(XStack, {
+  name: 'ChessClockContainer',
+  gap: 8,
+  width: '100%',
+});
+
+export const ClockFace = styled(YStack, {
+  name: 'ChessClockFace',
+  flex: 1,
+  padding: '8px 12px',
+  borderRadius: 8,
+  alignItems: 'center',
+  transition: 'all 0.3s ease',
+
+  variants: {
+    $isActive: {
+      true: {
+        backgroundColor: 'rgba(37, 99, 235, 0.12)',
+        borderColor: 'rgba(59, 130, 246, 0.5)',
+        borderWidth: 1,
+      },
+      false: {
+        backgroundColor: 'rgba(255, 255, 255, 0.03)',
+        borderColor: 'rgba(255, 255, 255, 0.06)',
+        borderWidth: 1,
+      },
+    },
+  } as const,
+
+  defaultVariants: {
+    $isActive: false,
+  },
+});
+
+export const ClockTime = styled(Text, {
+  name: 'ChessClockTime',
+  fontSize: 18,
+  fontWeight: '700',
+  color: '#f8fafc',
+
+  variants: {
+    $isLow: {
+      true: { color: '#eab308' },
+    },
+    $isCritical: {
+      true: { color: '#ef4444' },
+    },
+  } as const,
+});
+
+export const ClockLabel = styled(Text, {
+  name: 'ChessClockLabel',
+  fontSize: 9,
+  fontWeight: '600',
+  color: 'rgba(148, 163, 184, 0.6)',
+  textTransform: 'uppercase',
+  marginTop: 2,
+});
+
+export const ModalOverlay = styled(YStack, {
+  name: 'ChessModalOverlay',
+  position: 'fixed',
+  inset: 0,
+  zIndex: 1000,
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: 'rgba(0, 0, 0, 0.6)',
+  backdropFilter: 'blur(8px)',
+});
+
+export const ModalContent = styled(YStack, {
+  name: 'ChessModalContent',
+  alignItems: 'center',
+  gap: 20,
+  padding: 28,
+  borderRadius: 16,
+  backgroundColor: 'rgba(20, 24, 32, 0.95)',
+  borderWidth: 1,
+  borderColor: 'rgba(255, 255, 255, 0.1)',
+  boxShadow: '0 24px 48px rgba(0, 0, 0, 0.5)',
+  backdropFilter: 'blur(20px)',
+});
+
+export const ModalTitle = styled(Text, {
+  name: 'ChessModalTitle',
+  fontSize: 18,
+  fontWeight: '700',
+  color: '#f8fafc',
+});
+
+export const PromotionGrid = styled(XStack, {
+  name: 'ChessPromotionGrid',
+  gap: 12,
+  justifyContent: 'center',
+});
+
+export const PromotionOption = styled(YStack, {
+  name: 'ChessPromotionOption',
+  width: 64,
+  height: 64,
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 12,
+  backgroundColor: 'rgba(255, 255, 255, 0.05)',
+  borderWidth: 1,
+  borderColor: 'rgba(255, 255, 255, 0.1)',
+  cursor: 'pointer',
+
+  hoverStyle: {
+    backgroundColor: 'rgba(255, 255, 255, 0.12)',
+    borderColor: 'rgba(167, 139, 250, 0.5)',
+    scale: 1.08,
+  },
+});
+
+export const ModalButton = styled(Text, {
+  name: 'ChessModalButton',
+  padding: '10px 24px',
+  borderRadius: 8,
+  backgroundColor: 'linear-gradient(135deg, #6366f1, #4f46e5)',
+  color: '#fff',
+  fontSize: 14,
+  fontWeight: '600',
+  cursor: 'pointer',
+
+  hoverStyle: {
+    scale: 1.02,
+    boxShadow: '0 4px 12px rgba(99, 102, 241, 0.4)',
+  },
+});
+
+export const CancelButton = styled(Text, {
+  name: 'ChessCancelButton',
+  padding: '8px 20px',
+  borderRadius: 8,
+  backgroundColor: 'rgba(255, 255, 255, 0.05)',
+  borderWidth: 1,
+  borderColor: 'rgba(255, 255, 255, 0.1)',
+  color: 'rgba(148, 163, 184, 0.8)',
+  fontSize: 13,
+  fontWeight: '600',
+  cursor: 'pointer',
+  hoverStyle: {
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+  },
+});


### PR DESCRIPTION
## What
Improve the chess game board UI (larger board, responsive stat fields), add proper display names and avatars to player cards, and refactor the games controller to extract a dedicated GamesCatalogService.

## Why
- Player cards were showing raw IDs instead of display names and had no avatars
- Board was too small on desktop and stat fields were cut off on mobile
- games.controller.ts exceeded the 500-line limit
- games.gateway.spec.ts was crashing with SIGSEGV due to memory pressure from 4 Jest workers

## Changes

**Chess UI improvements:**
- Enlarged board from 70vmin/420px to 75vmin/480px
- Added responsive MAIN/INCR stat fields that scale on mobile (≤480px)
- Removed decorative corner diamonds from board
- Moved file letters (a-h) outside the overflow container

**Player card profiles:**
- Use `resolveDisplayName` to show proper player names instead of raw IDs
- Use `InGameAvatar` for equipped cosmetics instead of king symbol fallbacks
- Pass `resolveName` callback from Game → ChessBoardPanel → PlayerCards

**Backend refactor:**
- Extracted `GamesCatalogService` from `games.controller.ts` (499→229 lines)
- Moved `getCatalog`, `stripDisabledRules`, and visibility/role helpers into the service
- Updated controller and tests to use the new service

**Test stability:**
- Reduced Jest workers from 4 to 2 to fix SIGSEGV in `games.gateway.spec.ts`

**File cleanup:**
- Extracted chess panel sub-components to `ChessPanelComponents.tsx`
- Removed 24 unused styled components from `styles/index.ts`
- Fixed hooks-after-early-return lint error in `ChessBoardPanel.tsx`