### PR TITLE
fix(be): fix sea battle auto-place not placing all ships

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -116,6 +116,12 @@ export function runAutoPlace(
 ): GameActionResult<SeaBattleState> {
   const gridSize = state.gridSize ?? BOARD_SIZE;
   const activeShips = getActiveShips(state.shipCount);
+
+  const placements = randomlyPlaceShips(gridSize, state.shipCount);
+  if (Object.keys(placements).length === 0) {
+    return { success: false, error: 'Failed to generate ship placement' };
+  }
+
   for (let r = 0; r < gridSize; r++) {
     for (let c = 0; c < gridSize; c++) {
       if (player.board[r][c] === CELL_STATE.SHIP) {
@@ -125,10 +131,7 @@ export function runAutoPlace(
   }
   player.ships = [];
   player.placementComplete = false;
-  const placements = randomlyPlaceShips(gridSize, state.shipCount);
-  if (Object.keys(placements).length === 0) {
-    return { success: false, error: 'Failed to generate ship placement' };
-  }
+
   for (const shipId of Object.keys(placements)) {
     const cells = placements[shipId];
     const shipConfig = activeShips.find((s) => s.id === shipId);

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -220,14 +220,14 @@ export function randomlyPlaceShips(
   const activeShips = getActiveShips(shipCount);
   const sortedShips = [...activeShips].sort((a, b) => b.size - a.size);
 
-  // Try multiple times with different random seeds
-  for (let attempt = 0; attempt < 20; attempt++) {
+  const maxAttempts = Math.max(100, gridSize * gridSize);
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const board = createEmptyBoard(gridSize);
     const placements: Record<string, ShipCell[]> = {};
     let failed = false;
 
     for (const ship of sortedShips) {
-      // Collect all valid positions for this ship
       const validPositions: ShipCell[][] = [];
       for (let r = 0; r < gridSize; r++) {
         for (let c = 0; c < gridSize; c++) {
@@ -245,7 +245,6 @@ export function randomlyPlaceShips(
         break;
       }
 
-      // Pick a random valid position
       const chosen =
         validPositions[Math.floor(Math.random() * validPositions.length)];
       for (const cell of chosen) {


### PR DESCRIPTION
## What
Fix sea battle auto-place failing to place all ships on large boards and state corruption when placement fails.

## Why
The `randomlyPlaceShips` algorithm only tried 20 attempts, which frequently failed on a 20×20 board with 24 ships. When it failed, `runAutoPlace` had already cleared the player's board and ships before checking the result, leaving the player with an empty board.

## Changes
- `sea-battle.utils.ts`: Increased retry attempts from 20 to `Math.max(100, gridSize²)` (400 for 20×20 board)
- `sea-battle-placement-actions.utils.ts`: Moved board/ships clearing after `randomlyPlaceShips()` succeeds, preventing state corruption on failure

All 1269 backend + 1139 web unit tests pass.