### PR TITLE
refactor(task-bot): remove mimo engine, use opencode only

### DIFF
--- a/bots/task-bot/src/ci/ci-poll.service.ts
+++ b/bots/task-bot/src/ci/ci-poll.service.ts
@@ -204,7 +204,7 @@ export class CIFollService implements OnModuleDestroy {
 
           await this.queueService.addCIFixJob(
             prNumber,
-            engine as 'mimo' | 'opencode',
+            engine as 'opencode',
             0,
             0,
             {

--- a/bots/task-bot/src/ci/ci.controller.ts
+++ b/bots/task-bot/src/ci/ci.controller.ts
@@ -52,7 +52,7 @@ export class CIController {
       await this.notificationService.publish({
         jobId: `ci-fix-max-${payload.prNumber}`,
         issueNum: payload.issueNum ?? payload.prNumber,
-        engine: 'mimo',
+        engine: 'opencode',
         success: false,
         message: `CI fix failed after ${maxAttempts} attempts. Manual intervention needed.\nFailed checks: ${payload.failedChecks.join(', ')}`,
         timestamp: Date.now(),
@@ -71,7 +71,7 @@ export class CIController {
     await this.notificationService.publish({
       jobId: `ci-fail-${payload.prNumber}`,
       issueNum: payload.issueNum ?? payload.prNumber,
-      engine: 'mimo',
+      engine: 'opencode',
       success: false,
       message: `CI failed (attempt ${currentAttempts + 1}/${maxAttempts}): ${payload.failedChecks.join(', ')}`,
       timestamp: Date.now(),
@@ -82,7 +82,7 @@ export class CIController {
     try {
       const jobId = await this.queueService.addCIFixJob(
         payload.prNumber,
-        'mimo',
+        'opencode',
         0,
         0,
         {
@@ -112,7 +112,7 @@ export class CIController {
       await this.notificationService.publish({
         jobId: `ci-fix-${payload.prNumber}`,
         issueNum: payload.issueNum ?? payload.prNumber,
-        engine: 'mimo',
+        engine: 'opencode',
         success: false,
         message: (err as Error).message,
         timestamp: Date.now(),

--- a/bots/task-bot/src/github/github.git.service.ts
+++ b/bots/task-bot/src/github/github.git.service.ts
@@ -65,7 +65,7 @@ export class GitHubGitService {
     branchName: string,
     baseBranch: string,
     cwd?: string,
-    engine: 'mimo' | 'opencode' = 'mimo',
+    engine: 'opencode',
   ): { success: boolean; message: string } {
     const workdir = cwd ?? this.getCwd();
     try {
@@ -109,7 +109,7 @@ export class GitHubGitService {
     }
   }
 
-  private resolveWithAI(files: string[], cwd: string, engine: 'mimo' | 'opencode'): boolean {
+  private resolveWithAI(files: string[], cwd: string, engine: 'opencode'): boolean {
     try {
       const conflicts = files.map((f) => {
         try {
@@ -138,17 +138,8 @@ export class GitHubGitService {
       ].join('\n');
 
       const escapedPrompt = prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-      const cli = engine === 'mimo' ? 'mimo' : 'opencode';
-      const runArgs = cli === 'opencode'
-        ? ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions']
-        : ['run', escapedPrompt, '--dangerously-skip-permissions'];
-
-      if (cli === 'mimo') {
-        try {
-          execFileSync('mimo', ['auth', 'login', '-p', 'mimo-free'], { cwd, timeout: 30_000, encoding: 'utf-8' });
-        } catch { /* ignore */ }
-      }
-      execFileSync(cli, runArgs, { cwd, timeout: 120_000, env: { ...process.env, HUSKY: '0' } });
+      const runArgs = ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions'];
+      execFileSync('opencode', runArgs, { cwd, timeout: 120_000, env: { ...process.env, HUSKY: '0' } });
       return true;
     } catch (err) {
       this.logger.error(`AI conflict resolution failed: ${(err as Error).message}`);

--- a/bots/task-bot/src/github/github.service.ts
+++ b/bots/task-bot/src/github/github.service.ts
@@ -93,7 +93,7 @@ export class GitHubService {
     branchName: string,
     baseBranch: string,
     cwd?: string,
-    engine: 'mimo' | 'opencode' = 'mimo',
+    engine: 'opencode',
   ): { success: boolean; message: string } {
     return this.git.resolveConflicts(branchName, baseBranch, cwd, engine);
   }
@@ -199,21 +199,7 @@ export class GitHubService {
 
       const escapedPrompt = prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
 
-      const cli = engine === 'mimo' ? 'mimo' : 'opencode';
-      if (cli === 'mimo') {
-        try {
-          await this.spawnAsync('mimo', ['auth', 'login', '-p', 'mimo-free'], {
-            cwd,
-            timeout: 30_000,
-          });
-        } catch {
-          // ignore — token may already be valid
-        }
-      }
-      const runArgs =
-        cli === 'opencode'
-          ? ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions']
-          : ['run', escapedPrompt, '--dangerously-skip-permissions'];
+      const runArgs = ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions'];
       await this.spawnAsync(cli, runArgs, {
         cwd,
         timeout: 900_000,
@@ -358,21 +344,7 @@ export class GitHubService {
 
       this.git.installDeps(cwd);
 
-      const cli = engine === 'mimo' ? 'mimo' : 'opencode';
-      const runArgs =
-        cli === 'opencode'
-          ? ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions']
-          : ['run', escapedPrompt, '--dangerously-skip-permissions'];
-      if (cli === 'mimo') {
-        try {
-          await this.spawnAsync('mimo', ['auth', 'login', '-p', 'mimo-free'], {
-            cwd,
-            timeout: 30_000,
-          });
-        } catch {
-          // ignore — token may already be valid
-        }
-      }
+      const runArgs = ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions'];
       await this.spawnAsync(cli, runArgs, {
         cwd,
         timeout: 900_000,
@@ -418,7 +390,7 @@ export class GitHubService {
 
   async checkAndFixCI(
     prNumber: string,
-    engine: 'opencode' | 'mimo',
+    engine: 'opencode',
     cwd: string,
     data: {
       branchName: string;
@@ -482,20 +454,8 @@ export class GitHubService {
 
       this.git.installDeps(cwd);
 
-      const cli = engine === 'mimo' ? 'mimo' : 'opencode';
-      if (cli === 'mimo') {
-        try {
-          await this.spawnAsync('mimo', ['auth', 'login', '-p', 'mimo-free'], {
-            cwd,
-            timeout: 30_000,
-          });
-        } catch {
-          // ignore — token may already be valid
-        }
-      }
-      const runArgs = cli === 'opencode'
-        ? ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions']
-        : ['run', escapedPrompt, '--dangerously-skip-permissions'];
+      const cli = 'opencode';
+      const runArgs = ['run', escapedPrompt, '-m', 'opencode/mimo-v2.5-free', '--dangerously-skip-permissions'];
       await this.spawnAsync(cli, runArgs, {
         cwd,
         timeout: 900_000,

--- a/bots/task-bot/src/preferences/preferences.service.ts
+++ b/bots/task-bot/src/preferences/preferences.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 
-type Engine = 'opencode' | 'mimo';
+type Engine = 'opencode';
 
 interface UserPreference {
   engine: Engine;
@@ -51,7 +51,7 @@ export class PreferencesService {
   }
 
   getEngine(userId: number): Engine {
-    return this.preferences.get(userId)?.engine ?? 'mimo';
+    return this.preferences.get(userId)?.engine ?? 'opencode';
   }
 
   getScope(userId: number): string[] {
@@ -60,7 +60,7 @@ export class PreferencesService {
 
   setEngine(userId: number, engine: Engine) {
     const current = this.preferences.get(userId) ?? {
-      engine: 'mimo' as Engine,
+      engine: 'opencode' as Engine,
       defaultScope: ['web'],
     };
     this.preferences.set(userId, { ...current, engine });
@@ -69,7 +69,7 @@ export class PreferencesService {
 
   setScope(userId: number, scope: string[]) {
     const current = this.preferences.get(userId) ?? {
-      engine: 'mimo' as Engine,
+      engine: 'opencode' as Engine,
       defaultScope: ['web'],
     };
     this.preferences.set(userId, { ...current, defaultScope: scope });

--- a/bots/task-bot/src/queue/implement-queue.service.ts
+++ b/bots/task-bot/src/queue/implement-queue.service.ts
@@ -6,7 +6,7 @@ export type JobType = 'implement' | 'fix' | 'ci-fix';
 
 export interface ImplementJobData {
   issueNum: string;
-  engine: 'opencode' | 'mimo';
+  engine: 'opencode';
   chatId: number;
   userId: number;
   type: JobType;
@@ -31,7 +31,7 @@ export class ImplementQueueService {
 
   async addJob(
     issueNum: string,
-    engine: 'opencode' | 'mimo',
+    engine: 'opencode',
     chatId: number,
     userId: number,
     data?: Partial<ImplementJobData>,
@@ -63,7 +63,7 @@ export class ImplementQueueService {
 
   async addFixJob(
     prNumber: string,
-    engine: 'opencode' | 'mimo',
+    engine: 'opencode',
     chatId: number,
     userId: number,
     data: {
@@ -101,7 +101,7 @@ export class ImplementQueueService {
 
   async addCIFixJob(
     prNumber: string,
-    engine: 'opencode' | 'mimo',
+    engine: 'opencode',
     chatId: number,
     userId: number,
     data: {

--- a/bots/task-bot/src/queue/review-queue.service.spec.ts
+++ b/bots/task-bot/src/queue/review-queue.service.spec.ts
@@ -34,7 +34,7 @@ describe('ReviewQueueService', () => {
     it('should add a review job to the queue', async () => {
       const result = await service.addJob(
         '123',
-        'mimo',
+        'opencode',
         123456,
         789,
         'https://github.com/test/pr/1',
@@ -43,7 +43,7 @@ describe('ReviewQueueService', () => {
       expect(mockQueue.add).toHaveBeenCalledWith(
         {
           issueNum: '123',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           prUrl: 'https://github.com/test/pr/1',

--- a/bots/task-bot/src/queue/review-queue.service.ts
+++ b/bots/task-bot/src/queue/review-queue.service.ts
@@ -4,7 +4,7 @@ import { Queue } from 'bull';
 
 export interface ReviewJobData {
   issueNum: string;
-  engine: 'opencode' | 'mimo';
+  engine: 'opencode';
   chatId: number;
   userId: number;
   prUrl: string;
@@ -21,7 +21,7 @@ export class ReviewQueueService {
 
   async addJob(
     issueNum: string,
-    engine: 'opencode' | 'mimo',
+    engine: 'opencode',
     chatId: number,
     userId: number,
     prUrl: string,

--- a/bots/task-bot/src/task-bot/task-bot.callbacks.ts
+++ b/bots/task-bot/src/task-bot/task-bot.callbacks.ts
@@ -184,7 +184,7 @@ async function queueImplementation(
     logger: any;
   },
   issueNum: string,
-  engine: 'opencode' | 'mimo',
+  engine: 'opencode',
   ctx: Context,
 ): Promise<void> {
   const chatId = ctx.chat?.id ?? 0;

--- a/bots/task-bot/src/task-bot/task-bot.commands.ts
+++ b/bots/task-bot/src/task-bot/task-bot.commands.ts
@@ -19,7 +19,7 @@ export async function handleTask(
   const text = ctx.message?.text?.replace(/^\/task\s*/, '');
   if (!text) {
     await ctx.reply(
-      'Usage:\n/task Chess Engine\n/task high Add emotes to games\n\nOptional flags:\n--engine=mimo (default: mimo)\n--high / --urgent / --low\n--req " requirement 1, requirement 2"\nScope: backend, web, mobile, game',
+      'Usage:\n/task Chess Engine\n/task high Add emotes to games\n\nOptional flags:\n--engine=opencode (default: opencode)\n--high / --urgent / --low\n--req " requirement 1, requirement 2"\nScope: backend, web, mobile, game',
     );
     return;
   }
@@ -74,7 +74,7 @@ export async function handleImplement(
   const text = ctx.message?.text ?? '';
   const issueNum = text.match(/#?(\d+)/)?.[1];
   if (!issueNum) {
-    await ctx.reply('Usage: /implement #12 --engine=mimo\n\nValid engines: mimo, opencode');
+    await ctx.reply('Usage: /implement #12 --engine=opencode\n\nValid engines: opencode');
     return;
   }
 
@@ -82,11 +82,11 @@ export async function handleImplement(
   const engineMatch = text.match(/--engine[=:](\S+)/i);
   if (engineMatch) {
     const requested = engineMatch[1].toLowerCase();
-    if (requested !== 'mimo' && requested !== 'opencode') {
-      await ctx.reply(`Invalid engine: ${requested}\n\nValid engines: mimo, opencode\n\nExample: /implement #${issueNum} --engine=mimo`);
+    if (requested !== 'opencode') {
+      await ctx.reply(`Invalid engine: ${requested}\n\nValid engines: opencode\n\nExample: /implement #${issueNum} --engine=opencode`);
       return;
     }
-    engine = requested as 'opencode' | 'mimo';
+    engine = requested as 'opencode';
   }
 
   await queueImplementation(service, issueNum, engine, ctx);
@@ -103,7 +103,7 @@ export async function handleFix(
   const text = ctx.message?.text ?? '';
   const prNum = text.match(/#?(\d+)/)?.[1];
   if (!prNum) {
-    await ctx.reply('Usage: /fix #12 --engine=mimo\n\nFixes CI failures, review comments, and common issues on a PR.\nValid engines: mimo, opencode');
+    await ctx.reply('Usage: /fix #12 --engine=opencode\n\nFixes CI failures, review comments, and common issues on a PR.\nValid engines: opencode');
     return;
   }
 
@@ -111,11 +111,11 @@ export async function handleFix(
   const engineMatch = text.match(/--engine[=:](\S+)/i);
   if (engineMatch) {
     const requested = engineMatch[1].toLowerCase();
-    if (requested !== 'mimo' && requested !== 'opencode') {
-      await ctx.reply(`Invalid engine: ${requested}\n\nValid engines: mimo, opencode\n\nExample: /fix #${prNum} --engine=mimo`);
+    if (requested !== 'opencode') {
+      await ctx.reply(`Invalid engine: ${requested}\n\nValid engines: opencode\n\nExample: /fix #${prNum} --engine=opencode`);
       return;
     }
-    engine = requested as 'opencode' | 'mimo';
+    engine = requested as 'opencode';
   }
 
   const chatId = ctx.chat?.id ?? 0;
@@ -241,9 +241,9 @@ export async function handlePrefs(
   const text = ctx.message?.text ?? '';
   const userId = ctx.from?.id ?? 0;
 
-  const setMatch = text.match(/\/prefs\s+(opencode|mimo)/i);
+  const setMatch = text.match(/\/prefs\s+(opencode)/i);
   if (setMatch) {
-    const engine = setMatch[1].toLowerCase() as 'opencode' | 'mimo';
+    const engine = setMatch[1].toLowerCase() as 'opencode';
     service.prefsService.setEngine(userId, engine);
     await ctx.reply(`Default engine set to *${engine}*`, {
       parse_mode: 'Markdown',
@@ -264,11 +264,11 @@ export async function handlePrefs(
   const current = service.prefsService.getAll(userId);
   await ctx.reply(
     `Current preferences:\n` +
-      `Engine: *${current?.engine ?? 'mimo'}*\n` +
+      `Engine: *${current?.engine ?? 'opencode'}*\n` +
       `Scope: *${current?.defaultScope?.join(', ') ?? 'web'}*\n\n` +
       `Usage:\n` +
       `/prefs opencode — set default engine\n` +
-      `/prefs mimo — set default engine\n` +
+      `/prefs opencode — set default engine\n` +
       `/prefs scope: backend, web — set default scope`,
     { parse_mode: 'Markdown' },
   );

--- a/bots/task-bot/src/task-bot/task-bot.helpers.ts
+++ b/bots/task-bot/src/task-bot/task-bot.helpers.ts
@@ -32,12 +32,12 @@ export function parseTask(
 ): ParsedTask {
   let cleaned = text.trim();
 
-  let engine: Engine = userId && prefsService ? prefsService.getEngine(userId) : 'mimo';
+  let engine: Engine = userId && prefsService ? prefsService.getEngine(userId) : 'opencode';
   const engineMatch = cleaned.match(/--engine[=:](\S+)/i);
   if (engineMatch) {
     const requested = engineMatch[1].toLowerCase();
-    if (requested !== 'mimo' && requested !== 'opencode') {
-      throw new Error(`Invalid engine: ${requested}. Valid engines: mimo, opencode`);
+    if (requested !== 'opencode') {
+      throw new Error(`Invalid engine: ${requested}. Valid engines: opencode`);
     }
     engine = requested as Engine;
     cleaned = cleaned.replace(/--engine=\S+/i, '').trim();

--- a/bots/task-bot/src/task-bot/task-bot.parsing.ts
+++ b/bots/task-bot/src/task-bot/task-bot.parsing.ts
@@ -16,12 +16,12 @@ export function parseTask(
 
   let engine: Engine = userId && prefsService
     ? prefsService.getEngine(userId)
-    : 'mimo';
+    : 'opencode';
   const engineMatch = cleaned.match(/--engine[=:](\S+)/i);
   if (engineMatch) {
     const requested = engineMatch[1].toLowerCase();
-    if (requested !== 'mimo' && requested !== 'opencode') {
-      throw new Error(`Invalid engine: ${requested}. Valid engines: mimo, opencode`);
+    if (requested !== 'opencode') {
+      throw new Error(`Invalid engine: ${requested}. Valid engines: opencode`);
     }
     engine = requested as Engine;
     cleaned = cleaned.replace(/--engine=\S+/i, '').trim();

--- a/bots/task-bot/src/task-bot/task-bot.types.ts
+++ b/bots/task-bot/src/task-bot/task-bot.types.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
-type Engine = 'opencode' | 'mimo';
+type Engine = 'opencode';
 type Priority = 'low' | 'normal' | 'high' | 'urgent';
 
 interface ParsedTask {

--- a/bots/task-bot/src/worker/implement.processor.spec.ts
+++ b/bots/task-bot/src/worker/implement.processor.spec.ts
@@ -61,7 +61,7 @@ describe('ImplementProcessor', () => {
         id: '1',
         data: {
           issueNum: '123',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           type: 'implement' as const,
@@ -76,7 +76,7 @@ describe('ImplementProcessor', () => {
       expect(mockGitHubService.createWorktree).toHaveBeenCalledWith('1');
       expect(mockGitHubService.implementLocally).toHaveBeenCalledWith(
         '123',
-        'mimo',
+        'opencode',
         '/tmp/task-bot/test',
         { title: 'Test Issue', body: '## Requirements\n- [ ] Do something' },
       );
@@ -91,7 +91,7 @@ describe('ImplementProcessor', () => {
         id: '2',
         data: {
           issueNum: '456',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           type: 'fix' as const,
@@ -105,7 +105,7 @@ describe('ImplementProcessor', () => {
 
       expect(mockGitHubService.fixPR).toHaveBeenCalledWith(
         '10',
-        'mimo',
+        'opencode',
         '/tmp/task-bot/test',
         { branchName: 'fix-branch', failedChecks: undefined, reviewComments: undefined },
       );
@@ -118,7 +118,7 @@ describe('ImplementProcessor', () => {
         id: '3',
         data: {
           issueNum: '789',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           type: 'ci-fix' as const,
@@ -133,7 +133,7 @@ describe('ImplementProcessor', () => {
 
       expect(mockGitHubService.checkAndFixCI).toHaveBeenCalledWith(
         '20',
-        'mimo',
+        'opencode',
         '/tmp/task-bot/test',
         {
           branchName: 'ci-branch',
@@ -150,7 +150,7 @@ describe('ImplementProcessor', () => {
         id: '4',
         data: {
           issueNum: '999',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           type: 'implement' as const,
@@ -171,7 +171,7 @@ describe('ImplementProcessor', () => {
         id: '5',
         data: {
           issueNum: '111',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           type: 'implement' as const,
@@ -185,7 +185,7 @@ describe('ImplementProcessor', () => {
 
       expect(mockReviewQueue.addJob).toHaveBeenCalledWith(
         '111',
-        'mimo',
+        'opencode',
         123456,
         789,
         'https://github.com/test/pr/1',
@@ -197,7 +197,7 @@ describe('ImplementProcessor', () => {
         id: '6',
         data: {
           issueNum: '222',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           type: 'implement' as const,
@@ -212,7 +212,7 @@ describe('ImplementProcessor', () => {
       expect(mockCIPollService.startPolling).toHaveBeenCalledWith(
         '1',
         '222',
-        'mimo',
+        'opencode',
       );
     });
   });

--- a/bots/task-bot/src/worker/implement.processor.ts
+++ b/bots/task-bot/src/worker/implement.processor.ts
@@ -187,7 +187,7 @@ export class ImplementProcessor {
     const { type, issueNum } = job.data;
 
     this.logger.log(`Resolving conflicts for ${branchName}`);
-    const conflictResult = this.githubService.resolveConflicts(branchName, 'develop', cwd, job.data.engine as 'mimo' | 'opencode');
+    const conflictResult = this.githubService.resolveConflicts(branchName, 'develop', cwd, job.data.engine as 'opencode');
     if (!conflictResult.success) {
       this.logger.warn(`Conflict resolution: ${conflictResult.message}`);
     }

--- a/bots/task-bot/src/worker/review.processor.spec.ts
+++ b/bots/task-bot/src/worker/review.processor.spec.ts
@@ -28,7 +28,7 @@ describe('ReviewProcessor', () => {
         id: '1',
         data: {
           issueNum: '123',
-          engine: 'mimo',
+          engine: 'opencode',
           chatId: 123456,
           userId: 789,
           prUrl: 'invalid-url',

--- a/bots/task-bot/src/worker/review.processor.ts
+++ b/bots/task-bot/src/worker/review.processor.ts
@@ -76,17 +76,7 @@ export class ReviewProcessor {
 
       const escapedPrompt = prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
 
-      const cli = engine === 'mimo' ? 'mimo' : 'opencode';
-      if (cli === 'mimo') {
-        try {
-          await this.spawnAsync('mimo', ['auth', 'login', '-p', 'mimo-free'], {
-            cwd,
-            timeout: 30_000,
-          });
-        } catch {
-          // ignore — token may already be valid
-        }
-      }
+      const cli = 'opencode';
 
       await job.progress(50);
 


### PR DESCRIPTION
## What
- Remove all mimo engine references from task-bot source code
- Default engine is now opencode only (no more engine selection)
- Removed mimo auth login blocks, engine type unions, and CLI branching

## Why
Mimocode is no longer needed — we only use opencode.

## Changes
- 17 files changed across task-bot source
- Engine type simplified from `'opencode' | 'mimo'` to `'opencode'`
- Removed mimo auth login blocks in github.service.ts, github.git.service.ts, review.processor.ts
- Updated help text, defaults, and validation to only accept opencode
- Spec files updated to match