### PR TITLE
feat(deploy): dual OCI envs, api-dev subdomain, CSP fix, music URL fix

### DIFF
--- a/.github/workflows/deploy-render.yml
+++ b/.github/workflows/deploy-render.yml
@@ -2,7 +2,7 @@ name: Deploy to Render
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, staging]
     paths:
       - 'apps/be/**'
   workflow_dispatch:

--- a/scripts/deploy-tg-bot.sh
+++ b/scripts/deploy-tg-bot.sh
@@ -2,11 +2,12 @@
 set -euo pipefail
 
 DEPLOY_DIR="/opt/arcadeum"
+BRANCH="${1:-main}"
 
-echo "==> Pulling latest code..."
+echo "==> Pulling latest code from ${BRANCH}..."
 cd "${DEPLOY_DIR}"
-git fetch origin main
-git reset --hard origin/main
+git fetch origin "${BRANCH}"
+git reset --hard "origin/${BRANCH}"
 
 echo "==> Installing dependencies..."
 pnpm install --frozen-lockfile
@@ -17,6 +18,8 @@ pnpm --filter tg-bot build
 
 echo "==> Building task-bot..."
 cd "${DEPLOY_DIR}/bots/task-bot"
+git fetch origin "${BRANCH}"
+git reset --hard "origin/${BRANCH}"
 pnpm build
 cd "${DEPLOY_DIR}"
 


### PR DESCRIPTION
## What
- Add  — deploys BE + TG Bot to dev on push to  (PM2:  suffix, ,  DB)
- Add workflow_dispatch branch input to both  and  for manual deploys from any branch
- Add  to CSP connect-src
- Fix double-slash in music CDN URLs by stripping trailing slashes from 
- Update  — prod on main, dev on develop, manual dispatch
- Update  — creates  and  MongoDB databases

## Why
- Production and dev environments need to be isolated on the same OCI VM
- Manual deploy capability needed for hotfixes from any branch
- CSP was blocking  requests in production
- Music CDN URLs had double slashes causing format errors

## Changes
| File | Change |
|------|--------|
|  | New — dev deploy workflow |
|  | Add branch input, use selected branch |
|  | Add prod/dev split, manual dispatch |
|  | Add  to CSP |
|  | Fix CDN URL double-slash |
| ==> Installing Node.js 22... | Add prod/test DBs, Caddy config instructions |