### PR TITLE
feat(contact): add UI validation error display to contact form

### DIFF
--- a/apps/web/src/app/[locale]/contact/ContactForm.tsx
+++ b/apps/web/src/app/[locale]/contact/ContactForm.tsx
@@ -156,6 +156,7 @@ export function ContactForm({ form }: ContactFormProps) {
                     label={form?.name ?? form?.nameLabel ?? 'Your name'}
                     required
                     autoComplete="name"
+                    maxLength={120}
                     error={!!fieldErrors?.name}
                     data-testid="contact-name-input"
                   />
@@ -189,6 +190,7 @@ export function ContactForm({ form }: ContactFormProps) {
                   name="subject"
                   label={form?.subject ?? form?.subjectLabel ?? 'Subject'}
                   required
+                  maxLength={200}
                   error={!!fieldErrors?.subject}
                   data-testid="contact-subject-input"
                 />

--- a/apps/web/src/app/[locale]/contact/ContactForm.tsx
+++ b/apps/web/src/app/[locale]/contact/ContactForm.tsx
@@ -149,43 +149,72 @@ export function ContactForm({ form }: ContactFormProps) {
           <form key={formKey} action={formAction}>
             <YStack gap="$4">
               <div style={s.formGridStyle}>
-                <FloatingLabelInput
-                  id="contact-name"
-                  name="name"
-                  label={form?.name ?? form?.nameLabel ?? 'Your name'}
-                  required
-                  autoComplete="name"
-                  error={!!fieldErrors?.name}
-                  data-testid="contact-name-input"
-                />
-                <FloatingLabelInput
-                  id="contact-email"
-                  name="email"
-                  type="email"
-                  label={form?.email ?? form?.emailLabel ?? 'Email'}
-                  required
-                  autoComplete="email"
-                  error={!!fieldErrors?.email}
-                  data-testid="contact-email-input"
-                />
+                <div>
+                  <FloatingLabelInput
+                    id="contact-name"
+                    name="name"
+                    label={form?.name ?? form?.nameLabel ?? 'Your name'}
+                    required
+                    autoComplete="name"
+                    error={!!fieldErrors?.name}
+                    data-testid="contact-name-input"
+                  />
+                  {fieldErrors?.name && (
+                    <span style={s.errorTextStyle} role="alert">
+                      {fieldErrors.name}
+                    </span>
+                  )}
+                </div>
+                <div>
+                  <FloatingLabelInput
+                    id="contact-email"
+                    name="email"
+                    type="email"
+                    label={form?.email ?? form?.emailLabel ?? 'Email'}
+                    required
+                    autoComplete="email"
+                    error={!!fieldErrors?.email}
+                    data-testid="contact-email-input"
+                  />
+                  {fieldErrors?.email && (
+                    <span style={s.errorTextStyle} role="alert">
+                      {fieldErrors.email}
+                    </span>
+                  )}
+                </div>
               </div>
-              <FloatingLabelInput
-                id="contact-subject"
-                name="subject"
-                label={form?.subject ?? form?.subjectLabel ?? 'Subject'}
-                required
-                error={!!fieldErrors?.subject}
-                data-testid="contact-subject-input"
-              />
-              <FloatingLabelTextArea
-                id="contact-message"
-                name="message"
-                label={form?.message ?? form?.messageLabel ?? 'Message'}
-                required
-                maxLength={1200}
-                error={!!fieldErrors?.message}
-                data-testid="contact-message-textarea"
-              />
+              <div>
+                <FloatingLabelInput
+                  id="contact-subject"
+                  name="subject"
+                  label={form?.subject ?? form?.subjectLabel ?? 'Subject'}
+                  required
+                  error={!!fieldErrors?.subject}
+                  data-testid="contact-subject-input"
+                />
+                {fieldErrors?.subject && (
+                  <span style={s.errorTextStyle} role="alert">
+                    {fieldErrors.subject}
+                  </span>
+                )}
+              </div>
+              <div>
+                <FloatingLabelTextArea
+                  id="contact-message"
+                  name="message"
+                  label={form?.message ?? form?.messageLabel ?? 'Message'}
+                  required
+                  minLength={10}
+                  maxLength={1200}
+                  error={!!fieldErrors?.message}
+                  data-testid="contact-message-textarea"
+                />
+                {fieldErrors?.message && (
+                  <span style={s.errorTextStyle} role="alert">
+                    {fieldErrors.message}
+                  </span>
+                )}
+              </div>
               <div aria-hidden="true" style={honeypotStyle}>
                 <label htmlFor="contact-website">Website</label>
                 <input

--- a/apps/web/src/app/[locale]/contact/ContactView.styles.ts
+++ b/apps/web/src/app/[locale]/contact/ContactView.styles.ts
@@ -265,6 +265,13 @@ export const buildContactStyles = (t: ContactStyleTokens) => {
     fontSize: 13.5,
   };
 
+  const errorTextStyle: CSSProperties = {
+    fontSize: 12,
+    color: '#ef4444',
+    marginTop: 4,
+    lineHeight: 1.3,
+  };
+
   return {
     tokens: t,
     heroWrapStyle,
@@ -296,6 +303,7 @@ export const buildContactStyles = (t: ContactStyleTokens) => {
     faqAnswerStyle,
     chevronStyle,
     helpLinkStyle,
+    errorTextStyle,
   };
 };
 

--- a/packages/ui/src/components/FloatingLabelInput/FloatingLabelInput.tsx
+++ b/packages/ui/src/components/FloatingLabelInput/FloatingLabelInput.tsx
@@ -23,6 +23,7 @@ export type FloatingLabelInputProps = {
   autoComplete?: string;
   fullWidth?: boolean;
   error?: boolean;
+  maxLength?: number;
   'data-testid'?: string;
 };
 
@@ -93,6 +94,7 @@ export const FloatingLabelInput = forwardRef<
     autoComplete,
     fullWidth = true,
     error,
+    maxLength,
     'data-testid': testId,
   },
   ref,
@@ -154,6 +156,7 @@ export const FloatingLabelInput = forwardRef<
         disabled={disabled}
         autoComplete={autoComplete}
         error={error}
+        maxLength={maxLength}
         placeholder=" "
         data-testid={testId}
       />

--- a/packages/ui/src/components/FloatingLabelTextArea/FloatingLabelTextArea.tsx
+++ b/packages/ui/src/components/FloatingLabelTextArea/FloatingLabelTextArea.tsx
@@ -25,6 +25,7 @@ export type FloatingLabelTextAreaProps = {
   disabled?: boolean;
   fullWidth?: boolean;
   error?: boolean;
+  minLength?: number;
   maxLength?: number;
   rows?: number;
   'data-testid'?: string;
@@ -94,6 +95,7 @@ export const FloatingLabelTextArea = forwardRef<
     disabled,
     fullWidth = true,
     error,
+    minLength,
     maxLength,
     rows,
     'data-testid': testId,
@@ -166,6 +168,7 @@ export const FloatingLabelTextArea = forwardRef<
         disabled={disabled}
         error={error}
         rows={rows}
+        minLength={minLength}
         maxLength={maxLength}
         placeholder=" "
         data-testid={testId}


### PR DESCRIPTION
## What
- Add error text display below each form field when validation fails
- Add  prop to  component
- Add  to 
- Wrap form fields in container divs for error text positioning

## Why
The contact form only showed a red border on invalid fields but no error message text. Users had no idea what went wrong when validation failed.

## Changes
- `packages/ui/src/components/FloatingLabelTextArea/FloatingLabelTextArea.tsx` — Added `minLength` prop
- `apps/web/src/app/[locale]/contact/ContactView.styles.ts` — Added `errorTextStyle`
- `apps/web/src/app/[locale]/contact/ContactForm.tsx` — Added error text display and `minLength={10}` on textarea

## Testing
- Submit contact form with empty fields → see 'required' errors
- Submit with message < 10 chars → see 'min 10' error
- Submit with valid data → form submits successfully