### PR TITLE
fix(task-bot): add missing providers to GitHubModule

### DIFF
--- a/bots/task-bot/src/github/github.module.ts
+++ b/bots/task-bot/src/github/github.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { GitHubApiService } from './github.api.service';
+import { GitHubGitService } from './github.git.service';
 import { GitHubService } from './github.service';
 
 @Module({
-  providers: [GitHubService],
+  providers: [GitHubApiService, GitHubGitService, GitHubService],
   exports: [GitHubService],
 })
 export class GitHubModule {}


### PR DESCRIPTION
## What
- Added `GitHubApiService` and `GitHubGitService` as providers in `GitHubModule`

## Why
`GitHubService` depends on `GitHubApiService` and `GitHubGitService` via constructor injection, but `GitHubModule` only declared `GitHubService` as a provider. This caused a `UnknownDependenciesException` crash loop on the task-bot process.