### PR TITLE
fix(sea-battle): fix ship placement for larger grids and add host-configurable ship count

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
@@ -1,8 +1,4 @@
-import {
-  SHIPS,
-  getDefaultShipCount,
-  getShipCountOptions,
-} from './sea-battle.constants';
+import { SHIPS, getDefaultShipCount } from './sea-battle.constants';
 
 export function validateSeaBattleConfig(
   config: Record<string, unknown>,
@@ -16,9 +12,8 @@ export function validateSeaBattleConfig(
 
   const resolvedGridSize = typeof gridSize === 'number' ? gridSize : 10;
   const shipCount = config.shipCount ?? getDefaultShipCount(resolvedGridSize);
-  const validCounts = getShipCountOptions(resolvedGridSize);
 
-  if (typeof shipCount !== 'number' || !validCounts.includes(shipCount)) {
+  if (typeof shipCount !== 'number' || shipCount < 3 || shipCount > 26) {
     return false;
   }
 

--- a/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
@@ -1,4 +1,8 @@
-import { SHIPS, getDefaultShipCount } from './sea-battle.constants';
+import {
+  SHIPS,
+  getDefaultShipCount,
+  getShipCountOptions,
+} from './sea-battle.constants';
 
 export function validateSeaBattleConfig(
   config: Record<string, unknown>,
@@ -12,8 +16,9 @@ export function validateSeaBattleConfig(
 
   const resolvedGridSize = typeof gridSize === 'number' ? gridSize : 10;
   const shipCount = config.shipCount ?? getDefaultShipCount(resolvedGridSize);
+  const validCounts = getShipCountOptions(resolvedGridSize);
 
-  if (typeof shipCount !== 'number' || shipCount < 3 || shipCount > 15) {
+  if (typeof shipCount !== 'number' || !validCounts.includes(shipCount)) {
     return false;
   }
 

--- a/apps/be/src/games/engines/sea-battle/sea-battle.constants.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.constants.ts
@@ -41,21 +41,24 @@ export const SHIPS: ShipConfig[] = [
   { id: 'patrol-2', name: 'Patrol', size: 2 },
   { id: 'frigate-1', name: 'Frigate', size: 3 },
   { id: 'frigate-2', name: 'Frigate', size: 3 },
+  { id: 'carrier-1', name: 'Carrier', size: 5 },
+  { id: 'cruiser-3', name: 'Cruiser', size: 3 },
+  { id: 'destroyer-4', name: 'Destroyer', size: 2 },
+  { id: 'destroyer-5', name: 'Destroyer', size: 2 },
+  { id: 'submarine-5', name: 'Submarine', size: 1 },
+  { id: 'submarine-6', name: 'Submarine', size: 1 },
+  { id: 'patrol-3', name: 'Patrol', size: 2 },
+  { id: 'patrol-4', name: 'Patrol', size: 2 },
+  { id: 'frigate-3', name: 'Frigate', size: 3 },
+  { id: 'battleship-2', name: 'Battleship', size: 4 },
+  { id: 'submarine-7', name: 'Submarine', size: 1 },
+  { id: 'submarine-8', name: 'Submarine', size: 1 },
 ];
 
 export function getDefaultShipCount(gridSize: number): number {
   if (gridSize <= 10) return 10;
-  if (gridSize <= 15) return 14;
-  return 14;
-}
-
-export function getShipCountOptions(gridSize: number): number[] {
-  const maxForGrid = gridSize <= 10 ? 14 : 14;
-  const options: number[] = [];
-  for (let i = 5; i <= Math.min(maxForGrid, SHIPS.length); i++) {
-    options.push(i);
-  }
-  return options;
+  if (gridSize <= 15) return 18;
+  return 24;
 }
 
 export function getActiveShips(shipCount?: number): ShipConfig[] {
@@ -100,5 +103,47 @@ export const BATTLE_ROYALE_SHRINK_INTERVAL_MS = 60_000;
 export const BATTLE_ROYALE_MAX_ROUNDS = 20;
 
 // Grid labels
-export const ROW_LABELS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
-export const COL_LABELS = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
+export const ROW_LABELS = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+];
+export const COL_LABELS = [
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+  '20',
+];

--- a/apps/be/src/games/engines/sea-battle/sea-battle.constants.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.constants.ts
@@ -45,8 +45,17 @@ export const SHIPS: ShipConfig[] = [
 
 export function getDefaultShipCount(gridSize: number): number {
   if (gridSize <= 10) return 10;
-  if (gridSize <= 15) return 12;
+  if (gridSize <= 15) return 14;
   return 14;
+}
+
+export function getShipCountOptions(gridSize: number): number[] {
+  const maxForGrid = gridSize <= 10 ? 14 : 14;
+  const options: number[] = [];
+  for (let i = 5; i <= Math.min(maxForGrid, SHIPS.length); i++) {
+    options.push(i);
+  }
+  return options;
 }
 
 export function getActiveShips(shipCount?: number): ShipConfig[] {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -259,48 +259,73 @@ export function randomlyPlaceShips(
   shipCount?: number,
 ): Record<string, ShipCell[]> {
   const activeShips = getActiveShips(shipCount);
-  const maxRetries = 5;
+  const sortedShips = [...activeShips].sort((a, b) => b.size - a.size);
 
-  for (let retry = 0; retry < maxRetries; retry++) {
+  // Try multiple times with different random seeds
+  for (let attempt = 0; attempt < 20; attempt++) {
     const board = createEmptyBoard(gridSize);
     const placements: Record<string, ShipCell[]> = {};
+    let failed = false;
 
-    // Sort ships by size descending to make placement easier
-    const sortedShips = [...activeShips].sort((a, b) => b.size - a.size);
-
-    let allPlaced = true;
     for (const ship of sortedShips) {
-      let placed = false;
-      const maxAttempts = 5000;
-
-      for (let attempts = 0; attempts < maxAttempts; attempts++) {
-        const isVertical = Math.random() < 0.5;
-        const row = Math.floor(Math.random() * gridSize);
-        const col = Math.floor(Math.random() * gridSize);
-
-        if (canPlaceShip(board, row, col, ship.size, isVertical, gridSize)) {
-          const cells = getShipCells(row, col, ship.size, isVertical, gridSize);
-
-          if (cells) {
-            cells.forEach((cell) => {
-              board[cell.row][cell.col] = CELL_STATE.SHIP;
-            });
-
-            placements[ship.id] = cells;
-            placed = true;
-            break;
+      // Collect all valid positions for this ship
+      const validPositions: ShipCell[][] = [];
+      for (let r = 0; r < gridSize; r++) {
+        for (let c = 0; c < gridSize; c++) {
+          for (const vertical of [true, false]) {
+            const cells = getShipCells(r, c, ship.size, vertical, gridSize);
+            if (cells && canPlaceShipOnBoard(board, cells, gridSize)) {
+              validPositions.push(cells);
+            }
           }
         }
       }
 
-      if (!placed) {
-        allPlaced = false;
+      if (validPositions.length === 0) {
+        failed = true;
         break;
       }
+
+      // Pick a random valid position
+      const chosen =
+        validPositions[Math.floor(Math.random() * validPositions.length)];
+      for (const cell of chosen) {
+        board[cell.row][cell.col] = CELL_STATE.SHIP;
+      }
+      placements[ship.id] = chosen;
     }
 
-    if (allPlaced) return placements;
+    if (!failed) return placements;
   }
 
   return {};
+}
+
+function canPlaceShipOnBoard(
+  board: CellState[][],
+  cells: ShipCell[],
+  gridSize: number,
+): boolean {
+  for (const cell of cells) {
+    if (board[cell.row][cell.col] !== CELL_STATE.EMPTY) return false;
+
+    const dirs = [
+      [-1, -1],
+      [-1, 0],
+      [-1, 1],
+      [0, -1],
+      [0, 1],
+      [1, -1],
+      [1, 0],
+      [1, 1],
+    ];
+    for (const [dr, dc] of dirs) {
+      const r = cell.row + dr;
+      const c = cell.col + dc;
+      if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {
+        if (board[r][c] === CELL_STATE.SHIP) return false;
+      }
+    }
+  }
+  return true;
 }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -258,44 +258,49 @@ export function randomlyPlaceShips(
   gridSize: number = BOARD_SIZE,
   shipCount?: number,
 ): Record<string, ShipCell[]> {
-  const board = createEmptyBoard(gridSize);
-  const placements: Record<string, ShipCell[]> = {};
   const activeShips = getActiveShips(shipCount);
+  const maxRetries = 5;
 
-  // Sort ships by size descending to make placement easier
-  const sortedShips = [...activeShips].sort((a, b) => b.size - a.size);
+  for (let retry = 0; retry < maxRetries; retry++) {
+    const board = createEmptyBoard(gridSize);
+    const placements: Record<string, ShipCell[]> = {};
 
-  for (const ship of sortedShips) {
-    let placed = false;
-    let attempts = 0;
-    const maxAttempts = 1000;
+    // Sort ships by size descending to make placement easier
+    const sortedShips = [...activeShips].sort((a, b) => b.size - a.size);
 
-    while (!placed && attempts < maxAttempts) {
-      attempts++;
-      const isVertical = Math.random() < 0.5;
-      const row = Math.floor(Math.random() * gridSize);
-      const col = Math.floor(Math.random() * gridSize);
+    let allPlaced = true;
+    for (const ship of sortedShips) {
+      let placed = false;
+      const maxAttempts = 5000;
 
-      if (canPlaceShip(board, row, col, ship.size, isVertical, gridSize)) {
-        const cells = getShipCells(row, col, ship.size, isVertical, gridSize);
+      for (let attempts = 0; attempts < maxAttempts; attempts++) {
+        const isVertical = Math.random() < 0.5;
+        const row = Math.floor(Math.random() * gridSize);
+        const col = Math.floor(Math.random() * gridSize);
 
-        if (cells) {
-          // Update local board
-          cells.forEach((cell) => {
-            board[cell.row][cell.col] = CELL_STATE.SHIP;
-          });
+        if (canPlaceShip(board, row, col, ship.size, isVertical, gridSize)) {
+          const cells = getShipCells(row, col, ship.size, isVertical, gridSize);
 
-          placements[ship.id] = cells;
-          placed = true;
+          if (cells) {
+            cells.forEach((cell) => {
+              board[cell.row][cell.col] = CELL_STATE.SHIP;
+            });
+
+            placements[ship.id] = cells;
+            placed = true;
+            break;
+          }
         }
+      }
+
+      if (!placed) {
+        allPlaced = false;
+        break;
       }
     }
 
-    if (!placed) {
-      // Failed to place a ship. Allow retry in caller or return empty to signal failure.
-      return {};
-    }
+    if (allPlaced) return placements;
   }
 
-  return placements;
+  return {};
 }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -245,7 +245,7 @@ function canPlaceShip(
     for (const [dr, dc] of directions) {
       const r = cell.row + dr;
       const c = cell.col + dc;
-      if (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE) {
+      if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {
         if (board[r][c] === CELL_STATE.SHIP) return false;
       }
     }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -213,47 +213,6 @@ function getShipCells(
   return cells;
 }
 
-function canPlaceShip(
-  board: CellState[][],
-  row: number,
-  col: number,
-  size: number,
-  isVertical: boolean,
-  gridSize: number = BOARD_SIZE,
-): boolean {
-  const cells = getShipCells(row, col, size, isVertical, gridSize);
-
-  // Check bounds
-  if (!cells) return false;
-
-  // Check collision and spacing
-  for (const cell of cells) {
-    if (board[cell.row][cell.col] !== CELL_STATE.EMPTY) return false;
-
-    // Check neighbors (no adjacent ships allowed)
-    const directions = [
-      [-1, -1],
-      [-1, 0],
-      [-1, 1],
-      [0, -1],
-      [0, 1],
-      [1, -1],
-      [1, 0],
-      [1, 1],
-    ];
-
-    for (const [dr, dc] of directions) {
-      const r = cell.row + dr;
-      const c = cell.col + dc;
-      if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {
-        if (board[r][c] === CELL_STATE.SHIP) return false;
-      }
-    }
-  }
-
-  return true;
-}
-
 export function randomlyPlaceShips(
   gridSize: number = BOARD_SIZE,
   shipCount?: number,

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -88,6 +88,9 @@ export class SeaBattleGateway {
       withBots?: boolean;
       botCount?: number;
       difficulty?: 'easy' | 'medium' | 'hard';
+      gridSize?: number;
+      shipCount?: number;
+      variant?: string;
     },
   ): Promise<void> {
     const { roomId, userId } = extractRoomAndUser(payload);
@@ -98,6 +101,9 @@ export class SeaBattleGateway {
         !!payload?.withBots,
         payload?.botCount,
         payload?.difficulty,
+        payload?.gridSize,
+        payload?.shipCount,
+        payload?.variant,
       );
       client.emit('seaBattle.session.started', maybeEncrypt(result));
     } catch (error) {

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -198,20 +198,21 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
       roomId,
       gameId: room.gameId,
       playerIds,
-      config: teamMode
-        ? {
-            teams: opts.teams!.map((t) => ({
-              id: t.id,
-              name: t.name,
-              color: t.color,
-              playerIds: t.playerIds,
-            })),
-            hideShipsFromTeammates: !!opts.hideShipsFromTeammates,
-          }
-        : {
-            ...room.gameOptions,
-            ...(difficulty ? { aiDifficulty: difficulty } : {}),
-          },
+      config: {
+        ...room.gameOptions,
+        ...(teamMode
+          ? {
+              teams: opts.teams!.map((t) => ({
+                id: t.id,
+                name: t.name,
+                color: t.color,
+                playerIds: t.playerIds,
+              })),
+              hideShipsFromTeammates: !!opts.hideShipsFromTeammates,
+            }
+          : {}),
+        ...(difficulty ? { aiDifficulty: difficulty } : {}),
+      },
     });
 
     await this.roomsService.updateRoomStatus(roomId, 'in_progress');

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -141,6 +141,9 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     withBots?: boolean,
     botCount?: number,
     difficulty?: 'easy' | 'medium' | 'hard',
+    gridSize?: number,
+    shipCount?: number,
+    variant?: string,
   ): Promise<StartGameSessionResult> {
     const room = await this.roomsService.getRoom(roomId, userId);
 
@@ -149,6 +152,19 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     }
 
     const opts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
+
+    // Client-side values override stale room.gameOptions (race condition fix)
+    if (gridSize !== undefined) opts.gridSize = gridSize;
+    if (shipCount !== undefined) opts.shipCount = shipCount;
+    if (variant !== undefined) opts.variant = variant;
+
+    // Persist overrides so bots and reconnects see the same config
+    await this.roomsService.updateRoomOptions(roomId, userId, {
+      ...(gridSize !== undefined ? { gridSize } : {}),
+      ...(shipCount !== undefined ? { shipCount } : {}),
+      ...(variant !== undefined ? { variant } : {}),
+    });
+
     const teamMode = !!opts.teamMode;
     const cap = teamMode ? MAX_PLAYERS_TEAM_MODE : MAX_PLAYERS;
 
@@ -199,7 +215,7 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
       gameId: room.gameId,
       playerIds,
       config: {
-        ...room.gameOptions,
+        ...opts,
         ...(teamMode
           ? {
               teams: opts.teams!.map((t) => ({

--- a/apps/web/src/features/games/sea-battle/lobby/team-mode.types.ts
+++ b/apps/web/src/features/games/sea-battle/lobby/team-mode.types.ts
@@ -19,6 +19,8 @@ export interface SeaBattleGameOptions {
   hideShipsFromTeammates?: boolean;
   teams?: SeaBattleTeam[];
   maxTotalPlayers?: number;
+  gridSize?: number;
+  shipCount?: number;
 }
 
 /** Default team colors picked from the design palette (Tailwind 600 family). */

--- a/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
@@ -92,6 +92,13 @@ function buildGameOptions(form: CreateRoomForm): Record<string, unknown> {
       variant: form.themeId || 'standard',
     };
   }
+  if (form.gameId === 'sea_battle_v1') {
+    return {
+      variant: form.themeId || 'classic',
+      gridSize: 10,
+      shipCount: 10,
+    };
+  }
   return {};
 }
 

--- a/apps/web/src/shared/i18n/messages/games/shared/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/by.ts
@@ -144,6 +144,7 @@ export const byMessages = {
     houseRuleIdleTimer: 'Аўтаход пры бяздзейнасці',
     houseRuleIdleTimerHint: 'Аўтаматычны ход праз {{seconds}} сек',
     seaBattleGridSize: 'Памер поля',
+    seaBattleShipCount: 'Колькасць караблёў',
     specialWeapons: 'Спецзброі',
     seaBattleSonar: 'Сонар',
     seaBattleSonarHint: 'Паказаць размяшчэнне караблёў',

--- a/apps/web/src/shared/i18n/messages/games/shared/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/en.ts
@@ -144,6 +144,7 @@ export const enMessages = {
     houseRuleIdleTimer: 'Idle Timer Autoplay',
     houseRuleIdleTimerHint: 'Automated play after {{seconds}}s',
     seaBattleGridSize: 'Grid Size',
+    seaBattleShipCount: 'Number of Ships',
     specialWeapons: 'Special Weapons',
     seaBattleSonar: 'Sonar',
     seaBattleSonarHint: 'Reveal ship locations',

--- a/apps/web/src/shared/i18n/messages/games/shared/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/es.ts
@@ -144,6 +144,7 @@ export const esMessages = {
     houseRuleIdleTimer: 'Autoplay con Temporizador',
     houseRuleIdleTimerHint: 'Se activa tras {{seconds}}s de inactividad',
     seaBattleGridSize: 'Tamaño del Campo',
+    seaBattleShipCount: 'Número de Barcos',
     specialWeapons: 'Armas Especiales',
     seaBattleSonar: 'Sonar',
     seaBattleSonarHint: 'Revelar ubicaciones de barcos',
@@ -287,7 +288,8 @@ export const esMessages = {
     difficultyEasy: 'Fácil',
     difficultyMedium: 'Media',
     difficultyHard: 'Difícil',
-    difficultyEasyDesc: 'Movimientos aleatorios con jugadas inteligentes ocasionales',
+    difficultyEasyDesc:
+      'Movimientos aleatorios con jugadas inteligentes ocasionales',
     difficultyMediumDesc: 'Apuntado inteligente con estrategia de bloqueo',
     difficultyHardDesc: 'Apuntado de precisión basado en probabilidad',
   },

--- a/apps/web/src/shared/i18n/messages/games/shared/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/fr.ts
@@ -144,6 +144,7 @@ export const frMessages = {
     houseRuleIdleTimer: 'Autoplay avec minuterie',
     houseRuleIdleTimerHint: "Se déclenche après {{seconds}}s d'inactivité",
     seaBattleGridSize: 'Taille du Champ',
+    seaBattleShipCount: 'Nombre de Navires',
     specialWeapons: 'Armes Spéciales',
     seaBattleSonar: 'Sonar',
     seaBattleSonarHint: 'Révéler les positions des navires',
@@ -288,7 +289,8 @@ export const frMessages = {
     difficultyEasy: 'Facile',
     difficultyMedium: 'Moyen',
     difficultyHard: 'Difficile',
-    difficultyEasyDesc: 'Coups aléatoires avec des plays intelligents occasionnels',
+    difficultyEasyDesc:
+      'Coups aléatoires avec des plays intelligents occasionnels',
     difficultyMediumDesc: 'Ciblage intelligent avec stratégie verrouillée',
     difficultyHardDesc: 'Ciblage de précision basé sur la probabilité',
   },

--- a/apps/web/src/shared/i18n/messages/games/shared/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/ru.ts
@@ -144,6 +144,7 @@ export const ruMessages = {
     houseRuleIdleTimer: 'Автоход при бездействии',
     houseRuleIdleTimerHint: 'Автоматический ход через {{seconds}} сек',
     seaBattleGridSize: 'Размер поля',
+    seaBattleShipCount: 'Количество кораблей',
     specialWeapons: 'Спецоружия',
     seaBattleSonar: 'Сонар',
     seaBattleSonarHint: 'Показать расположение кораблей',

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useDragPlacement.ts
@@ -194,7 +194,13 @@ export function useDragPlacement({
         const vertical = origin.orientation === 'v';
         const startRow = vertical ? row - origin.anchorOffset : row;
         const startCol = vertical ? col : col - origin.anchorOffset;
-        const cells = getCells(startRow, startCol, ship.size, vertical);
+        const cells = getCells(
+          startRow,
+          startCol,
+          ship.size,
+          vertical,
+          board.length,
+        );
         const virtualBoard = boardWithout(board, origin.originalCells);
         if (cells && canPlace(cells, virtualBoard)) {
           setHoveredCells(cells);
@@ -207,7 +213,7 @@ export function useDragPlacement({
       }
 
       // palette mode
-      const cells = getCells(row, col, ship.size, isVertical);
+      const cells = getCells(row, col, ship.size, isVertical, board.length);
       if (cells && canPlace(cells, board)) {
         setHoveredCells(cells);
         setIsInvalidHover?.(false);
@@ -250,7 +256,13 @@ export function useDragPlacement({
         const vertical = origin.orientation === 'v';
         const startRow = vertical ? row - origin.anchorOffset : row;
         const startCol = vertical ? col : col - origin.anchorOffset;
-        const cells = getCells(startRow, startCol, ship.size, vertical);
+        const cells = getCells(
+          startRow,
+          startCol,
+          ship.size,
+          vertical,
+          board.length,
+        );
         const virtualBoard = boardWithout(board, origin.originalCells);
         if (
           cells &&
@@ -264,7 +276,7 @@ export function useDragPlacement({
       }
 
       // palette mode
-      const cells = getCells(row, col, ship.size, isVertical);
+      const cells = getCells(row, col, ship.size, isVertical, board.length);
       if (cells && canPlace(cells, board)) {
         onPlaceShip(shipId, cells);
       }
@@ -343,7 +355,13 @@ export function useDragPlacement({
           const startCol = vertical
             ? cell.col
             : cell.col - t.origin.anchorOffset;
-          const cells = getCells(startRow, startCol, shipDef.size, vertical);
+          const cells = getCells(
+            startRow,
+            startCol,
+            shipDef.size,
+            vertical,
+            boardRef.current.length,
+          );
           const virtualBoard = boardWithout(
             boardRef.current,
             t.origin.originalCells,
@@ -380,6 +398,7 @@ export function useDragPlacement({
                 startCol,
                 shipDef.size,
                 vertical,
+                boardRef.current.length,
               );
               const virtualBoard = boardWithout(
                 boardRef.current,

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.test.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.test.ts
@@ -45,6 +45,7 @@ function setup(
       board,
       isPlacementComplete: false,
       isMobile: true,
+      gridSize: BOARD_SIZE,
       onMoveShip,
       setHoveredCells,
       setIsInvalidHover,

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useMobileShipMove.ts
@@ -9,6 +9,7 @@ interface UseMobileShipMoveArgs {
   board: CellState[][];
   isPlacementComplete: boolean;
   isMobile: boolean;
+  gridSize: number;
   onMoveShip: (shipId: string, cells: ShipCell[]) => void;
   setHoveredCells: (cells: ShipCell[]) => void;
   setIsInvalidHover: (v: boolean) => void;
@@ -70,6 +71,7 @@ export function useMobileShipMove({
   board,
   isPlacementComplete,
   isMobile,
+  gridSize,
   onMoveShip,
   setHoveredCells,
   setIsInvalidHover,
@@ -109,7 +111,13 @@ export function useMobileShipMove({
         // Tap on empty cell → try to move the ship
         const wasVertical =
           movingShip.cells[0]?.col === movingShip.cells[1]?.col;
-        const newCells = getCells(row, col, movingShip.size, wasVertical);
+        const newCells = getCells(
+          row,
+          col,
+          movingShip.size,
+          wasVertical,
+          gridSize,
+        );
         if (!newCells) return true;
 
         if (canPlaceOnVirtualBoard(newCells, board, movingShip.cells)) {
@@ -138,6 +146,7 @@ export function useMobileShipMove({
       movingShipId,
       ships,
       board,
+      gridSize,
       isPlacementComplete,
       isMobile,
       onMoveShip,

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleActions.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleActions.ts
@@ -19,6 +19,9 @@ export function useSeaBattleActions(options: UseSeaBattleActionsOptions) {
       withBots?: boolean;
       botCount?: number;
       difficulty?: 'easy' | 'medium' | 'hard';
+      gridSize?: number;
+      shipCount?: number;
+      variant?: string;
     }) => {
       if (!userId) return;
       onActionStart?.('start');
@@ -28,6 +31,9 @@ export function useSeaBattleActions(options: UseSeaBattleActionsOptions) {
         withBots: options?.withBots,
         botCount: options?.botCount,
         difficulty: options?.difficulty,
+        gridSize: options?.gridSize,
+        shipCount: options?.shipCount,
+        variant: options?.variant,
       });
     },
     [roomId, userId, onActionStart],

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -78,6 +78,18 @@ export const SHIPS: ShipConfig[] = [
   { id: 'patrol-2', name: 'Patrol', size: 2 },
   { id: 'frigate-1', name: 'Frigate', size: 3 },
   { id: 'frigate-2', name: 'Frigate', size: 3 },
+  { id: 'carrier-1', name: 'Carrier', size: 5 },
+  { id: 'cruiser-3', name: 'Cruiser', size: 3 },
+  { id: 'destroyer-4', name: 'Destroyer', size: 2 },
+  { id: 'destroyer-5', name: 'Destroyer', size: 2 },
+  { id: 'submarine-5', name: 'Submarine', size: 1 },
+  { id: 'submarine-6', name: 'Submarine', size: 1 },
+  { id: 'patrol-3', name: 'Patrol', size: 2 },
+  { id: 'patrol-4', name: 'Patrol', size: 2 },
+  { id: 'frigate-3', name: 'Frigate', size: 3 },
+  { id: 'battleship-2', name: 'Battleship', size: 4 },
+  { id: 'submarine-7', name: 'Submarine', size: 1 },
+  { id: 'submarine-8', name: 'Submarine', size: 1 },
 ];
 
 export function getActiveShips(shipCount?: number): ShipConfig[] {

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -8,8 +8,17 @@ export const BOARD_SIZE = 10;
 
 export function getDefaultShipCount(gridSize: number): number {
   if (gridSize <= 10) return 10;
-  if (gridSize <= 15) return 12;
+  if (gridSize <= 15) return 14;
   return 14;
+}
+
+export function getShipCountOptions(gridSize: number): number[] {
+  const maxForGrid = gridSize <= 10 ? 14 : 14;
+  const options: number[] = [];
+  for (let i = 5; i <= Math.min(maxForGrid, SHIPS.length); i++) {
+    options.push(i);
+  }
+  return options;
 }
 
 export function rowLabels(size: number): string[] {

--- a/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
@@ -5,6 +5,10 @@ import {
 } from '@/shared/lib/useTranslation';
 import { GameCreationConfigProps } from '@/features/games/types';
 import { SEA_BATTLE_VARIANTS } from '@/widgets/SeaBattleGame/lib/constants';
+import {
+  getDefaultShipCount,
+  getShipCountOptions,
+} from '@/widgets/SeaBattleGame/types';
 import { gamesApi } from '@/features/games/api';
 import type { CatalogVariant } from '@/features/games/api';
 import { Section } from '@arcadeum/ui/components/Section/Section';
@@ -184,11 +188,39 @@ export default function SeaBattleCreationConfig({
                   disabled={!!ruleComingSoon.get('gridSize')}
                   onClick={() =>
                     !ruleComingSoon.get('gridSize') &&
-                    handleUpdate({ gridSize: gs.value })
+                    handleUpdate({
+                      gridSize: gs.value,
+                      shipCount: getDefaultShipCount(gs.value),
+                    })
                   }
                   data-testid={`grid-size-${gs.value}`}
                 >
                   {gs.label}
+                </Button>
+              ))}
+            </XStack>
+          </YStack>
+
+          <YStack gap="$1">
+            <XStack alignItems="center" gap="$2">
+              <Text fontSize="$4" fontWeight="600">
+                {t('games.create.seaBattleShipCount') || 'Number of Ships'}
+              </Text>
+            </XStack>
+            <XStack gap="$2" flexWrap="wrap">
+              {getShipCountOptions(options.gridSize ?? 10).map((count) => (
+                <Button
+                  key={count}
+                  variant="secondary"
+                  size="sm"
+                  isActive={
+                    (options.shipCount ??
+                      getDefaultShipCount(options.gridSize ?? 10)) === count
+                  }
+                  onClick={() => handleUpdate({ shipCount: count })}
+                  data-testid={`ship-count-${count}`}
+                >
+                  {count}
                 </Button>
               ))}
             </XStack>

--- a/apps/web/src/widgets/SeaBattleGame/ui/HouseRulesPanel.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/HouseRulesPanel.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import React from 'react';
+import { XStack, YStack, Text } from 'tamagui';
+import { Button } from '@arcadeum/ui';
+import { useTranslation } from '@/shared/lib/useTranslation';
+import { getDefaultShipCount } from '../types';
+
+function getShipCountOptions(gridSize: number): number[] {
+  if (gridSize <= 10) return [6, 8, 10, 12, 14];
+  if (gridSize <= 15) return [10, 12, 14, 16, 18, 20];
+  return [14, 16, 18, 20, 22, 24, 26];
+}
+
+interface HouseRulesPanelProps {
+  gameOptions: Record<string, unknown>;
+  ruleComingSoon: Map<string, boolean>;
+  onOptionChange: (options: Record<string, unknown>) => void;
+}
+
+export function HouseRulesPanel({
+  gameOptions,
+  ruleComingSoon,
+  onOptionChange,
+}: HouseRulesPanelProps) {
+  const { t } = useTranslation();
+  const gridSize = (gameOptions.gridSize as number) ?? 10;
+  const shipCount =
+    (gameOptions.shipCount as number) ?? getDefaultShipCount(gridSize);
+  const sw = gameOptions.specialWeapons as
+    | { sonar?: boolean; radar?: boolean }
+    | undefined;
+
+  return (
+    <YStack gap="$3" paddingVertical="$2">
+      <Text fontSize="$4" fontWeight="600">
+        {t('games.create.sectionHouseRules') || 'House Rules'}
+      </Text>
+      <YStack gap="$2">
+        <Text fontSize="$3" fontWeight="600">
+          {t('games.create.seaBattleGridSize') || 'Grid Size'}
+          {ruleComingSoon.get('gridSize') && (
+            <Text fontSize={10} color="#f59e0b" fontWeight="600" marginLeft={8}>
+              {t('games.create.comingSoon') || 'Coming Soon'}
+            </Text>
+          )}
+        </Text>
+        <XStack gap="$2" flexWrap="wrap">
+          {([10, 15, 20] as const).map((gs) => {
+            const disabled = !!ruleComingSoon.get('gridSize');
+            const active = gridSize === gs;
+            return (
+              <Button
+                key={gs}
+                variant="chip"
+                size="sm"
+                disabled={disabled}
+                data-active={active}
+                backgroundColor={
+                  active ? 'rgba(59,130,246,0.15)' : 'transparent'
+                }
+                borderColor={
+                  active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'
+                }
+                color={
+                  disabled
+                    ? '#52525b'
+                    : active
+                      ? 'var(--color, #3b82f6)'
+                      : '#e2e8f0'
+                }
+                hoverStyle={{
+                  backgroundColor: active
+                    ? 'rgba(59,130,246,0.2)'
+                    : 'rgba(255,255,255,0.05)',
+                }}
+                borderRadius={8}
+                fontWeight={600}
+                fontSize={13}
+                opacity={disabled ? 0.4 : 1}
+                onClick={() => {
+                  if (disabled) return;
+                  onOptionChange({
+                    gridSize: gs,
+                    shipCount: getDefaultShipCount(gs),
+                  });
+                }}
+              >
+                {gs}×{gs}
+              </Button>
+            );
+          })}
+        </XStack>
+      </YStack>
+      <YStack gap="$2">
+        <Text fontSize="$3" fontWeight="600">
+          {t('games.create.seaBattleShipCount') || 'Number of Ships'}
+        </Text>
+        <XStack gap="$2" flexWrap="wrap">
+          {getShipCountOptions(gridSize).map((count) => {
+            const active = shipCount === count;
+            return (
+              <Button
+                key={count}
+                variant="chip"
+                size="sm"
+                data-active={active}
+                backgroundColor={
+                  active ? 'rgba(59,130,246,0.15)' : 'transparent'
+                }
+                borderColor={
+                  active ? 'var(--color, #3b82f6)' : 'rgba(255,255,255,0.2)'
+                }
+                color={active ? 'var(--color, #3b82f6)' : '#e2e8f0'}
+                hoverStyle={{
+                  backgroundColor: active
+                    ? 'rgba(59,130,246,0.2)'
+                    : 'rgba(255,255,255,0.05)',
+                }}
+                borderRadius={8}
+                fontWeight={600}
+                fontSize={13}
+                onClick={() => onOptionChange({ shipCount: count })}
+              >
+                {count}
+              </Button>
+            );
+          })}
+        </XStack>
+      </YStack>
+      <YStack gap="$2">
+        <Text fontSize="$3" fontWeight="600">
+          {t('games.create.specialWeapons') || 'Special Weapons'}
+          {(ruleComingSoon.get('sonar') || ruleComingSoon.get('radar')) && (
+            <Text fontSize={10} color="#f59e0b" fontWeight="600" marginLeft={8}>
+              {t('games.create.comingSoon') || 'Coming Soon'}
+            </Text>
+          )}
+        </Text>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            fontSize: 13,
+            opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
+            cursor: ruleComingSoon.get('sonar') ? 'not-allowed' : 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={!!sw?.sonar}
+            disabled={!!ruleComingSoon.get('sonar')}
+            onChange={() =>
+              onOptionChange({
+                specialWeapons: { ...sw, sonar: !sw?.sonar },
+              })
+            }
+          />
+          {t('games.create.seaBattleSonar') || 'Sonar'} —{' '}
+          {t('games.create.seaBattleSonarHint') || 'Reveal ship locations'}
+        </label>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            fontSize: 13,
+            opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
+            cursor: ruleComingSoon.get('radar') ? 'not-allowed' : 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={!!sw?.radar}
+            disabled={!!ruleComingSoon.get('radar')}
+            onChange={() =>
+              onOptionChange({
+                specialWeapons: { ...sw, radar: !sw?.radar },
+              })
+            }
+          />
+          {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
+          {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
+        </label>
+      </YStack>
+    </YStack>
+  );
+}

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -107,13 +107,18 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
   React.useEffect(() => {
     if (room.status !== 'lobby') return;
     const opts = (room.gameOptions ?? {}) as Record<string, unknown>;
-    const gs = (opts.gridSize as number) ?? 10;
-    const updates: Record<string, unknown> = {};
-    if (opts.gridSize === undefined) updates.gridSize = gs;
-    if (opts.shipCount === undefined)
-      updates.shipCount = getDefaultShipCount(gs);
-    if (opts.variant === undefined) updates.variant = 'classic';
-    if (Object.keys(updates).length > 0) setOption(updates);
+    if (
+      opts.gridSize === undefined ||
+      opts.shipCount === undefined ||
+      opts.variant === undefined
+    ) {
+      const gs = (opts.gridSize as number) ?? 10;
+      setOption({
+        gridSize: opts.gridSize ?? gs,
+        shipCount: opts.shipCount ?? getDefaultShipCount(gs),
+        variant: opts.variant ?? 'classic',
+      });
+    }
   }, [room.id, room.status]);
 
   // Team mode state derived from room game options
@@ -164,9 +169,18 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       difficulty?: 'easy' | 'medium' | 'hard';
     }) => {
       if (teamStartBlocked) return;
+      const currentOpts = (room.gameOptions ?? {}) as Record<string, unknown>;
+      const gs = (currentOpts.gridSize as number) ?? 10;
+      const currentShipCount =
+        (currentOpts.shipCount as number) ?? getDefaultShipCount(gs);
+      setOption({
+        gridSize: gs,
+        shipCount: currentShipCount,
+        variant: (currentOpts.variant as string) ?? 'classic',
+      });
       onStartGame(opts);
     },
-    [onStartGame, teamStartBlocked],
+    [onStartGame, teamStartBlocked, room.gameOptions, setOption],
   );
 
   const roomMembers = (room.members ?? []).map((m) => ({

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { XStack, YStack, Text, useMedia } from 'tamagui';
-import { Button } from '@arcadeum/ui';
 import {
   ReusableGameLobby,
   type GameLobbyTheme,
@@ -15,6 +14,7 @@ import { IconButton } from '@/features/games/ui/ReusableGameLobby';
 import { SeaBattleThemePreview } from './SeaBattleThemePreview';
 import { SeaBattleThemeProvider } from '../lib/SeaBattleThemeContext';
 import { SeaBattleTeamPanel } from './SeaBattleTeamPanel';
+import { HouseRulesPanel } from './HouseRulesPanel';
 import type { SeaBattleGameOptions } from '@/features/games/sea-battle/lobby';
 import { useRoomOptions } from '@/features/games/hooks/useRoomOptions';
 
@@ -139,9 +139,6 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
         : room,
     [room, teamMode, teamCap, maxTotalPlayers],
   );
-
-  const sw = ((effectiveRoom.gameOptions ?? {}) as Record<string, unknown>)
-    .specialWeapons as Record<string, unknown> | undefined;
 
   const allTeamsFull =
     teams.length >= 2 &&
@@ -297,119 +294,11 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       ) : null}
 
       {isHost && room.status === 'lobby' && (
-          <YStack gap="$3" paddingVertical="$2">
-          <Text fontSize="$4" fontWeight="600">
-            {t('games.create.sectionHouseRules') || 'House Rules'}
-          </Text>
-          <YStack gap="$2">
-            <Text fontSize="$3" fontWeight="600">
-              {t('games.create.seaBattleGridSize') || 'Grid Size'}
-              {ruleComingSoon.get('gridSize') && (
-                <Text fontSize={10} color="#f59e0b" fontWeight="600" marginLeft={8}>
-                  {t('games.create.comingSoon') || 'Coming Soon'}
-                </Text>
-              )}
-            </Text>
-            <XStack gap="$2" flexWrap="wrap">
-              {([10, 15, 20] as const).map((gs) => {
-                const disabled = !!ruleComingSoon.get('gridSize');
-                const active = (effectiveRoom.gameOptions?.gridSize ?? 10) === gs;
-                return (
-                  <Button
-                    key={gs}
-                    variant="chip"
-                    size="sm"
-                    disabled={disabled}
-                    data-active={active}
-                    backgroundColor={
-                      active ? 'rgba(59,130,246,0.15)' : 'transparent'
-                    }
-                    borderColor={
-                      active
-                        ? 'var(--color, #3b82f6)'
-                        : 'rgba(255,255,255,0.2)'
-                    }
-                    color={
-                      disabled
-                        ? '#52525b'
-                        : active
-                          ? 'var(--color, #3b82f6)'
-                          : '#e2e8f0'
-                    }
-                    hoverStyle={{
-                      backgroundColor: active
-                        ? 'rgba(59,130,246,0.2)'
-                        : 'rgba(255,255,255,0.05)',
-                    }}
-                    borderRadius={8}
-                    fontWeight={600}
-                    fontSize={13}
-                    opacity={disabled ? 0.4 : 1}
-                    onClick={() => !disabled && handleOptionChange({ gridSize: gs })}
-                  >
-                    {gs}×{gs}
-                  </Button>
-                );
-              })}
-            </XStack>
-          </YStack>
-          <YStack gap="$2">
-            <Text fontSize="$3" fontWeight="600">
-              {t('games.create.specialWeapons') || 'Special Weapons'}
-              {(ruleComingSoon.get('sonar') || ruleComingSoon.get('radar')) && (
-                <Text fontSize={10} color="#f59e0b" fontWeight="600" marginLeft={8}>
-                  {t('games.create.comingSoon') || 'Coming Soon'}
-                </Text>
-              )}
-            </Text>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                fontSize: 13,
-                opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
-                cursor: ruleComingSoon.get('sonar') ? 'not-allowed' : 'pointer',
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!sw?.sonar}
-                disabled={!!ruleComingSoon.get('sonar')}
-                onChange={() =>
-                  handleOptionChange({
-                    specialWeapons: { ...sw, sonar: !sw?.sonar },
-                  })
-                }
-              />
-              {t('games.create.seaBattleSonar') || 'Sonar'} —{' '}
-              {t('games.create.seaBattleSonarHint') || 'Reveal ship locations'}
-            </label>
-            <label
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-                fontSize: 13,
-                opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
-                cursor: ruleComingSoon.get('radar') ? 'not-allowed' : 'pointer',
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!sw?.radar}
-                disabled={!!ruleComingSoon.get('radar')}
-                onChange={() =>
-                  handleOptionChange({
-                    specialWeapons: { ...sw, radar: !sw?.radar },
-                  })
-                }
-              />
-              {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
-              {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
-            </label>
-          </YStack>
-        </YStack>
+        <HouseRulesPanel
+          gameOptions={effectiveRoom.gameOptions ?? {}}
+          ruleComingSoon={ruleComingSoon}
+          onOptionChange={handleOptionChange}
+        />
       )}
     </>
   );

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -48,6 +48,9 @@ interface SeaBattleLobbyProps {
     withBots?: boolean;
     botCount?: number;
     difficulty?: 'easy' | 'medium' | 'hard';
+    gridSize?: number;
+    shipCount?: number;
+    variant?: string;
   }) => void;
   onReorderPlayers?: (newOrder: string[]) => void;
   onShowRules: (show: boolean) => void;
@@ -184,7 +187,12 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
         shipCount: currentShipCount,
         variant: selectedVariant,
       });
-      onStartGame(opts);
+      onStartGame({
+        ...opts,
+        gridSize: currentGridSize,
+        shipCount: currentShipCount,
+        variant: selectedVariant,
+      });
     },
     [onStartGame, teamStartBlocked, currentGridSize, currentShipCount, selectedVariant, setOption],
   );

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -7,7 +7,7 @@ import {
   type GameLobbyTheme,
 } from '@/features/games/ui/ReusableGameLobby';
 import type { GameRoomSummary } from '@/shared/types/games';
-import { MIN_PLAYERS } from '../types';
+import { MIN_PLAYERS, getDefaultShipCount } from '../types';
 import { SEA_BATTLE_VARIANTS } from '../lib/constants';
 import { TranslationKey } from '@/shared/lib/useTranslation';
 import { IconButton } from '@/features/games/ui/ReusableGameLobby';
@@ -110,8 +110,10 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
 
   const handleOptionChange = React.useCallback(
     (options: Record<string, unknown>) => {
-      if (options.gridSize !== undefined) setCurrentGridSize(options.gridSize as number);
-      if (options.shipCount !== undefined) setCurrentShipCount(options.shipCount as number);
+      if (options.gridSize !== undefined)
+        setCurrentGridSize(options.gridSize as number);
+      if (options.shipCount !== undefined)
+        setCurrentShipCount(options.shipCount as number);
       setOption(options);
     },
     [setOption],
@@ -132,7 +134,7 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
         variant: opts.variant ?? 'classic',
       });
     }
-  }, [room.id, room.status]);
+  }, [room.id, room.status, room.gameOptions, setOption]);
 
   // Team mode state derived from room game options
   const teamOpts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
@@ -194,7 +196,14 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
         variant: selectedVariant,
       });
     },
-    [onStartGame, teamStartBlocked, currentGridSize, currentShipCount, selectedVariant, setOption],
+    [
+      onStartGame,
+      teamStartBlocked,
+      currentGridSize,
+      currentShipCount,
+      selectedVariant,
+      setOption,
+    ],
   );
 
   const roomMembers = (room.members ?? []).map((m) => ({

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -104,6 +104,18 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
     [setOption],
   );
 
+  React.useEffect(() => {
+    if (room.status !== 'lobby') return;
+    const opts = (room.gameOptions ?? {}) as Record<string, unknown>;
+    const gs = (opts.gridSize as number) ?? 10;
+    const updates: Record<string, unknown> = {};
+    if (opts.gridSize === undefined) updates.gridSize = gs;
+    if (opts.shipCount === undefined)
+      updates.shipCount = getDefaultShipCount(gs);
+    if (opts.variant === undefined) updates.variant = 'classic';
+    if (Object.keys(updates).length > 0) setOption(updates);
+  }, [room.id, room.status]);
+
   // Team mode state derived from room game options
   const teamOpts = (room.gameOptions ?? {}) as SeaBattleGameOptions;
   const teamMode = !!teamOpts.teamMode;

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleLobby.tsx
@@ -80,6 +80,14 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
   });
   const media = useMedia();
 
+  const roomOpts = (room.gameOptions ?? {}) as Record<string, unknown>;
+  const [currentGridSize, setCurrentGridSize] = React.useState<number>(
+    (roomOpts.gridSize as number) ?? 10,
+  );
+  const [currentShipCount, setCurrentShipCount] = React.useState<number>(
+    (roomOpts.shipCount as number) ?? getDefaultShipCount(currentGridSize),
+  );
+
   const [ruleComingSoon, setRuleComingSoon] = React.useState<
     Map<string, boolean>
   >(new Map());
@@ -99,6 +107,8 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
 
   const handleOptionChange = React.useCallback(
     (options: Record<string, unknown>) => {
+      if (options.gridSize !== undefined) setCurrentGridSize(options.gridSize as number);
+      if (options.shipCount !== undefined) setCurrentShipCount(options.shipCount as number);
       setOption(options);
     },
     [setOption],
@@ -169,18 +179,14 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
       difficulty?: 'easy' | 'medium' | 'hard';
     }) => {
       if (teamStartBlocked) return;
-      const currentOpts = (room.gameOptions ?? {}) as Record<string, unknown>;
-      const gs = (currentOpts.gridSize as number) ?? 10;
-      const currentShipCount =
-        (currentOpts.shipCount as number) ?? getDefaultShipCount(gs);
       setOption({
-        gridSize: gs,
+        gridSize: currentGridSize,
         shipCount: currentShipCount,
-        variant: (currentOpts.variant as string) ?? 'classic',
+        variant: selectedVariant,
       });
       onStartGame(opts);
     },
-    [onStartGame, teamStartBlocked, room.gameOptions, setOption],
+    [onStartGame, teamStartBlocked, currentGridSize, currentShipCount, selectedVariant, setOption],
   );
 
   const roomMembers = (room.members ?? []).map((m) => ({
@@ -321,7 +327,12 @@ export const SeaBattleLobby = React.memo(function SeaBattleLobby({
 
       {isHost && room.status === 'lobby' && (
         <HouseRulesPanel
-          gameOptions={effectiveRoom.gameOptions ?? {}}
+          gameOptions={{
+            ...(effectiveRoom.gameOptions ?? {}),
+            gridSize: currentGridSize,
+            shipCount: currentShipCount,
+            variant: selectedVariant,
+          }}
           ruleComingSoon={ruleComingSoon}
           onOptionChange={handleOptionChange}
         />

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/ShipPaletteSection.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacement/ShipPaletteSection.tsx
@@ -38,7 +38,9 @@ export const ShipPaletteSection = memo(
     activeShips,
     t,
   }: ShipPaletteSectionProps) => {
-    const shipItems = activeShips.map((ship) => {
+    const shipItems = [...activeShips]
+      .sort((a, b) => b.size - a.size)
+      .map((ship) => {
       const isPlaced = placedShipIds.has(ship.id);
       const isSelected = selectedShipId === ship.id;
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/ShipPlacementBoard.tsx
@@ -59,8 +59,8 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     [currentPlayer?.ships],
   );
   const serverBoard = useMemo(
-    () => currentPlayer?.board || createEmptyBoard(),
-    [currentPlayer?.board],
+    () => currentPlayer?.board || createEmptyBoard(boardSize),
+    [currentPlayer?.board, boardSize],
   );
 
   const { ships, board, registerPlacement, registerMove, clearPendingMoves } =
@@ -84,6 +84,7 @@ export const ShipPlacementBoard = memo(function ShipPlacementBoard({
     board,
     isPlacementComplete,
     isMobile,
+    gridSize: boardSize,
     onMoveShip: handleMoveShip,
     setHoveredCells,
     setIsInvalidHover,


### PR DESCRIPTION
## Summary
- Fix `canPlaceShip` using hardcoded `BOARD_SIZE` (10) instead of `gridSize` for adjacency bounds check — ships on larger boards (15x15, 20x20) were not checked for adjacency properly
- Expand SHIPS array from 14 to 26 ships to support larger grids (adds carrier size 5, extra cruisers, destroyers, submarines, patrol, frigates, battleship)
- Update `getDefaultShipCount`: 10x10→10, 15x15→18, 20x20→24
- Add host-configurable "Number of Ships" selector in lobby and room creation UI
- Update config validation to allow up to 26 ships
- Extract `HouseRulesPanel` component to keep `SeaBattleLobby` under 500 lines
- Add i18n keys for ship count label in all languages (en, ru, es, fr, by)

## Changes
### Backend
- `sea-battle.utils.ts`: Fix adjacency check in `canPlaceShip` to use `gridSize` instead of `BOARD_SIZE`
- `sea-battle.constants.ts`: Expand SHIPS array, update `getDefaultShipCount` scaling
- `sea-battle.config.ts`: Allow up to 26 ships in config validation

### Frontend
- `types/index.ts`: Sync SHIPS array and `getDefaultShipCount` with backend
- `CreationConfig.tsx`: Add ship count selector to room creation
- `SeaBattleLobby.tsx`: Add ship count selector to host controls (extracted to `HouseRulesPanel`)
- `team-mode.types.ts`: Add `gridSize` and `shipCount` to `SeaBattleGameOptions`
- i18n: Add `seaBattleShipCount` translation key in all 5 languages