### PR TITLE
feat(web): OCI deployment + cluster mode

### DIFF
--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'apps/be/**'
+      - 'apps/web/**'
       - 'bots/tg-bot/**'
       - 'bots/task-bot/**'
       - 'scripts/shorts-factory/**'
@@ -26,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       be-or-tg: ${{ steps.filter.outputs.be-or-tg }}
+      web: ${{ steps.filter.outputs.web }}
       task-bot: ${{ steps.filter.outputs.task-bot }}
       shorts-factory: ${{ steps.filter.outputs.shorts-factory }}
     steps:
@@ -40,10 +42,52 @@ jobs:
               - 'packages/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
+            web:
+              - 'apps/web/**'
+              - 'packages/ui/**'
             task-bot:
               - 'bots/task-bot/**'
             shorts-factory:
               - 'scripts/shorts-factory/**'
+
+  deploy-web:
+    name: Deploy Web (Next.js)
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.OCI_SSH_HOST }}
+          username: ${{ secrets.OCI_SSH_USER }}
+          key: ${{ secrets.OCI_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.OCI_SSH_PORT || 22 }}
+          script: |
+            set -euo pipefail
+            DEPLOY_DIR="/opt/arcadeum"
+            cd "$DEPLOY_DIR"
+
+            BRANCH="${{ github.event.inputs.branch || 'main' }}"
+            git fetch origin "$BRANCH"
+            git reset --hard "origin/$BRANCH"
+
+            pnpm install --frozen-lockfile
+
+            docker build -f apps/web/Dockerfile -t arcadeum-web .
+
+            docker stop arcadeum-web 2>/dev/null || true
+            docker rm arcadeum-web 2>/dev/null || true
+
+            docker run -d \
+              --name arcadeum-web \
+              --restart unless-stopped \
+              --env-file apps/web/.env.production \
+              -p 3000:3000 \
+              arcadeum-web
+
+            echo "==> Web deploy done (branch: $BRANCH)!"
+            docker ps --filter name=arcadeum-web
 
   deploy-tg-bot:
     name: Deploy TG Bot + Backend

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -117,7 +117,7 @@ jobs:
             pnpm --filter tg-bot build
 
             pm2 restart arcadeum-be arcadeum-tg-bot || \
-              (pm2 start "node apps/be/dist/src/main.js" --name arcadeum-be && \
+              (pm2 start "node apps/be/dist/src/main.js" --name arcadeum-be -i max && \
                pm2 start "node bots/tg-bot/dist/src/main.js" --name arcadeum-tg-bot && \
                pm2 save)
 

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+.github
+*.md
+.env*
+!.env.example

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:22-alpine AS base
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/ui/package.json ./packages/ui/
+RUN corepack enable && pnpm install --frozen-lockfile
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /app/packages/ui/node_modules ./packages/ui/node_modules
+COPY . .
+RUN corepack enable && pnpm --filter web build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/apps/web/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -53,23 +53,11 @@ const withPWA = withPWAInit({
   },
 });
 
-const cspConnectSrc = [
+const defaultConnectSrc = [
   'https://arcadeum.games',
   'wss://arcadeum.games',
-  'https://arcadeum.vercel.app',
-  'wss://arcadeum.vercel.app',
-  'https://arcadeum-dev.vercel.app',
-  'wss://arcadeum-dev.vercel.app',
-  'https://arcadeum-be-dev.onrender.com',
-  'wss://arcadeum-be-dev.onrender.com',
-  'https://arcadeum-be.onrender.com',
-  'wss://arcadeum-be.onrender.com',
-  'https://arcadeum-be-reserve.onrender.com',
-  'wss://arcadeum-be-reserve.onrender.com',
   'https://api.arcadeum.games',
   'wss://api.arcadeum.games',
-  'https://api2.arcadeum.games',
-  'wss://api2.arcadeum.games',
   'https://api-dev.arcadeum.games',
   'wss://api-dev.arcadeum.games',
   'https://accounts.google.com',
@@ -79,20 +67,20 @@ const cspConnectSrc = [
   process.env.NEXT_PUBLIC_CDN_URL || '',
 ];
 
+const cspConnectSrc = process.env.CSP_CONNECT_SRC
+  ? (JSON.parse(process.env.CSP_CONNECT_SRC) as string[])
+  : defaultConnectSrc;
+
 const cspScriptSrc = "'unsafe-inline' https://vercel.live https://*.vercel.app";
-
 const cspStyleSrc = "'self' 'unsafe-inline'";
-
 const cspImgSrc = "'self' blob: data: https:";
-
 const cspFontSrc = "'self' data:";
-
 const cspFrameSrc =
   "'self' https://www.youtube-nocookie.com https://vercel.com https://vercel.live";
-
 const cspMediaSrc = `'self' ${process.env.NEXT_PUBLIC_CDN_URL || ''}`;
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   headers: async () => {
     const isDev = process.env.NODE_ENV === 'development';
     const isE2E =

--- a/docs/oci-migration-plan.md
+++ b/docs/oci-migration-plan.md
@@ -18,6 +18,8 @@
 | Backend (NestJS)   | OCI Primary (same machine) | ~5ms             |
 | Database (MongoDB) | OCI Primary (same machine) | ~1ms             |
 
+**Subdomain**: `fast.arcadeum.games` (keeps Vercel as fallback on apex)
+
 ## Resource Requirements
 
 | Resource  | Primary (current) | Next.js needs      | Available        |
@@ -135,10 +137,11 @@ module.exports = {
 
 ### 6. DNS Update
 
-| Record               | Type  | Value          | TTL |
-| -------------------- | ----- | -------------- | --- |
-| `arcadeum.games`     | A     | 152.70.47.29   | 300 |
-| `www.arcadeum.games` | CNAME | arcadeum.games | 300 |
+| Record                | Type  | Value          | TTL |
+| --------------------- | ----- | -------------- | --- |
+| `fast.arcadeum.games` | A     | 152.70.47.29   | 300 |
+| `arcadeum.games`      | CNAME | vercel.app     | 300 |
+| `www.arcadeum.games`  | CNAME | arcadeum.games | 300 |
 
 Keep `api.arcadeum.games` → 152.70.47.29 (unchanged).
 
@@ -176,8 +179,8 @@ jobs:
 ### 8. SSL Certificate
 
 ```bash
-# On OCI primary
-sudo certbot --nginx -d arcadeum.games -d www.arcadeum.games
+# On OCI primary — fast.arcadeum.games
+sudo certbot --nginx -d fast.arcadeum.games
 ```
 
 ## Static Assets Strategy
@@ -209,9 +212,10 @@ Since OCI is single-region, static assets (images, fonts, JS bundles) will be sl
 - [ ] Create Dockerfile
 - [ ] Test locally with Docker
 - [ ] Deploy to OCI
-- [ ] Configure nginx
-- [ ] Update DNS
-- [ ] Verify SSL
-- [ ] Update CI/CD
+- [ ] Configure nginx for `fast.arcadeum.games`
+- [ ] Add DNS A record: `fast.arcadeum.games` → 152.70.47.29
+- [ ] Verify SSL on `fast.arcadeum.games`
+- [ ] CI/CD auto-deploy from main ✅ (updated deploy-oci.yml)
+- [ ] Disable Vercel auto-deploy ✅ (deploy-web.yml now manual only)
 - [ ] Monitor for 24h
 - [ ] Remove Vercel (optional)


### PR DESCRIPTION
## Changes
- Add Dockerfile for standalone Next.js build
- Add .dockerignore for faster builds
- Update deploy-oci.yml with web deploy job
- Update next.config.ts with output: standalone + CSP_CONNECT_SRC env var
- Enable PM2 cluster mode for 3x BE instances
- Document fast.arcadeum.games subdomain in migration plan

## Deployment
Manual deploy to OCI needed — workflow only triggers on main.