### PR TITLE
fix(ARC-899): show sea battle boards after game over

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle-attack.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-attack.utils.ts
@@ -221,6 +221,7 @@ function checkAndSetWinner(state: SeaBattleState): void {
       const winningTeamId = aliveTeamIds[0];
       if (winningTeamId) {
         state.winnerId = winningTeamId;
+        state.phase = GAME_PHASE.COMPLETED;
         state.logs.push(createLog('system', 'Game Over! Team has won!'));
       }
     }
@@ -229,6 +230,7 @@ function checkAndSetWinner(state: SeaBattleState): void {
   const alivePlayers = state.players.filter((p) => p.alive);
   if (alivePlayers.length === 1) {
     state.winnerId = alivePlayers[0].playerId;
+    state.phase = GAME_PHASE.COMPLETED;
     state.logs.push(createLog('system', 'Game Over! We have a winner!'));
   }
 }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.removePlayer.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.removePlayer.spec.ts
@@ -101,6 +101,7 @@ describe('SeaBattleEngine — removePlayer', () => {
       const ns = result.state!;
 
       expect(ns.winnerId).toBe('t2');
+      expect(ns.phase).toBe(GAME_PHASE.COMPLETED);
       expect(engine.isGameOver(ns)).toBe(true);
     });
   });

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.team.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.team.spec.ts
@@ -365,6 +365,7 @@ describe('SeaBattleEngine — team mode', () => {
         { targetPlayerId: 'c', row: 0, col: 0 },
       );
       const ns = result.state!;
+      expect(ns.phase).toBe(GAME_PHASE.COMPLETED);
       expect(engine.isGameOver(ns)).toBe(true);
       expect(ns.winnerId).toBe('t1');
       expect(

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -257,6 +257,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
   }
 
   isGameOver(state: SeaBattleState): boolean {
+    if (state.phase === GAME_PHASE.COMPLETED) return true;
     if (state.phase !== GAME_PHASE.BATTLE) return false;
     if (state.teams) return countAliveTeams(state) <= 1;
     return state.players.filter((p) => p.alive).length <= 1;
@@ -360,6 +361,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
         );
         if (winningTeamId) {
           state.winnerId = winningTeamId;
+          state.phase = GAME_PHASE.COMPLETED;
           state.logs.push(
             this.createLogEntry('system', 'Game Over! Team has won!'),
           );
@@ -370,6 +372,7 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
     const alivePlayers = state.players.filter((p) => p.alive);
     if (alivePlayers.length === 1) {
       state.winnerId = alivePlayers[0].playerId;
+      state.phase = GAME_PHASE.COMPLETED;
       state.logs.push(
         this.createLogEntry('system', 'Game Over! We have a winner!'),
       );

--- a/apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleState.ts
+++ b/apps/web/src/widgets/SeaBattleGame/hooks/useSeaBattleState.ts
@@ -5,6 +5,7 @@ import type {
   SeaBattlePlayerState,
   SeaBattleTeam,
 } from '../types';
+import { GAME_PHASE } from '../types';
 
 import { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
@@ -79,10 +80,10 @@ export function useSeaBattleState({
   }, [snapshot, currentUserId]);
 
   const gamePhase = snapshot?.phase || 'lobby';
-  const isPlacementPhase = gamePhase === 'placement';
-  const isBattlePhase = gamePhase === 'battle';
+  const isPlacementPhase = gamePhase === GAME_PHASE.PLACEMENT;
+  const isBattlePhase = gamePhase === GAME_PHASE.BATTLE;
   const isGameOver =
-    gamePhase === 'game_over' || session?.status === 'completed';
+    gamePhase === GAME_PHASE.COMPLETED || session?.status === 'completed';
 
   const winnerTeam = useMemo<SeaBattleTeam | undefined>(() => {
     if (!isGameOver || !snapshot || !teams) return undefined;

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -44,7 +44,7 @@ export const GAME_PHASE = {
   LOBBY: 'lobby',
   PLACEMENT: 'placement',
   BATTLE: 'battle',
-  GAME_OVER: 'game_over',
+  COMPLETED: 'completed',
 } as const;
 
 export type GamePhase = (typeof GAME_PHASE)[keyof typeof GAME_PHASE];

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -76,7 +76,7 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   t,
 }: AttackPlayerBoardProps) {
   const isAttackDisabled = disabled || isTeammate;
-  const showTargeting = isMyTurn && !isTeammate;
+  const showTargeting = isMyTurn && !isAttackDisabled;
   const boardSize = player.board.length || 10;
   const rowLbls = rowLabels(boardSize);
   const colLbls = colLabels(boardSize);
@@ -149,11 +149,13 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
           const isAttackable =
             !isMe &&
             !isTeammate &&
+            !disabled &&
             cellState !== CELL_STATE.HIT &&
             cellState !== CELL_STATE.MISS &&
             !isSunk &&
             !isPending;
-          const isWeaponClickable = !isMe && !isTeammate && !!weaponMode;
+          const isWeaponClickable =
+            !isMe && !isTeammate && !disabled && !!weaponMode;
           const cellKey = `${player.playerId}-${rIndex}-${cIndex}`;
           const isSonarCell = !isMe && sonarHighlightCells?.has(cellKey);
           const isRadarCell = !isMe && radarHighlightCells?.has(cellKey);

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.test.ts
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getVisibleOpponents } from './index';
+
+const players = [
+  { playerId: 'me', alive: true },
+  { playerId: 'winner', alive: true },
+  { playerId: 'eliminated', alive: false },
+];
+
+describe('getVisibleOpponents', () => {
+  it('hides eliminated opponents during an active game', () => {
+    expect(getVisibleOpponents(players, 'me', false)).toEqual([players[1]]);
+  });
+
+  it('shows all opponents after the game ends', () => {
+    expect(getVisibleOpponents(players, 'me', true)).toEqual([
+      players[1],
+      players[2],
+    ]);
+  });
+});

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -30,6 +30,21 @@ export interface AttackBoardProps {
   onCellHover?: (playerId: string, row: number, col: number) => void;
   onCellHoverEnd?: () => void;
   weaponMode?: boolean;
+  showEliminatedPlayers?: boolean;
+}
+
+export function getVisibleOpponents<
+  T extends Pick<SeaBattlePlayerState, 'playerId' | 'alive'>,
+>(
+  players: T[],
+  currentUserId: string | null,
+  showEliminatedPlayers: boolean,
+): T[] {
+  return players.filter(
+    (player) =>
+      player.playerId !== currentUserId &&
+      (showEliminatedPlayers || player.alive),
+  );
 }
 
 export const AttackBoard = memo(function AttackBoard({
@@ -49,6 +64,7 @@ export const AttackBoard = memo(function AttackBoard({
   onCellHover,
   onCellHoverEnd,
   weaponMode,
+  showEliminatedPlayers = false,
 }: AttackBoardProps) {
   const { t } = useTranslation();
   const theme = useSeaBattleTheme();
@@ -59,8 +75,8 @@ export const AttackBoard = memo(function AttackBoard({
   );
 
   const opponents = useMemo(
-    () => players.filter((p) => p.playerId !== currentUserId && p.alive),
-    [players, currentUserId],
+    () => getVisibleOpponents(players, currentUserId, showEliminatedPlayers),
+    [players, currentUserId, showEliminatedPlayers],
   );
 
   const idlePlayers = useGameStore((s: GameState) => s.idlePlayers);

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -196,12 +196,26 @@ export const SeaBattleGame = memo(function SeaBattleGame({
     [currentUserId, room, t, snapshot],
   );
 
+  const gameResult = useMemo(() => {
+    if (!isGameOver) return null;
+    if (teamMode) {
+      return isWinner ? 'victory' : 'defeat';
+    }
+    if (isWinner || snapshot?.winnerId === currentUserId) return 'victory';
+    return 'defeat';
+  }, [isGameOver, isWinner, snapshot?.winnerId, currentUserId, teamMode]);
+
+  const localGameResult = useMemo(() => {
+    if (!gameResult) return null;
+    return gameResult === 'victory' ? ('won' as const) : ('lost' as const);
+  }, [gameResult]);
+  useRecordGameResult(localGameResult, 'sea_battle_v1', session?.id);
   const gameEnd = useGameEndState({
     roomId,
     currentUserId,
     session,
     isGameOver,
-    result: null,
+    result: localGameResult,
     rematchGameOptions,
     players:
       snapshot?.players
@@ -295,21 +309,6 @@ export const SeaBattleGame = memo(function SeaBattleGame({
       resolveDisplayNameBound,
     ],
   );
-
-  const gameResult = useMemo(() => {
-    if (!isGameOver) return null;
-    if (teamMode) {
-      return isWinner ? 'victory' : 'defeat';
-    }
-    if (isWinner || snapshot?.winnerId === currentUserId) return 'victory';
-    return 'defeat';
-  }, [isGameOver, isWinner, snapshot?.winnerId, currentUserId, teamMode]);
-
-  const localGameResult = useMemo(() => {
-    if (!gameResult) return null;
-    return gameResult === 'victory' ? ('won' as const) : ('lost' as const);
-  }, [gameResult]);
-  useRecordGameResult(localGameResult, 'sea_battle_v1', session?.id);
 
   const headerTitle = useMemo(
     () =>

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -219,9 +219,9 @@ export function SeaBattleBoards({
         </Card>
       )}
 
-      {isBattlePhase && snapshot && (
+      {(isBattlePhase || isGameOver) && snapshot && (
         <>
-          {isMyTurn && (hasSonar || hasRadar) && (
+          {!isGameOver && isMyTurn && (hasSonar || hasRadar) && (
             <div
               style={{
                 display: 'flex',
@@ -376,6 +376,8 @@ export function SeaBattleBoards({
             isMyTurn={isMyTurn}
             onAttack={isWeaponMode ? handleWeaponFire : attack}
             resolveDisplayName={resolveDisplayNameBound}
+            disabled={isGameOver}
+            showEliminatedPlayers={isGameOver}
             teammateIds={teammateIds}
             teams={teams}
             gridSize={snapshot.gridSize}


### PR DESCRIPTION
## What
Fixes Sea Battle completion so the win/loss result is shown and final boards remain visible.

## Why
Completed games used a terminal phase that the client did not recognize, and the board renderer hid every field after the game ended.

## Changes
- Mark Sea Battle winner resolution with the shared completed phase and recognize it on the client.
- Pass win/loss results into the shared game-end modal flow.
- Keep all player boards visible after completion in a read-only state.
- Add coverage for showing eliminated opponents after a game ends.