### PR TITLE
fix(ci): update appleboy/ssh-action to v1.0.3 in deploy workflows

### DIFF
--- a/.github/workflows/deploy-oci-dev.yml
+++ b/.github/workflows/deploy-oci-dev.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.OCI_SSH_HOST }}
           username: ${{ secrets.OCI_SSH_USER }}

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.OCI_SSH_HOST }}
           username: ${{ secrets.OCI_SSH_USER }}
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.2
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.OCI_SSH_HOST }}
           username: ${{ secrets.OCI_SSH_USER }}
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to OCI via SSH
-        uses: appleboy/ssh-action@v1.2
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.OCI_SSH_HOST }}
           username: ${{ secrets.OCI_SSH_USER }}


### PR DESCRIPTION
## Summary
- Fixed invalid GitHub Action version  for  in deploy workflows
- Changed to valid version  across all 3 OCI deploy workflows

## Changes
- : Line 47
- : Lines 55, 90, 124

## Why
The action version  doesn't exist, causing the workflow 'Deploy BE + TG Bot (Dev)' to fail with 'Unable to resolve action' error.