### PR TITLE
fix(ci): add CodeQL config and cover staging branch

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,22 @@
+name: "CodeQL Configuration"
+
+queries:
+  - uses: security-and-quality
+
+paths:
+  - apps/web/src
+  - apps/be/src
+  - apps/mobile/src
+  - packages/ui/src
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.tsx"
+  - "**/*.test.js"
+  - "**/*.spec.js"
+  - "**/dist/**"
+  - "**/.next/**"
+  - "**/coverage/**"

--- a/.github/workflows/codeql-security.yml
+++ b/.github/workflows/codeql-security.yml
@@ -2,9 +2,9 @@ name: CodeQL Security Analysis
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, staging]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, staging]
   schedule:
     - cron: '0 6 * * 1'
 
@@ -32,7 +32,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          queries: security-and-quality
+          config-file: .github/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## What
Add a dedicated CodeQL configuration file and extend the CodeQL workflow to cover the `staging` branch, fixing the failing legacy `CodeQL` check on PRs to `main`.

## Why
PR #1036 (staging → main) has a failing `CodeQL` check (GitHub's built-in default code scanning, `workflowName: `) while our custom `CodeQL Security Analysis` workflow succeeds. The default setup runs because our custom workflow didn't cover the `staging` branch, so GitHub's auto-scanning kicked in. Adding a proper `codeql-config.yml` and extending triggers to include `staging` ensures our custom workflow takes precedence and the default scan doesn't produce conflicting failures.

## Changes
- **New** `.github/codeql-config.yml` — explicit CodeQL configuration: scoped to source directories, ignores test/build files, uses `security-and-quality` query suite
- **Updated** `.github/workflows/codeql-security.yml` — added `staging` to push/PR triggers; switched from inline `queries` param to `config-file` referencing the new config