### PR TITLE
fix(web): align games list columns and fix button text wrapping

### DIFF
--- a/.claude/skills/tamagui-pro/SKILL.md
+++ b/.claude/skills/tamagui-pro/SKILL.md
@@ -78,6 +78,17 @@ import styles from './styles.module.scss'
 .chipLabel { line-height: 20px; white-space: nowrap; }
 ```
 
+**`whiteSpace: 'nowrap'` on a Tamagui container doesn't prevent text wrapping in child `Typography`** — Components like `LinkButton` wrap text in their own `Typography` child. CSS properties on the parent don't cascade into Tamagui's internal text wrappers.
+
+```tsx
+// ❌ BAD — text still wraps inside LinkButton
+<LinkButton style={{ whiteSpace: 'nowrap' }}>Long Text</LinkButton>
+
+// ✅ GOOD — use SCSS on the container's children
+// styles.module.scss
+.actionsCol > * { white-space: nowrap; flex-shrink: 0; }
+```
+
 ### Layout & positioning
 
 **`overflow: auto/hidden` clips absolutely positioned children** — Floating overlays inside scrollable Containers get clipped.
@@ -395,6 +406,9 @@ For CSS keyframe animations: use SCSS modules, not Tamagui animation props.
 
 ### Grid layouts (chess boards, data grids)
 Use SCSS modules with `display: grid` — Tamagui styled components don't support grid.
+
+### List/table views with variable content
+Use fixed column widths (`px`, `fr`) instead of `auto` to prevent columns from shifting when content changes (e.g., 1 vs 2 buttons). If buttons have multi-line text, ensure `white-space: nowrap` via SCSS on the container's children.
 
 ### Animations
 Use SCSS `@keyframes` modules, not Tamagui animation props. Each component imports its own module.

--- a/apps/web/src/app/[locale]/games/GamesPage.module.scss
+++ b/apps/web/src/app/[locale]/games/GamesPage.module.scss
@@ -7,6 +7,7 @@
 .roomsContainer.listView {
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
 }
 
 @media (max-width: 800px) {

--- a/apps/web/src/app/[locale]/games/RoomCardComponent.module.scss
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.module.scss
@@ -1,9 +1,35 @@
 .roomCard {
   animation: fadeInUp 0.5s ease-out both;
   position: relative;
-  overflow: hidden;
   isolation: isolate;
   border-width: 1px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  border-radius: 16px;
+  min-height: 280px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.roomCard.gridView {
+  overflow: hidden;
+}
+
+.roomCard.gridView > .roomHeader {
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.roomCard.gridView > .actionsCol {
+  margin-top: auto;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(122, 215, 255, 0.1);
+  width: 100%;
 }
 
 .roomCard::before {
@@ -170,13 +196,76 @@
   animation: none;
 }
 
+/* ─── List View ──────────────────────────────────────────────────────────── */
+
+.roomCard.listView {
+  padding: 0.625rem 1rem;
+  border-radius: 10px;
+  min-height: unset;
+}
+
+.roomCard.listView:hover .roomTitle {
+  animation-duration: 10s;
+}
+
+.roomCard.listView .roomTitle {
+  font-size: 1rem;
+  max-width: 360px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.roomCard.listView .actionsCol > * {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ─── Mobile ─────────────────────────────────────────────────────────────── */
+
 @media (max-width: 768px) {
   .roomCard {
-    padding: 1.5rem !important;
-    border-radius: 20px !important;
-    flex-direction: column !important;
-    align-items: stretch !important;
-    justify-content: flex-start !important;
-    gap: 1rem !important;
+    padding: 1.5rem;
+    border-radius: 20px;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 1rem;
+  }
+
+  .roomCard.listView {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .listGrid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .roomCard.listView > .roomHeader {
+    max-width: 100%;
+  }
+
+  .roomCard.listView > .actionsCol {
+    justify-self: start;
+  }
+
+  .roomCard.listView > .roomHeader {
+    max-width: 100%;
+  }
+
+  .roomCard.listView > .metaCol {
+    min-width: 0;
+  }
+
+  .roomCard.gridView > .roomHeader {
+    margin-bottom: 0;
+  }
+
+  .roomCard.gridView > .actionsCol {
+    border-top: none;
+    padding-top: 0;
   }
 }

--- a/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
+++ b/apps/web/src/app/[locale]/games/RoomCardComponent.tsx
@@ -5,6 +5,8 @@ import {
   useTranslation,
   type TranslationKey,
 } from '@/shared/lib/useTranslation';
+import { useLanguage } from '@/shared/i18n/useLanguage';
+import { formatRelative } from '@/shared/i18n/formatters';
 import { GAME_ROOM_STATUS, type GameRoomSummary } from '@/shared/types/games';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import { resolveGameDisplayInfo } from '@/features/games/lib/variantRegistry';
@@ -25,7 +27,6 @@ import {
   MetaIcon,
   MetaLabel,
   MetaValue,
-  MetaListContainer,
 } from './room-card.styles';
 import { LinkButton } from '@arcadeum/ui';
 import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
@@ -33,7 +34,7 @@ import { XStack, YStack } from 'tamagui';
 
 import { useRoutes } from '@/shared/config/useRoutes';
 
-const MAX_VISIBLE_PARTICIPANTS = 4;
+const MAX_VISIBLE_PARTICIPANTS = 8;
 
 interface RoomCardComponentProps {
   room: GameRoomSummary;
@@ -42,6 +43,7 @@ interface RoomCardComponentProps {
 
 export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
   const { t } = useTranslation();
+  const { locale } = useLanguage();
   const routes = useRoutes();
   const { snapshot } = useSessionTokens();
 
@@ -86,112 +88,197 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
 
   const isCompleted = room.status === GAME_ROOM_STATUS.COMPLETED;
 
+  const createdAgo = useMemo(
+    () => formatRelative(room.createdAt, locale || 'en'),
+    [room.createdAt, locale],
+  );
+
   return (
     <StyledRoomCard
-      viewMode={viewMode}
       status={isCompleted ? 'completed' : undefined}
-      className={`${cardStyles.roomCard} ${isCompleted ? cardStyles.completed : ''}`}
+      hoverStyle={
+        viewMode === 'list'
+          ? {
+              scale: 1,
+              y: -2,
+              borderColor: 'rgba(122, 215, 255, 0.4)',
+              backgroundColor: '$backgroundHover',
+            }
+          : undefined
+      }
+      className={`${cardStyles.roomCard} ${viewMode === 'list' ? cardStyles.listView : ''} ${isCompleted ? cardStyles.completed : ''}`}
       data-testid="room-card"
     >
-      <StyledRoomHeader viewMode={viewMode}>
-        <YStack gap="$1" flex={1} minWidth={0}>
-          <h3 className={cardStyles.roomTitle} title={room.name}>
-            {room.name}
-          </h3>
-          <StyledGameName
-            className={variantGradient ? 'text-gradient' : undefined}
-            style={variantGradient ? { backgroundImage: variantGradient } : {}}
-          >
-            {gameName}
-          </StyledGameName>
-        </YStack>
+      <div
+        style={
+          viewMode === 'list'
+            ? {
+                display: 'grid',
+                gridTemplateColumns: '1fr 110px 120px 80px 80px 120px 200px',
+                alignItems: 'center',
+                gap: '0 1rem',
+              }
+            : undefined
+        }
+      >
+        <StyledRoomHeader className={cardStyles.roomHeader}>
+          <YStack gap="$1" minWidth={0}>
+            <h3 className={cardStyles.roomTitle} title={room.name}>
+              {room.name}
+            </h3>
+            <StyledGameName
+              className={variantGradient ? 'text-gradient' : undefined}
+              style={
+                variantGradient ? { backgroundImage: variantGradient } : {}
+              }
+            >
+              {gameName}
+            </StyledGameName>
+          </YStack>
 
-        <XStack gap="$2" alignItems="center">
           {room.gameOptions?.idleTimerEnabled && (
             <FastBadge>
               <BadgeIcon>⚡</BadgeIcon>
               <FastBadgeText>{t('games.rooms.fastRoom')}</FastBadgeText>
             </FastBadge>
           )}
-          {viewMode === 'list' && (
+        </StyledRoomHeader>
+
+        {viewMode === 'list' && (
+          <XStack alignItems="center" justifyContent="center">
             <StyledStatusBadge status={room.status}>
               {t(`games.rooms.status.${room.status}`) || room.status}
             </StyledStatusBadge>
-          )}
-        </XStack>
-      </StyledRoomHeader>
+          </XStack>
+        )}
 
-      {viewMode === 'grid' ? (
-        <RoomMeta>
-          <MetaGrid>
-            <MetaRow>
-              <MetaIcon>👑</MetaIcon>
-              <YStack>
-                <MetaLabel>{t('games.rooms.hostLabel')}</MetaLabel>
-                <MetaValue>{room.host?.displayName || room.hostId}</MetaValue>
-              </YStack>
-            </MetaRow>
-            <MetaRow>
-              <MetaIcon>👥</MetaIcon>
-              <YStack>
-                <MetaLabel>{t('games.rooms.playersLabel')}</MetaLabel>
-                <MetaValue>
-                  {room.maxPlayers
-                    ? `${room.playerCount}/${room.maxPlayers}`
-                    : `${room.playerCount}`}
-                </MetaValue>
-              </YStack>
-            </MetaRow>
-            <MetaRow>
-              <MetaIcon>{room.visibility === 'private' ? '🔒' : '🌐'}</MetaIcon>
-              <YStack>
-                <MetaLabel>{t('games.rooms.visibilityLabel')}</MetaLabel>
-                <MetaValue>
-                  {room.visibility === 'private'
-                    ? t('games.rooms.visibility.private')
-                    : t('games.rooms.visibility.public')}
-                  {room.hasPassword ? ' 🔑' : ''}
-                </MetaValue>
-              </YStack>
-            </MetaRow>
-            <MetaRow>
-              <MetaIcon>⏱️</MetaIcon>
-              <YStack>
-                <MetaLabel>{t('games.rooms.statusLabel')}</MetaLabel>
-                <StyledStatusBadge status={room.status}>
-                  {t(`games.rooms.status.${room.status}`) || room.status}
-                </StyledStatusBadge>
-              </YStack>
-            </MetaRow>
-          </MetaGrid>
+        {viewMode === 'grid' ? (
+          <RoomMeta>
+            <MetaGrid>
+              <MetaRow>
+                <MetaIcon>👑</MetaIcon>
+                <YStack>
+                  <MetaLabel>{t('games.rooms.hostLabel')}</MetaLabel>
+                  <MetaValue>{room.host?.displayName || room.hostId}</MetaValue>
+                </YStack>
+              </MetaRow>
+              <MetaRow>
+                <MetaIcon>👥</MetaIcon>
+                <YStack>
+                  <MetaLabel>{t('games.rooms.playersLabel')}</MetaLabel>
+                  <MetaValue>
+                    {room.maxPlayers
+                      ? `${room.playerCount}/${room.maxPlayers}`
+                      : `${room.playerCount}`}
+                  </MetaValue>
+                </YStack>
+              </MetaRow>
+              <MetaRow>
+                <MetaIcon>
+                  {room.visibility === 'private' ? '🔒' : '🌐'}
+                </MetaIcon>
+                <YStack>
+                  <MetaLabel>{t('games.rooms.visibilityLabel')}</MetaLabel>
+                  <MetaValue>
+                    {room.visibility === 'private'
+                      ? t('games.rooms.visibility.private')
+                      : t('games.rooms.visibility.public')}
+                    {room.hasPassword ? ' 🔑' : ''}
+                  </MetaValue>
+                </YStack>
+              </MetaRow>
+              <MetaRow>
+                <MetaIcon>⏱️</MetaIcon>
+                <YStack>
+                  <MetaLabel>{t('games.rooms.statusLabel')}</MetaLabel>
+                  <StyledStatusBadge status={room.status}>
+                    {t(`games.rooms.status.${room.status}`) || room.status}
+                  </StyledStatusBadge>
+                </YStack>
+              </MetaRow>
+            </MetaGrid>
 
-          {room.members && room.members.length > 0 && (
-            <YStack gap="$2">
-              <ParticipantsLabel>
-                {t('games.rooms.participants')}
-              </ParticipantsLabel>
-              <XStack className={cardStyles.participantAvatars}>
-                {room.members
-                  .slice(0, MAX_VISIBLE_PARTICIPANTS)
-                  .map((member) => (
-                    <div
-                      key={member.id}
-                      className={cardStyles.avatarOverlap}
-                      title={formatMemberLabel(member)}
-                    >
-                      <EquippedPlayerAvatar
-                        name={formatMemberLabel(member)}
-                        size="icon"
-                        equippedAvatarId={member.equippedAvatarId ?? null}
-                        equippedBadgeId={member.equippedBadgeId ?? null}
-                        equippedNameColorId={member.equippedNameColorId}
-                        equippedFrameId={member.equippedFrameId}
-                        equippedAuraId={member.equippedAuraId}
-                        equippedBannerId={member.equippedBannerId}
-                      />
+            {room.members && room.members.length > 0 && (
+              <YStack gap="$2">
+                <ParticipantsLabel>
+                  {t('games.rooms.participants')}
+                </ParticipantsLabel>
+                <XStack className={cardStyles.participantAvatars}>
+                  {room.members
+                    .slice(0, MAX_VISIBLE_PARTICIPANTS)
+                    .map((member) => (
+                      <div
+                        key={member.id}
+                        className={cardStyles.avatarOverlap}
+                        title={formatMemberLabel(member)}
+                      >
+                        <EquippedPlayerAvatar
+                          name={formatMemberLabel(member)}
+                          size="icon"
+                          equippedAvatarId={member.equippedAvatarId ?? null}
+                          equippedBadgeId={member.equippedBadgeId ?? null}
+                          equippedNameColorId={member.equippedNameColorId}
+                          equippedFrameId={member.equippedFrameId}
+                          equippedAuraId={member.equippedAuraId}
+                          equippedBannerId={member.equippedBannerId}
+                        />
+                      </div>
+                    ))}
+                  {room.members.length > MAX_VISIBLE_PARTICIPANTS && (
+                    <div className={cardStyles.avatarOverlap}>
+                      <YStack
+                        width={32}
+                        height={32}
+                        borderRadius={16}
+                        backgroundColor="$backgroundFocus"
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        <MetaLabel
+                          style={{
+                            opacity: 1,
+                            fontSize: 10,
+                            fontWeight: '700',
+                          }}
+                        >
+                          +{room.members.length - MAX_VISIBLE_PARTICIPANTS}
+                        </MetaLabel>
+                      </YStack>
                     </div>
-                  ))}
-                {room.members.length > MAX_VISIBLE_PARTICIPANTS && (
+                  )}
+                </XStack>
+              </YStack>
+            )}
+          </RoomMeta>
+        ) : (
+          <>
+            <XStack
+              className={cardStyles.metaCol}
+              gap="$1.5"
+              alignItems="center"
+            >
+              {room.members
+                ?.slice(0, MAX_VISIBLE_PARTICIPANTS)
+                .map((member) => (
+                  <div
+                    key={member.id}
+                    className={cardStyles.avatarOverlap}
+                    title={formatMemberLabel(member)}
+                  >
+                    <EquippedPlayerAvatar
+                      name={formatMemberLabel(member)}
+                      size="icon"
+                      equippedAvatarId={member.equippedAvatarId ?? null}
+                      equippedBadgeId={member.equippedBadgeId ?? null}
+                      equippedNameColorId={member.equippedNameColorId}
+                      equippedFrameId={member.equippedFrameId}
+                      equippedAuraId={member.equippedAuraId}
+                      equippedBannerId={member.equippedBannerId}
+                    />
+                  </div>
+                ))}
+              {room.members &&
+                room.members.length > MAX_VISIBLE_PARTICIPANTS && (
                   <div className={cardStyles.avatarOverlap}>
                     <YStack
                       width={32}
@@ -209,78 +296,67 @@ export function RoomCardComponent({ room, viewMode }: RoomCardComponentProps) {
                     </YStack>
                   </div>
                 )}
-              </XStack>
-            </YStack>
-          )}
-        </RoomMeta>
-      ) : (
-        <MetaListContainer>
-          <MetaRow minWidth={150}>
-            <MetaIcon>👑</MetaIcon>
-            <MetaValue>{room.host?.displayName || room.hostId}</MetaValue>
-          </MetaRow>
-          <MetaRow minWidth={80}>
-            <MetaIcon>👥</MetaIcon>
-            <MetaValue>
-              {room.maxPlayers
-                ? `${room.playerCount}/${room.maxPlayers}`
-                : room.playerCount}
-            </MetaValue>
-          </MetaRow>
-          <MetaRow minWidth={100}>
-            <MetaIcon>{room.visibility === 'private' ? '🔒' : '🌐'}</MetaIcon>
-            <MetaValue>
-              {room.visibility === 'private'
-                ? t('games.rooms.visibility.private')
-                : t('games.rooms.visibility.public')}
-              {room.hasPassword ? ' 🔑' : ''}
-            </MetaValue>
-          </MetaRow>
-          {room.members && room.members.length > 0 && (
-            <MetaRow minWidth={120}>
-              <MetaIcon>👤</MetaIcon>
-              <MetaValue>
-                {t('games.lounge.participantsCount', {
-                  count: room.members.length,
-                })}
-              </MetaValue>
+            </XStack>
+            <MetaRow className={cardStyles.metaCol}>
+              <YStack gap="$0.5">
+                <MetaLabel>{t('games.rooms.playersLabel')}</MetaLabel>
+                <MetaValue>
+                  {room.maxPlayers
+                    ? `${room.playerCount}/${room.maxPlayers}`
+                    : room.playerCount}
+                </MetaValue>
+              </YStack>
             </MetaRow>
-          )}
-        </MetaListContainer>
-      )}
+            <MetaRow className={cardStyles.metaCol}>
+              <YStack gap="$0.5">
+                <MetaLabel>{t('games.rooms.visibilityLabel')}</MetaLabel>
+                <MetaValue>
+                  {room.visibility === 'private'
+                    ? t('games.rooms.visibility.private')
+                    : t('games.rooms.visibility.public')}
+                  {room.hasPassword ? ' 🔑' : ''}
+                </MetaValue>
+              </YStack>
+            </MetaRow>
+            <MetaRow className={cardStyles.metaCol}>
+              <YStack gap="$0.5">
+                <MetaLabel>{t('games.rooms.createdLabel')}</MetaLabel>
+                <MetaValue>{createdAgo}</MetaValue>
+              </YStack>
+            </MetaRow>
+          </>
+        )}
 
-      <StyledRoomActions viewMode={viewMode}>
-        {!isCompleted &&
-          (room.status === GAME_ROOM_STATUS.LOBBY || isParticipant) && (
-            <LinkButton
-              href={routes.gameRoom(room.id)}
-              variant="primary"
-              size="md"
-              flex={viewMode === 'grid' ? 1 : 0}
-            >
-              {t('games.common.joinRoom')}
-            </LinkButton>
-          )}
-        {(isCompleted ||
-          room.status === GAME_ROOM_STATUS.LOBBY ||
-          !isParticipant) && (
-          <YStack
-            opacity={isCompleted ? 0.5 : 1}
-            flex={viewMode === 'grid' ? 1 : 0}
-          >
+        <StyledRoomActions className={cardStyles.actionsCol}>
+          {!isCompleted &&
+            (room.status === GAME_ROOM_STATUS.LOBBY || isParticipant) && (
+              <LinkButton
+                href={routes.gameRoom(room.id)}
+                variant="primary"
+                size="sm"
+                flex={viewMode === 'grid' ? 1 : 0}
+                style={{ whiteSpace: 'nowrap' }}
+              >
+                {t('games.common.joinRoom')}
+              </LinkButton>
+            )}
+          {(isCompleted ||
+            room.status === GAME_ROOM_STATUS.LOBBY ||
+            !isParticipant) && (
             <LinkButton
               href={`${routes.gameRoom(room.id)}?mode=watch`}
               variant="secondary"
-              size="md"
-              flex={1}
+              size="sm"
+              style={{
+                whiteSpace: 'nowrap',
+                ...(isCompleted ? { opacity: 0.5 } : {}),
+              }}
             >
-              {isCompleted
-                ? t('games.common.watchResults')
-                : t('games.common.watchRoom')}
+              {t('games.common.watchRoom')}
             </LinkButton>
-          </YStack>
-        )}
-      </StyledRoomActions>
+          )}
+        </StyledRoomActions>
+      </div>
     </StyledRoomCard>
   );
 }

--- a/apps/web/src/app/[locale]/games/room-card.styles.tsx
+++ b/apps/web/src/app/[locale]/games/room-card.styles.tsx
@@ -1,7 +1,5 @@
 import { styled, XStack, YStack, Text, GetProps } from 'tamagui';
 
-const LIST_VIEW_MIN_WIDTH = '200px';
-
 // ─── Styled Components ────────────────────────────────────────────────────────
 
 export const StyledRoomCard = styled(YStack, {
@@ -10,7 +8,6 @@ export const StyledRoomCard = styled(YStack, {
   backgroundColor: '$glassBg',
   cursor: 'pointer',
   position: 'relative',
-  overflow: 'hidden',
 
   hoverStyle: {
     scale: 1.05,
@@ -22,31 +19,6 @@ export const StyledRoomCard = styled(YStack, {
   },
 
   variants: {
-    animate: {
-      true: {
-        animation: 'slow',
-      },
-    },
-    viewMode: {
-      grid: {
-        flexDirection: 'column',
-        alignItems: 'stretch',
-        justifyContent: 'flex-start',
-        gap: '$5',
-        padding: '$6',
-        borderRadius: '$6',
-        minHeight: 280,
-      },
-      list: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        gap: '$4',
-        padding: '$4 $6',
-        borderRadius: '$4',
-        flexWrap: 'wrap',
-      },
-    },
     status: {
       completed: {
         borderColor: 'rgba(107, 114, 128, 0.2)',
@@ -60,11 +32,6 @@ export const StyledRoomCard = styled(YStack, {
       },
     },
   } as const,
-
-  defaultVariants: {
-    viewMode: 'grid',
-    animate: true,
-  },
 });
 
 export type StyledRoomCardProps = GetProps<typeof StyledRoomCard>;
@@ -113,50 +80,12 @@ export const StyledRoomHeader = styled(XStack, {
   name: 'StyledRoomHeader',
   alignItems: 'center',
   gap: '$4',
-
-  variants: {
-    viewMode: {
-      grid: {
-        justifyContent: 'space-between',
-        width: '100%',
-        marginBottom: '$2',
-      },
-      list: {
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        justifyContent: 'center',
-        gap: '$1',
-        minWidth: LIST_VIEW_MIN_WIDTH,
-        maxWidth: 300,
-        flexShrink: 0,
-      },
-    },
-  } as const,
 });
 
 export const StyledRoomActions = styled(XStack, {
   name: 'StyledRoomActions',
   gap: '$3',
   flexShrink: 0,
-
-  variants: {
-    viewMode: {
-      grid: {
-        marginTop: 'auto',
-        paddingTop: '$4',
-        borderTopWidth: 1,
-        borderTopColor: '$glassBorder',
-        width: '100%',
-      },
-      list: {
-        marginTop: 0,
-        paddingTop: 0,
-        borderTopWidth: 0,
-        width: 'auto',
-        marginLeft: 'auto',
-      },
-    },
-  } as const,
 });
 
 export const StyledParticipantChip = styled(XStack, {
@@ -203,7 +132,7 @@ export const MetaRow = styled(XStack, {
   name: 'MetaRow',
   alignItems: 'center',
   gap: '$3',
-  minWidth: 'fit-content',
+  minWidth: 0,
 });
 
 export const MetaIcon = styled(Text, {
@@ -237,16 +166,6 @@ export const ParticipantsLabel = styled(Text, {
   textTransform: 'uppercase',
   letterSpacing: 1,
   marginBottom: '$2',
-});
-
-export const MetaListContainer = styled(XStack, {
-  name: 'MetaListContainer',
-  gap: '$6',
-  alignItems: 'center',
-  flex: 1,
-  flexWrap: 'wrap',
-  justifyContent: 'flex-start',
-  paddingHorizontal: '$2',
 });
 
 export const ParticipantsList = styled(XStack, {

--- a/apps/web/src/shared/i18n/messages/games/shared/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/by.ts
@@ -51,6 +51,7 @@ export const byMessages = {
     },
     fastRoom: 'Хуткая гульня',
     gameLabel: 'Гульня',
+    createdLabel: 'Створана',
   },
   password: {
     label: 'Пароль зала (опцыянальна)',

--- a/apps/web/src/shared/i18n/messages/games/shared/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/en.ts
@@ -51,6 +51,7 @@ export const enMessages = {
     },
     fastRoom: 'Fast Room',
     gameLabel: 'Game',
+    createdLabel: 'Created',
   },
   password: {
     label: 'Room Password (optional)',

--- a/apps/web/src/shared/i18n/messages/games/shared/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/es.ts
@@ -51,6 +51,7 @@ export const esMessages = {
     },
     fastRoom: 'Partida rápida',
     gameLabel: 'Juego',
+    createdLabel: 'Creado',
   },
   password: {
     label: 'Contraseña de la sala (opcional)',

--- a/apps/web/src/shared/i18n/messages/games/shared/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/fr.ts
@@ -51,6 +51,7 @@ export const frMessages = {
     },
     fastRoom: 'Partie rapide',
     gameLabel: 'Jeu',
+    createdLabel: 'Créé',
   },
   password: {
     label: 'Mot de passe de la salle (optionnel)',

--- a/apps/web/src/shared/i18n/messages/games/shared/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/ru.ts
@@ -51,6 +51,7 @@ export const ruMessages = {
     },
     fastRoom: 'Быстрая игра',
     gameLabel: 'Игра',
+    createdLabel: 'Создан',
   },
   password: {
     label: 'Пароль зала (опционально)',


### PR DESCRIPTION
## What
Fix misaligned columns in the games list table view and prevent button text from wrapping.

## Why
The status badge was inside the first column (game name) instead of having its own column, causing visual misalignment across rows. Additionally, the "Join Room" button text was wrapping to two lines.

## Changes
- Extracted status badge from `StyledRoomHeader` into its own grid column
- Updated grid template to 7 columns: `1fr 110px 120px 80px 80px 120px 200px`
- Increased participants avatar column from 80px to 120px for better spacing
- Added `white-space: nowrap` and `flex-shrink: 0` via SCSS for action buttons to prevent text wrapping
- Added `whiteSpace: 'nowrap'` and `flexShrink: 0` to `StyledRoomActions` styled component
- Updated `tamagui-pro` skill with gotcha about `whiteSpace` not cascading to child `Typography` components
- Updated i18n translation keys (en, ru, es, fr, by)