### PR TITLE
docs: add PR title convention for staging/main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,15 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 
 Branch naming: `ARC-XXX` (Jira tickets). Footer: `(ARC-XXX)` for issue tracking.
 
+### PR title rules
+
+PR titles are validated by CI (`branch-guard.yml`). The title must match the target branch:
+
+| Target branch | Title prefix | Example            |
+| ------------- | ------------ | ------------------ |
+| `staging`     | `demo`       | `demo: v1.23.84`   |
+| `main`        | `release`    | `release: v1.24.0` |
+
 ### Git rules
 
 - **Never push directly to `main`, `staging`, or `develop`** — always create a feature branch and open a PR targeting `develop`. These are protected branches; direct pushes bypass review.


### PR DESCRIPTION
## Summary
- Add PR title convention table to CLAUDE.md so all contributors know the CI-enforced format

## Changes
- `staging` PRs → title must start with `demo` (e.g. `demo: v1.23.84`)
- `main` PRs → title must start with `release` (e.g. `release: v1.24.0`)
- Validated against `.github/workflows/branch-guard.yml` regex