### PR TITLE
ci: switch dev deployment from develop to staging

### DIFF
--- a/.github/workflows/deploy-oci-dev.yml
+++ b/.github/workflows/deploy-oci-dev.yml
@@ -2,7 +2,7 @@ name: Deploy to OCI (Dev)
 
 on:
   push:
-    branches: [develop]
+    branches: [staging]
     paths:
       - 'apps/be/**'
       - 'bots/tg-bot/**'
@@ -14,7 +14,7 @@ on:
       branch:
         description: 'Branch to deploy'
         required: true
-        default: 'develop'
+        default: 'staging'
 
 permissions: {}
 
@@ -55,7 +55,7 @@ jobs:
             DEPLOY_DIR="/opt/arcadeum"
             cd "$DEPLOY_DIR"
 
-            BRANCH="${{ github.event.inputs.branch || 'develop' }}"
+            BRANCH="${{ github.event.inputs.branch || 'staging' }}"
             git fetch origin "$BRANCH"
             git reset --hard "origin/$BRANCH"
 


### PR DESCRIPTION
## What
- Changed `deploy-oci-dev.yml` to trigger on `staging` branch instead of `develop`
- Updated default branch input from `develop` to `staging`

## Why
Dev environment (`arcadeum-be-dev`) should auto-deploy from `staging` branch, not `develop`. This allows `develop` to be used for prod deployments via the standard merge flow.