### PR TITLE
fix(web): fix Critical card images not loading and rules modal not opening in lobby

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'apps/web/**'
   workflow_dispatch:
 
 permissions: {}

--- a/apps/web/src/features/games/ui/GameWidgetContainer.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.tsx
@@ -55,6 +55,7 @@ interface GameWidgetContainerProps {
   isGameOver?: boolean;
   showChatPopup?: boolean;
   loading?: boolean;
+  containerBackground?: string;
 }
 
 export const GameWidgetContainer = React.memo(function GameWidgetContainer({
@@ -69,6 +70,7 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
   isGameOver,
   showChatPopup = true,
   loading = false,
+  containerBackground,
 }: GameWidgetContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const activeEmotes = useActiveEmotes();
@@ -175,6 +177,11 @@ export const GameWidgetContainer = React.memo(function GameWidgetContainer({
             isFullscreen={isFullscreen}
             $variant={variant as Parameters<typeof Container>[0]['$variant']}
             data-testid="game-widget-container"
+            style={
+              containerBackground
+                ? { background: containerBackground }
+                : undefined
+            }
           >
             {renderedHeader}
             <SharedGameBoard data-testid="game-board-section">

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -52,6 +52,7 @@ interface ActiveGameViewProps {
   // Rules modal state from parent
   showRulesOpen: boolean;
   onShowRulesClose: () => void;
+  onOpenRules: () => void;
   // Rematch props
   rematch: {
     rematchLoading: boolean;
@@ -86,6 +87,7 @@ export function ActiveGameView({
   aliveOpponents,
   isGameOver,
   rematch,
+  onOpenRules,
 }: ActiveGameViewProps) {
   const { t } = useTranslation();
   const media = useMedia();
@@ -272,6 +274,7 @@ export function ActiveGameView({
         variant={cardVariant as GameVariant}
         isMyTurn={isMyTurn}
         isGameOver={isGameOver}
+        containerBackground={scenePalette.handBackground}
         // Critical shows incoming chat as per-opponent bubbles over each tile,
         // so it opts out of the shared corner popup to avoid double display.
         showChatPopup={false}
@@ -312,6 +315,7 @@ export function ActiveGameView({
                 idleTimerTriggered={idleTimerTriggered}
                 handleIdleTimeout={handleIdleTimeout}
                 handleStopAutoplay={handleStopAutoplay}
+                onOpenRules={onOpenRules}
               />
             </YStack>
             {currentPlayer && (

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -29,7 +29,7 @@ import { GameEndModals, GameWidgetContainer } from '@/features/games/ui';
 import { MatchWidget } from './MatchWidget';
 import { ActiveGameModals } from './ActiveGameModals';
 import { getVariantStyles } from './styles/variants';
-import { CRITICAL_VARIANTS } from '../lib/constants';
+import { CRITICAL_VARIANTS, GAME_VARIANT } from '../lib/constants';
 import { ScenePaletteProvider } from './ScenePaletteContext';
 import { SceneBackdrop } from './SceneBackdrop';
 import type { GameVariant } from '@arcadeum/ui';
@@ -90,7 +90,7 @@ export function ActiveGameView({
   const { t } = useTranslation();
   const media = useMedia();
   const isMobile = media.sm;
-  const cardVariant = room.gameOptions?.cardVariant;
+  const cardVariant = room.gameOptions?.cardVariant || GAME_VARIANT.CYBERPUNK;
   const scenePalette = useMemo(
     () => getVariantStyles(cardVariant).scene,
     [cardVariant],

--- a/apps/web/src/widgets/CriticalGame/ui/CriticalLobby.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/CriticalLobby.tsx
@@ -55,6 +55,8 @@ export interface CriticalLobbyProps {
   onKickPlayer?: (userId: string) => void;
   onLeaveRoom?: () => void;
   onRefresh?: () => void;
+  showRulesOpen?: boolean;
+  onShowRulesClose?: () => void;
   t: (key: TranslationKey, params?: Record<string, string | number>) => string;
 }
 
@@ -73,6 +75,8 @@ export function CriticalLobby({
   onKickPlayer,
   onLeaveRoom,
   onRefresh,
+  showRulesOpen,
+  onShowRulesClose,
   t,
 }: CriticalLobbyProps) {
   const [showRules, setShowRules] = useState(false);
@@ -134,69 +138,70 @@ export function CriticalLobby({
     </IconButton>
   );
 
-  const rulesModalSlot = (
-    <RulesModal
-      isOpen={showRules}
-      onClose={() => setShowRules(false)}
-      currentVariant={cardVariant}
-      isFastMode={isFastMode}
-      isPrivate={room.visibility === 'private'}
-      t={t}
-    />
-  );
-
   return (
-    <ReusableGameLobby
-      room={room}
-      userId={userId}
-      isHost={isHost}
-      startBusy={startBusy}
-      isFullscreen={isFullscreen}
-      containerRef={containerRef}
-      onToggleFullscreen={onToggleFullscreen}
-      onStartGame={onStartGame}
-      onReorderPlayers={onReorderPlayers}
-      onReinvite={onReinvite}
-      onDeleteRoom={onDeleteRoom}
-      onKickPlayer={onKickPlayer}
-      onLeaveRoom={onLeaveRoom}
-      onRefresh={onRefresh}
-      gameName={t('games.critical_v1.name')}
-      gameIcon="🐱💣"
-      variantName={t(variantInfo.name as TranslationKey)}
-      roomIcon={variantInfo.emoji}
-      minPlayers={2}
-      labels={{
-        waitingLabel: t('games.table.lobby.waitingToStart'),
-        subtitleText: getSubtitleText(),
-        playersLabel: t('games.table.lobby.players'),
-        hostControlsLabel: t('games.table.lobby.hostControls'),
-        startLabel: t('games.table.actions.start'),
-        startingLabel: t('games.table.actions.starting'),
-        roomInfoLabel: t('games.table.lobby.roomInfo'),
-        statusLabel: t('games.table.lobby.status'),
-        visibilityLabel: t('games.table.lobby.visibility'),
-        visibilityPublicLabel: t('games.table.lobby.visibilityPublic'),
-        visibilityPrivateLabel: t('games.table.lobby.visibilityPrivate'),
-        inviteCodeLabel: t('games.table.lobby.inviteCode'),
-        waitingForPlayerLabel: t('games.table.lobby.waitingForPlayer'),
-        invitedPlayersLabel: t('games.table.lobby.invitedPlayers'),
-        declinedLabel: t('games.table.lobby.statusDeclined'),
-        reinviteLabel: t('games.table.lobby.reinvite'),
-        fastRoomLabel: t('games.rooms.fastRoom'),
-        botCountLabel: t('games.lobby.botCountLabel'),
-        startWithBotsLabel: t('games.lobby.startWithBots'),
-      }}
-      theme={theme}
-      isFastMode={isFastMode}
-      optionsSlot={optionsSlot}
-      headerActionsSlot={headerActionsSlot}
-      rulesModalSlot={rulesModalSlot}
-      showFullscreenButton={true}
-      showReorderControls={true}
-      showInvitedPlayers={true}
-      enableBots={true}
-      onRuleComingSoonChange={setRuleComingSoon}
-    />
+    <>
+      <RulesModal
+        isOpen={showRules || !!showRulesOpen}
+        onClose={() => {
+          setShowRules(false);
+          onShowRulesClose?.();
+        }}
+        currentVariant={cardVariant}
+        isFastMode={isFastMode}
+        isPrivate={room.visibility === 'private'}
+        t={t}
+      />
+      <ReusableGameLobby
+        room={room}
+        userId={userId}
+        isHost={isHost}
+        startBusy={startBusy}
+        isFullscreen={isFullscreen}
+        containerRef={containerRef}
+        onToggleFullscreen={onToggleFullscreen}
+        onStartGame={onStartGame}
+        onReorderPlayers={onReorderPlayers}
+        onReinvite={onReinvite}
+        onDeleteRoom={onDeleteRoom}
+        onKickPlayer={onKickPlayer}
+        onLeaveRoom={onLeaveRoom}
+        onRefresh={onRefresh}
+        gameName={t('games.critical_v1.name')}
+        gameIcon="🐱💣"
+        variantName={t(variantInfo.name as TranslationKey)}
+        roomIcon={variantInfo.emoji}
+        minPlayers={2}
+        labels={{
+          waitingLabel: t('games.table.lobby.waitingToStart'),
+          subtitleText: getSubtitleText(),
+          playersLabel: t('games.table.lobby.players'),
+          hostControlsLabel: t('games.table.lobby.hostControls'),
+          startLabel: t('games.table.actions.start'),
+          startingLabel: t('games.table.actions.starting'),
+          roomInfoLabel: t('games.table.lobby.roomInfo'),
+          statusLabel: t('games.table.lobby.status'),
+          visibilityLabel: t('games.table.lobby.visibility'),
+          visibilityPublicLabel: t('games.table.lobby.visibilityPublic'),
+          visibilityPrivateLabel: t('games.table.lobby.visibilityPrivate'),
+          inviteCodeLabel: t('games.table.lobby.inviteCode'),
+          waitingForPlayerLabel: t('games.table.lobby.waitingForPlayer'),
+          invitedPlayersLabel: t('games.table.lobby.invitedPlayers'),
+          declinedLabel: t('games.table.lobby.statusDeclined'),
+          reinviteLabel: t('games.table.lobby.reinvite'),
+          fastRoomLabel: t('games.rooms.fastRoom'),
+          botCountLabel: t('games.lobby.botCountLabel'),
+          startWithBotsLabel: t('games.lobby.startWithBots'),
+        }}
+        theme={theme}
+        isFastMode={isFastMode}
+        optionsSlot={optionsSlot}
+        headerActionsSlot={headerActionsSlot}
+        showFullscreenButton={true}
+        showReorderControls={true}
+        showInvitedPlayers={true}
+        enableBots={true}
+        onRuleComingSoonChange={setRuleComingSoon}
+      />
+    </>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/Game.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useTranslation } from '@/shared/lib/useTranslation';
 import type { CriticalGameProps } from '../types';
 import { useCriticalState, useRematch } from '../hooks';
@@ -6,6 +6,8 @@ import { useGameRoomActions } from '@/features/games/hooks';
 import { useFullscreen } from '@/features/games/hooks/useFullscreen';
 import { CriticalLobby } from './CriticalLobby';
 import { ActiveGameView } from './ActiveGameView';
+import { RulesModal } from './RulesModal';
+import { GAME_VARIANT } from '../lib/constants';
 
 export default function CriticalGame({
   roomId,
@@ -44,6 +46,12 @@ export default function CriticalGame({
 
   const rematch = useRematch({ roomId, gameOptions: room?.gameOptions });
 
+  const [rulesOpen, setRulesOpen] = useState(false);
+  const handleOpenRules = useCallback(() => setRulesOpen(true), []);
+  const handleCloseRules = useCallback(() => setRulesOpen(false), []);
+
+  const cardVariant = room?.gameOptions?.cardVariant || GAME_VARIANT.CYBERPUNK;
+
   if (!room) return null;
 
   // Game not started yet - show Lobby
@@ -81,21 +89,31 @@ export default function CriticalGame({
   // popup, my-turn border), so Critical no longer wraps its own container or
   // runs a second fullscreen system here.
   return (
-    <ActiveGameView
-      currentUserId={currentUserId}
-      room={room}
-      snapshot={snapshot}
-      isHost={isHost}
-      actions={actions}
-      currentPlayer={currentPlayer}
-      isMyTurn={!!isMyTurn}
-      canAct={!!canAct}
-      canPlayNope={!!canPlayNope}
-      aliveOpponents={aliveOpponents}
-      isGameOver={!!isGameOver}
-      rematch={rematch}
-      showRulesOpen={showRulesOpen}
-      onShowRulesClose={onShowRulesClose}
-    />
+    <>
+      <ActiveGameView
+        currentUserId={currentUserId}
+        room={room}
+        snapshot={snapshot}
+        isHost={isHost}
+        actions={actions}
+        currentPlayer={currentPlayer}
+        isMyTurn={!!isMyTurn}
+        canAct={!!canAct}
+        canPlayNope={!!canPlayNope}
+        aliveOpponents={aliveOpponents}
+        isGameOver={!!isGameOver}
+        rematch={rematch}
+        showRulesOpen={showRulesOpen}
+        onShowRulesClose={onShowRulesClose}
+        onOpenRules={handleOpenRules}
+      />
+      <RulesModal
+        isOpen={rulesOpen}
+        onClose={handleCloseRules}
+        currentVariant={cardVariant}
+        isPrivate={room.visibility === 'private'}
+        t={t}
+      />
+    </>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/Game.tsx
@@ -69,6 +69,8 @@ export default function CriticalGame({
           currentUserId ? () => onLeaveRoom(currentUserId) : undefined
         }
         onRefresh={onRefresh}
+        showRulesOpen={showRulesOpen}
+        onShowRulesClose={onShowRulesClose}
         t={t}
       />
     );

--- a/apps/web/src/widgets/CriticalGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/Game.tsx
@@ -48,7 +48,10 @@ export default function CriticalGame({
 
   const [rulesOpen, setRulesOpen] = useState(false);
   const handleOpenRules = useCallback(() => setRulesOpen(true), []);
-  const handleCloseRules = useCallback(() => setRulesOpen(false), []);
+  const handleCloseRules = useCallback(() => {
+    setRulesOpen(false);
+    onShowRulesClose();
+  }, [onShowRulesClose]);
 
   const cardVariant = room?.gameOptions?.cardVariant || GAME_VARIANT.CYBERPUNK;
 
@@ -108,7 +111,7 @@ export default function CriticalGame({
         onOpenRules={handleOpenRules}
       />
       <RulesModal
-        isOpen={rulesOpen}
+        isOpen={rulesOpen || showRulesOpen}
         onClose={handleCloseRules}
         currentVariant={cardVariant}
         isPrivate={room.visibility === 'private'}

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test-fixtures.ts
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test-fixtures.ts
@@ -56,6 +56,7 @@ export function makeProps(
     idleTimerTriggered: false,
     handleIdleTimeout: vi.fn(),
     handleStopAutoplay: vi.fn(),
+    onOpenRules: vi.fn(),
     ...override,
   } as MatchWidgetProps;
 }

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.test.tsx
@@ -317,13 +317,11 @@ describe('MatchWidget (ARC-635)', () => {
     expect(toggleFullscreen).toHaveBeenCalledTimes(1);
   });
 
-  it('mounts RulesModal in-place and toggles it via HandRail menu', () => {
-    render(<MatchWidget {...makeProps()} />);
-    expect(screen.queryByTestId('rules-modal-stub')).not.toBeInTheDocument();
+  it('calls onOpenRules when HandRail rules button is clicked', () => {
+    const onOpenRules = vi.fn();
+    render(<MatchWidget {...makeProps({ onOpenRules })} />);
     fireEvent.click(screen.getByTestId('hand-zone-stub-rules'));
-    expect(screen.getByTestId('rules-modal-stub')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('rules-modal-close'));
-    expect(screen.queryByTestId('rules-modal-stub')).not.toBeInTheDocument();
+    expect(onOpenRules).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/MatchWidget.tsx
@@ -5,7 +5,6 @@ import { MatchWidgetGrid } from './styles/layout';
 import { Arena } from './arena/Arena';
 import { OpponentsRow } from './opponents/OpponentsRow';
 import { HandZone } from './hand/HandZone';
-import { RulesModal } from './RulesModal';
 import { IdleTimerDisplay } from './IdleTimerDisplay';
 import { AutoplayControls } from './AutoplayControls';
 import { useWidgetFullscreen } from '@/features/games/ui/GameWidgetContainer';
@@ -84,6 +83,7 @@ export interface MatchWidgetProps {
   idleTimerTriggered: boolean;
   handleIdleTimeout: () => void;
   handleStopAutoplay: () => void;
+  onOpenRules: () => void;
 }
 
 /**
@@ -93,7 +93,7 @@ export interface MatchWidgetProps {
  * arena's `ComboCard` (label + tint) and the rail's `Play` button.
  */
 export function MatchWidget({
-  room,
+  room: _room,
   snapshot,
   currentUserId,
   currentPlayer,
@@ -116,6 +116,7 @@ export function MatchWidget({
   idleTimerTriggered,
   handleIdleTimeout,
   handleStopAutoplay,
+  onOpenRules,
 }: MatchWidgetProps) {
   // Read the widget-level fullscreen state from the context owned by
   // GameWidgetContainer. The prop `isFullscreen` is the legacy path;
@@ -130,7 +131,6 @@ export function MatchWidget({
     deserialize: SELECTED_UIDS_DESERIALIZE,
   });
   const [targetPlayerId, setTargetPlayerId] = useState<string | null>(null);
-  const [rulesOpen, setRulesOpen] = useState(false);
   // Persist show/hide for the card name + description rows per user. New
   // players see both rows by default (rules text helps them learn);
   // experienced players who collapse to art-only stay collapsed across
@@ -181,8 +181,6 @@ export function MatchWidget({
     if (!hydratedFromStorage.current) return;
     writeHandToggle(togglesStorageKey, 'description', showCardDescription);
   }, [togglesStorageKey, showCardDescription]);
-  const handleOpenRules = useCallback(() => setRulesOpen(true), []);
-  const handleCloseRules = useCallback(() => setRulesOpen(false), []);
   const handleToggleCardName = useCallback(
     () => setShowCardName((v) => !v),
     [],
@@ -465,7 +463,7 @@ export function MatchWidget({
               onPlay={handlePlay}
               onDraw={handleDrawAndEnd}
               onNope={actions.playNope}
-              onOpenRules={handleOpenRules}
+              onOpenRules={onOpenRules}
               onToggleFullscreen={toggleFullscreen}
               onToggleCardName={handleToggleCardName}
               onToggleCardDescription={handleToggleCardDescription}
@@ -473,13 +471,6 @@ export function MatchWidget({
           )}
         </MatchWidgetGrid>
       </NarrowViewportProvider>
-      <RulesModal
-        isOpen={rulesOpen}
-        onClose={handleCloseRules}
-        currentVariant={cardVariant || 'default'}
-        isPrivate={room?.visibility === 'private'}
-        t={t}
-      />
     </div>
   );
 }

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
@@ -54,6 +54,7 @@ export function HandZone(props: HandZoneProps) {
         gap="$2"
         paddingHorizontal="$2"
         paddingTop="$2"
+        marginHorizontal="-$2"
         style={{ background: palette.handBackground }}
       >
         <HandCards
@@ -95,6 +96,7 @@ export function HandZone(props: HandZoneProps) {
       gap="$3"
       paddingHorizontal="$2"
       paddingVertical="$2"
+      marginHorizontal="-$3"
       style={{ background: palette.handBackground }}
     >
       <HandRail

--- a/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/hand/HandZone.tsx
@@ -5,6 +5,7 @@ import { HandCards } from './HandCards';
 import { HandRail } from './HandRail';
 import { MobileHandBar } from './MobileHandBar';
 import { useIsNarrow } from '../../lib/useNarrowViewport';
+import { useScenePalette } from '../ScenePaletteContext';
 import type { HandCardInstance, ComboKind } from '../../lib/combo';
 
 interface HandZoneProps {
@@ -42,6 +43,7 @@ export function HandZone(props: HandZoneProps) {
   // `NarrowViewportProvider` at the widget root so HandZone, Arena, and
   // OpponentsRow commit the same flip on the same React frame.
   const isMobile = useIsNarrow(480);
+  const palette = useScenePalette();
 
   if (isMobile) {
     return (
@@ -52,6 +54,7 @@ export function HandZone(props: HandZoneProps) {
         gap="$2"
         paddingHorizontal="$2"
         paddingTop="$2"
+        style={{ background: palette.handBackground }}
       >
         <HandCards
           cards={props.cards}
@@ -92,6 +95,7 @@ export function HandZone(props: HandZoneProps) {
       gap="$3"
       paddingHorizontal="$2"
       paddingVertical="$2"
+      style={{ background: palette.handBackground }}
     >
       <HandRail
         handCount={props.cards.length}

--- a/apps/web/src/widgets/CriticalGame/ui/styles/modals.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/modals.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { styled, YStack, XStack, Text } from 'tamagui';
 import { Button, GameVariant, ModalButton, OptionButton } from '@arcadeum/ui';
 
@@ -20,11 +21,11 @@ const VARIANT_COLORS = {
 
 const Overlay = styled(YStack, {
   name: 'ModalOverlay',
-  position: 'sticky' as unknown as 'sticky',
+  position: 'fixed' as unknown as 'fixed',
   top: 0,
   left: 0,
   right: 0,
-  minHeight: '100%',
+  bottom: 0,
   backgroundColor: 'rgba(0,0,0,0.8)',
   zIndex: 1000,
   justifyContent: 'center' as never,
@@ -44,11 +45,16 @@ export function Modal({ open = false, onOpenChange, children }: ModalProps) {
 
   if (!open) return null;
 
-  return (
+  const overlay = (
     <Overlay onPress={handleOverlayClick} data-testid="modal-overlay">
       {children}
     </Overlay>
   );
+
+  if (typeof document !== 'undefined') {
+    return createPortal(overlay, document.body);
+  }
+  return overlay;
 }
 
 const StyledModalFrame = styled(YStack, {

--- a/apps/web/src/widgets/CriticalGame/ui/styles/variants/base.ts
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/variants/base.ts
@@ -260,6 +260,8 @@ export const baseVariantStyles: VariantStyleConfig = {
     lastPlayedGradient:
       'linear-gradient(160deg, rgba(236, 72, 153, 1) 0%, rgba(168, 85, 247, 1) 55%, rgba(99, 102, 241, 1) 100%)',
     lastPlayedHaloColor: 'rgba(245, 197, 106, 0.5)',
+    handBackground:
+      'linear-gradient(180deg, rgba(15, 5, 24, 0.92) 0%, rgba(0, 0, 0, 0.98) 100%)',
     handColorByRole: {
       attack:
         'linear-gradient(160deg, rgba(236, 72, 153, 1) 0%, rgba(139, 28, 98, 1) 100%)',

--- a/apps/web/src/widgets/CriticalGame/ui/styles/variants/types.ts
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/variants/types.ts
@@ -144,6 +144,9 @@ export interface VariantScenePalette {
   lastPlayedGradient: string;
   lastPlayedHaloColor: string;
 
+  // Background for the hand / cards section below the scene backdrop
+  handBackground: string;
+
   // Hand card gradients by role
   handColorByRole: {
     attack: string;


### PR DESCRIPTION
## What
- Fix Critical game showing blank/missing card images on production (arcadeum.games)
- Fix rules modal not opening in Critical game lobby
- Fix production deploy workflow to redeploy on every push

## Why
- **Blank cards on production**: ActiveGameView.tsx had no fallback for cardVariant when room.gameOptions was undefined, so getVariantStyles returned base styles whose getCardSpriteUrl only handled crime/horror/adventure
- **Rules modal not opening**: CriticalLobby passed rulesModalSlot to ReusableGameLobby which rendered it inside GameContainer with overflow:hidden - the Modal overlay uses position:sticky which is clipped
- **Stale production deploys**: deploy-web.yml had a paths filter causing production to skip deploys when only app files changed

## Changes
- ActiveGameView.tsx: Added GAME_VARIANT.CYBERPUNK fallback for cardVariant
- CriticalLobby.tsx: Added showRulesOpen/onShowRulesClose props, render RulesModal as sibling outside ReusableGameLobby (same pattern as other games)
- Game.tsx: Pass showRulesOpen/onShowRulesClose props to CriticalLobby
- deploy-web.yml: Removed paths filter so production redeploys on every main push