### PR TITLE
feat(games): add checkers game (web integration + landing page)

### DIFF
--- a/apps/web/e2e/home-games-slider.spec.ts
+++ b/apps/web/e2e/home-games-slider.spec.ts
@@ -15,7 +15,7 @@ test.describe('Home Page Games Grid Refinement', () => {
     // We are filtering to only show available (playable) games
     const gamesSection = page.locator('#games');
     const gameCards = gamesSection.locator('h3');
-    await expect(gameCards).toHaveCount(6);
+    await expect(gameCards).toHaveCount(7);
 
     await expect(gameCards.nth(0)).toHaveText(/Critical/i);
     await expect(gameCards.nth(1)).toHaveText(/Sea Battle/i);
@@ -23,6 +23,7 @@ test.describe('Home Page Games Grid Refinement', () => {
     await expect(gameCards.nth(3)).toHaveText(/Tic-Tac-Toe/i);
     await expect(gameCards.nth(4)).toHaveText(/Cascade/i);
     await expect(gameCards.nth(5)).toHaveText(/Chess/i);
+    await expect(gameCards.nth(6)).toHaveText(/Checkers/i);
   });
 
   test('should navigate slider via arrows', async ({ page }) => {

--- a/apps/web/src/app/[locale]/games/checkers/CheckersFinalCtaButtons.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/CheckersFinalCtaButtons.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { QuickplayButton } from '@/features/games/ui/QuickplayButton';
+
+interface Props {
+  gameId: string;
+  roomsHref: string;
+  gamesHref: string;
+  ctaQuickplayLabel: string;
+  ctaQuickplayErrorLabel: string;
+  browseRoomsLabel: string;
+}
+
+export function CheckersFinalCtaButtons({
+  gameId,
+  roomsHref,
+  gamesHref,
+  ctaQuickplayLabel,
+  ctaQuickplayErrorLabel,
+  browseRoomsLabel,
+}: Props) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 12,
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+      }}
+    >
+      <QuickplayButton
+        gameId={gameId}
+        label={ctaQuickplayLabel}
+        mode="ai"
+        errorLabel={ctaQuickplayErrorLabel}
+      />
+      <Link
+        href={roomsHref}
+        style={{
+          padding: '14px 28px',
+          borderRadius: 12,
+          border: '1px solid currentColor',
+          color: 'inherit',
+          fontWeight: 700,
+          textDecoration: 'none',
+        }}
+      >
+        {browseRoomsLabel}
+      </Link>
+      <Link
+        href={gamesHref}
+        style={{
+          padding: '14px 28px',
+          borderRadius: 12,
+          color: 'inherit',
+          textDecoration: 'underline',
+        }}
+      >
+        ← Games
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/games/checkers/CheckersHero.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/CheckersHero.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import Link from 'next/link';
+import { QuickplayButton } from '@/features/games/ui/QuickplayButton';
+
+interface Props {
+  title: string;
+  subtitle: string;
+  gameId: string;
+  roomsHref: string;
+  ctaQuickplayLabel: string;
+  ctaQuickplayErrorLabel: string;
+  browseRoomsLabel: string;
+}
+
+export function CheckersHero({
+  title,
+  subtitle,
+  gameId,
+  roomsHref,
+  ctaQuickplayLabel,
+  ctaQuickplayErrorLabel,
+  browseRoomsLabel,
+}: Props) {
+  const CELL_SIZE = 48;
+  const BOARD_SIZE = 8;
+  const board: Array<
+    Array<'light' | 'dark' | 'lightPiece' | 'darkPiece' | null>
+  > = [];
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    const row: Array<'light' | 'dark' | 'lightPiece' | 'darkPiece' | null> = [];
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      const isLight = (r + c) % 2 === 0;
+      if (r < 3 && !isLight) row.push('darkPiece');
+      else if (r >= 5 && !isLight) row.push('lightPiece');
+      else row.push(isLight ? 'light' : 'dark');
+    }
+    board.push(row);
+  }
+
+  return (
+    <section
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 0.85fr)',
+        gap: 48,
+        alignItems: 'center',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <h1
+          style={{
+            fontSize: 'clamp(28px, 4.4vw, 52px)',
+            lineHeight: 1.1,
+            fontWeight: 900,
+            margin: 0,
+          }}
+        >
+          {title}
+        </h1>
+        <p style={{ fontSize: 18, opacity: 0.85, margin: 0, maxWidth: 540 }}>
+          {subtitle}
+        </p>
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <QuickplayButton
+            gameId={gameId}
+            label={ctaQuickplayLabel}
+            mode="ai"
+            errorLabel={ctaQuickplayErrorLabel}
+          />
+          <Link
+            href={roomsHref}
+            style={{
+              padding: '14px 24px',
+              borderRadius: 12,
+              border: '1px solid currentColor',
+              color: 'inherit',
+              fontWeight: 700,
+              textDecoration: 'none',
+            }}
+          >
+            {browseRoomsLabel}
+          </Link>
+        </div>
+      </div>
+
+      <div
+        aria-hidden
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${BOARD_SIZE}, ${CELL_SIZE}px)`,
+          gap: 2,
+          padding: 12,
+          backgroundColor: 'rgba(255, 255, 255, 0.05)',
+          borderRadius: 16,
+          width: 'fit-content',
+          margin: '0 auto',
+        }}
+      >
+        {board.flat().map((cell, idx) => {
+          const isLight = cell === 'light' || cell === 'lightPiece';
+          const isPiece = cell === 'lightPiece' || cell === 'darkPiece';
+          return (
+            <div
+              key={idx}
+              style={{
+                width: CELL_SIZE,
+                height: CELL_SIZE,
+                borderRadius: 6,
+                backgroundColor: isLight
+                  ? 'rgba(245, 245, 244, 0.15)'
+                  : 'rgba(87, 83, 78, 0.3)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              {isPiece ? (
+                <div
+                  style={{
+                    width: CELL_SIZE * 0.7,
+                    height: CELL_SIZE * 0.7,
+                    borderRadius: '50%',
+                    backgroundColor:
+                      cell === 'lightPiece'
+                        ? 'rgba(250, 250, 249, 0.9)'
+                        : 'rgba(41, 37, 36, 0.9)',
+                    border: `2px solid ${
+                      cell === 'lightPiece'
+                        ? 'rgba(168, 162, 158, 0.5)'
+                        : 'rgba(28, 25, 23, 0.5)'
+                    }`,
+                    boxShadow: '0 2px 4px rgba(0,0,0,0.3)',
+                  }}
+                />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/[locale]/games/checkers/CheckersLanding.module.scss
+++ b/apps/web/src/app/[locale]/games/checkers/CheckersLanding.module.scss
@@ -1,0 +1,152 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: 64px;
+  padding: 48px 0;
+}
+
+.highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.highlightCard {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 24px;
+  border-radius: 16px;
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.04),
+    rgba(255, 255, 255, 0.01)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.highlightIcon {
+  font-size: 32px;
+}
+
+.highlightTitle {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.highlightBody {
+  font-size: 14px;
+  margin: 0;
+  opacity: 0.8;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.stepCard {
+  position: relative;
+  padding: 24px;
+  border-radius: 16px;
+  background: linear-gradient(
+    135deg,
+    rgba(245, 158, 11, 0.06),
+    rgba(245, 158, 11, 0.02)
+  );
+  border: 1px solid rgba(245, 158, 11, 0.18);
+}
+
+.stepNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  color: white;
+  font-weight: 800;
+  margin-bottom: 12px;
+}
+
+.stepTitle {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 4px 0;
+}
+
+.stepBody {
+  font-size: 14px;
+  margin: 0;
+  opacity: 0.85;
+}
+
+.themes,
+.rules,
+.faq {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sectionTitle {
+  font-size: 28px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.sectionSubtitle {
+  font-size: 16px;
+  opacity: 0.8;
+  margin: 0;
+}
+
+.rules {
+  padding: 24px;
+  border-radius: 16px;
+  background: rgba(34, 197, 94, 0.04);
+  border: 1px solid rgba(34, 197, 94, 0.18);
+}
+
+.rulesNote {
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+.faq {
+  gap: 20px;
+}
+
+.faqItem {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.faqQuestion {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.faqAnswer {
+  font-size: 14px;
+  margin: 0;
+  opacity: 0.85;
+}
+
+.breadcrumbs {
+  display: flex;
+  gap: 8px;
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+.breadcrumbs a {
+  color: inherit;
+  text-decoration: underline;
+}

--- a/apps/web/src/app/[locale]/games/checkers/CheckersLanding.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/CheckersLanding.tsx
@@ -1,0 +1,138 @@
+import Link from 'next/link';
+import { Container, PageLayout } from '@arcadeum/ui';
+import type { CheckersMessages } from '@/shared/i18n/messages/games/checkers';
+import styles from './CheckersLanding.module.scss';
+import { CheckersHero } from './CheckersHero';
+import { CheckersThemesGrid } from './CheckersThemesGrid';
+import { CheckersFinalCtaButtons } from './CheckersFinalCtaButtons';
+
+type CkMessages = CheckersMessages['checkers_v1'];
+type Landing = CkMessages['landing'];
+type Variants = CkMessages['variants'];
+type Rules = CkMessages['rules'];
+
+interface Props {
+  landing?: Landing;
+  variants?: Variants;
+  rules?: Rules;
+  gameId: string;
+  createRoomHref: string;
+  roomsHref: string;
+  gamesHref: string;
+  homeHref: string;
+}
+
+export default function CheckersLanding({
+  landing,
+  variants,
+  rules,
+  gameId,
+  createRoomHref,
+  roomsHref,
+  gamesHref,
+  homeHref,
+}: Props) {
+  if (!landing) return null;
+
+  const highlights = [
+    { key: 'players', icon: '👥', ...landing.highlights.players },
+    { key: 'captures', icon: '⚡', ...landing.highlights.captures },
+    { key: 'kings', icon: '👑', ...landing.highlights.kings },
+  ];
+
+  const steps = [
+    { key: 'create', step: '1', ...landing.steps.create },
+    { key: 'join', step: '2', ...landing.steps.join },
+    { key: 'play', step: '3', ...landing.steps.play },
+  ];
+
+  return (
+    <PageLayout>
+      <Container>
+        <main className={styles.root}>
+          <CheckersHero
+            title={landing.hero.title}
+            subtitle={landing.hero.subtitle}
+            gameId={gameId}
+            roomsHref={roomsHref}
+            ctaQuickplayLabel={landing.hero.ctaQuickplay}
+            ctaQuickplayErrorLabel={landing.hero.ctaQuickplayError}
+            browseRoomsLabel={landing.hero.browseRooms}
+          />
+
+          <section className={styles.highlights}>
+            {highlights.map((h) => (
+              <div key={h.key} className={styles.highlightCard}>
+                <span className={styles.highlightIcon}>{h.icon}</span>
+                <h2 className={styles.highlightTitle}>{h.title}</h2>
+                <p className={styles.highlightBody}>{h.body}</p>
+              </div>
+            ))}
+          </section>
+
+          <section className={styles.steps}>
+            {steps.map((s) => (
+              <div key={s.key} className={styles.stepCard}>
+                <span className={styles.stepNumber}>{s.step}</span>
+                <h3 className={styles.stepTitle}>{s.title}</h3>
+                <p className={styles.stepBody}>{s.body}</p>
+              </div>
+            ))}
+          </section>
+
+          {variants ? (
+            <section className={styles.themes}>
+              <h2 className={styles.sectionTitle}>{landing.themes.title}</h2>
+              <p className={styles.sectionSubtitle}>
+                {landing.themes.subtitle}
+              </p>
+              <CheckersThemesGrid
+                variants={variants}
+                baseHref={createRoomHref}
+              />
+            </section>
+          ) : null}
+
+          {rules ? (
+            <section className={styles.rules}>
+              <h2 className={styles.sectionTitle}>{rules.title}</h2>
+              <p>{rules.objective}</p>
+              <p>{rules.steps}</p>
+              <p>{rules.kingPromotion}</p>
+              <p>{rules.forcedCaptures}</p>
+            </section>
+          ) : null}
+
+          <section id="faq" className={styles.faq}>
+            {Object.entries(landing.faq).map(([key, entry]) => {
+              const e = entry as { question: string; answer: string };
+              return (
+                <div key={key} className={styles.faqItem}>
+                  <h3 className={styles.faqQuestion}>{e.question}</h3>
+                  <p className={styles.faqAnswer}>{e.answer}</p>
+                </div>
+              );
+            })}
+          </section>
+
+          <CheckersFinalCtaButtons
+            gameId={gameId}
+            roomsHref={roomsHref}
+            gamesHref={gamesHref}
+            ctaQuickplayLabel={landing.hero.ctaQuickplay}
+            ctaQuickplayErrorLabel={landing.hero.ctaQuickplayError}
+            browseRoomsLabel={landing.hero.browseRooms}
+          />
+
+          <nav className={styles.breadcrumbs}>
+            <Link href={homeHref}>Home</Link>
+            <span aria-hidden> / </span>
+            <Link href={gamesHref}>Games</Link>
+            <span aria-hidden> / </span>
+            <span>Checkers</span>
+          </nav>
+        </main>
+      </Container>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/app/[locale]/games/checkers/CheckersThemesGrid.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/CheckersThemesGrid.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link';
+import type { CheckersMessages } from '@/shared/i18n/messages/games/checkers';
+
+type Variants = CheckersMessages['checkers_v1']['variants'];
+
+interface Props {
+  variants: Variants;
+  baseHref: string;
+}
+
+const VARIANT_EMOJI: Record<keyof Variants, string> = {
+  classic: '♟️',
+  neon: '💡',
+  wood: '🪵',
+  marble: '🏛️',
+  neon_glow: '🌟',
+};
+
+const VARIANT_GRADIENT: Record<keyof Variants, string> = {
+  classic: 'linear-gradient(135deg, #1f2937 0%, #374151 100%)',
+  neon: 'linear-gradient(135deg, #7c3aed 0%, #06b6d4 100%)',
+  wood: 'linear-gradient(135deg, #92400e 0%, #b45309 100%)',
+  marble: 'linear-gradient(135deg, #64748b 0%, #94a3b8 100%)',
+  neon_glow: 'linear-gradient(135deg, #0f172a 0%, #1e1b4b 100%)',
+};
+
+export function CheckersThemesGrid({ variants, baseHref }: Props) {
+  const entries = Object.entries(variants) as Array<
+    [keyof Variants, Variants[keyof Variants]]
+  >;
+  const separator = baseHref.includes('?') ? '&' : '?';
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+        gap: 16,
+      }}
+    >
+      {entries.map(([id, copy]) => (
+        <Link
+          key={id}
+          href={`${baseHref}${separator}variant=${id}`}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            padding: 20,
+            borderRadius: 16,
+            background: VARIANT_GRADIENT[id],
+            color: 'white',
+            textDecoration: 'none',
+            minHeight: 140,
+          }}
+        >
+          <span style={{ fontSize: 32 }}>{VARIANT_EMOJI[id]}</span>
+          <strong style={{ fontSize: 18 }}>{copy.name}</strong>
+          <span style={{ fontSize: 13, opacity: 0.85 }}>
+            {copy.description}
+          </span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/games/checkers/opengraph-image.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/opengraph-image.tsx
@@ -1,0 +1,176 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+export const alt = 'Checkers — free multiplayer board game';
+
+const CELL = 52;
+const GAP = 3;
+
+function drawBoard() {
+  const cells: React.ReactElement[] = [];
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      const isLight = (r + c) % 2 === 0;
+      const hasPiece = (r < 3 && !isLight) || (r >= 5 && !isLight);
+      const isLightPiece = r >= 5 && !isLight;
+      cells.push(
+        <div
+          key={`${r}-${c}`}
+          style={{
+            width: CELL,
+            height: CELL,
+            borderRadius: 6,
+            background: isLight
+              ? 'rgba(245, 245, 244, 0.12)'
+              : 'rgba(87, 83, 78, 0.25)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {hasPiece ? (
+            <div
+              style={{
+                width: CELL * 0.65,
+                height: CELL * 0.65,
+                borderRadius: '50%',
+                background: isLightPiece
+                  ? 'rgba(250, 250, 249, 0.9)'
+                  : 'rgba(41, 37, 36, 0.9)',
+                border: `2px solid ${isLightPiece ? 'rgba(168,162,158,0.4)' : 'rgba(28,25,23,0.4)'}`,
+                boxShadow: '0 2px 6px rgba(0,0,0,0.3)',
+              }}
+            />
+          ) : null}
+        </div>,
+      );
+    }
+  }
+  return cells;
+}
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: 1200,
+          height: 630,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 80px',
+          background:
+            'linear-gradient(135deg, #0f172a 0%, #1e1b4b 50%, #312e81 100%)',
+          color: 'white',
+          fontFamily: 'system-ui, sans-serif',
+          position: 'relative',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            right: -60,
+            top: -60,
+            width: 360,
+            height: 360,
+            borderRadius: 180,
+            background:
+              'radial-gradient(circle, rgba(245, 158, 11, 0.15) 0%, transparent 60%)',
+          }}
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 32,
+            maxWidth: 560,
+            position: 'relative',
+            zIndex: 1,
+          }}
+        >
+          <div style={{ fontSize: 22, opacity: 0.7, letterSpacing: 2 }}>
+            ARCADEUM
+          </div>
+          <div
+            style={{
+              fontSize: 84,
+              fontWeight: 900,
+              lineHeight: 1,
+              display: 'flex',
+            }}
+          >
+            Checkers
+          </div>
+          <div
+            style={{
+              fontSize: 30,
+              opacity: 0.9,
+              lineHeight: 1.3,
+              display: 'flex',
+            }}
+          >
+            Classic 8×8 · forced captures · king promotion
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              gap: 12,
+              fontSize: 18,
+              flexWrap: 'wrap',
+              opacity: 0.95,
+            }}
+          >
+            <span
+              style={{
+                padding: '8px 16px',
+                borderRadius: 999,
+                background: 'rgba(255,255,255,0.12)',
+              }}
+            >
+              2 players
+            </span>
+            <span
+              style={{
+                padding: '8px 16px',
+                borderRadius: 999,
+                background: 'rgba(255,255,255,0.12)',
+              }}
+            >
+              Bots day one
+            </span>
+            <span
+              style={{
+                padding: '8px 16px',
+                borderRadius: 999,
+                background: 'rgba(255,255,255,0.12)',
+              }}
+            >
+              Five themes
+            </span>
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(8, ${CELL}px)`,
+            gap: GAP,
+            padding: 20,
+            background: 'rgba(255, 255, 255, 0.06)',
+            borderRadius: 24,
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            boxShadow: '0 20px 50px rgba(0,0,0,0.4)',
+            position: 'relative',
+            zIndex: 1,
+          }}
+        >
+          {drawBoard()}
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/apps/web/src/app/[locale]/games/checkers/page.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from 'next';
+import { appConfig } from '@/shared/config/app-config';
+import { buildRoutes } from '@/shared/config/routes';
+import { getTranslations } from '@/shared/i18n/server';
+import { isLocale, DEFAULT_LOCALE, type Locale } from '@/shared/i18n';
+import { JsonLd } from '@/shared/ui/JsonLd';
+import { buildPageMetadata } from '@/shared/seo/buildPageMetadata';
+import { buildVideoGameJsonLd } from '@/shared/seo/videoGameJsonLd';
+import { buildFaqJsonLd } from '@/shared/seo/faqJsonLd';
+import { buildHowToJsonLd } from '@/shared/seo/howToJsonLd';
+import CheckersLanding from './CheckersLanding';
+
+const CHECKERS_SLUG = 'checkers_v1';
+const CHECKERS_MIN_PLAYERS = 2;
+const CHECKERS_MAX_PLAYERS = 2;
+const CHECKERS_GENRE = 'Board Game';
+
+type PageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+function resolveLocale(raw: string): Locale {
+  return isLocale(raw) ? raw : DEFAULT_LOCALE;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale: rawLocale } = await params;
+  const locale = resolveLocale(rawLocale);
+  const base = await buildPageMetadata({ locale, page: 'checkersLanding' });
+  return {
+    ...base,
+    openGraph: {
+      ...base.openGraph,
+      images: [
+        {
+          url: `${appConfig.siteUrl}/${locale}/games/checkers/opengraph-image`,
+          width: 1200,
+          height: 630,
+          alt: 'Checkers — free multiplayer on Arcadeum',
+        },
+      ],
+    },
+    twitter: {
+      ...base.twitter,
+      card: 'summary_large_image',
+      images: [`${appConfig.siteUrl}/${locale}/games/checkers/opengraph-image`],
+    },
+  };
+}
+
+export default async function CheckersLandingRoute({ params }: PageProps) {
+  const { locale: rawLocale } = await params;
+  const locale = resolveLocale(rawLocale);
+  const messages = await getTranslations(locale);
+  const routes = buildRoutes(locale);
+
+  const landing = messages.games?.checkers_v1?.landing;
+  const variants = messages.games?.checkers_v1?.variants;
+  const rules = messages.games?.checkers_v1?.rules;
+  const gameName = messages.games?.checkers_v1?.name ?? 'Checkers';
+  const description =
+    messages.games?.checkers_v1?.description ?? landing?.meta?.description;
+
+  const jsonLd: Record<string, unknown>[] = [
+    ...buildVideoGameJsonLd({
+      gameId: CHECKERS_SLUG,
+      gameName,
+      description: description ?? '',
+      locale,
+      minPlayers: CHECKERS_MIN_PLAYERS,
+      maxPlayers: CHECKERS_MAX_PLAYERS,
+      genre: CHECKERS_GENRE,
+      breadcrumb: {
+        home: messages.navigation?.homeTab ?? 'Home',
+        games: messages.navigation?.gamesTab ?? 'Games',
+        game: gameName,
+      },
+    }),
+  ];
+
+  const pageUrl = `${appConfig.siteUrl}${routes.checkersLanding}`;
+
+  const faqItems = landing?.faq;
+  if (faqItems) {
+    const faqQuestions = Object.values(faqItems).map(
+      (item: { question: string; answer: string }) => ({
+        question: item.question,
+        answer: item.answer,
+      }),
+    );
+    const faqJsonLd = buildFaqJsonLd({
+      locale,
+      questions: faqQuestions,
+      pageUrl,
+      speakableSelectors: ['#faq'],
+    });
+    if (faqJsonLd) jsonLd.push(faqJsonLd);
+  }
+
+  const howToSteps = landing?.steps;
+  if (howToSteps) {
+    const howToJsonLd = buildHowToJsonLd({
+      locale,
+      pageUrl,
+      name: `How to play ${gameName}`,
+      description: description ?? '',
+      steps: [howToSteps.create, howToSteps.join, howToSteps.play]
+        .filter((s): s is { title: string; body: string } => s !== undefined)
+        .map((s) => ({ name: s.title, text: s.body })),
+    });
+    if (howToJsonLd) jsonLd.push(howToJsonLd);
+  }
+
+  return (
+    <>
+      <JsonLd id="json-ld-checkers" data={jsonLd} />
+      <CheckersLanding
+        landing={landing}
+        variants={variants}
+        rules={rules}
+        gameId={CHECKERS_SLUG}
+        createRoomHref={`${routes.gameCreate}?gameId=${CHECKERS_SLUG}`}
+        roomsHref={routes.games}
+        gamesHref={routes.games}
+        homeHref={routes.home}
+      />
+    </>
+  );
+}

--- a/apps/web/src/app/[locale]/games/checkers/twitter-image.tsx
+++ b/apps/web/src/app/[locale]/games/checkers/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from './opengraph-image';

--- a/apps/web/src/app/[locale]/home/data/games.ts
+++ b/apps/web/src/app/[locale]/home/data/games.ts
@@ -46,6 +46,7 @@ import { GLIMWORM_VARIANTS } from '@/features/games/lib/glimwormVariants';
 import { TIC_TAC_TOE_VARIANTS } from '@/widgets/TicTacToeGame/lib/constants';
 import { CASCADE_VARIANTS } from '@/widgets/CascadeGame/lib/constants';
 import { CHESS_VARIANTS } from '@/widgets/ChessGame/lib/constants';
+import { CHECKERS_VARIANTS } from '@/widgets/CheckersGame/lib/constants';
 
 export const featuredGames: FeaturedGame[] = [
   {
@@ -177,6 +178,27 @@ export const featuredGames: FeaturedGame[] = [
     rulesPrefix: 'games.chess_v1.rules',
     rulesKeys: ['objective', 'pieces', 'special'],
     variants: CHESS_VARIANTS.map((v) => ({
+      id: v.id,
+      nameKey: v.name as TranslationKey,
+    })),
+  },
+  {
+    id: 'checkers_v1',
+    nameKey: 'games.checkers_v1.name' as TranslationKey,
+    descriptionKey: 'games.checkers_v1.description' as TranslationKey,
+    accentColor: '#f59e0b',
+    genre: 'Board',
+    pace: 'Strategy',
+    category: 'Board Game',
+    players: '2',
+    duration: '20 min',
+    playingNow: null,
+    isPlayable: true,
+    landingHref: '/games/checkers',
+    type: 'board',
+    rulesPrefix: 'games.checkers_v1.rules',
+    rulesKeys: ['objective', 'steps', 'kingPromotion', 'forcedCaptures'],
+    variants: CHECKERS_VARIANTS.map((v) => ({
       id: v.id,
       nameKey: v.name as TranslationKey,
     })),

--- a/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/GameCreateView.tsx
@@ -41,6 +41,7 @@ const URL_TO_GAME_ID: Record<string, GameId> = {
   tic_tac_toe_v1: 'tic_tac_toe_v1',
   cascade_v1: 'cascade_v1',
   chess_v1: 'chess_v1',
+  checkers_v1: 'checkers_v1',
 };
 
 function parseInitialGameId(raw: string | null | undefined): GameId {
@@ -97,6 +98,11 @@ function buildGameOptions(form: CreateRoomForm): Record<string, unknown> {
       variant: form.themeId || 'classic',
       gridSize: 10,
       shipCount: 10,
+    };
+  }
+  if (form.gameId === 'checkers_v1') {
+    return {
+      variant: form.themeId || 'classic',
     };
   }
   return {};

--- a/apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/RulesAccess.tsx
@@ -36,6 +36,12 @@ const ChessRulesModal = dynamic(
   { ssr: false },
 );
 
+const CheckersRulesModal = dynamic(
+  () =>
+    import('@/widgets/CheckersGame/ui/RulesModal').then((m) => m.RulesModal),
+  { ssr: false },
+);
+
 interface Props {
   gameId: GameId;
   themeId: string;
@@ -100,6 +106,9 @@ export function RulesAccess({ gameId, themeId }: Props) {
       ) : null}
       {gameId === 'chess_v1' ? (
         <ChessRulesModal open={open} onClose={() => setOpen(false)} />
+      ) : null}
+      {gameId === 'checkers_v1' ? (
+        <CheckersRulesModal open={open} onClose={() => setOpen(false)} />
       ) : null}
     </>
   );

--- a/apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/ThemePicker.tsx
@@ -8,6 +8,7 @@ import { SeaBattleBoardPoster } from './art/SeaBattleBoardPoster';
 import { TicTacToeBoardPoster } from './art/TicTacToeBoardPoster';
 import { CascadeBoardPoster } from './art/CascadeBoardPoster';
 import { ChessBoardPoster } from './art/ChessBoardPoster';
+import { CheckersBoardPoster } from './art/CheckersBoardPoster';
 import {
   CRITICAL_THEMES,
   SEA_BATTLE_THEMES,
@@ -21,6 +22,10 @@ import {
   type ChessThemeMeta,
   type GameId,
 } from './data/themes';
+import {
+  CHECKERS_THEMES,
+  type CheckersThemeMeta,
+} from './data/checkers-themes';
 
 const SeaBattleRealPreview = dynamic(() => import('./SeaBattleRealPreview'), {
   ssr: false,
@@ -248,6 +253,49 @@ export function ThemePicker({ gameId, value, onChange }: Props) {
     );
   }
 
+  if (gameId === 'checkers_v1') {
+    return (
+      <div className={s.themeStripWrap}>
+        <div
+          className={s.themeStrip}
+          role="radiogroup"
+          aria-label="Checkers variant"
+          data-testid="theme-picker-checkers"
+        >
+          {CHECKERS_THEMES.map((theme) => {
+            const active = value === theme.id;
+            return (
+              <button
+                key={theme.id}
+                type="button"
+                role="radio"
+                aria-checked={active}
+                data-testid={`theme-${theme.id}`}
+                onClick={() => onChange(theme.id)}
+                style={{ '--theme-color': theme.color } as CSSProperties}
+                className={`${s.themeCard} ${active ? s.themeCardActive : ''}`}
+              >
+                <div className={s.themeArt}>
+                  <CheckersThumbnail theme={theme} />
+                </div>
+                <div className={s.themeBody}>
+                  <div className={s.themeRow}>
+                    <span className={s.themeDot} />
+                    <span className={s.themeName}>{theme.name}</span>
+                  </div>
+                  <p className={s.themeDesc}>{theme.desc}</p>
+                </div>
+                <span className={s.themeCheck} aria-hidden="true">
+                  ✓
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
   return null;
 }
 
@@ -261,6 +309,10 @@ function CascadeThumbnail({ theme }: { theme: CascadeThemeMeta }) {
 
 function ChessThumbnail({ theme }: { theme: ChessThemeMeta }) {
   return <ChessBoardPoster theme={theme} size="sm" />;
+}
+
+function CheckersThumbnail({ theme }: { theme: CheckersThemeMeta }) {
+  return <CheckersBoardPoster theme={theme} size="sm" />;
 }
 
 // Three-card fan. The SVG poster shows as a placeholder until the variant's

--- a/apps/web/src/features/games/ui/create/redesign/art/CheckersBoardPoster.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/art/CheckersBoardPoster.tsx
@@ -1,0 +1,122 @@
+import type { CheckersThemeMeta } from '../data/checkers-themes';
+
+interface Props {
+  theme: CheckersThemeMeta;
+  size?: 'sm' | 'lg';
+}
+
+const THEME_COLORS: Record<
+  string,
+  {
+    light: string;
+    dark: string;
+    bg: string;
+    lightPiece: string;
+    darkPiece: string;
+  }
+> = {
+  classic: {
+    light: '#f5f5f4',
+    dark: '#57534e',
+    bg: '#292524',
+    lightPiece: '#fafaf9',
+    darkPiece: '#292524',
+  },
+  neon: {
+    light: '#1e293b',
+    dark: '#4c1d95',
+    bg: '#0f172a',
+    lightPiece: '#e0e7ff',
+    darkPiece: '#312e81',
+  },
+  wood: {
+    light: '#d4a574',
+    dark: '#92400e',
+    bg: '#451a03',
+    lightPiece: '#fef3c7',
+    darkPiece: '#451a03',
+  },
+  marble: {
+    light: '#f1f5f9',
+    dark: '#64748b',
+    bg: '#1e293b',
+    lightPiece: '#ffffff',
+    darkPiece: '#334155',
+  },
+  neon_glow: {
+    light: '#1e1b4b',
+    dark: '#312e81',
+    bg: '#0f172a',
+    lightPiece: '#c4b5fd',
+    darkPiece: '#3b0764',
+  },
+};
+
+export function CheckersBoardPoster({ theme, size = 'sm' }: Props) {
+  const big = size === 'lg';
+  const w = big ? 400 : 240;
+  const h = big ? 320 : 135;
+  const cellSize = big ? 36 : 22;
+  const boardSize = cellSize * 8;
+  const offsetX = (w - boardSize) / 2;
+  const offsetY = (h - boardSize) / 2;
+
+  const colors = THEME_COLORS[theme.id] ?? THEME_COLORS.classic;
+
+  const squares: React.ReactElement[] = [];
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      const isLight = (r + c) % 2 === 0;
+      squares.push(
+        <rect
+          key={`${r}-${c}`}
+          x={offsetX + c * cellSize}
+          y={offsetY + r * cellSize}
+          width={cellSize}
+          height={cellSize}
+          fill={isLight ? colors.light : colors.dark}
+        />,
+      );
+    }
+  }
+
+  const pieces: Array<{ r: number; c: number; fill: string }> = [];
+  for (let r = 0; r < 3; r++) {
+    for (let c = 0; c < 8; c++) {
+      if ((r + c) % 2 === 1) pieces.push({ r, c, fill: colors.darkPiece });
+    }
+  }
+  for (let r = 5; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      if ((r + c) % 2 === 1) pieces.push({ r, c, fill: colors.lightPiece });
+    }
+  }
+
+  const pieceElements = pieces.map((p) => (
+    <circle
+      key={`${p.r}-${p.c}`}
+      cx={offsetX + p.c * cellSize + cellSize / 2}
+      cy={offsetY + p.r * cellSize + cellSize / 2}
+      r={cellSize * 0.38}
+      fill={p.fill}
+      stroke={
+        p.fill === colors.lightPiece
+          ? 'rgba(0,0,0,0.15)'
+          : 'rgba(255,255,255,0.1)'
+      }
+      strokeWidth={1}
+    />
+  ));
+
+  return (
+    <svg
+      viewBox={`0 0 ${w} ${h}`}
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden="true"
+    >
+      <rect width={w} height={h} fill={colors.bg} />
+      {squares}
+      {pieceElements}
+    </svg>
+  );
+}

--- a/apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx
+++ b/apps/web/src/features/games/ui/create/redesign/art/GameArt.tsx
@@ -3,6 +3,7 @@ import { SeaBattleBoardPoster } from './SeaBattleBoardPoster';
 import { TicTacToeBoardPoster } from './TicTacToeBoardPoster';
 import { CascadeBoardPoster } from './CascadeBoardPoster';
 import { ChessBoardPoster } from './ChessBoardPoster';
+import { CheckersBoardPoster } from './CheckersBoardPoster';
 import {
   findCascadeTheme,
   findChessTheme,
@@ -11,6 +12,7 @@ import {
   findTicTacToeTheme,
   type GameId,
 } from '../data/themes';
+import { findCheckersTheme } from '../data/checkers-themes';
 
 interface Props {
   gameId: GameId;
@@ -40,6 +42,10 @@ export function GameArt({ gameId, themeId, size = 'sm' }: Props) {
   if (gameId === 'chess_v1') {
     const theme = findChessTheme(themeId);
     return <ChessBoardPoster theme={theme} size={size} />;
+  }
+  if (gameId === 'checkers_v1') {
+    const theme = findCheckersTheme(themeId);
+    return <CheckersBoardPoster theme={theme} size={size} />;
   }
   return <GlimwormPoster size={size} />;
 }

--- a/apps/web/src/features/games/ui/create/redesign/data/checkers-themes.ts
+++ b/apps/web/src/features/games/ui/create/redesign/data/checkers-themes.ts
@@ -1,0 +1,43 @@
+export interface CheckersThemeMeta {
+  id: string;
+  name: string;
+  desc: string;
+  color: string;
+}
+
+export const CHECKERS_THEMES: CheckersThemeMeta[] = [
+  {
+    id: 'classic',
+    name: 'Classic',
+    desc: 'Traditional checkers board with warm wood tones.',
+    color: '#92400e',
+  },
+  {
+    id: 'neon',
+    name: 'Neon',
+    desc: 'Glowing cyan and purple neon aesthetic.',
+    color: '#7c3aed',
+  },
+  {
+    id: 'wood',
+    name: 'Wood',
+    desc: 'Rich wooden board with natural grain.',
+    color: '#b45309',
+  },
+  {
+    id: 'marble',
+    name: 'Marble',
+    desc: 'Elegant marble finish with cool stone tones.',
+    color: '#64748b',
+  },
+  {
+    id: 'neon_glow',
+    name: 'Neon Glow',
+    desc: 'Deep purple neon with electric glow.',
+    color: '#4338ca',
+  },
+];
+
+export function findCheckersTheme(id: string | undefined): CheckersThemeMeta {
+  return CHECKERS_THEMES.find((t) => t.id === id) ?? CHECKERS_THEMES[0];
+}

--- a/apps/web/src/features/games/ui/create/redesign/data/themes.ts
+++ b/apps/web/src/features/games/ui/create/redesign/data/themes.ts
@@ -4,7 +4,8 @@ export type GameId =
   | 'glimworm_v1'
   | 'tic_tac_toe_v1'
   | 'cascade_v1'
-  | 'chess_v1';
+  | 'chess_v1'
+  | 'checkers_v1';
 
 export interface GameMeta {
   id: GameId;
@@ -92,6 +93,18 @@ export const GAMES: Record<GameId, GameMeta> = {
     hasThemes: false,
     rules: ['idle', 'spectators'],
   },
+  checkers_v1: {
+    id: 'checkers_v1',
+    title: 'Checkers',
+    desc: 'Classic 8×8 checkers with forced captures, multi-jump, and king promotion.',
+    players: { min: 2, max: 2, label: '2' },
+    duration: '20 min',
+    kind: 'Board · strategy',
+    category: 'Board Game',
+    hasExpansion: false,
+    hasThemes: true,
+    rules: ['idle', 'spectators'],
+  },
 };
 
 export const VISIBLE_GAMES: GameId[] = [
@@ -101,6 +114,7 @@ export const VISIBLE_GAMES: GameId[] = [
   'tic_tac_toe_v1',
   'cascade_v1',
   'chess_v1',
+  'checkers_v1',
 ];
 
 export function getGamesByCategory(): Array<{
@@ -455,12 +469,12 @@ import {
   findCascadeTheme,
   type CascadeThemeMeta,
 } from './cascade-themes';
-
 import {
   CHESS_THEMES,
   findChessTheme,
   type ChessThemeMeta,
 } from './chess-themes';
+import { CHECKERS_THEMES } from './checkers-themes';
 
 export { CASCADE_THEMES, findCascadeTheme, type CascadeThemeMeta };
 export { CHESS_THEMES, findChessTheme, type ChessThemeMeta };
@@ -471,6 +485,7 @@ export function themesFor(gameId: GameId) {
   if (gameId === 'tic_tac_toe_v1') return TIC_TAC_TOE_THEMES;
   if (gameId === 'cascade_v1') return CASCADE_THEMES;
   if (gameId === 'chess_v1') return CHESS_THEMES;
+  if (gameId === 'checkers_v1') return CHECKERS_THEMES;
   return [];
 }
 

--- a/apps/web/src/widgets/CheckersGame/lib/checkersClientLogic.ts
+++ b/apps/web/src/widgets/CheckersGame/lib/checkersClientLogic.ts
@@ -1,0 +1,110 @@
+import type { Board, MoveStep, Piece } from '../types';
+
+const BOARD_SIZE = 8;
+
+type PlayerColor = 'light' | 'dark';
+
+function inBounds(row: number, col: number): boolean {
+  return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
+}
+
+function getDirectionsForPiece(
+  piece: Piece,
+  playerColor: PlayerColor,
+): Array<[number, number]> {
+  if (piece.type === 'king') {
+    return [
+      [-1, -1],
+      [-1, 1],
+      [1, -1],
+      [1, 1],
+    ];
+  }
+  if (playerColor === 'light') {
+    return [
+      [-1, -1],
+      [-1, 1],
+    ];
+  }
+  return [
+    [1, -1],
+    [1, 1],
+  ];
+}
+
+export function findCapturesFrom(
+  board: Board,
+  row: number,
+  col: number,
+  playerId: string,
+  playerColor: PlayerColor,
+): MoveStep[] {
+  const piece = board[row][col];
+  if (!piece || piece.playerId !== playerId) return [];
+
+  const directions = getDirectionsForPiece(piece, playerColor);
+  const captures: MoveStep[] = [];
+
+  for (const [dr, dc] of directions) {
+    const midRow = row + dr;
+    const midCol = col + dc;
+    const toRow = row + 2 * dr;
+    const toCol = col + 2 * dc;
+
+    if (!inBounds(toRow, toCol)) continue;
+    if (board[midRow][midCol] === null) continue;
+    if (board[midRow][midCol]?.playerId === playerId) continue;
+    if (board[toRow][toCol] !== null) continue;
+
+    captures.push({
+      fromRow: row,
+      fromCol: col,
+      toRow,
+      toCol,
+      capturedRow: midRow,
+      capturedCol: midCol,
+    });
+  }
+
+  return captures;
+}
+
+export function applyMoveToBoard(board: Board, steps: MoveStep[]): Board {
+  const newBoard: Board = board.map((row) =>
+    row.map((cell) => (cell ? { ...cell } : null)),
+  );
+
+  if (steps.length === 0) return newBoard;
+
+  const firstStep = steps[0];
+  const piece = newBoard[firstStep.fromRow][firstStep.fromCol];
+  if (!piece) return newBoard;
+
+  for (const step of steps) {
+    if (step.capturedRow !== undefined && step.capturedCol !== undefined) {
+      newBoard[step.capturedRow][step.capturedCol] = null;
+    }
+  }
+
+  const lastStep = steps[steps.length - 1];
+  const movingPiece = { ...piece };
+
+  if (
+    movingPiece.type === 'man' &&
+    (lastStep.toRow === 0 || lastStep.toRow === BOARD_SIZE - 1)
+  ) {
+    movingPiece.type = 'king';
+  }
+
+  newBoard[firstStep.fromRow][firstStep.fromCol] = null;
+  newBoard[lastStep.toRow][lastStep.toCol] = movingPiece;
+
+  return newBoard;
+}
+
+export function getPlayerColor(
+  players: Array<{ playerId: string; color: PlayerColor }>,
+  playerId: string,
+): PlayerColor | null {
+  return players.find((p) => p.playerId === playerId)?.color ?? null;
+}

--- a/apps/web/src/widgets/CheckersGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CheckersGame/ui/Game.tsx
@@ -2,7 +2,10 @@
 
 import { memo, useCallback, useMemo, useState } from 'react';
 import { YStack } from 'tamagui';
-import { GameWidgetContainer, RematchInvitationModal } from '@/features/games/ui';
+import {
+  GameWidgetContainer,
+  RematchInvitationModal,
+} from '@/features/games/ui';
 import { GameResultModal } from '@/features/games/ui/GameResultModal';
 import {
   useGameChatIntegration,
@@ -16,10 +19,15 @@ import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
 import { useRecordGameResult } from '@/features/stats/hooks/useRecordGameResult';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import { reorderRoomParticipants } from '@/shared/api/gamesApi';
-import type { CheckersGameProps, MoveStep } from '../types';
+import type { Board, CheckersGameProps, MoveStep } from '../types';
 import { useCheckersState } from '../hooks/useCheckersState';
 import { useCheckersActions } from '../hooks/useCheckersActions';
 import { CheckersThemeProvider } from '../lib/CheckersThemeContext';
+import {
+  findCapturesFrom,
+  applyMoveToBoard,
+  getPlayerColor,
+} from '../lib/checkersClientLogic';
 import { CheckersLobby } from './CheckersLobby';
 import { CheckersBoard } from './CheckersBoard';
 import { TurnBadge } from './TurnBadge';
@@ -130,8 +138,7 @@ function CheckersGameImpl({
 
   const variantTokens = useMemo(
     () =>
-      CHECKERS_VARIANTS.find((v) => v.id === variant) ??
-      CHECKERS_VARIANTS[0],
+      CHECKERS_VARIANTS.find((v) => v.id === variant) ?? CHECKERS_VARIANTS[0],
     [variant],
   );
 
@@ -139,21 +146,41 @@ function CheckersGameImpl({
     void handleRematch([], undefined);
   }, [handleRematch]);
 
-  const [selectedPiece, setSelectedPiece] = useState<{ row: number; col: number } | null>(null);
+  const [selectedPiece, setSelectedPiece] = useState<{
+    row: number;
+    col: number;
+  } | null>(null);
   const [pendingSteps, setPendingSteps] = useState<MoveStep[]>([]);
+  const [optimisticBoard, setOptimisticBoard] = useState<Board | null>(null);
+  const [lastServerBoard, setLastServerBoard] = useState<Board | null>(null);
+
+  const displayBoard = optimisticBoard ?? snapshot?.board ?? null;
+
+  // Clear optimistic board when server state changes
+  if (snapshot?.board && snapshot.board !== lastServerBoard) {
+    setLastServerBoard(snapshot.board);
+    if (optimisticBoard) {
+      setOptimisticBoard(null);
+    }
+  }
 
   const handleCellClick = useCallback(
     (row: number, col: number) => {
       if (!snapshot || !currentUserId || isGameOver || !myTurn) return;
+      if (!displayBoard) return;
 
-      const piece = snapshot.board[row][col];
+      const piece = displayBoard[row][col];
 
-      // If clicking own piece, select it
+      // If clicking own piece, select it (start or restart chain)
       if (piece && piece.playerId === currentUserId) {
         setSelectedPiece({ row, col });
         setPendingSteps([]);
+        setOptimisticBoard(null);
         return;
       }
+
+      // If clicking on a piece that isn't ours, ignore
+      if (piece) return;
 
       // If a piece is selected and clicking empty, try to move
       if (selectedPiece) {
@@ -176,20 +203,47 @@ function CheckersGameImpl({
 
         const newSteps = [...pendingSteps, moveStep];
 
-        // If it's a capture chain, check if more captures are available from the destination
         if (isCapture) {
-          // For simplicity, send the chain immediately
-          movePiece(newSteps);
-          setSelectedPiece(null);
-          setPendingSteps([]);
+          const nextBoard = applyMoveToBoard(displayBoard, newSteps);
+
+          // Check if more captures available from the landing square
+          const playerColor = getPlayerColor(snapshot.players, currentUserId);
+          const moreCaptures = playerColor
+            ? findCapturesFrom(nextBoard, row, col, currentUserId, playerColor)
+            : [];
+
+          if (moreCaptures.length > 0) {
+            // Multi-jump: keep piece selected at landing, show optimistic board
+            setPendingSteps(newSteps);
+            setOptimisticBoard(nextBoard);
+            setSelectedPiece({ row, col });
+          } else {
+            // End of chain: send full chain to server, show optimistic board
+            setOptimisticBoard(nextBoard);
+            setSelectedPiece(null);
+            setPendingSteps([]);
+            movePiece(newSteps);
+          }
         } else {
-          movePiece(newSteps);
+          // Simple move: send to server, show optimistic board
+          const nextBoard = applyMoveToBoard(displayBoard, newSteps);
+          setOptimisticBoard(nextBoard);
           setSelectedPiece(null);
           setPendingSteps([]);
+          movePiece(newSteps);
         }
       }
     },
-    [snapshot, currentUserId, isGameOver, myTurn, selectedPiece, pendingSteps, movePiece],
+    [
+      snapshot,
+      currentUserId,
+      isGameOver,
+      myTurn,
+      displayBoard,
+      selectedPiece,
+      pendingSteps,
+      movePiece,
+    ],
   );
 
   if (!room) return null;
@@ -223,7 +277,7 @@ function CheckersGameImpl({
 
   const board = (
     <YStack gap="$3" alignItems="stretch" padding="$3" width="100%">
-      {snapshot ? (
+      {snapshot && displayBoard ? (
         <>
           <TurnBadge
             currentTurnUserId={currentTurnUserId}
@@ -232,7 +286,7 @@ function CheckersGameImpl({
             resolveName={resolveDisplayNameBound}
           />
           <CheckersBoard
-            board={snapshot.board}
+            board={displayBoard}
             players={snapshot.players}
             selectedPiece={selectedPiece}
             disabled={!myTurn || isGameOver}
@@ -263,10 +317,7 @@ function CheckersGameImpl({
         onDecline={handleDeclineInvitation}
         t={t}
       />
-      <RulesModal
-        open={showRulesOpen}
-        onClose={onShowRulesClose}
-      />
+      <RulesModal open={showRulesOpen} onClose={onShowRulesClose} />
     </>
   );
 


### PR DESCRIPTION
## Summary
- Complete checkers game web frontend integration: create page (themes, theme picker, board poster, rules modal, game options), home featured games list with symbol
- Full SEO landing page with hero, highlights, steps, themes grid, rules, FAQ, CTAs, and OG/Twitter images
- Rules modal wired in both lobby and in-game branches of Game.tsx
- E2E test updated for new game count

## What was already done
Backend engine, service, bot, gateway, widget, i18n (5 locales), registry, and both GameType unions already existed. This PR fills in the remaining create page integration points and the landing page.

## Files changed
- **New**: Landing page (8 files in `app/[locale]/games/checkers/`)
- **New**: `CheckersBoardPoster.tsx`, `checkers-themes.ts`
- **Modified**: themes.ts, GameArt.tsx, ThemePicker.tsx, RulesAccess.tsx, GameCreateView.tsx, home/data/games.ts, e2e test

## Verification
- BE: 131 test suites, 1269 tests passing
- Web: 157 test files, 1139 tests passing
- Typecheck clean
- Lint clean
- File length check passing
- Build successful