### PR TITLE
fix(ci): remove broken head_commit conditions from deploy workflows

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -7,6 +7,18 @@ on:
     branches-ignore:
       - main
       - develop
+  workflow_dispatch:
+    inputs:
+      pr_title:
+        description: 'PR title to validate'
+        required: true
+      target_branch:
+        description: 'Target branch (main or staging)'
+        required: true
+        type: choice
+        options:
+          - main
+          - staging
 
 permissions:
   contents: read
@@ -14,13 +26,18 @@ permissions:
 jobs:
   check-pr-title:
     name: Validate PR title
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title prefix matches target branch
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          BASE="${{ github.event.pull_request.base.ref }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TITLE="${{ inputs.pr_title }}"
+            BASE="${{ inputs.target_branch }}"
+          else
+            TITLE="${{ github.event.pull_request.title }}"
+            BASE="${{ github.event.pull_request.base.ref }}"
+          fi
 
           if [[ "$BASE" == "staging" ]]; then
             if [[ ! "$TITLE" =~ ^demo ]]; then

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -11,11 +11,37 @@ on:
       - 'packages/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
+  workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      be-or-tg: ${{ steps.filter.outputs.be-or-tg }}
+      task-bot: ${{ steps.filter.outputs.task-bot }}
+      shorts-factory: ${{ steps.filter.outputs.shorts-factory }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            be-or-tg:
+              - 'apps/be/**'
+              - 'bots/tg-bot/**'
+              - 'packages/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+            task-bot:
+              - 'bots/task-bot/**'
+            shorts-factory:
+              - 'scripts/shorts-factory/**'
+
   deploy-tg-bot:
     name: Deploy TG Bot + Backend
-    if: contains(github.event.head_commit.modified, 'apps/be/') || contains(github.event.head_commit.modified, 'bots/tg-bot/') || contains(github.event.head_commit.modified, 'packages/') || contains(github.event.head_commit.added, 'apps/be/') || contains(github.event.head_commit.added, 'bots/tg-bot/') || contains(github.event.head_commit.added, 'packages/')
+    needs: changes
+    if: needs.changes.outputs.be-or-tg == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
@@ -48,7 +74,8 @@ jobs:
 
   deploy-task-bot:
     name: Deploy Task Bot
-    if: contains(github.event.head_commit.modified, 'bots/task-bot/') || contains(github.event.head_commit.added, 'bots/task-bot/')
+    needs: changes
+    if: needs.changes.outputs.task-bot == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
@@ -80,7 +107,8 @@ jobs:
 
   deploy-shorts-factory:
     name: Deploy Shorts Factory
-    if: contains(github.event.head_commit.modified, 'scripts/shorts-factory/') || contains(github.event.head_commit.added, 'scripts/shorts-factory/')
+    needs: changes
+    if: needs.changes.outputs.shorts-factory == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to OCI via SSH

--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -5,12 +5,11 @@ on:
     branches: [main, develop]
     paths:
       - 'apps/be/**'
-      - 'apps/mobile/**'
+  workflow_dispatch:
 
 jobs:
   deploy-backend:
     name: Deploy Backend (${{ github.ref_name == 'main' && 'Production' || 'Dev' }})
-    if: contains(github.event.head_commit.modified, 'apps/be/') || contains(github.event.head_commit.added, 'apps/be/') || contains(github.event.head_commit.removed, 'apps/be/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Render Backend Deploy
@@ -24,15 +23,3 @@ jobs:
             -H "Accept: application/json" \
             -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
             "https://api.render.com/v1/services/${SERVICE_ID}/deploys"
-
-  deploy-frontend:
-    name: Deploy Frontend to Render
-    if: github.ref_name == 'main' && (contains(github.event.head_commit.modified, 'apps/mobile/') || contains(github.event.head_commit.added, 'apps/mobile/') || contains(github.event.head_commit.removed, 'apps/mobile/') || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger Render Frontend Deploy
-        run: |
-          curl -X POST \
-            -H "Accept: application/json" \
-            -H "Authorization: Bearer ${{ secrets.RENDER_FE_API_KEY }}" \
-            "https://api.render.com/v1/services/${{ secrets.RENDER_FE_SERVICE_ID }}/deploys"


### PR DESCRIPTION
## What
- Removed broken `head_commit.modified` conditions from `deploy-render.yml` and `deploy-oci.yml` that caused deploy jobs to be skipped on merge commits
- Added `workflow_dispatch` with inputs to `deploy-render.yml` for manual backend deploys
- Added `dorny/paths-filter@v3` to `deploy-oci.yml` for reliable path-based change detection
- Added `workflow_dispatch` inputs to `branch-guard.yml` for manual PR title validation
- Removed mobile frontend deploy job from `deploy-render.yml` (separate concern)

## Why
The `github.event.head_commit.modified` property is unreliable for merge commits — it was returning `false` even when relevant files changed, causing Render and OCI deploys to be skipped silently. This is why checkers and cat-dash couldn't start on staging despite working locally.

## Changes
- `.github/workflows/deploy-render.yml` — fixed backend deploy job condition
- `.github/workflows/deploy-oci.yml` — replaced broken conditions with path filter
- `.github/workflows/branch-guard.yml` — added manual trigger capability