### PR TITLE
fix(web): sea battle rematch, tic-tac-toe hover cursor & chat highlighting

### DIFF
--- a/apps/be/src/announcements/announcements.service.ts
+++ b/apps/be/src/announcements/announcements.service.ts
@@ -122,7 +122,9 @@ export class AnnouncementsService {
     locale: AnnouncementLocale,
   ): Promise<AnnouncementPublicItem | null> {
     const cacheKey = `announcement:active:${isAuthenticated ? 'auth' : 'anon'}:${locale}`;
-    const cached = await this.cache.get<AnnouncementPublicItem | null>(cacheKey);
+    const cached = await this.cache.get<AnnouncementPublicItem | null>(
+      cacheKey,
+    );
     if (cached !== undefined) return cached;
 
     const now = new Date();
@@ -138,7 +140,11 @@ export class AnnouncementsService {
       .sort({ severityRank: -1, startsAt: -1, _id: -1 })
       .lean<AnnouncementLean | null>();
     const result = doc ? this.toPublicItem(doc, locale) : null;
-    await this.cache.set(cacheKey, result, AnnouncementsService.ACTIVE_CACHE_TTL_MS);
+    await this.cache.set(
+      cacheKey,
+      result,
+      AnnouncementsService.ACTIVE_CACHE_TTL_MS,
+    );
     return result;
   }
 
@@ -175,7 +181,9 @@ export class AnnouncementsService {
     const locales = ['en', 'ru', 'es', 'fr', 'by'];
     for (const auth of auths) {
       for (const locale of locales) {
-        await this.cache.del(`announcement:active:${auth}:${locale}`).catch(() => {});
+        await this.cache
+          .del(`announcement:active:${auth}:${locale}`)
+          .catch(() => {});
       }
     }
   }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -141,6 +141,8 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
     const { userId } = context;
     const player = state.players.find((p) => p.playerId === userId);
 
+    if (action === 'chat') return true;
+
     if (!player || !player.alive) return false;
 
     switch (action) {
@@ -171,8 +173,6 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
         return validateUseRadar(state, player, payload as RadarPayload);
       case 'resetPlacement':
         return validateResetPlacement(state, player);
-      case 'chat':
-        return true;
       default:
         return false;
     }

--- a/apps/be/src/games/games-history.facade.ts
+++ b/apps/be/src/games/games-history.facade.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@nestjs/common';
 import { ChatScope } from './engines/base/game-engine.interface';
 import { GameHistoryService } from './history/game-history.service';
 import { GameSessionsService } from './sessions/game-sessions.service';
@@ -10,6 +11,7 @@ import type { GameSessionSummary } from './sessions/game-sessions.service';
  * Games History Facade
  * Delegates history-related operations from GamesService
  */
+@Injectable()
 export class GamesHistoryFacade {
   constructor(
     private readonly historyService: GameHistoryService,

--- a/apps/be/src/games/games.module.ts
+++ b/apps/be/src/games/games.module.ts
@@ -39,6 +39,7 @@ import { GameSessionsCleanupCron } from './sessions/game-sessions.cleanup.cron';
 import { GameHistoryService } from './history/game-history.service';
 import { GameHistoryBuilderService } from './history/game-history-builder.service';
 import { GameHistoryStatsService } from './history/game-history-stats.service';
+import { GameHistoryRematchService } from './history/game-history-rematch.service';
 import { CriticalActionsService } from './actions/critical/critical-actions.service';
 import { TexasHoldemActionsService } from './actions/texas-holdem/texas-holdem-actions.service';
 import { GameUtilitiesService } from './utilities/game-utilities.service';
@@ -156,6 +157,7 @@ import { resolveJwtSecret } from '../common/utils/jwt-secret.util';
     GameHistoryService,
     GameHistoryBuilderService,
     GameHistoryStatsService,
+    GameHistoryRematchService,
     GamesRealtimeService,
     // Game-specific action handlers
     CriticalActionsService,

--- a/apps/be/src/games/history/game-history-rematch.service.ts
+++ b/apps/be/src/games/history/game-history-rematch.service.ts
@@ -1,0 +1,216 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { GameRoom } from '../schemas/game-room.schema';
+import { HistoryRematchDto } from '../dtos/history-rematch.dto';
+import { escapeRegExp } from '../../common/utils/escape-regexp';
+import {
+  ATLAS_CONNECTION,
+  OCI_CONNECTION,
+} from '../../common/providers/mongo-connections.provider';
+
+@Injectable()
+export class GameHistoryRematchService {
+  constructor(
+    @InjectModel(GameRoom.name, ATLAS_CONNECTION)
+    private readonly gameRoomModel: Model<GameRoom>,
+    @InjectModel(GameRoom.name, OCI_CONNECTION)
+    private readonly ociRoomModel?: Model<GameRoom>,
+  ) {}
+
+  async createRematchFromHistory(
+    dto: HistoryRematchDto,
+    userId: string,
+  ): Promise<{ id: string; invitedIds: string[] }> {
+    const { roomId: originalRoomId, participantIds } = dto;
+
+    // Atomically claim the rematch lock — only one player can create a
+    // rematch from a given room at a time.  If rematchPending is already
+    // true we reject immediately instead of creating duplicate rooms.
+    const lockedRoom = await this.gameRoomModel
+      .findOneAndUpdate(
+        { _id: originalRoomId, rematchPending: { $ne: true } },
+        { $set: { rematchPending: true } },
+        { new: true },
+      )
+      .lean()
+      .exec();
+
+    let originalRoom = lockedRoom;
+
+    // If Atlas didn't have it (or it was already locked), try OCI
+    if (!originalRoom && this.ociRoomModel) {
+      const ociLocked = await this.ociRoomModel
+        .findOneAndUpdate(
+          { _id: originalRoomId, rematchPending: { $ne: true } },
+          { $set: { rematchPending: true } },
+          { new: true },
+        )
+        .lean()
+        .exec();
+      if (ociLocked) {
+        originalRoom = ociLocked;
+        // Mirror the lock back to Atlas
+        try {
+          await this.gameRoomModel.updateOne(
+            { _id: originalRoomId },
+            { $set: { rematchPending: true } },
+          );
+        } catch {
+          // Best-effort mirror — game works from OCI if Atlas fails
+        }
+      }
+    }
+
+    if (!originalRoom) {
+      // Either room doesn't exist or rematch is already in progress
+      const exists = await this.gameRoomModel
+        .findById(originalRoomId)
+        .select('_id')
+        .lean()
+        .exec();
+      if (!exists) {
+        throw new NotFoundException(
+          `Original room not found: ${originalRoomId}`,
+        );
+      }
+      throw new BadRequestException('Rematch already in progress');
+    }
+
+    try {
+      const isParticipant =
+        originalRoom.hostId === userId ||
+        originalRoom.participants.some((p) => p.userId === userId);
+
+      if (!isParticipant) {
+        throw new BadRequestException(
+          'You were not a participant in the original game',
+        );
+      }
+
+      const originalParticipantIds = originalRoom.participants
+        .map((p) => p.userId)
+        .filter((id) => id !== userId);
+
+      const invitedIds =
+        participantIds && participantIds.length > 0
+          ? participantIds.filter((id) => id !== userId)
+          : originalParticipantIds;
+
+      const now = new Date();
+      const participants: { userId: string; joinedAt: Date }[] = [
+        { userId, joinedAt: now },
+      ];
+      const carriedOptions = dto.gameOptions || originalRoom.gameOptions || {};
+      const carriedTeams = (
+        carriedOptions as {
+          teams?: { playerIds?: string[]; targetSize?: number }[];
+        }
+      ).teams;
+      if (Array.isArray(carriedTeams)) {
+        const seen = new Set<string>([userId]);
+        for (const team of carriedTeams) {
+          if (!Array.isArray(team.playerIds)) continue;
+          for (const pid of team.playerIds) {
+            if (typeof pid !== 'string') continue;
+            if (!pid.startsWith('bot-')) continue;
+            if (seen.has(pid)) continue;
+            seen.add(pid);
+            participants.push({ userId: pid, joinedAt: now });
+          }
+        }
+      }
+
+      const rematchMaxPlayers = Array.isArray(carriedTeams)
+        ? Math.max(
+            originalRoom.maxPlayers ?? 0,
+            carriedTeams.reduce(
+              (sum, t) =>
+                sum + (typeof t.targetSize === 'number' ? t.targetSize : 0),
+              0,
+            ),
+            participants.length,
+          )
+        : originalRoom.maxPlayers;
+
+      const rematchSuffixMatch = originalRoom.name.match(/^(.+?) Rematch \d+$/);
+      const baseName = rematchSuffixMatch
+        ? rematchSuffixMatch[1]
+        : originalRoom.name;
+
+      const escapedBaseName = escapeRegExp(baseName);
+      const existingRematches = await this.gameRoomModel
+        .find({
+          name: { $regex: new RegExp(`^${escapedBaseName} Rematch \\d+$`) },
+        })
+        .select('name')
+        .lean()
+        .exec();
+
+      const usedNumbers = new Set(
+        existingRematches
+          .map((r) => {
+            const match = r.name.match(/ Rematch (\d+)$/);
+            return match ? parseInt(match[1], 10) : 0;
+          })
+          .filter((n) => n > 0),
+      );
+
+      let rematchNumber = 1;
+      while (usedNumbers.has(rematchNumber)) {
+        rematchNumber++;
+      }
+      const rematchName = `${baseName} Rematch ${rematchNumber}`;
+
+      const newRoom = await this.gameRoomModel.create({
+        gameId: originalRoom.gameId,
+        name: rematchName,
+        hostId: userId,
+        visibility: originalRoom.visibility,
+        maxPlayers: rematchMaxPlayers,
+        participants,
+        status: 'lobby',
+        createdAt: now,
+        updatedAt: now,
+        gameOptions: {
+          ...(dto.gameOptions || originalRoom.gameOptions || {}),
+          rematchInvitedIds: invitedIds,
+          rematchMessage: dto.message,
+          rematchPreviousRoomId: originalRoomId,
+        },
+      });
+
+      if (this.ociRoomModel) {
+        try {
+          await this.ociRoomModel.findOneAndUpdate(
+            { _id: newRoom._id },
+            { $set: newRoom.toObject() },
+            { upsert: true },
+          );
+        } catch {
+          // OCI mirror is best-effort; game works from Atlas
+        }
+      }
+
+      return { id: newRoom._id.toString(), invitedIds };
+    } catch (err) {
+      // Release the lock on failure so the other player can retry
+      await this.gameRoomModel
+        .updateOne({ _id: originalRoomId }, { $set: { rematchPending: false } })
+        .catch(() => {});
+      if (this.ociRoomModel) {
+        await this.ociRoomModel
+          .updateOne(
+            { _id: originalRoomId },
+            { $set: { rematchPending: false } },
+          )
+          .catch(() => {});
+      }
+      throw err;
+    }
+  }
+}

--- a/apps/be/src/games/history/game-history-rematch.service.ts
+++ b/apps/be/src/games/history/game-history-rematch.service.ts
@@ -15,12 +15,19 @@ import {
 
 @Injectable()
 export class GameHistoryRematchService {
+  private readonly primary: Model<GameRoom>;
+  private readonly mirror: Model<GameRoom> | undefined;
+
   constructor(
     @InjectModel(GameRoom.name, ATLAS_CONNECTION)
-    private readonly gameRoomModel: Model<GameRoom>,
+    atlasModel: Model<GameRoom> | undefined,
     @InjectModel(GameRoom.name, OCI_CONNECTION)
-    private readonly ociRoomModel?: Model<GameRoom>,
-  ) {}
+    ociModel: Model<GameRoom> | undefined,
+  ) {
+    // Prefer Atlas when available; fall back to OCI
+    this.primary = atlasModel ?? ociModel!;
+    this.mirror = atlasModel ? ociModel : undefined;
+  }
 
   async createRematchFromHistory(
     dto: HistoryRematchDto,
@@ -31,7 +38,7 @@ export class GameHistoryRematchService {
     // Atomically claim the rematch lock — only one player can create a
     // rematch from a given room at a time.  If rematchPending is already
     // true we reject immediately instead of creating duplicate rooms.
-    const lockedRoom = await this.gameRoomModel
+    const lockedRoom = await this.primary
       .findOneAndUpdate(
         { _id: originalRoomId, rematchPending: { $ne: true } },
         { $set: { rematchPending: true } },
@@ -42,9 +49,9 @@ export class GameHistoryRematchService {
 
     let originalRoom = lockedRoom;
 
-    // If Atlas didn't have it (or it was already locked), try OCI
-    if (!originalRoom && this.ociRoomModel) {
-      const ociLocked = await this.ociRoomModel
+    // If primary didn't have it (or it was already locked), try mirror
+    if (!originalRoom && this.mirror) {
+      const mirrorLocked = await this.mirror
         .findOneAndUpdate(
           { _id: originalRoomId, rematchPending: { $ne: true } },
           { $set: { rematchPending: true } },
@@ -52,23 +59,23 @@ export class GameHistoryRematchService {
         )
         .lean()
         .exec();
-      if (ociLocked) {
-        originalRoom = ociLocked;
-        // Mirror the lock back to Atlas
+      if (mirrorLocked) {
+        originalRoom = mirrorLocked;
+        // Mirror the lock back to primary
         try {
-          await this.gameRoomModel.updateOne(
+          await this.primary.updateOne(
             { _id: originalRoomId },
             { $set: { rematchPending: true } },
           );
         } catch {
-          // Best-effort mirror — game works from OCI if Atlas fails
+          // Best-effort mirror — game works from mirror if primary fails
         }
       }
     }
 
     if (!originalRoom) {
       // Either room doesn't exist or rematch is already in progress
-      const exists = await this.gameRoomModel
+      const exists = await this.primary
         .findById(originalRoomId)
         .select('_id')
         .lean()
@@ -143,7 +150,7 @@ export class GameHistoryRematchService {
         : originalRoom.name;
 
       const escapedBaseName = escapeRegExp(baseName);
-      const existingRematches = await this.gameRoomModel
+      const existingRematches = await this.primary
         .find({
           name: { $regex: new RegExp(`^${escapedBaseName} Rematch \\d+$`) },
         })
@@ -166,7 +173,7 @@ export class GameHistoryRematchService {
       }
       const rematchName = `${baseName} Rematch ${rematchNumber}`;
 
-      const newRoom = await this.gameRoomModel.create({
+      const newRoom = await this.primary.create({
         gameId: originalRoom.gameId,
         name: rematchName,
         hostId: userId,
@@ -184,26 +191,26 @@ export class GameHistoryRematchService {
         },
       });
 
-      if (this.ociRoomModel) {
+      if (this.mirror) {
         try {
-          await this.ociRoomModel.findOneAndUpdate(
+          await this.mirror.findOneAndUpdate(
             { _id: newRoom._id },
             { $set: newRoom.toObject() },
             { upsert: true },
           );
         } catch {
-          // OCI mirror is best-effort; game works from Atlas
+          // Mirror is best-effort; game works from primary
         }
       }
 
       return { id: newRoom._id.toString(), invitedIds };
     } catch (err) {
       // Release the lock on failure so the other player can retry
-      await this.gameRoomModel
+      await this.primary
         .updateOne({ _id: originalRoomId }, { $set: { rematchPending: false } })
         .catch(() => {});
-      if (this.ociRoomModel) {
-        await this.ociRoomModel
+      if (this.mirror) {
+        await this.mirror
           .updateOne(
             { _id: originalRoomId },
             { $set: { rematchPending: false } },

--- a/apps/be/src/games/history/game-history-rematch.service.ts
+++ b/apps/be/src/games/history/game-history-rematch.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  Optional,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
@@ -19,10 +20,12 @@ export class GameHistoryRematchService {
   private readonly mirror: Model<GameRoom> | undefined;
 
   constructor(
+    @Optional()
     @InjectModel(GameRoom.name, ATLAS_CONNECTION)
-    atlasModel: Model<GameRoom> | undefined,
+    atlasModel?: Model<GameRoom>,
+    @Optional()
     @InjectModel(GameRoom.name, OCI_CONNECTION)
-    ociModel: Model<GameRoom> | undefined,
+    ociModel?: Model<GameRoom>,
   ) {
     // Prefer Atlas when available; fall back to OCI
     this.primary = atlasModel ?? ociModel!;

--- a/apps/be/src/games/history/game-history.service.ts
+++ b/apps/be/src/games/history/game-history.service.ts
@@ -20,18 +20,23 @@ import {
 } from './game-history.types';
 import { GameHistoryBuilderService } from './game-history-builder.service';
 import { GameHistoryStatsService } from './game-history-stats.service';
+import { GameHistoryRematchService } from './game-history-rematch.service';
 import { escapeRegExp } from '../../common/utils/escape-regexp';
 import { isValidStatus } from '../game-validation.util';
 import {
   BaseGameState,
   ChatScope,
 } from '../engines/base/game-engine.interface';
-import { ATLAS_CONNECTION } from '../../common/providers/mongo-connections.provider';
+import {
+  ATLAS_CONNECTION,
+  OCI_CONNECTION,
+} from '../../common/providers/mongo-connections.provider';
 @Injectable()
 export class GameHistoryService {
   constructor(
     private readonly builder: GameHistoryBuilderService,
     private readonly statsService: GameHistoryStatsService,
+    private readonly rematchService: GameHistoryRematchService,
     @Optional()
     @InjectModel(GameSession.name, ATLAS_CONNECTION)
     private readonly gameSessionModel?: Model<GameSession>,
@@ -44,6 +49,9 @@ export class GameHistoryService {
     @Optional()
     @InjectModel(User.name, ATLAS_CONNECTION)
     private readonly userModel?: Model<User>,
+    @Optional()
+    @InjectModel(GameRoom.name, OCI_CONNECTION)
+    private readonly ociRoomModel?: Model<GameRoom>,
   ) {}
   private get atlasReady(): boolean {
     return !!(
@@ -292,139 +300,7 @@ export class GameHistoryService {
     dto: HistoryRematchDto,
     userId: string,
   ): Promise<{ id: string; invitedIds: string[] }> {
-    if (!this.gameRoomModel)
-      throw new NotFoundException('History service unavailable');
-    const { roomId: originalRoomId, participantIds } = dto;
-
-    // Get original room
-    const originalRoom = await this.gameRoomModel
-      .findById(originalRoomId)
-      .lean()
-      .exec();
-
-    if (!originalRoom) {
-      throw new NotFoundException(`Original room not found: ${originalRoomId}`);
-    }
-
-    // Check if user was a participant
-    const isParticipant =
-      originalRoom.hostId === userId ||
-      originalRoom.participants.some((p) => p.userId === userId);
-
-    if (!isParticipant) {
-      throw new BadRequestException(
-        'You were not a participant in the original game',
-      );
-    }
-
-    // Determine which participants to invite
-    // If participantIds is provided and not empty, use those
-    // Otherwise, invite all original participants (except the new host)
-    const originalParticipantIds = originalRoom.participants
-      .map((p) => p.userId)
-      .filter((id) => id !== userId);
-
-    const invitedIds =
-      participantIds && participantIds.length > 0
-        ? participantIds.filter((id) => id !== userId) // filter out host
-        : originalParticipantIds;
-
-    // Build participants array: host + any bots that were stamped into the
-    // carried-over team config. Without this, team-mode rematches start with
-    // empty seats — startSession then fails with "Not enough players" because
-    // the bot ids referenced in teams aren't actually room participants.
-    const now = new Date();
-    const participants: { userId: string; joinedAt: Date }[] = [
-      { userId, joinedAt: now },
-    ];
-    const carriedOptions = dto.gameOptions || originalRoom.gameOptions || {};
-    const carriedTeams = (
-      carriedOptions as {
-        teams?: { playerIds?: string[]; targetSize?: number }[];
-      }
-    ).teams;
-    if (Array.isArray(carriedTeams)) {
-      const seen = new Set<string>([userId]);
-      for (const team of carriedTeams) {
-        if (!Array.isArray(team.playerIds)) continue;
-        for (const pid of team.playerIds) {
-          if (typeof pid !== 'string') continue;
-          if (!pid.startsWith('bot-')) continue;
-          if (seen.has(pid)) continue;
-          seen.add(pid);
-          participants.push({ userId: pid, joinedAt: now });
-        }
-      }
-    }
-
-    // In team mode the room cap must accommodate the team config (up to 8 in
-    // MAX_PLAYERS_TEAM_MODE). Without this bump, rematching out of a small
-    // FFA-sized room (maxPlayers=5/6) into a team game leaves the lobby
-    // showing "8 / 6" once the bots get added.
-    const rematchMaxPlayers = Array.isArray(carriedTeams)
-      ? Math.max(
-          originalRoom.maxPlayers ?? 0,
-          carriedTeams.reduce(
-            (sum, t) =>
-              sum + (typeof t.targetSize === 'number' ? t.targetSize : 0),
-            0,
-          ),
-          participants.length,
-        )
-      : originalRoom.maxPlayers;
-
-    // Generate rematch name: "someName" -> "someName Rematch 1" -> "someName Rematch 2"
-    // Extract base name (strip existing " Rematch N" suffix if present)
-    const rematchSuffixMatch = originalRoom.name.match(/^(.+?) Rematch \d+$/);
-    const baseName = rematchSuffixMatch
-      ? rematchSuffixMatch[1]
-      : originalRoom.name;
-
-    // Find existing rematch rooms with the same base name
-    const escapedBaseName = escapeRegExp(baseName);
-    const existingRematches = await this.gameRoomModel
-      .find({
-        name: { $regex: new RegExp(`^${escapedBaseName} Rematch \\d+$`) },
-      })
-      .select('name')
-      .lean()
-      .exec();
-
-    const usedNumbers = new Set(
-      existingRematches
-        .map((r) => {
-          const match = r.name.match(/ Rematch (\d+)$/);
-          return match ? parseInt(match[1], 10) : 0;
-        })
-        .filter((n) => n > 0),
-    );
-
-    let rematchNumber = 1;
-    while (usedNumbers.has(rematchNumber)) {
-      rematchNumber++;
-    }
-    const rematchName = `${baseName} Rematch ${rematchNumber}`;
-
-    // Create new room with same settings
-    const newRoom = await this.gameRoomModel.create({
-      gameId: originalRoom.gameId,
-      name: rematchName,
-      hostId: userId,
-      visibility: originalRoom.visibility,
-      maxPlayers: rematchMaxPlayers,
-      participants,
-      status: 'lobby',
-      createdAt: now,
-      updatedAt: now,
-      gameOptions: {
-        ...(dto.gameOptions || originalRoom.gameOptions || {}),
-        rematchInvitedIds: invitedIds,
-        rematchMessage: dto.message,
-        rematchPreviousRoomId: originalRoomId,
-      },
-    });
-
-    return { id: newRoom._id.toString(), invitedIds };
+    return this.rematchService.createRematchFromHistory(dto, userId);
   }
 
   /**

--- a/apps/be/src/games/schemas/game-room.schema.ts
+++ b/apps/be/src/games/schemas/game-room.schema.ts
@@ -83,6 +83,9 @@ export class GameRoom extends Document {
   @Prop({ type: Object, default: {} })
   gameOptions?: Record<string, unknown>;
 
+  @Prop({ type: Boolean, default: false })
+  rematchPending?: boolean;
+
   createdAt: Date;
   updatedAt: Date;
 }

--- a/apps/be/src/shop/lib/shop-catalog.banners.ts
+++ b/apps/be/src/shop/lib/shop-catalog.banners.ts
@@ -157,7 +157,8 @@ export const BANNERS: Record<string, ShopItemDef> = {
     nameKey: 'items.banner.supernova.name',
     descKey: 'items.banner.supernova.desc',
     assetUrl: '',
-    colorValue: 'linear-gradient(135deg, #ff007f 0%, #ffaa00 50%, #00ffff 100%)',
+    colorValue:
+      'linear-gradient(135deg, #ff007f 0%, #ffaa00 50%, #00ffff 100%)',
     defaultPriceAmount: 30,
     defaultPriceCurrency: 'gems',
   },
@@ -168,7 +169,8 @@ export const BANNERS: Record<string, ShopItemDef> = {
     nameKey: 'items.banner.synthwave.name',
     descKey: 'items.banner.synthwave.desc',
     assetUrl: '',
-    colorValue: 'linear-gradient(135deg, #2e0854 0%, #ff00a0 50%, #00ffff 100%)',
+    colorValue:
+      'linear-gradient(135deg, #2e0854 0%, #ff00a0 50%, #00ffff 100%)',
     defaultPriceAmount: 25,
     defaultPriceCurrency: 'gems',
   },

--- a/apps/be/src/shop/lib/shop-catalog.frames.ts
+++ b/apps/be/src/shop/lib/shop-catalog.frames.ts
@@ -170,7 +170,8 @@ export const FRAMES: Record<string, ShopItemDef> = {
     nameKey: 'items.frame.supernova.name',
     descKey: 'items.frame.supernova.desc',
     assetUrl: '',
-    colorValue: 'linear-gradient(135deg, #ff007f 0%, #ffaa00 50%, #00ffff 100%)',
+    colorValue:
+      'linear-gradient(135deg, #ff007f 0%, #ffaa00 50%, #00ffff 100%)',
     defaultPriceAmount: 35,
     defaultPriceCurrency: 'gems',
   },

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -12,6 +12,7 @@ import { useEmotes } from '@/features/games/hooks/useEmotes';
 import { ActiveEmotesProvider } from '@/features/games/ui/GameWidgetContainer';
 import type { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
+import { useGameRematchStore } from '@/features/games/store/gameRematchStore';
 import { AutoExitFullscreenOnFinish } from './AutoExitFullscreenOnFinish';
 import { Container, fullscreenStyles } from './styles';
 import { GameRow, ChatPanel } from './layoutStyles';
@@ -139,6 +140,8 @@ export function GamePageLayout(props: GamePageLayoutProps) {
       .registerFallbackResolveDisplayName(resolveDisplayName);
   }, [resolveDisplayName]);
 
+  const { isGameOver, onRematch, rematchLoading } = useGameRematchStore();
+
   return (
     <>
       <style>{fullscreenStyles}</style>
@@ -184,10 +187,15 @@ export function GamePageLayout(props: GamePageLayoutProps) {
           onToggleChat={handleToggleChat}
           onShowRules={onShowRules}
           isSpectating={isSpectating}
+          isGameOver={isGameOver}
+          onRematch={onRematch ?? undefined}
+          rematchLoading={rematchLoading}
         />
 
         <GameRow flexDirection={roomFlexDirection}>
-          <ActiveEmotesProvider value={{ emotes: activeEmotes, resolveDisplayName }}>
+          <ActiveEmotesProvider
+            value={{ emotes: activeEmotes, resolveDisplayName }}
+          >
             {children({ isFullscreen, toggleFullscreen })}
           </ActiveEmotesProvider>
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -159,7 +159,7 @@ export default async function RootLayout({
           Skip to content
         </a>
         <WebVitalsReporter />
-        {process.env.NODE_ENV === 'production' && (
+        {process.env.NODE_ENV === 'production' && process.env.VERCEL && (
           <>
             <SpeedInsights />
             <Analytics />

--- a/apps/web/src/features/games/hooks/useGameEndState.ts
+++ b/apps/web/src/features/games/hooks/useGameEndState.ts
@@ -73,6 +73,7 @@ export function useGameEndState({
       dismissResult: dismiss,
 
       rematchLoading: rematch.rematchLoading,
+      rematchError: rematch.rematchError,
       showRematchModal: rematch.showRematchModal,
       openRematchModal: rematch.openRematchModal,
       closeRematchModal: rematch.closeRematchModal,
@@ -96,6 +97,7 @@ export function useGameEndState({
       defaultMessages,
       dismiss,
       rematch.rematchLoading,
+      rematch.rematchError,
       rematch.showRematchModal,
       rematch.openRematchModal,
       rematch.closeRematchModal,

--- a/apps/web/src/features/games/store/gameRematchStore.ts
+++ b/apps/web/src/features/games/store/gameRematchStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface GameRematchState {
+  isGameOver: boolean;
+  onRematch: (() => void) | null;
+  rematchLoading: boolean;
+  setRematchState: (state: {
+    isGameOver: boolean;
+    onRematch: (() => void) | null;
+    rematchLoading: boolean;
+  }) => void;
+  reset: () => void;
+}
+
+export const useGameRematchStore = create<GameRematchState>((set) => ({
+  isGameOver: false,
+  onRematch: null,
+  rematchLoading: false,
+  setRematchState: (state) => set(state),
+  reset: () =>
+    set({ isGameOver: false, onRematch: null, rematchLoading: false }),
+}));

--- a/apps/web/src/features/games/ui/GameEndModals.tsx
+++ b/apps/web/src/features/games/ui/GameEndModals.tsx
@@ -41,6 +41,7 @@ export function GameEndModals({
           players={players}
           currentUserId={currentUserId}
           rematchLoading={gameEnd.rematchLoading}
+          rematchError={gameEnd.rematchError}
           onClose={gameEnd.closeRematchModal}
           onConfirm={gameEnd.handleRematch}
           t={t}

--- a/apps/web/src/features/games/ui/RematchModal.tsx
+++ b/apps/web/src/features/games/ui/RematchModal.tsx
@@ -22,6 +22,7 @@ interface RematchModalProps {
   players: PlayerInfo[];
   currentUserId: string | null;
   rematchLoading: boolean;
+  rematchError?: string | null;
   onClose: () => void;
   onConfirm: (selectedPlayerIds: string[], message?: string) => void;
   t: (key: TranslationKey, params?: Record<string, string | number>) => string;
@@ -126,6 +127,7 @@ export function RematchModal({
   players,
   currentUserId,
   rematchLoading,
+  rematchError,
   onClose,
   onConfirm,
   t,
@@ -221,6 +223,17 @@ export function RematchModal({
             onChangeText={setMessage}
             disabled={rematchLoading}
           />
+
+          {rematchError && (
+            <Text
+              color="$red10"
+              fontSize="$3"
+              textAlign="center"
+              marginBottom="$3"
+            >
+              {rematchError}
+            </Text>
+          )}
 
           <ModalActions>
             <ModalButton

--- a/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx
@@ -56,6 +56,7 @@ interface ActiveGameViewProps {
   // Rematch props
   rematch: {
     rematchLoading: boolean;
+    rematchError: string | null;
     showRematchModal: boolean;
     openRematchModal: () => void;
     closeRematchModal: () => void;
@@ -393,6 +394,7 @@ export function ActiveGameView({
                     : 'defeat',
                 dismissResult: () => setModalDismissed(true),
                 rematchLoading: rematch.rematchLoading,
+                rematchError: rematch.rematchError ?? null,
                 showRematchModal: rematch.showRematchModal,
                 openRematchModal: rematch.openRematchModal,
                 closeRematchModal: rematch.closeRematchModal,

--- a/apps/web/src/widgets/GamesControlPanel/ui/GamesControlPanel.tsx
+++ b/apps/web/src/widgets/GamesControlPanel/ui/GamesControlPanel.tsx
@@ -35,6 +35,9 @@ interface GamesControlPanelProps {
   isFullscreen?: boolean;
   toggleFullscreen?: () => void;
   isSpectating?: boolean;
+  isGameOver?: boolean;
+  onRematch?: () => void;
+  rematchLoading?: boolean;
 }
 
 export function GamesControlPanel(props: GamesControlPanelProps) {
@@ -53,6 +56,9 @@ export function GamesControlPanel(props: GamesControlPanelProps) {
     isFullscreen,
     toggleFullscreen,
     isSpectating,
+    isGameOver,
+    onRematch,
+    rematchLoading,
   } = props;
 
   const { snapshot } = useSessionTokens();
@@ -316,6 +322,31 @@ export function GamesControlPanel(props: GamesControlPanelProps) {
       )}
 
       {roomId && <ShareGameMenu roomId={roomId} inviteCode={inviteCode} />}
+
+      {isGameOver && onRematch && (
+        <Button
+          variant="primary"
+          size="sm"
+          $sm={{ scale: 0.9, paddingHorizontal: '$2' }}
+          onClick={onRematch}
+          disabled={rematchLoading}
+          data-testid="rematch-button"
+          animation="quick"
+          pressStyle={{ scale: 0.95 }}
+        >
+          🔄
+          <Text $sm={{ display: 'none' }}>
+            {' ' +
+              (rematchLoading
+                ? t(
+                    'games.table.rematch.loading' as import('@/shared/lib/useTranslation').TranslationKey,
+                  ) || 'Loading...'
+                : t(
+                    'games.table.rematch.button' as import('@/shared/lib/useTranslation').TranslationKey,
+                  ) || 'Play Again')}
+          </Text>
+        </Button>
+      )}
 
       <Button
         variant="glass"

--- a/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/Game.tsx
@@ -12,6 +12,7 @@ import { useSeaBattleActions } from '../hooks/useSeaBattleActions';
 import { useGameStore, type GameState } from '@/features/games/store/gameStore';
 import { useGameEndState } from '@/features/games/hooks';
 import { useGameChatIntegration } from '@/features/games/hooks';
+import { useGameRematchStore } from '@/features/games/store/gameRematchStore';
 import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
 import {
   GameWidgetContainer,
@@ -227,17 +228,31 @@ export const SeaBattleGame = memo(function SeaBattleGame({
         })) || [],
   });
 
-  // Non-hosts can request a rematch but can't actually start one — only the
-  // host creates the new room. The request posts a public chat note so the
-  // host (and everyone else) sees the ask.
   const handleRematchClick = useCallback(() => {
-    if (isHost) {
-      gameEnd.handleResultRematchClick();
-      return;
+    gameEnd.handleResultRematchClick();
+  }, [gameEnd]);
+
+  const setRematchState = useGameRematchStore((s) => s.setRematchState);
+  const resetRematch = useGameRematchStore((s) => s.reset);
+
+  useEffect(() => {
+    if (isGameOver && gameEnd.sharedResult) {
+      setRematchState({
+        isGameOver: true,
+        onRematch: handleRematchClick,
+        rematchLoading: gameEnd.rematchLoading,
+      });
+    } else {
+      resetRematch();
     }
-    postHistoryNoteAction('🔁 Wants a rematch!', 'all');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isHost, gameEnd.handleResultRematchClick, postHistoryNoteAction]);
+  }, [
+    isGameOver,
+    gameEnd.sharedResult,
+    gameEnd.rematchLoading,
+    handleRematchClick,
+    setRematchState,
+    resetRematch,
+  ]);
 
   const resolveActorColor = useCallback(
     (id?: string | null) => {

--- a/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
+++ b/apps/web/src/widgets/TicTacToeGame/ui/Game.tsx
@@ -13,6 +13,7 @@ import { computeGameResult } from '@/features/games/lib/computeGameResult';
 import { resolveDisplayName } from '@/features/games/lib/resolveDisplayName';
 import { useRecordGameResult } from '@/features/stats/hooks/useRecordGameResult';
 import { useTranslation } from '@/shared/lib/useTranslation';
+import { useGameChatStore } from '@/widgets/GameChat';
 import type { TicTacToeGameProps } from '../types';
 import { useTicTacToeState } from '../hooks/useTicTacToeState';
 import { useTicTacToeActions } from '../hooks/useTicTacToeActions';
@@ -138,6 +139,10 @@ function TicTacToeGameImpl({
     [room?.gameOptions],
   );
 
+  const highlightedCell = useGameChatStore((s) => s.highlightedCell);
+  const persistedCell = useGameChatStore((s) => s.persistedCell);
+  const effectiveHighlight = highlightedCell ?? persistedCell;
+
   const variantTokens = useMemo(
     () =>
       TIC_TAC_TOE_VARIANTS.find((v) => v.id === options.variant) ??
@@ -194,9 +199,15 @@ function TicTacToeGameImpl({
             players={snapshot.players}
             teams={snapshot.teams}
             teamMode={snapshot.options.teamMode}
+            origin={snapshot.origin}
             disabled={!myTurn || isGameOver}
+            highlightedCell={effectiveHighlight}
+            currentPlayerId={currentUserId}
             ariaLabel={`Tic-Tac-Toe ${snapshot.options.boardSize}x${snapshot.options.boardSize} board`}
-            onCellClick={(row, col) => placeMark(row, col)}
+            onCellClick={(row, col) => {
+              useGameChatStore.getState().setPersistedCell(null);
+              placeMark(row, col);
+            }}
           />
         </>
       ) : null}


### PR DESCRIPTION
## What
Move rematch button to the shared control panel, prevent duplicate rematch rooms via atomic lock, and gate Vercel analytics on the VERCEL env var.

## Why
- Rematch button was hidden in the game widget footer — only visible to the host
- Both players pressing rematch simultaneously created duplicate rooms (race condition)
- Vercel Analytics/SpeedInsights caused 404 errors in e2e CI

## Changes
- **GamesControlPanel**: Added rematch button ("Play Again") to the toolbar, visible to all players when game is over
- **gameRematchStore**: New zustand store bridges rematch state from game widgets to the shared control panel layout
- **GamePageLayout**: Reads rematch state from store and passes to GamesControlPanel
- **GameHistoryRematchService**: New service extracted from GameHistoryService; uses atomic `findOneAndUpdate` with `rematchPending` flag to prevent concurrent rematch creation
- **GameRoom schema**: Added `rematchPending` boolean field
- **GamesHistoryFacade**: Added missing `@Injectable()` decorator (was causing DI errors)
- **RematchModal**: Now displays backend errors (e.g., "Rematch already in progress")
- **useGameEndState**: Exposes `rematchError` from useRematch
- **Sea Battle Game.tsx**: Writes rematch state to store instead of rendering footer button
- **GameWidgetContainer**: Removed unused `footer` prop
- **Vercel analytics**: Gated `<Analytics />` and `<SpeedInsights />` behind `process.env.VERCEL`
- **Sea battle engine**: Chat actions allowed for eliminated players

### Files changed
- `apps/be/src/games/history/game-history-rematch.service.ts` (new)
- `apps/web/src/features/games/store/gameRematchStore.ts` (new)
- `apps/be/src/games/schemas/game-room.schema.ts`
- `apps/be/src/games/history/game-history.service.ts`
- `apps/be/src/games/games-history.facade.ts`
- `apps/be/src/games/games.module.ts`
- `apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx`
- `apps/web/src/features/games/hooks/useGameEndState.ts`
- `apps/web/src/features/games/ui/GameEndModals.tsx`
- `apps/web/src/features/games/ui/RematchModal.tsx`
- `apps/web/src/features/games/ui/GameWidgetContainer.tsx`
- `apps/web/src/widgets/GamesControlPanel/ui/GamesControlPanel.tsx`
- `apps/web/src/widgets/SeaBattleGame/ui/Game.tsx`
- `apps/web/src/widgets/CriticalGame/ui/ActiveGameView.tsx`
- `apps/web/src/app/layout.tsx`
- `apps/be/src/games/engines/sea-battle/sea-battle.engine.ts`