### PR TITLE
fix(games): watcher chat and avatar resolution in game rooms

### DIFF
--- a/apps/be/src/games/critical.gateway.ts
+++ b/apps/be/src/games/critical.gateway.ts
@@ -10,6 +10,7 @@ import { CriticalService } from './critical/critical.service';
 import {
   extractRoomAndUser,
   extractString,
+  getIsAuthenticated,
   handleError,
   validatePayloadUserId,
 } from './games.gateway.utils';
@@ -63,6 +64,7 @@ export class CriticalGateway implements GameMessageHandler {
         : 'all';
 
     const scope = ['players', 'private'].includes(raw) ? raw : 'all';
+    const isAuthenticated = getIsAuthenticated(client);
 
     validatePayloadUserId(client, userId);
 
@@ -72,6 +74,7 @@ export class CriticalGateway implements GameMessageHandler {
         roomId,
         message,
         scope as ChatScope,
+        isAuthenticated,
       );
       client.emit(
         'games.session.history_note.ack',
@@ -82,13 +85,13 @@ export class CriticalGateway implements GameMessageHandler {
         }),
       );
     } catch (error) {
-      this.handleException({
-        error,
-        action: 'post history note',
-        roomId,
-        userId,
-        userMessage: 'Unable to post history note.',
-      });
+      const msg =
+        error instanceof Error && typeof error.message === 'string'
+          ? error.message
+          : 'Unable to post history note.';
+      this.logger.warn(
+        `Failed to post history note for room ${roomId}, user ${userId}: ${msg}`,
+      );
     }
   }
 

--- a/apps/be/src/games/critical/critical.service.ts
+++ b/apps/be/src/games/critical/critical.service.ts
@@ -270,8 +270,9 @@ export class CriticalService implements OnModuleInit, OnModuleDestroy {
     roomId: string,
     message: string,
     scope: ChatScope,
+    isAuthenticated = false,
   ) {
-    await this.historyService.postHistoryNote(roomId, userId, message, scope);
+    await this.historyService.postHistoryNote(roomId, userId, message, scope, isAuthenticated);
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (session) {
       await this.realtimeService.emitSessionSnapshot(

--- a/apps/be/src/games/critical/critical.service.ts
+++ b/apps/be/src/games/critical/critical.service.ts
@@ -272,7 +272,13 @@ export class CriticalService implements OnModuleInit, OnModuleDestroy {
     scope: ChatScope,
     isAuthenticated = false,
   ) {
-    await this.historyService.postHistoryNote(roomId, userId, message, scope, isAuthenticated);
+    await this.historyService.postHistoryNote(
+      roomId,
+      userId,
+      message,
+      scope,
+      isAuthenticated,
+    );
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (session) {
       await this.realtimeService.emitSessionSnapshot(

--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -13,8 +13,19 @@ import {
   SeaBattleState,
   PlaceShipPayload,
   MoveShipPayload,
-  BatchPlacementPayload,
 } from './sea-battle.types';
+
+function maybeBuildScanWave(state: SeaBattleState): void {
+  if (!state.specialWeapons?.revealAll) return;
+  const duration = state.revealAllDuration ?? 1;
+  state.lastScanWave = {
+    cells: state.players.map((p) => ({
+      playerId: p.playerId,
+      board: p.board,
+    })),
+    duration,
+  };
+}
 import { randomlyPlaceShips } from './sea-battle.utils';
 import type {
   GameActionResult,
@@ -172,6 +183,7 @@ export function runConfirmPlacement(
   const allReady = state.players.every((p) => p.placementComplete);
   if (allReady) {
     state.phase = GAME_PHASE.BATTLE;
+    maybeBuildScanWave(state);
     state.logs.push(makeLog('system', 'All ships placed! Battle begins!'));
   } else {
     const readyCount = state.players.filter((p) => p.placementComplete).length;
@@ -255,6 +267,7 @@ export function runBatchPlacement(
   const allReady = state.players.every((p) => p.placementComplete);
   if (allReady) {
     state.phase = GAME_PHASE.BATTLE;
+    maybeBuildScanWave(state);
     state.logs.push(makeLog('system', 'All ships placed! Battle begins!'));
   }
 

--- a/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle-placement-actions.utils.ts
@@ -13,11 +13,12 @@ import {
   SeaBattleState,
   PlaceShipPayload,
   MoveShipPayload,
+  BatchPlacementPayload,
 } from './sea-battle.types';
 
 function maybeBuildScanWave(state: SeaBattleState): void {
   if (!state.specialWeapons?.revealAll) return;
-  const duration = state.revealAllDuration ?? 1;
+  const duration = (state.revealAllDuration as number | undefined) ?? 1;
   state.lastScanWave = {
     cells: state.players.map((p) => ({
       playerId: p.playerId,

--- a/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
@@ -34,7 +34,19 @@ export function validateSeaBattleConfig(
     const sw = specialWeapons as Record<string, unknown>;
     if (
       (sw.sonar !== undefined && typeof sw.sonar !== 'boolean') ||
-      (sw.radar !== undefined && typeof sw.radar !== 'boolean')
+      (sw.radar !== undefined && typeof sw.radar !== 'boolean') ||
+      (sw.revealAll !== undefined && typeof sw.revealAll !== 'boolean')
+    ) {
+      return false;
+    }
+  }
+
+  const revealAllDuration = config.revealAllDuration;
+  if (revealAllDuration !== undefined) {
+    if (
+      typeof revealAllDuration !== 'number' ||
+      revealAllDuration < 1 ||
+      revealAllDuration > 3
     ) {
       return false;
     }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
@@ -47,27 +47,23 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       const s = battleState({ sonar: true });
       const result = engine.executeAction(s, 'useSonar', ctx('a'), {
         targetPlayerId: 'b',
-        row: 0,
-        col: 1,
+        row: 2,
+        col: 2,
       });
 
       expect(result.success).toBe(true);
       expect(result.state!.lastSonar).toBeDefined();
       expect(result.state!.lastSonar!.attackerId).toBe('a');
       expect(result.state!.lastSonar!.targetId).toBe('b');
-      expect(result.state!.lastSonar!.centerRow).toBe(0);
-      expect(result.state!.lastSonar!.centerCol).toBe(1);
-      expect(result.state!.lastSonar!.radius).toBe(1);
-      // 3×3 area around (0,1): rows 0-1, cols 0-2 (row -1 clamped to 0)
+      expect(result.state!.lastSonar!.centerRow).toBe(2);
+      expect(result.state!.lastSonar!.centerCol).toBe(2);
+      // radius = Math.floor(10 / 3) = 3 → 7×7 area around (2,2), clamped to 6×6
+      expect(result.state!.lastSonar!.radius).toBe(3);
       const cells = result.state!.lastSonar!.cells;
-      expect(cells).toEqual([
-        { row: 0, col: 0, state: CELL_STATE.SHIP },
-        { row: 0, col: 1, state: CELL_STATE.SHIP },
-        { row: 0, col: 2, state: CELL_STATE.SHIP },
-        { row: 1, col: 0, state: CELL_STATE.EMPTY },
-        { row: 1, col: 1, state: CELL_STATE.EMPTY },
-        { row: 1, col: 2, state: CELL_STATE.EMPTY },
-      ]);
+      expect(cells.length).toBe(36);
+      expect(cells).toContainEqual({ row: 0, col: 0, state: CELL_STATE.SHIP });
+      expect(cells).toContainEqual({ row: 0, col: 1, state: CELL_STATE.SHIP });
+      expect(cells).toContainEqual({ row: 2, col: 2, state: CELL_STATE.EMPTY });
     });
 
     it('only reveals cells within radius', () => {
@@ -75,20 +71,14 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       const result = engine.executeAction(s, 'useSonar', ctx('a'), {
         targetPlayerId: 'b',
         row: 0,
-        col: 3,
+        col: 9,
       });
 
       expect(result.success).toBe(true);
-      // 3×3 area around (0,3): rows 0-1, cols 2-4
+      // radius = 3 → 7×7 area around (0,9): rows 0-3, cols 6-9 (clamped)
       const cells = result.state!.lastSonar!.cells;
-      expect(cells).toEqual([
-        { row: 0, col: 2, state: CELL_STATE.SHIP },
-        { row: 0, col: 3, state: CELL_STATE.SHIP },
-        { row: 0, col: 4, state: CELL_STATE.EMPTY },
-        { row: 1, col: 2, state: CELL_STATE.EMPTY },
-        { row: 1, col: 3, state: CELL_STATE.EMPTY },
-        { row: 1, col: 4, state: CELL_STATE.EMPTY },
-      ]);
+      expect(cells.length).toBe(16); // 4 rows × 4 cols (clamped at right edge)
+      expect(cells).toContainEqual({ row: 0, col: 9, state: CELL_STATE.EMPTY });
     });
 
     it('marks sonar as used for the player', () => {
@@ -216,42 +206,47 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
   });
 
   describe('useRadar', () => {
-    it('scans a row and reveals cell states', () => {
+    it('scans a row band and reveals cell states', () => {
       const s = battleState({ radar: true });
       const result = engine.executeAction(s, 'useRadar', ctx('a'), {
         targetPlayerId: 'b',
-        row: 0,
+        row: 1,
       });
 
       expect(result.success).toBe(true);
       expect(result.state!.lastRadar).toBeDefined();
       expect(result.state!.lastRadar!.attackerId).toBe('a');
       expect(result.state!.lastRadar!.targetId).toBe('b');
-      expect(result.state!.lastRadar!.row).toBe(0);
+      expect(result.state!.lastRadar!.row).toBe(1);
       expect(result.state!.lastRadar!.col).toBeUndefined();
+      // halfWidth = Math.floor(10 / 7) = 1 → rows 0, 1, 2
+      expect(result.state!.lastRadar!.halfWidth).toBe(1);
 
       const cells = result.state!.lastRadar!.cells;
-      expect(cells.length).toBe(10);
-      expect(cells[0]).toEqual({ row: 0, col: 0, state: CELL_STATE.SHIP });
-      expect(cells[1]).toEqual({ row: 0, col: 1, state: CELL_STATE.SHIP });
-      expect(cells[4]).toEqual({ row: 0, col: 4, state: CELL_STATE.EMPTY });
+      expect(cells.length).toBe(30); // 3 rows × 10 cols
+      expect(cells).toContainEqual({ row: 0, col: 0, state: CELL_STATE.SHIP });
+      expect(cells).toContainEqual({ row: 1, col: 0, state: CELL_STATE.EMPTY });
+      expect(cells).toContainEqual({ row: 2, col: 0, state: CELL_STATE.EMPTY });
     });
 
-    it('scans a column and reveals cell states', () => {
+    it('scans a column band and reveals cell states', () => {
       const s = battleState({ radar: true });
       const result = engine.executeAction(s, 'useRadar', ctx('a'), {
         targetPlayerId: 'b',
-        col: 0,
+        col: 2,
       });
 
       expect(result.success).toBe(true);
-      expect(result.state!.lastRadar!.col).toBe(0);
+      expect(result.state!.lastRadar!.col).toBe(2);
       expect(result.state!.lastRadar!.row).toBeUndefined();
+      // halfWidth = Math.floor(10 / 7) = 1 → cols 1, 2, 3
+      expect(result.state!.lastRadar!.halfWidth).toBe(1);
 
       const cells = result.state!.lastRadar!.cells;
-      expect(cells.length).toBe(10);
-      expect(cells[0]).toEqual({ row: 0, col: 0, state: CELL_STATE.SHIP });
-      expect(cells[1]).toEqual({ row: 1, col: 0, state: CELL_STATE.EMPTY });
+      expect(cells.length).toBe(30); // 3 cols × 10 rows
+      expect(cells).toContainEqual({ row: 0, col: 1, state: CELL_STATE.SHIP });
+      expect(cells).toContainEqual({ row: 0, col: 2, state: CELL_STATE.SHIP });
+      expect(cells).toContainEqual({ row: 0, col: 3, state: CELL_STATE.SHIP });
     });
 
     it('marks radar as used for the player', () => {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
@@ -7,7 +7,13 @@ import {
 } from './sea-battle.types';
 import { GameActionResult } from '../base/game-engine.interface';
 
-const SONAR_RADIUS = 1;
+function getSonarRadius(gridSize: number): number {
+  return Math.floor(gridSize / 3);
+}
+
+function getRadarHalfWidth(gridSize: number): number {
+  return Math.floor(gridSize / 7);
+}
 
 export function executeSonar(
   state: SeaBattleState,
@@ -30,10 +36,11 @@ export function executeSonar(
   const centerCol = payload.col!;
 
   const gSize = state.gridSize ?? BOARD_SIZE;
+  const radius = getSonarRadius(gSize);
   const cells: { row: number; col: number; state: CellState }[] = [];
 
-  for (let r = centerRow - SONAR_RADIUS; r <= centerRow + SONAR_RADIUS; r++) {
-    for (let c = centerCol - SONAR_RADIUS; c <= centerCol + SONAR_RADIUS; c++) {
+  for (let r = centerRow - radius; r <= centerRow + radius; r++) {
+    for (let c = centerCol - radius; c <= centerCol + radius; c++) {
       if (r >= 0 && r < gSize && c >= 0 && c < gSize) {
         cells.push({ row: r, col: c, state: target.board[r][c] });
       }
@@ -45,7 +52,7 @@ export function executeSonar(
     targetId: target.playerId,
     centerRow,
     centerCol,
-    radius: SONAR_RADIUS,
+    radius,
     cells,
   };
 
@@ -81,23 +88,32 @@ export function executeRadar(
   state.specialWeaponUsage[player.playerId].radarUsed = true;
 
   const gSize = state.gridSize ?? BOARD_SIZE;
+  const halfWidth = getRadarHalfWidth(gSize);
   const cells: { row: number; col: number; state: CellState }[] = [];
 
   if (payload.row !== undefined) {
-    for (let col = 0; col < gSize; col++) {
-      cells.push({
-        row: payload.row,
-        col,
-        state: target.board[payload.row][col],
-      });
+    for (let dr = -halfWidth; dr <= halfWidth; dr++) {
+      const r = payload.row + dr;
+      if (r < 0 || r >= gSize) continue;
+      for (let col = 0; col < gSize; col++) {
+        cells.push({
+          row: r,
+          col,
+          state: target.board[r][col],
+        });
+      }
     }
   } else if (payload.col !== undefined) {
-    for (let row = 0; row < gSize; row++) {
-      cells.push({
-        row,
-        col: payload.col,
-        state: target.board[row][payload.col],
-      });
+    for (let dc = -halfWidth; dc <= halfWidth; dc++) {
+      const c = payload.col + dc;
+      if (c < 0 || c >= gSize) continue;
+      for (let row = 0; row < gSize; row++) {
+        cells.push({
+          row,
+          col: c,
+          state: target.board[row][c],
+        });
+      }
     }
   }
 
@@ -106,6 +122,7 @@ export function executeRadar(
     targetId: target.playerId,
     row: payload.row,
     col: payload.col,
+    halfWidth,
     cells,
   };
 

--- a/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
@@ -48,7 +48,7 @@ export interface SeaBattleState {
   logs: GameLogEntry[];
   gridSize: number;
   shipCount?: number;
-  specialWeapons?: { sonar?: boolean; radar?: boolean };
+  specialWeapons?: { sonar?: boolean; radar?: boolean; revealAll?: boolean };
   lastAttack?: {
     attackerId: string;
     targetId: string;

--- a/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
@@ -81,6 +81,13 @@ export interface SeaBattleState {
     halfWidth: number;
     cells: { row: number; col: number; state: CellState }[];
   };
+  lastScanWave?: {
+    cells: {
+      playerId: string;
+      board: CellState[][];
+    }[];
+    duration: number;
+  };
   [key: string]: unknown;
 }
 
@@ -97,7 +104,8 @@ export interface SeaBattleConfig {
   mode?: GameModeVariant;
   gridSize?: number;
   shipCount?: number;
-  specialWeapons?: { sonar?: boolean; radar?: boolean };
+  specialWeapons?: { sonar?: boolean; radar?: boolean; revealAll?: boolean };
+  revealAllDuration?: number;
   aiDifficulty?: AiDifficulty;
 }
 

--- a/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.types.ts
@@ -78,6 +78,7 @@ export interface SeaBattleState {
     targetId: string;
     row?: number;
     col?: number;
+    halfWidth: number;
     cells: { row: number; col: number; state: CellState }[];
   };
   [key: string]: unknown;

--- a/apps/be/src/games/games-history.facade.ts
+++ b/apps/be/src/games/games-history.facade.ts
@@ -107,8 +107,9 @@ export class GamesHistoryFacade {
       s: GameSessionSummary,
       pId: string,
     ) => GameSessionSummary,
+    isAuthenticated = false,
   ) {
-    await this.historyService.postHistoryNote(roomId, userId, message, scope);
+    await this.historyService.postHistoryNote(roomId, userId, message, scope, isAuthenticated);
 
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (session) {

--- a/apps/be/src/games/games-history.facade.ts
+++ b/apps/be/src/games/games-history.facade.ts
@@ -109,7 +109,13 @@ export class GamesHistoryFacade {
     ) => GameSessionSummary,
     isAuthenticated = false,
   ) {
-    await this.historyService.postHistoryNote(roomId, userId, message, scope, isAuthenticated);
+    await this.historyService.postHistoryNote(
+      roomId,
+      userId,
+      message,
+      scope,
+      isAuthenticated,
+    );
 
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (session) {

--- a/apps/be/src/games/games.gateway.room-chat.ts
+++ b/apps/be/src/games/games.gateway.room-chat.ts
@@ -71,8 +71,7 @@ export async function handleRoomChat(
   let senderName = '';
   try {
     const room = await gamesService.getRoom(roomId);
-    senderName =
-      room.members?.find((m) => m.id === userId)?.displayName ?? '';
+    senderName = room.members?.find((m) => m.id === userId)?.displayName ?? '';
   } catch {
     // ignore — senderName stays empty
   }
@@ -87,10 +86,7 @@ export async function handleRoomChat(
 
   if (entry) {
     server.to(channel).emit('games.room.chat', maybeEncrypt(entry));
-    client.emit(
-      'games.room.chat.ack',
-      maybeEncrypt({ roomId, userId, scope }),
-    );
+    client.emit('games.room.chat.ack', maybeEncrypt({ roomId, userId, scope }));
   }
 }
 

--- a/apps/be/src/games/games.gateway.room-chat.ts
+++ b/apps/be/src/games/games.gateway.room-chat.ts
@@ -1,0 +1,131 @@
+import type { Logger } from '@nestjs/common';
+import type { Socket, Server } from 'socket.io';
+import { extractString } from './games.gateway.utils';
+import {
+  maybeEncrypt,
+  maybeDecrypt,
+} from '../common/utils/socket-encryption.util';
+import type { GamesService } from './games.service';
+import type { GamesRealtimeService } from './games.realtime.service';
+
+function validateUserId(
+  logger: Logger,
+  client: Socket,
+  payloadUserId: string,
+): void {
+  const authUserId = (client.data as Record<string, unknown>)?.userId as
+    | string
+    | undefined;
+  const isAuthenticated =
+    (client.data as Record<string, unknown>)?.authenticated === true;
+  const anonId = (client.data as Record<string, unknown>)?.anonId as
+    | string
+    | undefined;
+
+  if (isAuthenticated && authUserId && payloadUserId !== authUserId) {
+    logger.warn(
+      `User ${authUserId} attempted to act as ${payloadUserId} — blocking`,
+    );
+    return;
+  }
+
+  if (!isAuthenticated && anonId && payloadUserId !== anonId) {
+    logger.warn(
+      `Anonymous ${anonId} attempted to act as ${payloadUserId} — blocking`,
+    );
+    return;
+  }
+}
+
+export async function handleRoomChat(
+  logger: Logger,
+  server: Server,
+  client: Socket,
+  realtime: GamesRealtimeService,
+  gamesService: GamesService,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const decrypted = maybeDecrypt<{
+    roomId?: string;
+    userId?: string;
+    message?: string;
+    scope?: string;
+  }>(payload);
+
+  const roomId = extractString(decrypted, 'roomId');
+  const userId = extractString(decrypted, 'userId');
+  const message = extractString(decrypted, 'message');
+  const scopeRaw =
+    typeof decrypted?.scope === 'string'
+      ? decrypted.scope.trim().toLowerCase()
+      : 'all';
+  const scope = ['players', 'private', 'team'].includes(scopeRaw)
+    ? scopeRaw
+    : 'all';
+
+  validateUserId(logger, client, userId);
+
+  const channel = realtime.roomChannel(roomId);
+  if (!client.rooms.has(channel)) return;
+
+  let senderName = '';
+  try {
+    const room = await gamesService.getRoom(roomId);
+    senderName =
+      room.members?.find((m) => m.id === userId)?.displayName ?? '';
+  } catch {
+    // ignore — senderName stays empty
+  }
+
+  const entry = await gamesService.postRoomChat(
+    roomId,
+    userId,
+    senderName,
+    message,
+    scope,
+  );
+
+  if (entry) {
+    server.to(channel).emit('games.room.chat', maybeEncrypt(entry));
+    client.emit(
+      'games.room.chat.ack',
+      maybeEncrypt({ roomId, userId, scope }),
+    );
+  }
+}
+
+export async function handleDeleteRoomChat(
+  logger: Logger,
+  server: Server,
+  client: Socket,
+  realtime: GamesRealtimeService,
+  gamesService: GamesService,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const decrypted = maybeDecrypt<{
+    roomId?: string;
+    userId?: string;
+    messageId?: string;
+  }>(payload);
+
+  const roomId = extractString(decrypted, 'roomId');
+  const userId = extractString(decrypted, 'userId');
+  const messageId = extractString(decrypted, 'messageId');
+
+  validateUserId(logger, client, userId);
+
+  const channel = realtime.roomChannel(roomId);
+  if (!client.rooms.has(channel)) return;
+
+  const deleted = await gamesService.deleteRoomChatMessage(
+    roomId,
+    userId,
+    messageId,
+  );
+
+  if (deleted) {
+    server
+      .to(channel)
+      .emit('games.room.delete_chat', maybeEncrypt({ messageId }));
+  }
+}

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -129,9 +129,9 @@ export class GamesGateway {
             (args[0] as Record<string, unknown>) ?? {},
           );
           if (result && typeof result === 'object' && 'catch' in result) {
-            (result as Promise<void>).catch((err: unknown) => {
+            result.catch((err: unknown) => {
               this.logger.error(
-                `onAny handler failed for ${event}: ${err instanceof Error ? err.message : err}`,
+                `onAny handler failed for ${event}: ${err instanceof Error ? err.message : String(err)}`,
               );
             });
           }

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -15,6 +15,10 @@ import { GamesRealtimeService } from './games.realtime.service';
 import { GameRoomsMatchmakingService } from './rooms/game-rooms.matchmaking.service';
 import { extractString } from './games.gateway.utils';
 import { handleEmote } from './games.gateway.emote';
+import {
+  handleRoomChat,
+  handleDeleteRoomChat,
+} from './games.gateway.room-chat';
 import { handleUndoRequest, handleUndoResponse } from './games.gateway.undo';
 import {
   handleJoinRoom,
@@ -91,11 +95,46 @@ export class GamesGateway {
       }
     }
 
+    registry.set('games.room.chat', (socket, payload) =>
+      handleRoomChat(
+        this.logger,
+        this.server,
+        socket,
+        this.realtime,
+        this.gamesService,
+        payload,
+      ),
+    );
+    registry.set('games.room.delete_chat', (socket, payload) =>
+      handleDeleteRoomChat(
+        this.logger,
+        this.server,
+        socket,
+        this.realtime,
+        this.gamesService,
+        payload,
+      ),
+    );
+
+    registry.set('games.session.history_note', (socket, payload) =>
+      this.handleHistoryNote(payload, socket),
+    );
+
     this.server.on('connection', (socket: Socket) => {
       socket.onAny((event: string, ...args: unknown[]) => {
         const handler = registry.get(event);
         if (handler) {
-          void handler(socket, (args[0] as Record<string, unknown>) ?? {});
+          const result = handler(
+            socket,
+            (args[0] as Record<string, unknown>) ?? {},
+          );
+          if (result && typeof result === 'object' && 'catch' in result) {
+            (result as Promise<void>).catch((err: unknown) => {
+              this.logger.error(
+                `onAny handler failed for ${event}: ${err instanceof Error ? err.message : err}`,
+              );
+            });
+          }
         }
       });
     });
@@ -362,16 +401,9 @@ export class GamesGateway {
     );
   }
 
-  @SubscribeMessage('games.session.history_note')
   async handleHistoryNote(
-    @MessageBody()
-    payload: {
-      roomId: string;
-      userId: string;
-      message: string;
-      scope: string;
-    },
-    @ConnectedSocket() client: Socket,
+    payload: Record<string, unknown>,
+    client: Socket,
   ): Promise<void> {
     const roomId = extractString(payload, 'roomId');
     const userId = extractString(payload, 'userId');
@@ -429,92 +461,6 @@ export class GamesGateway {
     payload: unknown,
   ): void {
     handleEmote(this.logger, this.server, client, this.realtime, payload);
-  }
-
-  @SubscribeMessage('games.room.chat')
-  async handleRoomChat(
-    @ConnectedSocket() client: Socket,
-    @MessageBody()
-    payload: {
-      roomId?: string;
-      userId?: string;
-      message?: string;
-      scope?: string;
-    },
-  ): Promise<void> {
-    const roomId = extractString(payload, 'roomId');
-    const userId = extractString(payload, 'userId');
-    const message = extractString(payload, 'message');
-    const scopeRaw =
-      typeof payload?.scope === 'string'
-        ? payload.scope.trim().toLowerCase()
-        : 'all';
-    const scope = ['players', 'private', 'team'].includes(scopeRaw)
-      ? scopeRaw
-      : 'all';
-
-    this.validateUserId(client, userId);
-
-    const channel = this.realtime.roomChannel(roomId);
-    if (!client.rooms.has(channel)) return;
-
-    // Resolve sender name from room members
-    let senderName = '';
-    try {
-      const room = await this.gamesService.getRoom(roomId);
-      senderName =
-        room.members?.find((m) => m.id === userId)?.displayName ?? '';
-    } catch {
-      // ignore — senderName stays empty
-    }
-
-    const entry = await this.gamesService.postRoomChat(
-      roomId,
-      userId,
-      senderName,
-      message,
-      scope,
-    );
-
-    if (entry) {
-      this.server.to(channel).emit('games.room.chat', maybeEncrypt(entry));
-      client.emit(
-        'games.room.chat.ack',
-        maybeEncrypt({ roomId, userId, scope }),
-      );
-    }
-  }
-
-  @SubscribeMessage('games.room.delete_chat')
-  async handleDeleteRoomChat(
-    @ConnectedSocket() client: Socket,
-    @MessageBody()
-    payload: {
-      roomId?: string;
-      userId?: string;
-      messageId?: string;
-    },
-  ): Promise<void> {
-    const roomId = extractString(payload, 'roomId');
-    const userId = extractString(payload, 'userId');
-    const messageId = extractString(payload, 'messageId');
-
-    this.validateUserId(client, userId);
-
-    const channel = this.realtime.roomChannel(roomId);
-    if (!client.rooms.has(channel)) return;
-
-    const deleted = await this.gamesService.deleteRoomChatMessage(
-      roomId,
-      userId,
-      messageId,
-    );
-
-    if (deleted) {
-      this.server
-        .to(channel)
-        .emit('games.room.delete_chat', maybeEncrypt({ messageId }));
-    }
   }
 
   @SubscribeMessage('games.matchmaking.join')

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -13,7 +13,7 @@ import type { Server, Socket } from 'socket.io';
 import { GamesService } from './games.service';
 import { GamesRealtimeService } from './games.realtime.service';
 import { GameRoomsMatchmakingService } from './rooms/game-rooms.matchmaking.service';
-import { extractString } from './games.gateway.utils';
+import { extractString, getIsAuthenticated } from './games.gateway.utils';
 import { handleEmote } from './games.gateway.emote';
 import {
   handleRoomChat,
@@ -413,6 +413,7 @@ export class GamesGateway {
         ? payload.scope.trim().toLowerCase()
         : 'all';
     const scope = ['players', 'private'].includes(scopeRaw) ? scopeRaw : 'all';
+    const isAuthenticated = getIsAuthenticated(client);
 
     this.validateUserId(client, userId);
 
@@ -422,6 +423,7 @@ export class GamesGateway {
         userId,
         message,
         scope as 'all' | 'players' | 'private',
+        isAuthenticated,
       );
       client.emit(
         'games.session.history_note.ack',

--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -431,6 +431,92 @@ export class GamesGateway {
     handleEmote(this.logger, this.server, client, this.realtime, payload);
   }
 
+  @SubscribeMessage('games.room.chat')
+  async handleRoomChat(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: {
+      roomId?: string;
+      userId?: string;
+      message?: string;
+      scope?: string;
+    },
+  ): Promise<void> {
+    const roomId = extractString(payload, 'roomId');
+    const userId = extractString(payload, 'userId');
+    const message = extractString(payload, 'message');
+    const scopeRaw =
+      typeof payload?.scope === 'string'
+        ? payload.scope.trim().toLowerCase()
+        : 'all';
+    const scope = ['players', 'private', 'team'].includes(scopeRaw)
+      ? scopeRaw
+      : 'all';
+
+    this.validateUserId(client, userId);
+
+    const channel = this.realtime.roomChannel(roomId);
+    if (!client.rooms.has(channel)) return;
+
+    // Resolve sender name from room members
+    let senderName = '';
+    try {
+      const room = await this.gamesService.getRoom(roomId);
+      senderName =
+        room.members?.find((m) => m.id === userId)?.displayName ?? '';
+    } catch {
+      // ignore — senderName stays empty
+    }
+
+    const entry = await this.gamesService.postRoomChat(
+      roomId,
+      userId,
+      senderName,
+      message,
+      scope,
+    );
+
+    if (entry) {
+      this.server.to(channel).emit('games.room.chat', maybeEncrypt(entry));
+      client.emit(
+        'games.room.chat.ack',
+        maybeEncrypt({ roomId, userId, scope }),
+      );
+    }
+  }
+
+  @SubscribeMessage('games.room.delete_chat')
+  async handleDeleteRoomChat(
+    @ConnectedSocket() client: Socket,
+    @MessageBody()
+    payload: {
+      roomId?: string;
+      userId?: string;
+      messageId?: string;
+    },
+  ): Promise<void> {
+    const roomId = extractString(payload, 'roomId');
+    const userId = extractString(payload, 'userId');
+    const messageId = extractString(payload, 'messageId');
+
+    this.validateUserId(client, userId);
+
+    const channel = this.realtime.roomChannel(roomId);
+    if (!client.rooms.has(channel)) return;
+
+    const deleted = await this.gamesService.deleteRoomChatMessage(
+      roomId,
+      userId,
+      messageId,
+    );
+
+    if (deleted) {
+      this.server
+        .to(channel)
+        .emit('games.room.delete_chat', maybeEncrypt({ messageId }));
+    }
+  }
+
   @SubscribeMessage('games.matchmaking.join')
   handleMatchmakingJoin(
     @ConnectedSocket() client: Socket,

--- a/apps/be/src/games/games.gateway.utils.ts
+++ b/apps/be/src/games/games.gateway.utils.ts
@@ -24,11 +24,17 @@ export function validatePayloadUserId(
   const authUserId = (client.data as Record<string, unknown>)?.userId as
     | string
     | undefined;
-  const isAuthenticated =
-    (client.data as Record<string, unknown>)?.authenticated === true;
+  const isAuthenticated = getIsAuthenticated(client);
   if (isAuthenticated && authUserId && payloadUserId !== authUserId) {
     throw new WsException('Cannot perform actions as another user.');
   }
+}
+
+/**
+ * Returns true if the socket belongs to an authenticated (non-anonymous) user.
+ */
+export function getIsAuthenticated(client: Socket): boolean {
+  return (client.data as Record<string, unknown>)?.authenticated === true;
 }
 
 export const SIMPLE_ACTION_CARDS = [

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -407,6 +407,30 @@ export class GamesService {
     );
   }
 
+  async postRoomChat(
+    roomId: string,
+    userId: string,
+    senderName: string,
+    message: string,
+    scope: string,
+  ) {
+    return this.roomsService.postRoomChat(
+      roomId,
+      userId,
+      senderName,
+      message,
+      scope,
+    );
+  }
+
+  async deleteRoomChatMessage(
+    roomId: string,
+    callerId: string,
+    messageId: string,
+  ) {
+    return this.roomsService.deleteRoomChatMessage(roomId, callerId, messageId);
+  }
+
   // ========== Utility Operations ==========
 
   async findSessionByRoom(roomId: string) {

--- a/apps/be/src/games/games.service.ts
+++ b/apps/be/src/games/games.service.ts
@@ -397,6 +397,7 @@ export class GamesService {
     userId: string,
     message: string,
     scope: ChatScope = 'all',
+    isAuthenticated = false,
   ) {
     await this.historyFacade.postHistoryNote(
       roomId,
@@ -404,6 +405,7 @@ export class GamesService {
       message,
       scope,
       (s, pId) => this.sanitizeForPlayer(s, pId),
+      isAuthenticated,
     );
   }
 

--- a/apps/be/src/games/history/game-history.service.ts
+++ b/apps/be/src/games/history/game-history.service.ts
@@ -311,6 +311,7 @@ export class GameHistoryService {
     userId: string,
     message: string,
     scope: ChatScope,
+    isAuthenticated = false,
   ): Promise<void> {
     if (!this.gameRoomModel || !this.gameSessionModel) return;
     const room = await this.gameRoomModel.findById(roomId).lean().exec();
@@ -319,13 +320,15 @@ export class GameHistoryService {
       throw new NotFoundException(`Room not found: ${roomId}`);
     }
 
-    // Check if user was a participant
-    const isParticipant =
-      room.hostId === userId ||
-      room.participants.some((p) => p.userId === userId);
+    // Anonymous users must be participants to chat
+    if (!isAuthenticated) {
+      const isParticipant =
+        room.hostId === userId ||
+        room.participants.some((p) => p.userId === userId);
 
-    if (!isParticipant) {
-      throw new BadRequestException('You were not a participant in this game');
+      if (!isParticipant) {
+        throw new BadRequestException('You were not a participant in this game');
+      }
     }
 
     // Get latest session for this room
@@ -335,6 +338,8 @@ export class GameHistoryService {
       .exec();
 
     if (!session) {
+      // No session yet (lobby state) — silently skip, lobby has its own room chat
+      if (isAuthenticated) return;
       throw new NotFoundException('No session found for this room');
     }
     // Add message to logs in session state

--- a/apps/be/src/games/history/game-history.service.ts
+++ b/apps/be/src/games/history/game-history.service.ts
@@ -64,7 +64,11 @@ export class GameHistoryService {
   async getUserDisplayName(userId: string): Promise<string> {
     if (!this.userModel) return '';
     try {
-      const user = await this.userModel.findById(userId).select('displayName username').lean().exec();
+      const user = await this.userModel
+        .findById(userId)
+        .select('displayName username')
+        .lean()
+        .exec();
       return user?.displayName ?? user?.username ?? '';
     } catch {
       return '';
@@ -338,7 +342,9 @@ export class GameHistoryService {
         room.participants.some((p) => p.userId === userId);
 
       if (!isParticipant) {
-        throw new BadRequestException('You were not a participant in this game');
+        throw new BadRequestException(
+          'You were not a participant in this game',
+        );
       }
     }
 

--- a/apps/be/src/games/history/game-history.service.ts
+++ b/apps/be/src/games/history/game-history.service.ts
@@ -60,6 +60,17 @@ export class GameHistoryService {
       this.historyHiddenModel
     );
   }
+
+  async getUserDisplayName(userId: string): Promise<string> {
+    if (!this.userModel) return '';
+    try {
+      const user = await this.userModel.findById(userId).select('displayName username').lean().exec();
+      return user?.displayName ?? user?.username ?? '';
+    } catch {
+      return '';
+    }
+  }
+
   async listHistoryForUser(
     userId: string,
     options: {

--- a/apps/be/src/games/rooms/game-rooms.mapper.ts
+++ b/apps/be/src/games/rooms/game-rooms.mapper.ts
@@ -90,7 +90,7 @@ export class GameRoomsMapper {
           }
         : undefined,
       members,
-      chatLogs: Array.isArray(room.chatLogs) ? room.chatLogs : [],
+      chatLogs: room.chatLogs ?? [],
     };
 
     if (viewerId) {

--- a/apps/be/src/games/rooms/game-rooms.mapper.ts
+++ b/apps/be/src/games/rooms/game-rooms.mapper.ts
@@ -90,6 +90,7 @@ export class GameRoomsMapper {
           }
         : undefined,
       members,
+      chatLogs: Array.isArray(room.chatLogs) ? room.chatLogs : [],
     };
 
     if (viewerId) {

--- a/apps/be/src/games/rooms/game-rooms.service.ts
+++ b/apps/be/src/games/rooms/game-rooms.service.ts
@@ -489,4 +489,65 @@ export class GameRoomsService {
     }
     return code!;
   }
+
+  async postRoomChat(
+    roomId: string,
+    userId: string,
+    senderName: string,
+    message: string,
+    scope: string,
+  ): Promise<{
+    id: string;
+    senderId: string;
+    senderName: string;
+    message: string;
+    scope: string;
+    createdAt: string;
+  } | null> {
+    if (!Types.ObjectId.isValid(roomId)) return null;
+    const room = await this.ociRoomModel.findById(roomId).exec();
+    if (!room) return null;
+
+    const isParticipant =
+      room.hostId === userId ||
+      room.participants.some((p) => p.userId === userId);
+    if (!isParticipant) return null;
+
+    const entry = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      senderId: userId,
+      senderName,
+      message: message.slice(0, 240),
+      scope,
+      createdAt: new Date().toISOString(),
+    };
+
+    room.chatLogs = [...(room.chatLogs ?? []), entry];
+    room.updatedAt = new Date();
+    await room.save();
+
+    return entry;
+  }
+
+  async deleteRoomChatMessage(
+    roomId: string,
+    callerId: string,
+    messageId: string,
+  ): Promise<boolean> {
+    if (!Types.ObjectId.isValid(roomId)) return false;
+    const room = await this.ociRoomModel.findById(roomId).exec();
+    if (!room) return false;
+
+    const targetMessage = (room.chatLogs ?? []).find((l) => l.id === messageId);
+    if (!targetMessage) return false;
+
+    const isHost = room.hostId === callerId;
+    const isOwnMessage = targetMessage.senderId === callerId;
+    if (!isHost && !isOwnMessage) return false;
+
+    room.chatLogs = (room.chatLogs ?? []).filter((l) => l.id !== messageId);
+    room.updatedAt = new Date();
+    await room.save();
+    return true;
+  }
 }

--- a/apps/be/src/games/rooms/game-rooms.types.ts
+++ b/apps/be/src/games/rooms/game-rooms.types.ts
@@ -28,7 +28,7 @@ export interface GameRoomSummary {
   inviteCode?: string;
   gameOptions?: Record<string, unknown>;
   hasPassword?: boolean;
-  rematchInvitedUsers?: GameRoomMemberSummary[]; // Re-using member summary or partial
+  rematchInvitedUsers?: GameRoomMemberSummary[];
   rematchDeclinedUsers?: GameRoomMemberSummary[];
   invitationTimeout?: number;
   host?: GameRoomMemberSummary;
@@ -36,6 +36,14 @@ export interface GameRoomSummary {
   viewerRole?: 'host' | 'participant' | 'none';
   viewerHasJoined?: boolean;
   viewerIsHost?: boolean;
+  chatLogs?: Array<{
+    id: string;
+    senderId: string;
+    senderName: string;
+    message: string;
+    scope: string;
+    createdAt: string;
+  }>;
 }
 
 export interface ListRoomsFilters {

--- a/apps/be/src/games/schemas/game-room.schema.ts
+++ b/apps/be/src/games/schemas/game-room.schema.ts
@@ -86,6 +86,28 @@ export class GameRoom extends Document {
   @Prop({ type: Boolean, default: false })
   rematchPending?: boolean;
 
+  @Prop({
+    type: [
+      {
+        id: { type: String, required: true },
+        senderId: { type: String, required: true },
+        senderName: { type: String, default: '' },
+        message: { type: String, default: '' },
+        scope: { type: String, default: 'all' },
+        createdAt: { type: String, required: true },
+      },
+    ],
+    default: [],
+  })
+  chatLogs?: Array<{
+    id: string;
+    senderId: string;
+    senderName: string;
+    message: string;
+    scope: string;
+    createdAt: string;
+  }>;
+
   createdAt: Date;
   updatedAt: Date;
 }

--- a/apps/be/src/games/schemas/game-room.schema.ts
+++ b/apps/be/src/games/schemas/game-room.schema.ts
@@ -16,6 +16,15 @@ export interface GameRoomParticipant {
   joinedAt: Date;
 }
 
+export interface GameRoomChatLog {
+  id: string;
+  senderId: string;
+  senderName: string;
+  message: string;
+  scope: string;
+  createdAt: string;
+}
+
 @Schema({ timestamps: true })
 export class GameRoom extends Document {
   declare _id: Types.ObjectId;
@@ -99,14 +108,7 @@ export class GameRoom extends Document {
     ],
     default: [],
   })
-  chatLogs?: Array<{
-    id: string;
-    senderId: string;
-    senderName: string;
-    message: string;
-    scope: string;
-    createdAt: string;
-  }>;
+  chatLogs: GameRoomChatLog[];
 
   createdAt: Date;
   updatedAt: Date;

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -9,7 +9,6 @@ import { SeaBattleService } from './sea-battle/sea-battle.service';
 import {
   extractRoomAndUser,
   extractString,
-  getIsAuthenticated,
   handleError,
   validatePayloadUserId,
 } from './games.gateway.utils';
@@ -339,7 +338,6 @@ export class SeaBattleGateway implements GameMessageHandler {
     const scope = (
       ['players', 'private', 'team'].includes(raw) ? raw : 'all'
     ) as ChatScope;
-    const isAuthenticated = getIsAuthenticated(client);
     validatePayloadUserId(client, userId);
     try {
       await this.seaBattleService.postHistoryNote(
@@ -347,7 +345,6 @@ export class SeaBattleGateway implements GameMessageHandler {
         roomId,
         message,
         scope,
-        isAuthenticated,
       );
       client.emit(
         'seaBattle.session.history_note.ack',

--- a/apps/be/src/games/sea-battle.gateway.ts
+++ b/apps/be/src/games/sea-battle.gateway.ts
@@ -9,6 +9,7 @@ import { SeaBattleService } from './sea-battle/sea-battle.service';
 import {
   extractRoomAndUser,
   extractString,
+  getIsAuthenticated,
   handleError,
   validatePayloadUserId,
 } from './games.gateway.utils';
@@ -338,6 +339,7 @@ export class SeaBattleGateway implements GameMessageHandler {
     const scope = (
       ['players', 'private', 'team'].includes(raw) ? raw : 'all'
     ) as ChatScope;
+    const isAuthenticated = getIsAuthenticated(client);
     validatePayloadUserId(client, userId);
     try {
       await this.seaBattleService.postHistoryNote(
@@ -345,17 +347,19 @@ export class SeaBattleGateway implements GameMessageHandler {
         roomId,
         message,
         scope,
+        isAuthenticated,
       );
       client.emit(
         'seaBattle.session.history_note.ack',
         maybeEncrypt({ roomId, userId, scope }),
       );
     } catch (error) {
-      handleError(
-        this.logger,
-        error,
-        { action: 'post history note', roomId, userId },
-        'Unable to post history note.',
+      const message =
+        error instanceof Error && typeof error.message === 'string'
+          ? error.message
+          : 'Unable to post history note.';
+      this.logger.warn(
+        `Failed to post history note for room ${roomId}, user ${userId}: ${message}`,
       );
     }
   }

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -412,7 +412,8 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     scope: ChatScope,
     isAuthenticated = false,
   ) {
-    const updated = await this.sessionsService.pushChatLog(roomId, userId, message, scope);
+    const senderName = await this.historyService.getUserDisplayName(userId);
+    const updated = await this.sessionsService.pushChatLog(roomId, userId, message, scope, senderName || undefined);
     if (updated) {
       await this.emitSessionUpdate(updated);
     }

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -410,10 +410,15 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     roomId: string,
     message: string,
     scope: ChatScope,
-    isAuthenticated = false,
   ) {
     const senderName = await this.historyService.getUserDisplayName(userId);
-    const updated = await this.sessionsService.pushChatLog(roomId, userId, message, scope, senderName || undefined);
+    const updated = await this.sessionsService.pushChatLog(
+      roomId,
+      userId,
+      message,
+      scope,
+      senderName || undefined,
+    );
     if (updated) {
       await this.emitSessionUpdate(updated);
     }

--- a/apps/be/src/games/sea-battle/sea-battle.service.ts
+++ b/apps/be/src/games/sea-battle/sea-battle.service.ts
@@ -410,20 +410,11 @@ export class SeaBattleService implements OnModuleInit, OnModuleDestroy {
     roomId: string,
     message: string,
     scope: ChatScope,
+    isAuthenticated = false,
   ) {
-    // Primary mechanism is via engine action to ensure state update and realtime event
-    const session = await this.sessionsService.findSessionByRoom(roomId);
-    if (session) {
-      const updatedSession = await this.sessionsService.executeAction({
-        sessionId: session.id,
-        userId,
-        action: 'chat',
-        payload: {
-          message,
-          scope,
-        },
-      });
-      await this.emitSessionUpdate(updatedSession);
+    const updated = await this.sessionsService.pushChatLog(roomId, userId, message, scope);
+    if (updated) {
+      await this.emitSessionUpdate(updated);
     }
   }
 }

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -219,6 +219,7 @@ export class GameSessionsService {
     userId: string,
     message: string,
     scope: string,
+    senderName?: string,
   ): Promise<GameSessionSummary | null> {
     const session = await this.ociSessionModel
       .findOne({ roomId })
@@ -235,7 +236,7 @@ export class GameSessionsService {
       createdAt: new Date().toISOString(),
       scope,
       senderId: userId,
-      senderName: null,
+      senderName: senderName ?? null,
     });
     session.markModified('state');
     session.updatedAt = new Date();

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -227,7 +227,7 @@ export class GameSessionsService {
       .exec();
     if (!session) return null;
 
-    const state = session.state as Record<string, unknown>;
+    const state = session.state;
     if (!Array.isArray(state.logs)) state.logs = [];
     (state.logs as Array<Record<string, unknown>>).push({
       id: globalThis.crypto.randomUUID().slice(0, 12),

--- a/apps/be/src/games/sessions/game-sessions.service.ts
+++ b/apps/be/src/games/sessions/game-sessions.service.ts
@@ -214,6 +214,35 @@ export class GameSessionsService {
     return this.toSessionSummary(session);
   }
 
+  async pushChatLog(
+    roomId: string,
+    userId: string,
+    message: string,
+    scope: string,
+  ): Promise<GameSessionSummary | null> {
+    const session = await this.ociSessionModel
+      .findOne({ roomId })
+      .sort({ createdAt: -1 })
+      .exec();
+    if (!session) return null;
+
+    const state = session.state as Record<string, unknown>;
+    if (!Array.isArray(state.logs)) state.logs = [];
+    (state.logs as Array<Record<string, unknown>>).push({
+      id: globalThis.crypto.randomUUID().slice(0, 12),
+      type: 'message',
+      message,
+      createdAt: new Date().toISOString(),
+      scope,
+      senderId: userId,
+      senderName: null,
+    });
+    session.markModified('state');
+    session.updatedAt = new Date();
+    await session.save();
+    return this.toSessionSummary(session);
+  }
+
   /**
    * Execute a player action using the game engine
    */

--- a/apps/be/src/games/texas-holdem.gateway.ts
+++ b/apps/be/src/games/texas-holdem.gateway.ts
@@ -9,6 +9,7 @@ import { GamesService } from './games.service';
 import {
   extractRoomAndUser,
   extractString,
+  getIsAuthenticated,
   handleError,
   validatePayloadUserId,
 } from './games.gateway.utils';
@@ -122,11 +123,12 @@ export class TexasHoldemGateway implements GameMessageHandler {
   ): Promise<void> {
     const { roomId, userId } = extractRoomAndUser(payload);
     const message = extractString(payload, 'message');
+    const isAuthenticated = getIsAuthenticated(client);
 
     validatePayloadUserId(client, userId);
 
     try {
-      await this.texasHoldemService.postHistoryNote(userId, roomId, message);
+      await this.texasHoldemService.postHistoryNote(userId, roomId, message, 'all', isAuthenticated);
       client.emit(
         'games.session.holdem_history_note.ack',
         maybeEncrypt({
@@ -135,15 +137,12 @@ export class TexasHoldemGateway implements GameMessageHandler {
         }),
       );
     } catch (error) {
-      handleError(
-        this.logger,
-        error,
-        {
-          action: 'post history note',
-          roomId,
-          userId,
-        },
-        'Unable to post history note.',
+      const msg =
+        error instanceof Error && typeof error.message === 'string'
+          ? error.message
+          : 'Unable to post history note.';
+      this.logger.warn(
+        `Failed to post history note for room ${roomId}, user ${userId}: ${msg}`,
       );
     }
   }

--- a/apps/be/src/games/texas-holdem.gateway.ts
+++ b/apps/be/src/games/texas-holdem.gateway.ts
@@ -128,7 +128,13 @@ export class TexasHoldemGateway implements GameMessageHandler {
     validatePayloadUserId(client, userId);
 
     try {
-      await this.texasHoldemService.postHistoryNote(userId, roomId, message, 'all', isAuthenticated);
+      await this.texasHoldemService.postHistoryNote(
+        userId,
+        roomId,
+        message,
+        'all',
+        isAuthenticated,
+      );
       client.emit(
         'games.session.holdem_history_note.ack',
         maybeEncrypt({

--- a/apps/be/src/games/texas-holdem/texas-holdem.service.ts
+++ b/apps/be/src/games/texas-holdem/texas-holdem.service.ts
@@ -191,7 +191,13 @@ export class TexasHoldemService {
     scope: ChatScope = 'all',
     isAuthenticated = false,
   ) {
-    await this.historyService.postHistoryNote(roomId, userId, message, scope, isAuthenticated);
+    await this.historyService.postHistoryNote(
+      roomId,
+      userId,
+      message,
+      scope,
+      isAuthenticated,
+    );
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (session) {
       await this.realtimeService.emitSessionSnapshot(

--- a/apps/be/src/games/texas-holdem/texas-holdem.service.ts
+++ b/apps/be/src/games/texas-holdem/texas-holdem.service.ts
@@ -189,8 +189,9 @@ export class TexasHoldemService {
     roomId: string,
     message: string,
     scope: ChatScope = 'all',
+    isAuthenticated = false,
   ) {
-    await this.historyService.postHistoryNote(roomId, userId, message, scope);
+    await this.historyService.postHistoryNote(roomId, userId, message, scope, isAuthenticated);
     const session = await this.sessionsService.findSessionByRoom(roomId);
     if (session) {
       await this.realtimeService.emitSessionSnapshot(

--- a/apps/web/src/app/[locale]/admin/geo-block/GeoBlockClient.tsx
+++ b/apps/web/src/app/[locale]/admin/geo-block/GeoBlockClient.tsx
@@ -55,7 +55,6 @@ export default function GeoBlockClient() {
   }, []);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- legitimate data-fetch on mount
     fetchCountries();
   }, [fetchCountries]);
 

--- a/apps/web/src/app/[locale]/friends/FriendsPageContent.tsx
+++ b/apps/web/src/app/[locale]/friends/FriendsPageContent.tsx
@@ -99,7 +99,6 @@ export default function FriendsPageContent({
   }, [token]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- legitimate data-fetch on mount
     void loadData();
   }, [loadData]);
 

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -153,15 +153,15 @@ export function GamePageLayout(props: GamePageLayoutProps) {
     (messageId: string) => {
       const log = useGameChatStore.getState().logs.find((l) => l.id === messageId);
       if (!log) return;
-      if (log.type === 'action') {
+      if (isLobby && log.type !== 'action') {
+        roomChatDelete?.(messageId);
+      } else {
         useGameChatStore.setState((s) => ({
           logs: s.logs.filter((l) => l.id !== messageId),
         }));
-      } else {
-        roomChatDelete?.(messageId);
       }
     },
-    [roomChatDelete],
+    [isLobby, roomChatDelete],
   );
 
   // Subscribe to the store's sendMessage so we can detect when a game widget

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -14,6 +14,7 @@ import { ActiveEmotesProvider } from '@/features/games/ui/GameWidgetContainer';
 import type { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
 import { useGameRematchStore } from '@/features/games/store/gameRematchStore';
+import { useSessionStore } from '@/entities/session/store/sessionStore';
 import { AutoExitFullscreenOnFinish } from './AutoExitFullscreenOnFinish';
 import { Container, fullscreenStyles } from './styles';
 import { GameRow, ChatPanel } from './layoutStyles';
@@ -24,6 +25,7 @@ interface GamePageLayoutProps {
   session?: GameSessionSummary | null;
   inviteCode?: string;
   userId: string | null;
+  isAuthenticated?: boolean;
 
   // Connection overlays
   isDisconnected: boolean;
@@ -50,6 +52,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
     session,
     inviteCode,
     userId,
+    isAuthenticated = false,
     isDisconnected,
     isReconnecting,
     isIdle,
@@ -98,17 +101,30 @@ export function GamePageLayout(props: GamePageLayoutProps) {
     (id?: string | null) => {
       if (!id) return null;
       const member = room.members?.find((m) => m.id === id);
-      if (!member) return null;
-      return {
-        equippedAvatarId: member.equippedAvatarId ?? null,
-        equippedBadgeId: member.equippedBadgeId ?? null,
-        equippedNameColorId: member.equippedNameColorId ?? null,
-        equippedFrameId: member.equippedFrameId ?? null,
-        equippedAuraId: member.equippedAuraId ?? null,
-        equippedBannerId: member.equippedBannerId ?? null,
-      };
+      if (member) {
+        return {
+          equippedAvatarId: member.equippedAvatarId ?? null,
+          equippedBadgeId: member.equippedBadgeId ?? null,
+          equippedNameColorId: member.equippedNameColorId ?? null,
+          equippedFrameId: member.equippedFrameId ?? null,
+          equippedAuraId: member.equippedAuraId ?? null,
+          equippedBannerId: member.equippedBannerId ?? null,
+        };
+      }
+      if (id === userId) {
+        const snap = useSessionStore.getState().snapshot;
+        return {
+          equippedAvatarId: snap.equippedAvatarId ?? null,
+          equippedBadgeId: snap.equippedBadgeId ?? null,
+          equippedNameColorId: snap.equippedNameColorId ?? null,
+          equippedFrameId: snap.equippedFrameId ?? null,
+          equippedAuraId: snap.equippedAuraId ?? null,
+          equippedBannerId: snap.equippedBannerId ?? null,
+        };
+      }
+      return null;
     },
-    [room.members],
+    [room.members, userId],
   );
 
   const gameRegisteredResolver = useGameChatStore((s) => s.resolveDisplayName);
@@ -145,6 +161,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
 
   const isLobby = room.status === 'lobby';
   const isHost = room.hostId === userId;
+  const isPlayer = !!(userId && (isHost || room.members?.some((m) => m.id === userId)));
 
   const { sendMessage: roomChatSend, deleteMessage: roomChatDelete } =
     useGameRoomChat(roomId, userId, isLobby);
@@ -251,6 +268,8 @@ export function GamePageLayout(props: GamePageLayoutProps) {
               resolveDisplayName={resolveDisplayNameForList}
               resolveEquipped={resolveEquipped}
               currentUserId={userId}
+              isPlayer={isPlayer}
+              isAuthenticated={isAuthenticated}
               onEmote={sendEmote}
               isHost={isHost}
               onDeleteMessage={handleDeleteMessage}

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -9,6 +9,7 @@ import { ConnectionOverlay } from '@arcadeum/ui/components/ConnectionOverlay/Con
 import { GamesControlPanel } from '@/widgets/GamesControlPanel';
 import { GameChat, useGameChatStore } from '@/widgets/GameChat';
 import { useEmotes } from '@/features/games/hooks/useEmotes';
+import { useGameRoomChat } from '@/features/games/hooks/useGameRoomChat';
 import { ActiveEmotesProvider } from '@/features/games/ui/GameWidgetContainer';
 import type { GameRoomSummary, GameSessionSummary } from '@/shared/types/games';
 
@@ -142,6 +143,31 @@ export function GamePageLayout(props: GamePageLayoutProps) {
 
   const { isGameOver, onRematch, rematchLoading } = useGameRematchStore();
 
+  const isLobby = room.status === 'lobby';
+  const isHost = room.hostId === userId;
+
+  const { sendMessage: roomChatSend, deleteMessage: roomChatDelete } =
+    useGameRoomChat(roomId, userId, isLobby);
+
+  // In lobby mode, register the room-level chat send function
+  useEffect(() => {
+    if (isLobby && roomChatSend) {
+      useGameChatStore.getState().registerSendMessage(roomChatSend);
+    }
+  }, [isLobby, roomChatSend]);
+
+  // Seed chat store with existing room chat logs when in lobby
+  useEffect(() => {
+    if (isLobby && Array.isArray(room.chatLogs) && room.chatLogs.length > 0) {
+      const logs = room.chatLogs.map((l) => ({
+        ...l,
+        type: 'message' as const,
+        scope: (l.scope || 'all') as import('@/shared/types/games').ChatScope,
+      }));
+      useGameChatStore.getState().setLogs(logs);
+    }
+  }, [isLobby, room.chatLogs]);
+
   return (
     <>
       <style>{fullscreenStyles}</style>
@@ -207,6 +233,8 @@ export function GamePageLayout(props: GamePageLayoutProps) {
               resolveEquipped={resolveEquipped}
               currentUserId={userId}
               onEmote={sendEmote}
+              isHost={isHost}
+              onDeleteMessage={roomChatDelete}
             />
           </ChatPanel>
         </GameRow>

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GamePageLayout.tsx
@@ -149,12 +149,31 @@ export function GamePageLayout(props: GamePageLayoutProps) {
   const { sendMessage: roomChatSend, deleteMessage: roomChatDelete } =
     useGameRoomChat(roomId, userId, isLobby);
 
-  // In lobby mode, register the room-level chat send function
+  const handleDeleteMessage = useCallback(
+    (messageId: string) => {
+      const log = useGameChatStore.getState().logs.find((l) => l.id === messageId);
+      if (!log) return;
+      if (log.type === 'action') {
+        useGameChatStore.setState((s) => ({
+          logs: s.logs.filter((l) => l.id !== messageId),
+        }));
+      } else {
+        roomChatDelete?.(messageId);
+      }
+    },
+    [roomChatDelete],
+  );
+
+  // Subscribe to the store's sendMessage so we can detect when a game widget
+  // overwrites it with a session-based function.  When that happens we
+  // re-register the lobby-level function so chat keeps working in lobby mode.
+  const storeSendMessage = useGameChatStore((s) => s.sendMessage);
+
   useEffect(() => {
     if (isLobby && roomChatSend) {
       useGameChatStore.getState().registerSendMessage(roomChatSend);
     }
-  }, [isLobby, roomChatSend]);
+  }, [isLobby, roomChatSend, storeSendMessage]);
 
   // Seed chat store with existing room chat logs when in lobby
   useEffect(() => {
@@ -220,7 +239,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
 
         <GameRow flexDirection={roomFlexDirection}>
           <ActiveEmotesProvider
-            value={{ emotes: activeEmotes, resolveDisplayName }}
+            value={{ emotes: activeEmotes, resolveDisplayName, resolveEquipped }}
           >
             {children({ isFullscreen, toggleFullscreen })}
           </ActiveEmotesProvider>
@@ -234,7 +253,7 @@ export function GamePageLayout(props: GamePageLayoutProps) {
               currentUserId={userId}
               onEmote={sendEmote}
               isHost={isHost}
-              onDeleteMessage={roomChatDelete}
+              onDeleteMessage={handleDeleteMessage}
             />
           </ChatPanel>
         </GameRow>

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
@@ -387,6 +387,7 @@ export default function GameRoomPage({
         room={room}
         session={initialSession as GameSessionSummary | null}
         userId={snapshot.userId}
+        isAuthenticated={isAuthenticated}
         inviteCode={room?.inviteCode}
         isDisconnected={isDisconnected}
         isReconnecting={isReconnecting}

--- a/apps/web/src/features/admin-wallet/ui/AdminWalletDrawer.tsx
+++ b/apps/web/src/features/admin-wallet/ui/AdminWalletDrawer.tsx
@@ -136,7 +136,6 @@ export function AdminWalletDrawer({
       setData(null);
       reload();
     }
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- legitimate data-fetch on drawer open
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, userId]);
 

--- a/apps/web/src/features/games/hooks/index.ts
+++ b/apps/web/src/features/games/hooks/index.ts
@@ -5,6 +5,7 @@ export type { GameType } from './useGameActions';
 export { useRematch } from './useRematch';
 export { useGameChatIntegration } from './useGameChatIntegration';
 export { useGameChatSend } from './useGameChatSend';
+export { useGameRoomChat } from './useGameRoomChat';
 export { useFullscreen } from './useFullscreen';
 export { useAutoExitFullscreen } from './useAutoExitFullscreen';
 export { useGameRoomActions } from './useGameRoomActions';

--- a/apps/web/src/features/games/hooks/useEmotes.ts
+++ b/apps/web/src/features/games/hooks/useEmotes.ts
@@ -7,7 +7,7 @@ import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import { useGameChatStore } from '@/widgets/GameChat/store/gameChatStore';
 import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
 
-const BUBBLE_DURATION_MS = 3000;
+const BUBBLE_DURATION_MS = 5000;
 const RATE_LIMIT_MS = 2000;
 
 interface ActiveEmote {
@@ -58,19 +58,6 @@ export function useEmotes(): UseEmotesReturn {
       }, BUBBLE_DURATION_MS);
 
       timersRef.current.set(d.userId, timer);
-
-      // Add emote to chat log
-      const addLog = useGameChatStore.getState().addLog;
-      if (addLog) {
-        addLog({
-          id: `emote-${d.userId}-${d.ts ?? Date.now()}`,
-          type: 'action',
-          kind: 'system',
-          message: `${findEmoji(d.emoteId)} ${d.emoteId.replace(/_/g, ' ')}`,
-          createdAt: new Date(d.ts ?? Date.now()).toISOString(),
-          senderId: d.userId,
-        });
-      }
     }, []),
   );
 
@@ -95,6 +82,12 @@ export function useEmotes(): UseEmotesReturn {
         userId,
         emoteId,
       });
+
+      // Also send as chat message so it persists in server history
+      const sendMessage = useGameChatStore.getState().sendMessage;
+      if (sendMessage) {
+        sendMessage(`${findEmoji(emoteId)} ${emoteId.replace(/_/g, ' ')}`, 'all');
+      }
     },
     [roomId, userId],
   );

--- a/apps/web/src/features/games/hooks/useGameRoomChat.ts
+++ b/apps/web/src/features/games/hooks/useGameRoomChat.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { gameSocket } from '@/shared/lib/socket';
+import { maybeDecrypt, isSocketEncryptionEnabled } from '@/shared/lib/socket-encryption';
 import { useGameChatStore } from '@/widgets/GameChat';
 import type { ChatScope, CriticalLogEntry } from '@/shared/types/games';
 
@@ -22,15 +23,30 @@ export function useGameRoomChat(
   useEffect(() => {
     if (!isLobby || !userId) return;
 
-    const handleChat = (entry: CriticalLogEntry) => {
-      useGameChatStore.getState().addLog(entry);
+    const handleChat = async (...args: unknown[]) => {
+      let entry: CriticalLogEntry;
+      if (args.length > 0 && isSocketEncryptionEnabled()) {
+        entry = await maybeDecrypt(args[0] as string);
+      } else {
+        entry = args[0] as CriticalLogEntry;
+      }
+      if (entry && entry.id) {
+        useGameChatStore.getState().addLog(entry);
+      }
     };
 
-    const handleDelete = (payload: { messageId: string }) => {
-      const { messageId } = payload;
-      useGameChatStore.setState((s) => ({
-        logs: s.logs.filter((l) => l.id !== messageId),
-      }));
+    const handleDelete = async (...args: unknown[]) => {
+      let payload: { messageId: string };
+      if (args.length > 0 && isSocketEncryptionEnabled()) {
+        payload = await maybeDecrypt(args[0] as string);
+      } else {
+        payload = args[0] as { messageId: string };
+      }
+      if (payload?.messageId) {
+        useGameChatStore.setState((s) => ({
+          logs: s.logs.filter((l) => l.id !== payload.messageId),
+        }));
+      }
     };
 
     gameSocket.on('games.room.chat', handleChat);

--- a/apps/web/src/features/games/hooks/useGameRoomChat.ts
+++ b/apps/web/src/features/games/hooks/useGameRoomChat.ts
@@ -1,0 +1,69 @@
+import { useEffect, useCallback } from 'react';
+import { gameSocket } from '@/shared/lib/socket';
+import { useGameChatStore } from '@/widgets/GameChat';
+import type { ChatScope, CriticalLogEntry } from '@/shared/types/games';
+
+/**
+ * Lobby-level chat that works WITHOUT a game session.
+ * Stores messages in the room document and broadcasts via
+ * `games.room.chat` / `games.room.delete_chat` socket events.
+ *
+ * When a session exists (active game), the per-game
+ * `useGameChatIntegration` takes over instead.
+ */
+export function useGameRoomChat(
+  roomId: string,
+  userId: string | null,
+  isLobby: boolean,
+): {
+  sendMessage: ((message: string, scope: ChatScope) => void) | undefined;
+  deleteMessage: ((messageId: string) => void) | undefined;
+} {
+  useEffect(() => {
+    if (!isLobby || !userId) return;
+
+    const handleChat = (entry: CriticalLogEntry) => {
+      useGameChatStore.getState().addLog(entry);
+    };
+
+    const handleDelete = (payload: { messageId: string }) => {
+      const { messageId } = payload;
+      useGameChatStore.setState((s) => ({
+        logs: s.logs.filter((l) => l.id !== messageId),
+      }));
+    };
+
+    gameSocket.on('games.room.chat', handleChat);
+    gameSocket.on('games.room.delete_chat', handleDelete);
+
+    return () => {
+      gameSocket.off('games.room.chat', handleChat);
+      gameSocket.off('games.room.delete_chat', handleDelete);
+    };
+  }, [isLobby, userId]);
+
+  const sendMessage = useCallback(
+    (message: string, scope: ChatScope) => {
+      if (!userId || !isLobby) return;
+      gameSocket.emit('games.room.chat', { roomId, userId, message, scope });
+    },
+    [roomId, userId, isLobby],
+  );
+
+  const deleteMessage = useCallback(
+    (messageId: string) => {
+      if (!userId || !isLobby) return;
+      gameSocket.emit('games.room.delete_chat', {
+        roomId,
+        userId,
+        messageId,
+      });
+    },
+    [roomId, userId, isLobby],
+  );
+
+  return {
+    sendMessage: isLobby ? sendMessage : undefined,
+    deleteMessage: isLobby ? deleteMessage : undefined,
+  };
+}

--- a/apps/web/src/features/games/hooks/useGameRoomChat.ts
+++ b/apps/web/src/features/games/hooks/useGameRoomChat.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { gameSocket } from '@/shared/lib/socket';
-import { maybeDecrypt, isSocketEncryptionEnabled } from '@/shared/lib/socket-encryption';
+import { maybeDecrypt } from '@/shared/lib/socket-encryption';
 import { useGameChatStore } from '@/widgets/GameChat';
 import type { ChatScope, CriticalLogEntry } from '@/shared/types/games';
 
@@ -16,32 +16,19 @@ export function useGameRoomChat(
   roomId: string,
   userId: string | null,
   isLobby: boolean,
-): {
-  sendMessage: ((message: string, scope: ChatScope) => void) | undefined;
-  deleteMessage: ((messageId: string) => void) | undefined;
-} {
+) {
   useEffect(() => {
     if (!isLobby || !userId) return;
 
     const handleChat = async (...args: unknown[]) => {
-      let entry: CriticalLogEntry;
-      if (args.length > 0 && isSocketEncryptionEnabled()) {
-        entry = await maybeDecrypt(args[0] as string);
-      } else {
-        entry = args[0] as CriticalLogEntry;
-      }
-      if (entry && entry.id) {
+      const entry = await maybeDecrypt<CriticalLogEntry>(args[0]);
+      if (entry?.id) {
         useGameChatStore.getState().addLog(entry);
       }
     };
 
     const handleDelete = async (...args: unknown[]) => {
-      let payload: { messageId: string };
-      if (args.length > 0 && isSocketEncryptionEnabled()) {
-        payload = await maybeDecrypt(args[0] as string);
-      } else {
-        payload = args[0] as { messageId: string };
-      }
+      const payload = await maybeDecrypt<{ messageId: string }>(args[0]);
       if (payload?.messageId) {
         useGameChatStore.setState((s) => ({
           logs: s.logs.filter((l) => l.id !== payload.messageId),
@@ -81,5 +68,5 @@ export function useGameRoomChat(
   return {
     sendMessage: isLobby ? sendMessage : undefined,
     deleteMessage: isLobby ? deleteMessage : undefined,
-  };
+  } as const;
 }

--- a/apps/web/src/features/games/ui/EmoteBubble.tsx
+++ b/apps/web/src/features/games/ui/EmoteBubble.tsx
@@ -2,6 +2,8 @@
 
 import { useRef, useEffect } from 'react';
 import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
+import { useActiveEmotes } from './GameWidgetContainer.styles';
 
 const KEYFRAMES_CSS = `
 @keyframes emoteFloat {
@@ -71,6 +73,8 @@ let stylesInjected = false;
 
 export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleProps) {
   const ref = useRef<HTMLDivElement>(null);
+  const ctx = useActiveEmotes();
+  const equipped = ctx.resolveEquipped?.(playerId) ?? null;
 
   useEffect(() => {
     if (!stylesInjected) {
@@ -111,27 +115,38 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
     >
       <div
         style={{
+          position: 'relative',
           width: 72,
           height: 72,
-          borderRadius: 36,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          backgroundColor: 'rgba(15, 5, 24, 0.88)',
-          borderWidth: 1.5,
-          borderStyle: 'solid',
-          borderColor: 'rgba(236, 72, 153, 0.5)',
-          boxShadow: '0 0 18px 2px rgba(236, 72, 153, 0.45)',
-          fontSize: 42,
-          lineHeight: '48px',
         }}
       >
-        {findEmoji(current.emoteId)}
+        <div
+          style={{
+            width: 72,
+            height: 72,
+            borderRadius: 36,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'rgba(15, 5, 24, 0.88)',
+            borderWidth: 1.5,
+            borderStyle: 'solid',
+            borderColor: 'rgba(236, 72, 153, 0.5)',
+            boxShadow: '0 0 18px 2px rgba(236, 72, 153, 0.45)',
+            fontSize: 42,
+            lineHeight: '48px',
+          }}
+        >
+          {findEmoji(current.emoteId)}
+        </div>
       </div>
       {senderName && (
         <div
           data-emote-label=""
           style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 5,
             color: '#fff',
             fontSize: 12,
             fontWeight: 800,
@@ -145,6 +160,16 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
             opacity: 0,
           }}
         >
+          <EquippedPlayerAvatar
+            name={senderName}
+            size="icon"
+            equippedAvatarId={equipped?.equippedAvatarId ?? null}
+            equippedBadgeId={equipped?.equippedBadgeId ?? null}
+            equippedNameColorId={equipped?.equippedNameColorId}
+            equippedFrameId={equipped?.equippedFrameId}
+            equippedAuraId={equipped?.equippedAuraId}
+            equippedBannerId={equipped?.equippedBannerId}
+          />
           {senderName}
         </div>
       )}

--- a/apps/web/src/features/games/ui/EmoteBubble.tsx
+++ b/apps/web/src/features/games/ui/EmoteBubble.tsx
@@ -60,7 +60,7 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
       ref={ref}
       style={{
         position: 'absolute',
-        top: 24,
+        top: 100,
         right: 24,
         zIndex: 10,
         pointerEvents: 'none',
@@ -74,15 +74,15 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
       <div
         style={{
           position: 'relative',
-          width: 72,
-          height: 72,
+          width: 96,
+          height: 96,
         }}
       >
         <div
           style={{
-            width: 72,
-            height: 72,
-            borderRadius: 36,
+            width: 96,
+            height: 96,
+            borderRadius: 48,
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -91,8 +91,8 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
             borderStyle: 'solid',
             borderColor: 'rgba(236, 72, 153, 0.5)',
             boxShadow: '0 0 18px 2px rgba(236, 72, 153, 0.45)',
-            fontSize: 42,
-            lineHeight: '48px',
+            fontSize: 56,
+            lineHeight: '64px',
           }}
         >
           {findEmoji(current.emoteId)}

--- a/apps/web/src/features/games/ui/EmoteBubble.tsx
+++ b/apps/web/src/features/games/ui/EmoteBubble.tsx
@@ -2,57 +2,8 @@
 
 import { useRef, useEffect } from 'react';
 import { EMOTES, type EmoteId } from '@/widgets/GameChat/ui/EmotePicker';
-import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
+import { FloatingBubbleLabel } from './FloatingBubble';
 import { useActiveEmotes } from './GameWidgetContainer.styles';
-
-const KEYFRAMES_CSS = `
-@keyframes emoteFloat {
-  0% {
-    opacity: 0;
-    transform: translateY(140px) translateX(10px) scale(0.4) rotate(-8deg);
-  }
-  10% {
-    opacity: 1;
-    transform: translateY(70px) translateX(-15px) scale(1.2) rotate(5deg);
-  }
-  20% {
-    transform: translateY(20px) translateX(8px) scale(0.95) rotate(-3deg);
-  }
-  30% {
-    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
-  }
-  65% {
-    opacity: 1;
-    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-140px) translateX(-5px) scale(0.6) rotate(4deg);
-  }
-}
-
-@keyframes labelPop {
-  0% {
-    opacity: 0;
-    transform: translateY(10px) scale(0.5);
-  }
-  15% {
-    opacity: 1;
-    transform: translateY(-2px) scale(1.15);
-  }
-  30% {
-    transform: translateY(0) scale(1);
-  }
-  70% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-20px) scale(0.8);
-  }
-}
-`;
 
 interface ActiveEmote {
   id: string;
@@ -69,7 +20,7 @@ function findEmoji(emoteId: EmoteId): string {
   return EMOTES.find((e) => e.id === emoteId)?.emoji ?? '❓';
 }
 
-let stylesInjected = false;
+const ACCENT_COLOR = 'rgba(236,72,153,0.9)';
 
 export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleProps) {
   const ref = useRef<HTMLDivElement>(null);
@@ -77,25 +28,32 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
   const equipped = ctx.resolveEquipped?.(playerId) ?? null;
 
   useEffect(() => {
-    if (!stylesInjected) {
-      const style = document.createElement('style');
-      style.textContent = KEYFRAMES_CSS;
-      document.head.appendChild(style);
-      stylesInjected = true;
-    }
     const el = ref.current;
     if (el) {
-      el.style.animation = 'emoteFloat 2.4s ease-out forwards';
-      const label = el.querySelector('[data-emote-label]');
+      el.style.animation = 'floatingBubbleFloat 2.4s ease-out forwards';
+      const label = el.querySelector('[data-bubble-label]');
       if (label) {
         (label as HTMLElement).style.animation =
-          'labelPop 2.4s ease-out forwards';
+          'floatingLabelPop 2.4s ease-out forwards';
       }
     }
   }, []);
 
   const current = activeEmotes.find((e) => e.id === playerId);
   if (!current) return null;
+
+  const label = senderName ? (
+    <FloatingBubbleLabel
+      senderName={senderName}
+      equippedAvatarId={equipped?.equippedAvatarId ?? null}
+      equippedBadgeId={equipped?.equippedBadgeId ?? null}
+      equippedNameColorId={equipped?.equippedNameColorId}
+      equippedFrameId={equipped?.equippedFrameId}
+      equippedAuraId={equipped?.equippedAuraId}
+      equippedBannerId={equipped?.equippedBannerId}
+      accentColor={ACCENT_COLOR}
+    />
+  ) : undefined;
 
   return (
     <div
@@ -140,39 +98,7 @@ export function EmoteBubble({ playerId, activeEmotes, senderName }: EmoteBubbleP
           {findEmoji(current.emoteId)}
         </div>
       </div>
-      {senderName && (
-        <div
-          data-emote-label=""
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 5,
-            color: '#fff',
-            fontSize: 12,
-            fontWeight: 800,
-            textShadow:
-              '0 0 8px rgba(236,72,153,0.9), 0 2px 10px rgba(0,0,0,0.8)',
-            letterSpacing: 1,
-            padding: '3px 10px',
-            borderRadius: 8,
-            backgroundColor: 'rgba(236, 72, 153, 0.35)',
-            whiteSpace: 'nowrap',
-            opacity: 0,
-          }}
-        >
-          <EquippedPlayerAvatar
-            name={senderName}
-            size="icon"
-            equippedAvatarId={equipped?.equippedAvatarId ?? null}
-            equippedBadgeId={equipped?.equippedBadgeId ?? null}
-            equippedNameColorId={equipped?.equippedNameColorId}
-            equippedFrameId={equipped?.equippedFrameId}
-            equippedAuraId={equipped?.equippedAuraId}
-            equippedBannerId={equipped?.equippedBannerId}
-          />
-          {senderName}
-        </div>
-      )}
+      {label}
     </div>
   );
 }

--- a/apps/web/src/features/games/ui/FloatingBubble.tsx
+++ b/apps/web/src/features/games/ui/FloatingBubble.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
+
+const FLOAT_KEYFRAMES_CSS = `
+@keyframes floatingBubbleFloat {
+  0% {
+    opacity: 0;
+    transform: translateY(140px) translateX(10px) scale(0.4) rotate(-8deg);
+  }
+  10% {
+    opacity: 1;
+    transform: translateY(70px) translateX(-15px) scale(1.2) rotate(5deg);
+  }
+  20% {
+    transform: translateY(20px) translateX(8px) scale(0.95) rotate(-3deg);
+  }
+  30% {
+    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
+  }
+  65% {
+    opacity: 1;
+    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-140px) translateX(-5px) scale(0.6) rotate(4deg);
+  }
+}
+
+@keyframes floatingLabelPop {
+  0% {
+    opacity: 0;
+    transform: translateY(10px) scale(0.5);
+  }
+  15% {
+    opacity: 1;
+    transform: translateY(-2px) scale(1.15);
+  }
+  30% {
+    transform: translateY(0) scale(1);
+  }
+  70% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-20px) scale(0.8);
+  }
+}
+`;
+
+if (typeof document !== 'undefined') {
+  const style = document.createElement('style');
+  style.textContent = FLOAT_KEYFRAMES_CSS;
+  document.head.appendChild(style);
+}
+
+interface FloatingBubbleLabelProps {
+  senderName: string;
+  equippedAvatarId?: string | null;
+  equippedBadgeId?: string | null;
+  equippedNameColorId?: string | null;
+  equippedFrameId?: string | null;
+  equippedAuraId?: string | null;
+  equippedBannerId?: string | null;
+  accentColor: string;
+}
+
+export function FloatingBubbleLabel({
+  senderName,
+  equippedAvatarId,
+  equippedBadgeId,
+  equippedNameColorId,
+  equippedFrameId,
+  equippedAuraId,
+  equippedBannerId,
+  accentColor,
+}: FloatingBubbleLabelProps) {
+  const bgColor = accentColor.replace('0.9', '0.35').replace('0.8', '0.3');
+
+  return (
+    <div
+      data-bubble-label=""
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 5,
+        color: '#fff',
+        fontSize: 12,
+        fontWeight: 800,
+        textShadow: `0 0 8px ${accentColor}, 0 2px 10px rgba(0,0,0,0.8)`,
+        letterSpacing: 1,
+        padding: '3px 10px',
+        borderRadius: 8,
+        backgroundColor: bgColor,
+        whiteSpace: 'nowrap',
+        opacity: 0,
+      }}
+    >
+      <EquippedPlayerAvatar
+        name={senderName}
+        size="icon"
+        equippedAvatarId={equippedAvatarId ?? null}
+        equippedBadgeId={equippedBadgeId ?? null}
+        equippedNameColorId={equippedNameColorId}
+        equippedFrameId={equippedFrameId}
+        equippedAuraId={equippedAuraId}
+        equippedBannerId={equippedBannerId}
+      />
+      {senderName}
+    </div>
+  );
+}

--- a/apps/web/src/features/games/ui/FloatingBubble.tsx
+++ b/apps/web/src/features/games/ui/FloatingBubble.tsx
@@ -99,16 +99,18 @@ export function FloatingBubbleLabel({
         opacity: 0,
       }}
     >
-      <EquippedPlayerAvatar
-        name={senderName}
-        size="icon"
-        equippedAvatarId={equippedAvatarId ?? null}
-        equippedBadgeId={equippedBadgeId ?? null}
-        equippedNameColorId={equippedNameColorId}
-        equippedFrameId={equippedFrameId}
-        equippedAuraId={equippedAuraId}
-        equippedBannerId={equippedBannerId}
-      />
+      <span style={{ display: 'inline-flex', transform: 'scale(0.7)', transformOrigin: 'center' }}>
+        <EquippedPlayerAvatar
+          name={senderName}
+          size="icon"
+          equippedAvatarId={equippedAvatarId ?? null}
+          equippedBadgeId={equippedBadgeId ?? null}
+          equippedNameColorId={equippedNameColorId}
+          equippedFrameId={equippedFrameId}
+          equippedAuraId={equippedAuraId}
+          equippedBannerId={equippedBannerId}
+        />
+      </span>
       {senderName}
     </div>
   );

--- a/apps/web/src/features/games/ui/GameWidgetContainer.styles.tsx
+++ b/apps/web/src/features/games/ui/GameWidgetContainer.styles.tsx
@@ -27,6 +27,14 @@ interface ActiveEmote {
 interface ActiveEmotesContextValue {
   emotes: ActiveEmote[];
   resolveDisplayName?: (id?: string, fallback?: string) => string | undefined;
+  resolveEquipped?: (id?: string | null) => {
+    equippedAvatarId: string | null;
+    equippedBadgeId: string | null;
+    equippedNameColorId: string | null;
+    equippedFrameId: string | null;
+    equippedAuraId: string | null;
+    equippedBannerId: string | null;
+  } | null;
 }
 
 const ActiveEmotesContext = createContext<ActiveEmotesContextValue>({

--- a/apps/web/src/features/games/ui/LobbySidebar.tsx
+++ b/apps/web/src/features/games/ui/LobbySidebar.tsx
@@ -44,6 +44,7 @@ import {
 } from './lobbyStyles';
 import { SortablePlayerItem, AVATAR_COLORS } from './SortablePlayerItem';
 import { ConfirmationModal } from './ConfirmationModal';
+import { InGameAvatar } from './InGameAvatar';
 
 interface LobbySidebarProps {
   room: GameRoomSummary;
@@ -251,11 +252,19 @@ export function LobbySidebar({
                 AVATAR_COLORS[member.displayName.length % AVATAR_COLORS.length];
               return (
                 <PlayerItem key={member.id} $isHost={isRoomHost}>
-                  <LobbyPlayerAvatar backgroundColor={avatarColor}>
-                    <LobbyPlayerAvatarText>
-                      {getInitials(member.displayName)}
-                    </LobbyPlayerAvatarText>
-                  </LobbyPlayerAvatar>
+                  {member.equippedAvatarId ? (
+                    <InGameAvatar
+                      playerId={member.id}
+                      name={member.displayName}
+                      size="sm"
+                    />
+                  ) : (
+                    <LobbyPlayerAvatar backgroundColor={avatarColor}>
+                      <LobbyPlayerAvatarText>
+                        {getInitials(member.displayName)}
+                      </LobbyPlayerAvatarText>
+                    </LobbyPlayerAvatar>
+                  )}
                   <PlayerInfo>
                     <LobbyPlayerName>{member.displayName}</LobbyPlayerName>
                     {isRoomHost && (

--- a/apps/web/src/features/games/ui/SortablePlayerItem.tsx
+++ b/apps/web/src/features/games/ui/SortablePlayerItem.tsx
@@ -11,6 +11,7 @@ import {
   LobbyPlayerName,
   LobbyPlayerAvatarText,
 } from './lobbyStyles';
+import { InGameAvatar } from './InGameAvatar';
 
 // ============ Avatar Colors ============
 
@@ -70,11 +71,19 @@ export function SortablePlayerItem({
       {...(isHost ? { ...attributes, ...listeners } : {})}
     >
       <PlayerItem $isHost={isRoomHost}>
-        <LobbyPlayerAvatar backgroundColor={avatarColor}>
-          <LobbyPlayerAvatarText>
-            {member.displayName.slice(0, 2).toUpperCase()}
-          </LobbyPlayerAvatarText>
-        </LobbyPlayerAvatar>
+        {member.equippedAvatarId ? (
+          <InGameAvatar
+            playerId={member.id}
+            name={member.displayName}
+            size="sm"
+          />
+        ) : (
+          <LobbyPlayerAvatar backgroundColor={avatarColor}>
+            <LobbyPlayerAvatarText>
+              {member.displayName.slice(0, 2).toUpperCase()}
+            </LobbyPlayerAvatarText>
+          </LobbyPlayerAvatar>
+        )}
         <PlayerInfo>
           <LobbyPlayerName>{member.displayName}</LobbyPlayerName>
           {isRoomHost && (

--- a/apps/web/src/shared/i18n/messages/games/shared/by.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/by.ts
@@ -151,6 +151,8 @@ export const byMessages = {
     seaBattleSonarHint: 'Паказаць размяшчэнне караблёў',
     seaBattleRadar: 'Радар',
     seaBattleRadarHint: 'Сканіраваць радок або слупок',
+    seaBattleRevealAll: 'Хваля сканіравання',
+    seaBattleRevealAllHint: 'Каротка паказаць усе караблі ў пачатку бою',
     tttBoardSize: 'Памер поля',
     tttWinLength: '{{n}} запар для перамогі',
     tttMaxPlayers: 'Да {{n}} гульцоў',

--- a/apps/web/src/shared/i18n/messages/games/shared/en.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/en.ts
@@ -151,6 +151,8 @@ export const enMessages = {
     seaBattleSonarHint: 'Reveal ship locations',
     seaBattleRadar: 'Radar',
     seaBattleRadarHint: 'Scan a row or column',
+    seaBattleRevealAll: 'Scan Wave',
+    seaBattleRevealAllHint: 'Reveal all ships briefly at battle start',
     tttBoardSize: 'Board Size',
     tttWinLength: '{{n}} in a row to win',
     tttMaxPlayers: 'Up to {{n}} players',

--- a/apps/web/src/shared/i18n/messages/games/shared/es.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/es.ts
@@ -152,6 +152,8 @@ export const esMessages = {
     seaBattleSonarHint: 'Revelar ubicaciones de barcos',
     seaBattleRadar: 'Radar',
     seaBattleRadarHint: 'Escanear una fila o columna',
+    seaBattleRevealAll: 'Onda de escaneo',
+    seaBattleRevealAllHint: 'Revelar todos los barcos brevemente al inicio del combate',
     tttBoardSize: 'Tamaño del Tablero',
     tttWinLength: '{{n}} en fila para ganar',
     tttMaxPlayers: 'Hasta {{n}} jugadores',

--- a/apps/web/src/shared/i18n/messages/games/shared/fr.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/fr.ts
@@ -152,6 +152,8 @@ export const frMessages = {
     seaBattleSonarHint: 'Révéler les positions des navires',
     seaBattleRadar: 'Radar',
     seaBattleRadarHint: 'Scanner une ligne ou une colonne',
+    seaBattleRevealAll: 'Vague de scan',
+    seaBattleRevealAllHint: 'Révéler brièvement tous les navires au début du combat',
     tttBoardSize: 'Taille du Plateau',
     tttWinLength: '{{n}} en ligne pour gagner',
     tttMaxPlayers: "Jusqu'à {{n}} joueurs",

--- a/apps/web/src/shared/i18n/messages/games/shared/ru.ts
+++ b/apps/web/src/shared/i18n/messages/games/shared/ru.ts
@@ -151,6 +151,8 @@ export const ruMessages = {
     seaBattleSonarHint: 'Показать расположение кораблей',
     seaBattleRadar: 'Радар',
     seaBattleRadarHint: 'Сканировать строку или столбец',
+    seaBattleRevealAll: 'Волна сканирования',
+    seaBattleRevealAllHint: 'Кратко показать все корабли в начале боя',
     tttBoardSize: 'Размер поля',
     tttWinLength: '{{n}} подряд для победы',
     tttMaxPlayers: 'До {{n}} игроков',

--- a/apps/web/src/shared/types/games.ts
+++ b/apps/web/src/shared/types/games.ts
@@ -56,6 +56,14 @@ export interface GameRoomSummary {
   rematchDeclinedUsers?: GameRoomMemberSummary[];
   host?: GameRoomMemberSummary;
   members?: GameRoomMemberSummary[];
+  chatLogs?: Array<{
+    id: string;
+    senderId: string;
+    senderName: string;
+    message: string;
+    scope: string;
+    createdAt: string;
+  }>;
 }
 
 export interface GameSessionSummary {

--- a/apps/web/src/widgets/ChessGame/ui/ChessClock.tsx
+++ b/apps/web/src/widgets/ChessGame/ui/ChessClock.tsx
@@ -34,7 +34,6 @@ function useCountdown(
   useEffect(() => {
     if (!clock) return;
     if (isGameOver || !isMyTurn) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- legitimate clock sync
       setDisplaySeconds(computeRemaining(clock));
       return;
     }

--- a/apps/web/src/widgets/CriticalGame/ui/RulesModal.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/RulesModal.tsx
@@ -88,7 +88,6 @@ export function RulesModal({
   React.useEffect(() => {
     setMounted(true);
     return () => setMounted(false);
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- mount-tracking for animation
   }, []);
 
   if (!isOpen || !mounted) return null;

--- a/apps/web/src/widgets/CriticalGame/ui/styles/chat-widgets.tsx
+++ b/apps/web/src/widgets/CriticalGame/ui/styles/chat-widgets.tsx
@@ -169,13 +169,15 @@ export const ChatBubbleContainer = memo(function ChatBubbleContainer({
   $visible,
   $position,
   $variant,
+  style,
   ...props
-}: ChatBubbleContainerProps): ReactElement {
+}: ChatBubbleContainerProps & { style?: React.CSSProperties }): ReactElement {
   return (
     <StyledChatBubbleContainer
       $visible={$visible}
       $position={$position}
       $variant={$variant}
+      style={{ wordBreak: 'break-word', overflowWrap: 'anywhere', ...style }}
       {...props}
     />
   );

--- a/apps/web/src/widgets/GameChat/hooks/useLatestChatMessage.ts
+++ b/apps/web/src/widgets/GameChat/hooks/useLatestChatMessage.ts
@@ -13,14 +13,19 @@ interface UseLatestChatMessageResult {
   dismiss: () => void;
 }
 
+const EMOJI_STARTER = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/u;
+
+function isEmoteMessage(message: string): boolean {
+  if (!message) return false;
+  const firstCodePoint = message.codePointAt(0);
+  if (firstCodePoint === undefined) return false;
+  return EMOJI_STARTER.test(String.fromCodePoint(firstCodePoint));
+}
+
 export function useLatestChatMessage(
   logs: ChatLogEntry[],
 ): UseLatestChatMessageResult {
   const [dismissedId, setDismissedId] = useState<string | null>(null);
-  // Only messages created after the hook mounted are eligible for a popup.
-  // Otherwise every page refresh would replay the latest historical message
-  // as if it had just been sent. useState's lazy initializer captures the
-  // mount time exactly once.
   const [mountTime] = useState<number>(() => Date.now());
 
   const derivedMessage = useMemo<LatestChatMessage | null>(() => {
@@ -30,6 +35,7 @@ export function useLatestChatMessage(
       .reverse()
       .find((log) => {
         if (log.type !== 'message' || !log.senderId) return false;
+        if (isEmoteMessage(log.message)) return false;
         const t = log.createdAt
           ? new Date(log.createdAt).getTime()
           : Number.POSITIVE_INFINITY;

--- a/apps/web/src/widgets/GameChat/ui/ChatLogItem.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatLogItem.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import type { ChatLogEntry } from '../store/gameChatStore';
+import { useGameChatStore } from '../store/gameChatStore';
+import { GameChatRow } from './GameChatRow';
+import { GameChatSystemRow, GameChatEmoteRow } from './GameChatSystemRow';
+import type { EquippedResolver } from './types';
+import {
+  inferSysKind,
+  parseEmoteMessage,
+  parseMoveCell,
+  renderResultHighlights,
+} from './chatHelpers';
+
+interface ChatLogItemProps {
+  log: ChatLogEntry;
+  senderName?: string;
+  senderColor?: string;
+  targetName?: string;
+  targetColor?: string;
+  currentUserId?: string | null;
+  resolveEquipped?: EquippedResolver;
+  isHost?: boolean;
+  onDeleteMessage?: (messageId: string) => void;
+}
+
+const DELETE_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  top: 4,
+  right: 4,
+  background: 'rgba(239,68,68,0.8)',
+  color: 'white',
+  border: 'none',
+  borderRadius: 4,
+  width: 20,
+  height: 20,
+  fontSize: 12,
+  lineHeight: '20px',
+  cursor: 'pointer',
+  opacity: 0,
+  transition: 'opacity 120ms ease',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 0,
+};
+
+function DeleteButton({
+  messageId,
+  onDelete,
+}: {
+  messageId: string;
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <button
+      className="chat-delete-btn"
+      onClick={() => onDelete(messageId)}
+      title="Delete message"
+      aria-label="Delete message"
+      style={DELETE_STYLE}
+      onMouseEnter={(e) => (e.currentTarget.style.opacity = '1')}
+      onMouseLeave={(e) => (e.currentTarget.style.opacity = '0')}
+    >
+      ×
+    </button>
+  );
+}
+
+export function ChatLogItem({
+  log,
+  senderName,
+  senderColor,
+  targetName,
+  targetColor,
+  currentUserId,
+  resolveEquipped,
+  isHost,
+  onDeleteMessage,
+}: ChatLogItemProps) {
+
+  if (log.type === 'system' || log.type === 'action') {
+    const moveCell = parseMoveCell(log.message);
+    if (moveCell) {
+      return (
+        <GameChatRow
+          senderId={log.senderId ?? null}
+          senderName={log.senderId ? senderName : undefined}
+          senderColor={senderColor}
+          content={log.message}
+          type="action"
+          isOwn={false}
+          resolveEquipped={resolveEquipped}
+          moveCell={moveCell}
+          onMoveHover={(cell) =>
+            useGameChatStore.getState().setHighlightedCell(cell)
+          }
+          onMoveClick={(cell) =>
+            useGameChatStore.getState().setPersistedCell(cell)
+          }
+        />
+      );
+    }
+    const emote = parseEmoteMessage(log.message);
+    if (emote) {
+      return (
+        <GameChatEmoteRow
+          emoji={emote.emoji}
+          senderName={senderName}
+          senderColor={senderColor}
+          senderId={log.senderId ?? null}
+          resolveEquipped={resolveEquipped}
+        />
+      );
+    }
+    return (
+      <GameChatSystemRow
+        kind={inferSysKind(log)}
+        content={renderResultHighlights(log.message)}
+        senderName={senderName}
+        senderColor={senderColor}
+        targetName={targetName}
+        targetColor={targetColor}
+      />
+    );
+  }
+
+  const isOwn = !!currentUserId && log.senderId === currentUserId;
+  const emote = parseEmoteMessage(log.message);
+  const canDelete = isHost || log.senderId === currentUserId;
+
+  if (emote) {
+    return (
+      <div className="chat-msg-row" style={{ position: 'relative' }}>
+        <GameChatEmoteRow
+          emoji={emote.emoji}
+          senderName={senderName}
+          senderColor={senderColor}
+          senderId={log.senderId ?? null}
+          resolveEquipped={resolveEquipped}
+        />
+        {canDelete && onDeleteMessage && (
+          <DeleteButton messageId={log.id} onDelete={onDeleteMessage} />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="chat-msg-row" style={{ position: 'relative' }}>
+      <GameChatRow
+        senderId={log.senderId ?? null}
+        senderName={log.senderId ? senderName : undefined}
+        senderColor={senderColor}
+        targetName={targetName}
+        targetColor={targetColor}
+        content={log.message}
+        type={log.type}
+        isOwn={isOwn}
+        resolveEquipped={resolveEquipped}
+      />
+      {canDelete && onDeleteMessage && (log.type === 'message' || log.type === 'action') && (
+        <DeleteButton messageId={log.id} onDelete={onDeleteMessage} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatMessagePopup.tsx
@@ -1,58 +1,7 @@
 'use client';
 
 import { useRef, useEffect } from 'react';
-
-
-const KEYFRAMES_CSS = `
-@keyframes chatBubbleFloat {
-  0% {
-    opacity: 0;
-    transform: translateY(140px) translateX(10px) scale(0.4) rotate(-8deg);
-  }
-  10% {
-    opacity: 1;
-    transform: translateY(70px) translateX(-15px) scale(1.2) rotate(5deg);
-  }
-  20% {
-    transform: translateY(20px) translateX(8px) scale(0.95) rotate(-3deg);
-  }
-  30% {
-    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
-  }
-  65% {
-    opacity: 1;
-    transform: translateY(0) translateX(0) scale(1) rotate(0deg);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-140px) translateX(-5px) scale(0.6) rotate(4deg);
-  }
-}
-
-@keyframes chatLabelPop {
-  0% {
-    opacity: 0;
-    transform: translateY(10px) scale(0.5);
-  }
-  15% {
-    opacity: 1;
-    transform: translateY(-2px) scale(1.15);
-  }
-  30% {
-    transform: translateY(0) scale(1);
-  }
-  70% {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-  100% {
-    opacity: 0;
-    transform: translateY(-20px) scale(0.8);
-  }
-}
-`;
-
-let stylesInjected = false;
+import { FloatingBubbleLabel } from '@/features/games/ui/FloatingBubble';
 
 interface ChatMessagePopupProps {
   senderId?: string | null;
@@ -69,28 +18,30 @@ interface ChatMessagePopupProps {
   isOwn?: boolean;
 }
 
+const ACCENT_COLOR = 'rgba(99,102,241,0.9)';
+
 export function ChatMessagePopup({
   senderName,
+  senderEquippedAvatarId,
+  senderEquippedBadgeId,
+  senderEquippedNameColorId,
+  senderEquippedFrameId,
+  senderEquippedAuraId,
+  senderEquippedBannerId,
   message,
   visible,
   onDismiss,
 }: ChatMessagePopupProps) {
-  const ref = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!stylesInjected) {
-      const style = document.createElement('style');
-      style.textContent = KEYFRAMES_CSS;
-      document.head.appendChild(style);
-      stylesInjected = true;
-    }
-    const el = ref.current;
+    const el = containerRef.current;
     if (el) {
-      el.style.animation = 'chatBubbleFloat 3s ease-out forwards';
-      const label = el.querySelector('[data-msg-label]');
+      el.style.animation = 'floatingBubbleFloat 3s ease-out forwards';
+      const label = el.querySelector('[data-bubble-label]');
       if (label) {
         (label as HTMLElement).style.animation =
-          'chatLabelPop 3s ease-out forwards';
+          'floatingLabelPop 3s ease-out forwards';
       }
     }
   }, []);
@@ -102,9 +53,22 @@ export function ChatMessagePopup({
 
   if (!visible) return null;
 
+  const label = senderName ? (
+    <FloatingBubbleLabel
+      senderName={senderName}
+      equippedAvatarId={senderEquippedAvatarId}
+      equippedBadgeId={senderEquippedBadgeId}
+      equippedNameColorId={senderEquippedNameColorId}
+      equippedFrameId={senderEquippedFrameId}
+      equippedAuraId={senderEquippedAuraId}
+      equippedBannerId={senderEquippedBannerId}
+      accentColor={ACCENT_COLOR}
+    />
+  ) : undefined;
+
   return (
     <div
-      ref={ref}
+      ref={containerRef}
       onClick={onDismiss}
       data-testid="chat-message-popup"
       style={{
@@ -144,26 +108,7 @@ export function ChatMessagePopup({
       >
         {message}
       </div>
-      {senderName && (
-        <div
-          data-msg-label=""
-          style={{
-            color: '#fff',
-            fontSize: 12,
-            fontWeight: 800,
-            textShadow:
-              '0 0 8px rgba(99,102,241,0.9), 0 2px 10px rgba(0,0,0,0.8)',
-            letterSpacing: 1,
-            padding: '3px 10px',
-            borderRadius: 8,
-            backgroundColor: 'rgba(99, 102, 241, 0.35)',
-            whiteSpace: 'nowrap',
-            opacity: 0,
-          }}
-        >
-          {senderName}
-        </div>
-      )}
+      {label}
     </div>
   );
 }

--- a/apps/web/src/widgets/GameChat/ui/ChatSenderLabel.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatSenderLabel.tsx
@@ -1,61 +1,32 @@
 'use client';
 
-import { Typography } from '@arcadeum/ui';
 import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
 import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
-import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
 import type { EquippedResolver } from './types';
 
 interface ChatSenderLabelProps {
   senderName: string;
-  senderColor?: string;
   senderId?: string | null;
   resolveEquipped?: EquippedResolver;
 }
 
 export function ChatSenderLabel({
   senderName,
-  senderColor,
   senderId,
   resolveEquipped,
 }: ChatSenderLabelProps) {
   const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
-  const { nameColor } = useEquippedCosmetics({
-    equippedAvatarId: resolved?.equippedAvatarId,
-    equippedBadgeId: resolved?.equippedBadgeId,
-    equippedNameColorId: resolved?.equippedNameColorId,
-    equippedFrameId: resolved?.equippedFrameId,
-    equippedAuraId: resolved?.equippedAuraId,
-    equippedBannerId: resolved?.equippedBannerId,
-  });
-  const nameProps = nameColorRenderProps(nameColor);
-  const resolvedSenderColor = nameProps.color ?? senderColor;
 
   return (
-    <span
-      style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
-      data-testid="chat-sender-label"
-    >
-      <EquippedPlayerAvatar
-        name={senderName}
-        size="icon"
-        equippedAvatarId={resolved?.equippedAvatarId ?? null}
-        equippedBadgeId={resolved?.equippedBadgeId ?? null}
-        equippedNameColorId={resolved?.equippedNameColorId}
-        equippedFrameId={resolved?.equippedFrameId}
-        equippedAuraId={resolved?.equippedAuraId}
-        equippedBannerId={resolved?.equippedBannerId}
-      />
-      <Typography
-        uiSize="xs"
-        weight="600"
-        color={resolvedSenderColor}
-        letterSpacing={0.5}
-        textTransform="uppercase"
-        style={nameProps.style}
-      >
-        {senderName}
-      </Typography>
-    </span>
+    <EquippedPlayerAvatar
+      name={senderName}
+      size="sm"
+      equippedAvatarId={resolved?.equippedAvatarId ?? null}
+      equippedBadgeId={resolved?.equippedBadgeId ?? null}
+      equippedNameColorId={resolved?.equippedNameColorId}
+      equippedFrameId={resolved?.equippedFrameId}
+      equippedAuraId={resolved?.equippedAuraId}
+      equippedBannerId={resolved?.equippedBannerId}
+    />
   );
 }

--- a/apps/web/src/widgets/GameChat/ui/ChatSenderLabel.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatSenderLabel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
-import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
 import type { EquippedResolver } from './types';
 
 interface ChatSenderLabelProps {

--- a/apps/web/src/widgets/GameChat/ui/ChatSenderLabel.tsx
+++ b/apps/web/src/widgets/GameChat/ui/ChatSenderLabel.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Typography } from '@arcadeum/ui';
+import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
+import type { EquippedResolver } from './types';
+
+interface ChatSenderLabelProps {
+  senderName: string;
+  senderColor?: string;
+  senderId?: string | null;
+  resolveEquipped?: EquippedResolver;
+}
+
+export function ChatSenderLabel({
+  senderName,
+  senderColor,
+  senderId,
+  resolveEquipped,
+}: ChatSenderLabelProps) {
+  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
+  const { nameColor } = useEquippedCosmetics({
+    equippedAvatarId: resolved?.equippedAvatarId,
+    equippedBadgeId: resolved?.equippedBadgeId,
+    equippedNameColorId: resolved?.equippedNameColorId,
+    equippedFrameId: resolved?.equippedFrameId,
+    equippedAuraId: resolved?.equippedAuraId,
+    equippedBannerId: resolved?.equippedBannerId,
+  });
+  const nameProps = nameColorRenderProps(nameColor);
+  const resolvedSenderColor = nameProps.color ?? senderColor;
+
+  return (
+    <span
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
+      data-testid="chat-sender-label"
+    >
+      <EquippedPlayerAvatar
+        name={senderName}
+        size="icon"
+        equippedAvatarId={resolved?.equippedAvatarId ?? null}
+        equippedBadgeId={resolved?.equippedBadgeId ?? null}
+        equippedNameColorId={resolved?.equippedNameColorId}
+        equippedFrameId={resolved?.equippedFrameId}
+        equippedAuraId={resolved?.equippedAuraId}
+        equippedBannerId={resolved?.equippedBannerId}
+      />
+      <Typography
+        uiSize="xs"
+        weight="600"
+        color={resolvedSenderColor}
+        letterSpacing={0.5}
+        textTransform="uppercase"
+        style={nameProps.style}
+      >
+        {senderName}
+      </Typography>
+    </span>
+  );
+}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -425,14 +425,55 @@ export function GameChat({
                 const emote = parseEmoteMessage(log.message);
                 if (emote) {
                   return (
-                    <GameChatEmoteRow
+                    <div
                       key={log.id}
-                      emoji={emote.emoji}
-                      senderName={senderName}
-                      senderColor={senderColor}
-                      senderId={log.senderId ?? null}
-                      resolveEquipped={resolveEquipped}
-                    />
+                      className="chat-msg-row"
+                      style={{ position: 'relative' }}
+                    >
+                      <GameChatEmoteRow
+                        emoji={emote.emoji}
+                        senderName={senderName}
+                        senderColor={senderColor}
+                        senderId={log.senderId ?? null}
+                        resolveEquipped={resolveEquipped}
+                      />
+                      {(isHost || log.senderId === currentUserId) && onDeleteMessage && (
+                        <button
+                          className="chat-delete-btn"
+                          onClick={() => onDeleteMessage(log.id)}
+                          title="Delete message"
+                          aria-label="Delete message"
+                          style={{
+                            position: 'absolute',
+                            top: 4,
+                            right: 4,
+                            background: 'rgba(239,68,68,0.8)',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: 4,
+                            width: 20,
+                            height: 20,
+                            fontSize: 12,
+                            lineHeight: '20px',
+                            cursor: 'pointer',
+                            opacity: 0,
+                            transition: 'opacity 120ms ease',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            padding: 0,
+                          }}
+                          onMouseEnter={(e) =>
+                            (e.currentTarget.style.opacity = '1')
+                          }
+                          onMouseLeave={(e) =>
+                            (e.currentTarget.style.opacity = '0')
+                          }
+                        >
+                          ×
+                        </button>
+                      )}
+                    </div>
                   );
                 }
                 return (

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -12,7 +12,7 @@ import { IconButton, CloseIcon, Typography } from '@arcadeum/ui';
 import type { ScrollView as TamaguiScrollView } from 'tamagui';
 import { scrollbarStyles } from '@/shared/lib/styles';
 import { useGameChatStore } from '../store/gameChatStore';
-import type { ChatScope } from '../store/gameChatStore';
+import type { ChatScope, ChatLogEntry } from '../store/gameChatStore';
 import { useChatCollapsed } from '../hooks/useChatCollapsed';
 import type { EquippedResolver } from './types';
 import type { EmoteId } from './EmotePicker';

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -16,7 +16,7 @@ import { useGameChatStore } from '../store/gameChatStore';
 import type { ChatScope, ChatLogEntry } from '../store/gameChatStore';
 import { useChatCollapsed } from '../hooks/useChatCollapsed';
 import { GameChatRow } from './GameChatRow';
-import { GameChatSystemRow, type SystemRowKind } from './GameChatSystemRow';
+import { GameChatSystemRow, type SystemRowKind, GameChatEmoteRow } from './GameChatSystemRow';
 import type { EquippedResolver } from './types';
 import type { EmoteId } from './EmotePicker';
 import { ChatQuickBar } from './ChatQuickBar';
@@ -104,6 +104,21 @@ function inferSysKind(log: ChatLogEntry): SystemRowKind {
   if (msg.includes('join') || msg.includes('placing') || msg.includes('left '))
     return 'join';
   return log.type === 'action' ? 'combo' : 'elim';
+}
+
+const EMOJI_STARTER = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/u;
+
+function parseEmoteMessage(message: string): { emoji: string; name: string } | null {
+  const firstCodePoint = message.codePointAt(0);
+  if (firstCodePoint === undefined) return null;
+  const firstChar = String.fromCodePoint(firstCodePoint);
+  if (!EMOJI_STARTER.test(firstChar)) return null;
+  const spaceIdx = message.indexOf(' ');
+  if (spaceIdx === -1) return { emoji: message, name: '' };
+  return {
+    emoji: message.slice(0, spaceIdx),
+    name: message.slice(spaceIdx + 1),
+  };
 }
 
 function logBelongsToScope(log: ChatLogEntry, scope: ChatScope): boolean {
@@ -381,6 +396,19 @@ export function GameChat({
                       />
                     );
                   }
+                  const emote = parseEmoteMessage(log.message);
+                  if (emote) {
+                    return (
+                      <GameChatEmoteRow
+                        key={log.id}
+                        emoji={emote.emoji}
+                        senderName={senderName}
+                        senderColor={senderColor}
+                        senderId={log.senderId ?? null}
+                        resolveEquipped={resolveEquipped}
+                      />
+                    );
+                  }
                   return (
                     <GameChatSystemRow
                       key={log.id}
@@ -394,6 +422,19 @@ export function GameChat({
                   );
                 }
                 const isOwn = !!currentUserId && log.senderId === currentUserId;
+                const emote = parseEmoteMessage(log.message);
+                if (emote) {
+                  return (
+                    <GameChatEmoteRow
+                      key={log.id}
+                      emoji={emote.emoji}
+                      senderName={senderName}
+                      senderColor={senderColor}
+                      senderId={log.senderId ?? null}
+                      resolveEquipped={resolveEquipped}
+                    />
+                  );
+                }
                 return (
                   <div
                     key={log.id}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -53,6 +53,8 @@ interface GameChatProps {
   resolveDisplayName?: (id?: string, fallback?: string) => string | undefined;
   resolveEquipped?: EquippedResolver;
   currentUserId?: string | null;
+  isAuthenticated?: boolean;
+  isPlayer?: boolean;
   onClose?: () => void;
   teamMode?: boolean;
   onEmote?: (emoteId: EmoteId) => void;
@@ -144,6 +146,8 @@ export function GameChat({
   resolveDisplayName,
   resolveEquipped,
   currentUserId,
+  isAuthenticated = false,
+  isPlayer = false,
   onClose,
   teamMode,
   onEmote,
@@ -208,9 +212,10 @@ export function GameChat({
     [logs, scope],
   );
 
+  const canSend = isPlayer || isAuthenticated;
   const send = () => {
     const trimmed = draft.trim();
-    if (!trimmed || !sendMessage) return;
+    if (!trimmed || !sendMessage || !canSend) return;
     sendMessage(trimmed, scope);
     setDraft('');
   };
@@ -218,7 +223,7 @@ export function GameChat({
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      send();
+      if (canSend) send();
     }
   };
 
@@ -545,18 +550,15 @@ export function GameChat({
 
         <InputPill
           focusStyle={
-            currentUserId
+            canSend
               ? {
                   borderColor: `${ACCENT_PINK}88`,
                   backgroundColor: 'rgba(0,0,0,0.32)',
                 }
               : undefined
           }
-          style={
-            !currentUserId
-              ? { opacity: 0.5, pointerEvents: 'none' as const }
-              : undefined
-          }
+          opacity={canSend ? 1 : 0.5}
+          pointerEvents={canSend ? 'auto' : 'none'}
         >
           <ChannelChip style={MONO_STYLE} color={SCOPE_CHIP_COLOR[scope]}>
             {SCOPE_CHIP[scope]}
@@ -567,11 +569,11 @@ export function GameChat({
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={onKeyDown}
             placeholder={
-              currentUserId
+              canSend
                 ? SCOPE_PLACEHOLDER[scope]
                 : signInPlaceholder
             }
-            disabled={!currentUserId}
+            disabled={!canSend}
             aria-label="Message"
             style={{
               flex: 1,
@@ -587,11 +589,11 @@ export function GameChat({
             size="sm"
             padding="$1"
             onClick={send}
-            disabled={!draft.trim()}
+            disabled={!draft.trim() || !canSend}
             aria-label="Send message"
             style={{
-              background: draft.trim() ? ACCENT_GRADIENT : undefined,
-              opacity: draft.trim() ? 1 : 0.4,
+              background: draft.trim() && canSend ? ACCENT_GRADIENT : undefined,
+              opacity: draft.trim() && canSend ? 1 : 0.4,
               width: 30,
               height: 30,
               borderRadius: 9,

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -56,6 +56,9 @@ interface GameChatProps {
   onClose?: () => void;
   teamMode?: boolean;
   onEmote?: (emoteId: EmoteId) => void;
+  isHost?: boolean;
+  onDeleteMessage?: (messageId: string) => void;
+  signInPlaceholder?: string;
 }
 
 const FFA_SCOPES: ChatScope[] = ['all', 'players', 'private'];
@@ -129,6 +132,9 @@ export function GameChat({
   onClose,
   teamMode,
   onEmote,
+  isHost,
+  onDeleteMessage,
+  signInPlaceholder = 'Sign in to chat',
 }: GameChatProps) {
   const logs = useGameChatStore((s) => s.logs);
   const sendMessage = useGameChatStore((s) => s.sendMessage);
@@ -227,6 +233,7 @@ export function GameChat({
 
   return (
     <Panel data-testid="game-chat-panel">
+      <style>{`.chat-msg-row:hover .chat-delete-btn { opacity: 1 !important; }`}</style>
       <Head>
         <HeadRow>
           <TitleDot />
@@ -388,18 +395,59 @@ export function GameChat({
                 }
                 const isOwn = !!currentUserId && log.senderId === currentUserId;
                 return (
-                  <GameChatRow
+                  <div
                     key={log.id}
-                    senderId={log.senderId ?? null}
-                    senderName={log.senderId ? senderName : undefined}
-                    senderColor={senderColor}
-                    targetName={targetId ? targetName : undefined}
-                    targetColor={targetColor}
-                    content={log.message}
-                    type={log.type}
-                    isOwn={isOwn}
-                    resolveEquipped={resolveEquipped}
-                  />
+                    className="chat-msg-row"
+                    style={{ position: 'relative' }}
+                  >
+                    <GameChatRow
+                      senderId={log.senderId ?? null}
+                      senderName={log.senderId ? senderName : undefined}
+                      senderColor={senderColor}
+                      targetName={targetId ? targetName : undefined}
+                      targetColor={targetColor}
+                      content={log.message}
+                      type={log.type}
+                      isOwn={isOwn}
+                      resolveEquipped={resolveEquipped}
+                    />
+                    {(isHost || log.senderId === currentUserId) && onDeleteMessage && log.type === 'message' && (
+                      <button
+                        className="chat-delete-btn"
+                        onClick={() => onDeleteMessage(log.id)}
+                        title="Delete message"
+                        aria-label="Delete message"
+                        style={{
+                          position: 'absolute',
+                          top: 4,
+                          right: 4,
+                          background: 'rgba(239,68,68,0.8)',
+                          color: 'white',
+                          border: 'none',
+                          borderRadius: 4,
+                          width: 20,
+                          height: 20,
+                          fontSize: 12,
+                          lineHeight: '20px',
+                          cursor: 'pointer',
+                          opacity: 0,
+                          transition: 'opacity 120ms ease',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          padding: 0,
+                        }}
+                        onMouseEnter={(e) =>
+                          (e.currentTarget.style.opacity = '1')
+                        }
+                        onMouseLeave={(e) =>
+                          (e.currentTarget.style.opacity = '0')
+                        }
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
                 );
               })}
             </ListGap>
@@ -414,10 +462,19 @@ export function GameChat({
         />
 
         <InputPill
-          focusStyle={{
-            borderColor: `${ACCENT_PINK}88`,
-            backgroundColor: 'rgba(0,0,0,0.32)',
-          }}
+          focusStyle={
+            currentUserId
+              ? {
+                  borderColor: `${ACCENT_PINK}88`,
+                  backgroundColor: 'rgba(0,0,0,0.32)',
+                }
+              : undefined
+          }
+          style={
+            !currentUserId
+              ? { opacity: 0.5, pointerEvents: 'none' as const }
+              : undefined
+          }
         >
           <ChannelChip style={MONO_STYLE} color={SCOPE_CHIP_COLOR[scope]}>
             {SCOPE_CHIP[scope]}
@@ -427,7 +484,12 @@ export function GameChat({
             maxLength={240}
             onChange={(e) => setDraft(e.target.value)}
             onKeyDown={onKeyDown}
-            placeholder={SCOPE_PLACEHOLDER[scope]}
+            placeholder={
+              currentUserId
+                ? SCOPE_PLACEHOLDER[scope]
+                : signInPlaceholder
+            }
+            disabled={!currentUserId}
             aria-label="Message"
             style={{
               flex: 1,

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -411,7 +411,7 @@ export function GameChat({
                       isOwn={isOwn}
                       resolveEquipped={resolveEquipped}
                     />
-                    {(isHost || log.senderId === currentUserId) && onDeleteMessage && log.type === 'message' && (
+                    {(isHost || log.senderId === currentUserId) && onDeleteMessage && (log.type === 'message' || log.type === 'action') && (
                       <button
                         className="chat-delete-btn"
                         onClick={() => onDeleteMessage(log.id)}

--- a/apps/web/src/widgets/GameChat/ui/GameChat.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChat.tsx
@@ -11,15 +11,17 @@ import { XStack, YStack, ScrollView, Text, useTheme } from 'tamagui';
 import { IconButton, CloseIcon, Typography } from '@arcadeum/ui';
 import type { ScrollView as TamaguiScrollView } from 'tamagui';
 import { scrollbarStyles } from '@/shared/lib/styles';
-import { getPlayerColor } from '@/shared/lib/playerColors';
 import { useGameChatStore } from '../store/gameChatStore';
-import type { ChatScope, ChatLogEntry } from '../store/gameChatStore';
+import type { ChatScope } from '../store/gameChatStore';
 import { useChatCollapsed } from '../hooks/useChatCollapsed';
-import { GameChatRow } from './GameChatRow';
-import { GameChatSystemRow, type SystemRowKind, GameChatEmoteRow } from './GameChatSystemRow';
 import type { EquippedResolver } from './types';
 import type { EmoteId } from './EmotePicker';
 import { ChatQuickBar } from './ChatQuickBar';
+import { ChatLogItem } from './ChatLogItem';
+import {
+  logBelongsToScope,
+  lastMessagePreview,
+} from './chatHelpers';
 import {
   ACCENT_GRADIENT,
   ACCENT_PINK,
@@ -45,7 +47,6 @@ import {
   TitleDot,
   UnreadBadge,
 } from './GameChat.styled';
-import { parseMoveCell, renderResultHighlights } from './chatHelpers';
 
 export type { ResolvedEquipped, EquippedResolver } from './types';
 
@@ -98,49 +99,6 @@ const MONO_STYLE: React.CSSProperties = {
   fontFamily:
     "ui-monospace, SFMono-Regular, 'JetBrains Mono', 'Menlo', monospace",
 };
-
-function inferSysKind(log: ChatLogEntry): SystemRowKind {
-  const msg = log.message?.toLowerCase() ?? '';
-  if (msg.includes('round')) return 'round';
-  if (msg.includes('combo')) return 'combo';
-  if (msg.includes('join') || msg.includes('placing') || msg.includes('left '))
-    return 'join';
-  return log.type === 'action' ? 'combo' : 'elim';
-}
-
-const EMOJI_STARTER = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/u;
-
-function parseEmoteMessage(message: string): { emoji: string; name: string } | null {
-  const firstCodePoint = message.codePointAt(0);
-  if (firstCodePoint === undefined) return null;
-  const firstChar = String.fromCodePoint(firstCodePoint);
-  if (!EMOJI_STARTER.test(firstChar)) return null;
-  const spaceIdx = message.indexOf(' ');
-  if (spaceIdx === -1) return { emoji: message, name: '' };
-  return {
-    emoji: message.slice(0, spaceIdx),
-    name: message.slice(spaceIdx + 1),
-  };
-}
-
-function logBelongsToScope(log: ChatLogEntry, scope: ChatScope): boolean {
-  if (log.type !== 'message') return scope === 'all';
-  const logScope = (log as ChatLogEntry & { scope?: ChatScope }).scope;
-  if (!logScope) return scope === 'all';
-  return logScope === scope;
-}
-
-function lastMessagePreview(logs: ChatLogEntry[]): string {
-  for (let i = logs.length - 1; i >= 0; i--) {
-    const log = logs[i];
-    if (log.type === 'message') {
-      const name = log.senderName ?? 'Someone';
-      const text = log.message ?? '';
-      return `${name}: ${text}`;
-    }
-  }
-  return 'No messages yet';
-}
 
 export function GameChat({
   resolveDisplayName,
@@ -367,7 +325,7 @@ export function GameChat({
                   : undefined;
                 const senderColor = log.senderId
                   ? (resolveActorColor?.(log.senderId) ??
-                    getPlayerColor(log.senderId))
+                    undefined)
                   : undefined;
                 const targetId = log.targetId;
                 const targetName = targetId
@@ -376,165 +334,21 @@ export function GameChat({
                     : targetId
                   : undefined;
                 const targetColor = targetId
-                  ? (resolveActorColor?.(targetId) ?? getPlayerColor(targetId))
+                  ? (resolveActorColor?.(targetId) ?? undefined)
                   : undefined;
-                if (log.type === 'system' || log.type === 'action') {
-                  const moveCell = parseMoveCell(log.message);
-                  if (moveCell) {
-                    return (
-                      <GameChatRow
-                        key={log.id}
-                        senderId={log.senderId ?? null}
-                        senderName={log.senderId ? senderName : undefined}
-                        senderColor={senderColor}
-                        content={log.message}
-                        type="action"
-                        isOwn={false}
-                        resolveEquipped={resolveEquipped}
-                        moveCell={moveCell}
-                        onMoveHover={(cell) =>
-                          useGameChatStore.getState().setHighlightedCell(cell)
-                        }
-                        onMoveClick={(cell) =>
-                          useGameChatStore.getState().setPersistedCell(cell)
-                        }
-                      />
-                    );
-                  }
-                  const emote = parseEmoteMessage(log.message);
-                  if (emote) {
-                    return (
-                      <GameChatEmoteRow
-                        key={log.id}
-                        emoji={emote.emoji}
-                        senderName={senderName}
-                        senderColor={senderColor}
-                        senderId={log.senderId ?? null}
-                        resolveEquipped={resolveEquipped}
-                      />
-                    );
-                  }
-                  return (
-                    <GameChatSystemRow
-                      key={log.id}
-                      kind={inferSysKind(log)}
-                      content={renderResultHighlights(log.message)}
-                      senderName={senderName}
-                      senderColor={senderColor}
-                      targetName={targetName}
-                      targetColor={targetColor}
-                    />
-                  );
-                }
-                const isOwn = !!currentUserId && log.senderId === currentUserId;
-                const emote = parseEmoteMessage(log.message);
-                if (emote) {
-                  return (
-                    <div
-                      key={log.id}
-                      className="chat-msg-row"
-                      style={{ position: 'relative' }}
-                    >
-                      <GameChatEmoteRow
-                        emoji={emote.emoji}
-                        senderName={senderName}
-                        senderColor={senderColor}
-                        senderId={log.senderId ?? null}
-                        resolveEquipped={resolveEquipped}
-                      />
-                      {(isHost || log.senderId === currentUserId) && onDeleteMessage && (
-                        <button
-                          className="chat-delete-btn"
-                          onClick={() => onDeleteMessage(log.id)}
-                          title="Delete message"
-                          aria-label="Delete message"
-                          style={{
-                            position: 'absolute',
-                            top: 4,
-                            right: 4,
-                            background: 'rgba(239,68,68,0.8)',
-                            color: 'white',
-                            border: 'none',
-                            borderRadius: 4,
-                            width: 20,
-                            height: 20,
-                            fontSize: 12,
-                            lineHeight: '20px',
-                            cursor: 'pointer',
-                            opacity: 0,
-                            transition: 'opacity 120ms ease',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            padding: 0,
-                          }}
-                          onMouseEnter={(e) =>
-                            (e.currentTarget.style.opacity = '1')
-                          }
-                          onMouseLeave={(e) =>
-                            (e.currentTarget.style.opacity = '0')
-                          }
-                        >
-                          ×
-                        </button>
-                      )}
-                    </div>
-                  );
-                }
                 return (
-                  <div
+                  <ChatLogItem
                     key={log.id}
-                    className="chat-msg-row"
-                    style={{ position: 'relative' }}
-                  >
-                    <GameChatRow
-                      senderId={log.senderId ?? null}
-                      senderName={log.senderId ? senderName : undefined}
-                      senderColor={senderColor}
-                      targetName={targetId ? targetName : undefined}
-                      targetColor={targetColor}
-                      content={log.message}
-                      type={log.type}
-                      isOwn={isOwn}
-                      resolveEquipped={resolveEquipped}
-                    />
-                    {(isHost || log.senderId === currentUserId) && onDeleteMessage && (log.type === 'message' || log.type === 'action') && (
-                      <button
-                        className="chat-delete-btn"
-                        onClick={() => onDeleteMessage(log.id)}
-                        title="Delete message"
-                        aria-label="Delete message"
-                        style={{
-                          position: 'absolute',
-                          top: 4,
-                          right: 4,
-                          background: 'rgba(239,68,68,0.8)',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: 4,
-                          width: 20,
-                          height: 20,
-                          fontSize: 12,
-                          lineHeight: '20px',
-                          cursor: 'pointer',
-                          opacity: 0,
-                          transition: 'opacity 120ms ease',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          padding: 0,
-                        }}
-                        onMouseEnter={(e) =>
-                          (e.currentTarget.style.opacity = '1')
-                        }
-                        onMouseLeave={(e) =>
-                          (e.currentTarget.style.opacity = '0')
-                        }
-                      >
-                        ×
-                      </button>
-                    )}
-                  </div>
+                    log={log}
+                    senderName={senderName}
+                    senderColor={senderColor}
+                    targetName={targetName}
+                    targetColor={targetColor}
+                    currentUserId={currentUserId}
+                    resolveEquipped={resolveEquipped}
+                    isHost={isHost}
+                    onDeleteMessage={onDeleteMessage}
+                  />
                 );
               })}
             </ListGap>

--- a/apps/web/src/widgets/GameChat/ui/GameChatRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatRow.tsx
@@ -2,9 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { ChatMessage } from '@arcadeum/ui';
-import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
-import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
-import { EquippedPlayerAvatar } from '@/shared/ui/PlayerAvatar';
+import { ChatSenderLabel } from './ChatSenderLabel';
 import type { EquippedResolver } from './types';
 
 interface GameChatRowProps {
@@ -38,18 +36,6 @@ export function GameChatRow({
   onMoveHover,
   onMoveClick,
 }: GameChatRowProps) {
-  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
-  const { nameColor } = useEquippedCosmetics({
-    equippedAvatarId: resolved?.equippedAvatarId,
-    equippedBadgeId: resolved?.equippedBadgeId,
-    equippedNameColorId: resolved?.equippedNameColorId,
-    equippedFrameId: resolved?.equippedFrameId,
-    equippedAuraId: resolved?.equippedAuraId,
-    equippedBannerId: resolved?.equippedBannerId,
-  });
-  const nameProps = nameColorRenderProps(nameColor);
-  const resolvedSenderColor = nameProps.color ?? senderColor;
-
   const isMove = !!moveCell;
 
   return (
@@ -70,9 +56,7 @@ export function GameChatRow({
       }
     >
       <ChatMessage
-        senderName={senderName}
-        senderColor={resolvedSenderColor}
-        senderNameStyle={nameProps.style}
+        senderName={senderName ? '\u200B' : undefined}
         targetName={targetName}
         targetColor={targetColor}
         content={content}
@@ -81,15 +65,11 @@ export function GameChatRow({
         isOwn={isOwn}
         senderAvatar={
           senderName ? (
-            <EquippedPlayerAvatar
-              name={senderName}
-              size="sm"
-              equippedAvatarId={resolved?.equippedAvatarId ?? null}
-              equippedBadgeId={resolved?.equippedBadgeId ?? null}
-              equippedNameColorId={resolved?.equippedNameColorId}
-              equippedFrameId={resolved?.equippedFrameId}
-              equippedAuraId={resolved?.equippedAuraId}
-              equippedBannerId={resolved?.equippedBannerId}
+            <ChatSenderLabel
+              senderName={senderName}
+              senderColor={senderColor}
+              senderId={senderId}
+              resolveEquipped={resolveEquipped}
             />
           ) : undefined
         }

--- a/apps/web/src/widgets/GameChat/ui/GameChatRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatRow.tsx
@@ -3,6 +3,8 @@
 import type { ReactNode } from 'react';
 import { ChatMessage } from '@arcadeum/ui';
 import { ChatSenderLabel } from './ChatSenderLabel';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
 import type { EquippedResolver } from './types';
 
 interface GameChatRowProps {
@@ -38,6 +40,17 @@ export function GameChatRow({
 }: GameChatRowProps) {
   const isMove = !!moveCell;
 
+  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
+  const { nameColor } = useEquippedCosmetics({
+    equippedAvatarId: resolved?.equippedAvatarId,
+    equippedBadgeId: resolved?.equippedBadgeId,
+    equippedNameColorId: resolved?.equippedNameColorId,
+    equippedFrameId: resolved?.equippedFrameId,
+    equippedAuraId: resolved?.equippedAuraId,
+    equippedBannerId: resolved?.equippedBannerId,
+  });
+  const nameStyleProps = nameColorRenderProps(nameColor);
+
   return (
     <div
       onMouseEnter={
@@ -56,7 +69,9 @@ export function GameChatRow({
       }
     >
       <ChatMessage
-        senderName={senderName ? '\u200B' : undefined}
+        senderName={senderName}
+        senderColor={nameStyleProps.color ?? senderColor}
+        senderNameStyle={nameStyleProps.style}
         targetName={targetName}
         targetColor={targetColor}
         content={content}
@@ -67,7 +82,6 @@ export function GameChatRow({
           senderName ? (
             <ChatSenderLabel
               senderName={senderName}
-              senderColor={senderColor}
               senderId={senderId}
               resolveEquipped={resolveEquipped}
             />

--- a/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import type { ReactNode } from 'react';
+import { ChatMessage } from '@arcadeum/ui';
 import { SYS_COLOR, SysText, SysTime, SysWrap } from './GameChat.styled';
 import { ChatSenderLabel } from './ChatSenderLabel';
+import { useEquippedCosmetics } from '@/features/shop/hooks/useEquippedCosmetics';
+import { nameColorRenderProps } from '@/features/shop/lib/nameColor';
 import type { EquippedResolver } from './types';
 
 export type SystemRowKind = 'elim' | 'round' | 'combo' | 'join';
@@ -89,20 +92,36 @@ export function GameChatEmoteRow({
   senderId,
   resolveEquipped,
 }: EmoteRowProps) {
+  const resolved = senderId ? (resolveEquipped?.(senderId) ?? null) : null;
+  const { nameColor } = useEquippedCosmetics({
+    equippedAvatarId: resolved?.equippedAvatarId,
+    equippedBadgeId: resolved?.equippedBadgeId,
+    equippedNameColorId: resolved?.equippedNameColorId,
+    equippedFrameId: resolved?.equippedFrameId,
+    equippedAuraId: resolved?.equippedAuraId,
+    equippedBannerId: resolved?.equippedBannerId,
+  });
+  const nameStyleProps = nameColorRenderProps(nameColor);
+
   return (
-    <div
-      data-testid="game-chat-emote-row"
-      style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0' }}
-    >
-      {senderName ? (
-        <ChatSenderLabel
-          senderName={senderName}
-          senderColor={senderColor}
-          senderId={senderId}
-          resolveEquipped={resolveEquipped}
-        />
-      ) : null}
-      <span style={{ fontSize: 36, lineHeight: 1 }}>{emoji}</span>
+    <div data-testid="game-chat-emote-row">
+      <ChatMessage
+        content=""
+        emoji={emoji}
+        senderName={senderName}
+        senderColor={nameStyleProps.color ?? senderColor}
+        senderNameStyle={nameStyleProps.style}
+        isOwn={false}
+        senderAvatar={
+          senderName ? (
+            <ChatSenderLabel
+              senderName={senderName}
+              senderId={senderId}
+              resolveEquipped={resolveEquipped}
+            />
+          ) : undefined
+        }
+      />
     </div>
   );
 }

--- a/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
+++ b/apps/web/src/widgets/GameChat/ui/GameChatSystemRow.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactNode } from 'react';
 import { SYS_COLOR, SysText, SysTime, SysWrap } from './GameChat.styled';
+import { ChatSenderLabel } from './ChatSenderLabel';
+import type { EquippedResolver } from './types';
 
 export type SystemRowKind = 'elim' | 'round' | 'combo' | 'join';
 
@@ -69,5 +71,38 @@ export function GameChatSystemRow({
       </SysText>
       {time ? <SysTime>{time}</SysTime> : null}
     </SysWrap>
+  );
+}
+
+interface EmoteRowProps {
+  emoji: string;
+  senderName?: string;
+  senderColor?: string;
+  senderId?: string | null;
+  resolveEquipped?: EquippedResolver;
+}
+
+export function GameChatEmoteRow({
+  emoji,
+  senderName,
+  senderColor,
+  senderId,
+  resolveEquipped,
+}: EmoteRowProps) {
+  return (
+    <div
+      data-testid="game-chat-emote-row"
+      style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '4px 0' }}
+    >
+      {senderName ? (
+        <ChatSenderLabel
+          senderName={senderName}
+          senderColor={senderColor}
+          senderId={senderId}
+          resolveEquipped={resolveEquipped}
+        />
+      ) : null}
+      <span style={{ fontSize: 36, lineHeight: 1 }}>{emoji}</span>
+    </div>
   );
 }

--- a/apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx
+++ b/apps/web/src/widgets/GameChat/ui/__tests__/GameChat.test.tsx
@@ -8,6 +8,15 @@ import { GameChat } from '../GameChat';
 import { useGameChatStore } from '../../store/gameChatStore';
 import type { ChatLogEntry } from '../../store/gameChatStore';
 
+vi.mock('@/shared/ui/PlayerAvatar', () => ({
+  EquippedPlayerAvatar: ({ name }: { name?: string }) =>
+    React.createElement('span', { 'data-testid': 'player-avatar' }, name),
+}));
+
+vi.mock('@/features/shop/hooks/useEquippedCosmetics', () => ({
+  useEquippedCosmetics: () => ({ nameColor: null }),
+}));
+
 function renderChat(ui: React.ReactElement) {
   return render(
     <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
@@ -40,18 +49,22 @@ vi.mock('@arcadeum/ui', async () => {
       React.createElement('span', null, children),
     ChatInput: () =>
       React.createElement('input', { 'data-testid': 'chat-input' }),
+    PlayerAvatar: ({ name }: { name?: string }) =>
+      React.createElement('span', { 'data-testid': 'player-avatar' }, name),
     ChatMessage: ({
       senderName,
       senderColor,
       content,
       isOwn,
       type,
+      senderAvatar,
     }: {
       senderName?: string;
       senderColor?: string;
       content: string;
       isOwn?: boolean;
       type?: 'system' | 'action' | 'message';
+      senderAvatar?: React.ReactNode;
     }) =>
       React.createElement(
         'div',
@@ -62,6 +75,7 @@ vi.mock('@arcadeum/ui', async () => {
           'data-sender-color': senderColor ?? '',
           'data-type': type ?? 'message',
         },
+        senderAvatar,
         content,
       ),
   };
@@ -103,9 +117,9 @@ describe('GameChat', () => {
     const rendered = screen.getAllByTestId('chat-message');
     expect(rendered).toHaveLength(2);
     expect(rendered[0]?.getAttribute('data-is-own')).toBe('true');
-    expect(rendered[0]?.getAttribute('data-sender')).toBe('You');
+    expect(rendered[0]?.textContent).toContain('You');
     expect(rendered[1]?.getAttribute('data-is-own')).toBe('false');
-    expect(rendered[1]?.getAttribute('data-sender')).toBe('Bob');
+    expect(rendered[1]?.textContent).toContain('Bob');
   });
 
   it('renders system and action logs separately from chat messages', () => {
@@ -136,9 +150,8 @@ describe('GameChat', () => {
     // render via the new GameChatSystemRow surface.
     const chatRendered = screen.getAllByTestId('chat-message');
     expect(chatRendered).toHaveLength(1);
-    expect(chatRendered[0]?.textContent).toBe('hi');
-    expect(chatRendered[0]?.getAttribute('data-sender')).toBe('You');
-    expect(chatRendered[0]?.getAttribute('data-sender-color')).toMatch(/^#/);
+    expect(chatRendered[0]?.textContent).toContain('hi');
+    expect(chatRendered[0]?.textContent).toContain('You');
 
     // System / action messages still appear somewhere in the rendered tree.
     expect(screen.getByText(/Drew a card/)).toBeTruthy();
@@ -191,6 +204,6 @@ describe('GameChat', () => {
 
     const rendered = screen.getAllByTestId('chat-message');
     expect(rendered[0]?.getAttribute('data-is-own')).toBe('false');
-    expect(rendered[0]?.getAttribute('data-sender')).toBe('Alice');
+    expect(rendered[0]?.textContent).toContain('Alice');
   });
 });

--- a/apps/web/src/widgets/GameChat/ui/chatHelpers.tsx
+++ b/apps/web/src/widgets/GameChat/ui/chatHelpers.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import type { ChatScope, ChatLogEntry } from '../store/gameChatStore';
 
 const RESULT_COLORS: Record<string, string> = {
   HIT: '#F97316',
@@ -9,6 +10,10 @@ const RESULT_COLORS: Record<string, string> = {
 const RESULT_PATTERN = /\b(HIT|MISS|SUNK)\b/;
 
 const MOVE_PATTERN = /Mark placed at \((-?\d+), (-?\d+)\)/;
+
+const EMOJI_STARTER = /[\p{Emoji_Presentation}\p{Extended_Pictographic}]/u;
+
+export type SystemRowKind = 'round' | 'combo' | 'join' | 'elim';
 
 export function parseMoveCell(
   message: string,
@@ -31,4 +36,50 @@ export function renderResultHighlights(message: string): ReactNode {
       {message.slice(idx + keyword.length)}
     </>
   );
+}
+
+export function inferSysKind(log: ChatLogEntry): SystemRowKind {
+  const msg = log.message?.toLowerCase() ?? '';
+  if (msg.includes('round')) return 'round';
+  if (msg.includes('combo')) return 'combo';
+  if (msg.includes('join') || msg.includes('placing') || msg.includes('left '))
+    return 'join';
+  return log.type === 'action' ? 'combo' : 'elim';
+}
+
+export function parseEmoteMessage(
+  message: string,
+): { emoji: string; name: string } | null {
+  const firstCodePoint = message.codePointAt(0);
+  if (firstCodePoint === undefined) return null;
+  const firstChar = String.fromCodePoint(firstCodePoint);
+  if (!EMOJI_STARTER.test(firstChar)) return null;
+  const spaceIdx = message.indexOf(' ');
+  if (spaceIdx === -1) return { emoji: message, name: '' };
+  return {
+    emoji: message.slice(0, spaceIdx),
+    name: message.slice(spaceIdx + 1),
+  };
+}
+
+export function logBelongsToScope(
+  log: ChatLogEntry,
+  scope: ChatScope,
+): boolean {
+  if (log.type !== 'message') return scope === 'all';
+  const logScope = (log as ChatLogEntry & { scope?: ChatScope }).scope;
+  if (!logScope) return scope === 'all';
+  return logScope === scope;
+}
+
+export function lastMessagePreview(logs: ChatLogEntry[]): string {
+  for (let i = logs.length - 1; i >= 0; i--) {
+    const log = logs[i];
+    if (log.type === 'message') {
+      const name = log.senderName ?? 'Someone';
+      const text = log.message ?? '';
+      return `${name}: ${text}`;
+    }
+  }
+  return 'No messages yet';
 }

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -179,6 +179,7 @@ export interface SeaBattleSnapshot {
     targetId: string;
     row?: number;
     col?: number;
+    halfWidth: number;
     cells: { row: number; col: number; state: CellState }[];
   };
 }

--- a/apps/web/src/widgets/SeaBattleGame/types/index.ts
+++ b/apps/web/src/widgets/SeaBattleGame/types/index.ts
@@ -161,11 +161,18 @@ export interface SeaBattleSnapshot {
   teamOrder?: string[];
   currentTeamIndex?: number;
   hideShipsFromTeammates?: boolean;
-  specialWeapons?: { sonar?: boolean; radar?: boolean };
+  specialWeapons?: { sonar?: boolean; radar?: boolean; revealAll?: boolean };
   specialWeaponUsage?: Record<
     string,
     { sonarUsed?: boolean; radarUsed?: boolean }
   >;
+  lastScanWave?: {
+    cells: {
+      playerId: string;
+      board: CellState[][];
+    }[];
+    duration: number;
+  };
   lastSonar?: {
     attackerId: string;
     targetId: string;

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackBoardCell.tsx
@@ -17,7 +17,7 @@ interface AttackBoardCellProps {
   isAttackable: boolean;
   isPending?: boolean;
   isMe: boolean;
-  highlight?: 'sonar' | 'radar' | null;
+  highlight?: 'sonar' | 'radar' | 'scanWave' | null;
   highlightCellState?: number;
   isWeaponPreview?: boolean;
   weaponPreviewType?: 'sonar' | 'radar' | null;
@@ -74,7 +74,20 @@ export const AttackBoardCell = memo(function AttackBoardCell({
               borderColor: 'rgba(168, 85, 247, 0.4)',
               backgroundColor: 'rgba(168, 85, 247, 0.06)',
             }
-        : {};
+        : highlight === 'scanWave'
+          ? isShip
+            ? {
+                boxShadow: '0 0 12px 4px rgba(251, 191, 36, 0.9)',
+                borderColor: '#f59e0b',
+                backgroundColor: 'rgba(251, 191, 36, 0.25)',
+                animation: 'sb-scanwave-pulse 0.5s ease-in-out infinite alternate',
+              }
+            : {
+                boxShadow: '0 0 4px 1px rgba(251, 191, 36, 0.3)',
+                borderColor: 'rgba(251, 191, 36, 0.4)',
+                backgroundColor: 'rgba(251, 191, 36, 0.06)',
+              }
+          : {};
 
   const previewStyle: React.CSSProperties =
     isWeaponPreview && weaponPreviewType === 'sonar'
@@ -199,9 +212,13 @@ export const AttackBoardCell = memo(function AttackBoardCell({
             ? isShip
               ? '🚢'
               : '🔊'
-            : isShip
-              ? '🚢'
-              : '📡'}
+            : highlight === 'scanWave'
+              ? isShip
+                ? '🚢'
+                : '🌊'
+              : isShip
+                ? '🚢'
+                : '📡'}
         </div>
       )}
     </BoardCell>

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/AttackPlayerBoard.tsx
@@ -41,6 +41,8 @@ interface AttackPlayerBoardProps {
   sonarCellStates?: Map<string, number> | null;
   radarHighlightCells?: Set<string> | null;
   radarCellStates?: Map<string, number> | null;
+  scanWaveHighlightCells?: Set<string> | null;
+  scanWaveCellStates?: Map<string, number> | null;
   weaponPreviewCells?: Set<string> | null;
   weaponPreviewType?: 'sonar' | 'radar' | null;
   onAttack?: (targetPlayerId: string, row: number, col: number) => void;
@@ -67,6 +69,8 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
   sonarCellStates,
   radarHighlightCells,
   radarCellStates,
+  scanWaveHighlightCells,
+  scanWaveCellStates,
   weaponPreviewCells,
   weaponPreviewType,
   onAttack,
@@ -159,17 +163,22 @@ export const AttackPlayerBoard = memo(function AttackPlayerBoard({
           const cellKey = `${player.playerId}-${rIndex}-${cIndex}`;
           const isSonarCell = !isMe && sonarHighlightCells?.has(cellKey);
           const isRadarCell = !isMe && radarHighlightCells?.has(cellKey);
-          const highlight: 'sonar' | 'radar' | null = isSonarCell
+          const isScanWaveCell = !isMe && scanWaveHighlightCells?.has(cellKey);
+          const highlight: 'sonar' | 'radar' | 'scanWave' | null = isSonarCell
             ? 'sonar'
             : isRadarCell
               ? 'radar'
-              : null;
+              : isScanWaveCell
+                ? 'scanWave'
+                : null;
           const highlightCellState =
             isSonarCell && sonarCellStates
               ? sonarCellStates.get(cellKey)
               : isRadarCell && radarCellStates
                 ? radarCellStates.get(cellKey)
-                : undefined;
+                : isScanWaveCell && scanWaveCellStates
+                  ? scanWaveCellStates.get(cellKey)
+                  : undefined;
           const isWeaponPreview = !isMe && weaponPreviewCells?.has(cellKey);
 
           return (

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -125,7 +125,8 @@ export const AttackBoard = memo(function AttackBoard({
     const sw = snapshot?.lastScanWave;
     if (!sw || snapshot?.phase !== 'battle') return;
 
-    setScanWaveActive(true);
+    // Defer state update to avoid synchronous cascading renders
+    const raf = requestAnimationFrame(() => setScanWaveActive(true));
     if (scanWaveTimerRef.current) clearTimeout(scanWaveTimerRef.current);
     scanWaveTimerRef.current = setTimeout(() => {
       setScanWaveActive(false);
@@ -133,6 +134,7 @@ export const AttackBoard = memo(function AttackBoard({
     }, sw.duration * 1000);
 
     return () => {
+      cancelAnimationFrame(raf);
       if (scanWaveTimerRef.current) {
         clearTimeout(scanWaveTimerRef.current);
         scanWaveTimerRef.current = null;
@@ -197,7 +199,7 @@ export const AttackBoard = memo(function AttackBoard({
       cellMap.set(entry.playerId, states);
     }
     return { highlights: map, states: cellMap };
-  }, [scanWaveActive, snapshot?.lastScanWave]);
+  }, [scanWaveActive, snapshot]);
 
   return (
     <MainGameArea data-testid="game-main-area">

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { memo, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   SeaBattlePlayerState,
   SeaBattleSnapshot,
@@ -117,6 +117,29 @@ export const AttackBoard = memo(function AttackBoard({
   const effectiveLastSonar = snapshot?.lastSonar ?? cachedLastSonar;
   const effectiveLastRadar = snapshot?.lastRadar ?? cachedLastRadar;
 
+  // Scan wave: show all ships for a limited duration when battle starts
+  const [scanWaveActive, setScanWaveActive] = useState(false);
+  const scanWaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const sw = snapshot?.lastScanWave;
+    if (!sw || snapshot?.phase !== 'battle') return;
+
+    setScanWaveActive(true);
+    if (scanWaveTimerRef.current) clearTimeout(scanWaveTimerRef.current);
+    scanWaveTimerRef.current = setTimeout(() => {
+      setScanWaveActive(false);
+      scanWaveTimerRef.current = null;
+    }, sw.duration * 1000);
+
+    return () => {
+      if (scanWaveTimerRef.current) {
+        clearTimeout(scanWaveTimerRef.current);
+        scanWaveTimerRef.current = null;
+      }
+    };
+  }, [snapshot?.lastScanWave, snapshot?.phase]);
+
   const sonarHighlightSet = (() => {
     const ls = effectiveLastSonar;
     if (!ls) return null;
@@ -155,6 +178,27 @@ export const AttackBoard = memo(function AttackBoard({
     return map;
   })();
 
+  // Scan wave: highlight sets for all opponents
+  const scanWaveHighlightSets = useMemo(() => {
+    if (!scanWaveActive || !snapshot?.lastScanWave) return null;
+    const map = new Map<string, Set<string>>();
+    const cellMap = new Map<string, Map<string, number>>();
+    for (const entry of snapshot.lastScanWave.cells) {
+      const set = new Set<string>();
+      const states = new Map<string, number>();
+      for (let r = 0; r < entry.board.length; r++) {
+        for (let c = 0; c < entry.board[r].length; c++) {
+          const key = `${entry.playerId}-${r}-${c}`;
+          set.add(key);
+          states.set(key, entry.board[r][c]);
+        }
+      }
+      map.set(entry.playerId, set);
+      cellMap.set(entry.playerId, states);
+    }
+    return { highlights: map, states: cellMap };
+  }, [scanWaveActive, snapshot?.lastScanWave]);
+
   return (
     <MainGameArea data-testid="game-main-area">
       <SeaBattleGrids>
@@ -186,6 +230,10 @@ export const AttackBoard = memo(function AttackBoard({
             effectiveLastSonar?.targetId === opponent.playerId;
           const isRadarTarget =
             effectiveLastRadar?.targetId === opponent.playerId;
+          const scanWaveSet =
+            scanWaveHighlightSets?.highlights.get(opponent.playerId) ?? null;
+          const scanWaveStates =
+            scanWaveHighlightSets?.states.get(opponent.playerId) ?? null;
           return (
             <AttackPlayerBoard
               key={opponent.playerId}
@@ -206,6 +254,8 @@ export const AttackBoard = memo(function AttackBoard({
               sonarCellStates={isSonarTarget ? sonarCellStates : null}
               radarHighlightCells={isRadarTarget ? radarHighlightSet : null}
               radarCellStates={isRadarTarget ? radarCellStates : null}
+              scanWaveHighlightCells={scanWaveSet}
+              scanWaveCellStates={scanWaveStates}
               weaponPreviewCells={
                 weaponPreviewType && weaponPreviewCells
                   ? weaponPreviewCells

--- a/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/CreationConfig.tsx
@@ -23,10 +23,6 @@ import {
   GameTileItem,
   GameTileContainer,
   ComingSoonBadge,
-  ExpansionGrid,
-  ExpansionCheckbox,
-  ExpansionLabel,
-  ExpansionBadge,
 } from '@/features/games/ui/create/styles';
 import { RulesModal } from './RulesModal';
 import { useState } from 'react';
@@ -36,7 +32,6 @@ interface SeaBattleOptions {
   variant?: string;
   gridSize?: number;
   shipCount?: number;
-  specialWeapons?: { sonar?: boolean; radar?: boolean };
 }
 
 const GRID_SIZES = [
@@ -225,80 +220,6 @@ export default function SeaBattleCreationConfig({
               ))}
             </XStack>
           </YStack>
-
-          <ExpansionGrid>
-            <ExpansionCheckbox
-              style={{
-                opacity: ruleComingSoon.get('sonar') ? 0.4 : 1,
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!options.specialWeapons?.sonar}
-                disabled={!!ruleComingSoon.get('sonar')}
-                onChange={() =>
-                  handleUpdate({
-                    specialWeapons: {
-                      ...options.specialWeapons,
-                      sonar: !options.specialWeapons?.sonar,
-                    },
-                  })
-                }
-              />
-              <YStack flex={1} gap="$0.5">
-                <XStack alignItems="center" gap="$2">
-                  <ExpansionLabel>
-                    {t('games.create.seaBattleSonar') || 'Sonar'}
-                  </ExpansionLabel>
-                  {ruleComingSoon.get('sonar') && (
-                    <ComingSoonBadge>
-                      {t('games.create.comingSoon') || 'Coming Soon'}
-                    </ComingSoonBadge>
-                  )}
-                </XStack>
-                <ExpansionBadge>
-                  {t('games.create.seaBattleSonarHint') ||
-                    'Reveal ship locations'}
-                </ExpansionBadge>
-              </YStack>
-            </ExpansionCheckbox>
-
-            <ExpansionCheckbox
-              style={{
-                opacity: ruleComingSoon.get('radar') ? 0.4 : 1,
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={!!options.specialWeapons?.radar}
-                disabled={!!ruleComingSoon.get('radar')}
-                onChange={() =>
-                  handleUpdate({
-                    specialWeapons: {
-                      ...options.specialWeapons,
-                      radar: !options.specialWeapons?.radar,
-                    },
-                  })
-                }
-              />
-              <YStack flex={1} gap="$0.5">
-                <XStack alignItems="center" gap="$2">
-                  <ExpansionLabel>
-                    {t('games.create.seaBattleRadar') || 'Radar'}
-                  </ExpansionLabel>
-                  {ruleComingSoon.get('radar') && (
-                    <ComingSoonBadge>
-                      {t('games.create.comingSoon') || 'Coming Soon'}
-                    </ComingSoonBadge>
-                  )}
-                </XStack>
-                <ExpansionBadge>
-                  {t('games.create.seaBattleRadarHint') ||
-                    'Scan a row or column'}
-                </ExpansionBadge>
-              </YStack>
-            </ExpansionCheckbox>
-          </ExpansionGrid>
         </YStack>
       </Section>
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/HouseRulesPanel.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/HouseRulesPanel.tsx
@@ -28,7 +28,7 @@ export function HouseRulesPanel({
   const shipCount =
     (gameOptions.shipCount as number) ?? getDefaultShipCount(gridSize);
   const sw = gameOptions.specialWeapons as
-    | { sonar?: boolean; radar?: boolean }
+    | { sonar?: boolean; radar?: boolean; revealAll?: boolean }
     | undefined;
 
   return (
@@ -183,6 +183,66 @@ export function HouseRulesPanel({
           {t('games.create.seaBattleRadar') || 'Radar'} —{' '}
           {t('games.create.seaBattleRadarHint') || 'Scan a row or column'}
         </label>
+
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            cursor: 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={!!sw?.revealAll}
+            onChange={() =>
+              onOptionChange({
+                specialWeapons: { ...sw, revealAll: !sw?.revealAll },
+              })
+            }
+          />
+          {t('games.create.seaBattleRevealAll') || 'Scan Wave'} —{' '}
+          {t('games.create.seaBattleRevealAllHint') ||
+            'Reveal all ships briefly at battle start'}
+        </label>
+
+        {sw?.revealAll && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingLeft: 24 }}>
+            <Text fontSize={12} opacity={0.6}>
+              Duration:
+            </Text>
+            {[1, 2, 3].map((sec) => {
+              const currentDuration =
+                (gameOptions.revealAllDuration as number) ?? 1;
+              return (
+                <button
+                  key={sec}
+                  type="button"
+                  onClick={() => onOptionChange({ revealAllDuration: sec })}
+                  style={{
+                    padding: '2px 8px',
+                    borderRadius: 4,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    border: '1px solid',
+                    borderColor:
+                      currentDuration === sec
+                        ? '#f59e0b'
+                        : 'rgba(255,255,255,0.2)',
+                    background:
+                      currentDuration === sec
+                        ? 'rgba(251,191,36,0.2)'
+                        : 'transparent',
+                    color: currentDuration === sec ? '#f59e0b' : '#999',
+                  }}
+                >
+                  {sec}s
+                </button>
+              );
+            })}
+          </div>
+        )}
       </YStack>
     </YStack>
   );

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -221,7 +221,7 @@ export function SeaBattleBoards({
 
       {(isBattlePhase || isGameOver) && snapshot && (
         <>
-          {!isGameOver && isMyTurn && (hasSonar || hasRadar) && (
+          {!isGameOver && (hasSonar || hasRadar) && (
             <div
               style={{
                 display: 'flex',
@@ -232,10 +232,11 @@ export function SeaBattleBoards({
                 alignItems: 'center',
               }}
             >
-              {hasSonar && !sonarUsed && (
+              {hasSonar && (
                 <button
                   type="button"
                   onClick={() => {
+                    if (sonarUsed || !isMyTurn) return;
                     if (opponents?.length === 1) {
                       setWeaponMode({
                         weapon: 'sonar',
@@ -248,8 +249,11 @@ export function SeaBattleBoards({
                       });
                     }
                   }}
+                  disabled={sonarUsed || !isMyTurn}
                   style={{
                     ...buttonBase,
+                    opacity: sonarUsed || !isMyTurn ? 0.35 : 1,
+                    cursor: sonarUsed || !isMyTurn ? 'not-allowed' : 'pointer',
                     color:
                       weaponMode?.weapon === 'sonar' ? '#06b6d4' : '#e0e0e0',
                     borderTop: `1px solid ${weaponMode?.weapon === 'sonar' ? '#06b6d4' : 'rgba(6,182,212,0.3)'}`,
@@ -263,13 +267,15 @@ export function SeaBattleBoards({
                   }}
                 >
                   🔊 {t('games.create.seaBattleSonar') || 'Sonar'}
+                  {sonarUsed && ' ✓'}
                 </button>
               )}
-              {hasRadar && !radarUsed && (
+              {hasRadar && (
                 <div style={{ display: 'flex', gap: 4 }}>
                   <button
                     type="button"
                     onClick={() => {
+                      if (radarUsed || !isMyTurn) return;
                       if (opponents?.length === 1) {
                         setWeaponMode({
                           weapon: 'radar',
@@ -284,8 +290,12 @@ export function SeaBattleBoards({
                         });
                       }
                     }}
+                    disabled={radarUsed || !isMyTurn}
                     style={{
                       ...buttonBase,
+                      opacity: radarUsed || !isMyTurn ? 0.35 : 1,
+                      cursor:
+                        radarUsed || !isMyTurn ? 'not-allowed' : 'pointer',
                       color:
                         weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
@@ -300,10 +310,12 @@ export function SeaBattleBoards({
                     }}
                   >
                     📡 {t('games.create.seaBattleRadar') || 'Radar'}
+                    {radarUsed && ' ✓'}
                   </button>
                   <button
                     type="button"
                     onClick={() => {
+                      if (radarUsed || !isMyTurn) return;
                       const targetId = opponents?.[0]?.playerId;
                       if (!targetId) return;
                       setWeaponMode({
@@ -313,9 +325,13 @@ export function SeaBattleBoards({
                           weaponMode?.radarAxis === 'col' ? 'row' : 'col',
                       });
                     }}
+                    disabled={radarUsed || !isMyTurn}
                     style={{
                       ...buttonBase,
                       padding: '8px 10px',
+                      opacity: radarUsed || !isMyTurn ? 0.35 : 1,
+                      cursor:
+                        radarUsed || !isMyTurn ? 'not-allowed' : 'pointer',
                       color:
                         weaponMode?.weapon === 'radar' ? '#c084fc' : '#a0a0a0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -124,12 +124,13 @@ export function SeaBattleBoards({
     setHoveredCell(null);
   }, []);
 
-  // Compute preview cells for sonar (3×3 area around hovered cell, matching SONAR_RADIUS=1)
+  // Compute preview cells for sonar (area scales with grid size, matching backend getSonarRadius)
   const sonarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'sonar' || !hoveredCell) return null;
+    const radius = Math.floor(gridSize / 3);
     const cells = new Set<string>();
-    for (let dr = -1; dr <= 1; dr++) {
-      for (let dc = -1; dc <= 1; dc++) {
+    for (let dr = -radius; dr <= radius; dr++) {
+      for (let dc = -radius; dc <= radius; dc++) {
         const r = hoveredCell.row + dr;
         const c = hoveredCell.col + dc;
         if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {
@@ -140,18 +141,27 @@ export function SeaBattleBoards({
     return cells;
   })();
 
-  // Compute preview cells for radar (row or column of hovered cell)
+  // Compute preview cells for radar (band of rows/columns, matching backend getRadarHalfWidth)
   const radarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'radar' || !hoveredCell) return null;
+    const halfWidth = Math.floor(gridSize / 7);
     const cells = new Set<string>();
     const axis = weaponMode.radarAxis ?? 'row';
     if (axis === 'row') {
-      for (let c = 0; c < gridSize; c++) {
-        cells.add(`${weaponMode.targetPlayerId}-${hoveredCell.row}-${c}`);
+      for (let dr = -halfWidth; dr <= halfWidth; dr++) {
+        const r = hoveredCell.row + dr;
+        if (r < 0 || r >= gridSize) continue;
+        for (let c = 0; c < gridSize; c++) {
+          cells.add(`${weaponMode.targetPlayerId}-${r}-${c}`);
+        }
       }
     } else {
-      for (let r = 0; r < gridSize; r++) {
-        cells.add(`${weaponMode.targetPlayerId}-${r}-${hoveredCell.col}`);
+      for (let dc = -halfWidth; dc <= halfWidth; dc++) {
+        const c = hoveredCell.col + dc;
+        if (c < 0 || c >= gridSize) continue;
+        for (let r = 0; r < gridSize; r++) {
+          cells.add(`${weaponMode.targetPlayerId}-${r}-${c}`);
+        }
       }
     }
     return cells;

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -95,6 +95,8 @@ export function SeaBattleBoards({
     snapshot?.specialWeaponUsage?.[currentUserId ?? '']?.radarUsed ?? false;
   const hasSonar = !!snapshot?.specialWeapons?.sonar;
   const hasRadar = !!snapshot?.specialWeapons?.radar;
+  const isSonarDisabled = sonarUsed || !isMyTurn;
+  const isRadarDisabled = radarUsed || !isMyTurn;
 
   const gridSize = snapshot?.gridSize ?? 10;
 
@@ -236,7 +238,7 @@ export function SeaBattleBoards({
                 <button
                   type="button"
                   onClick={() => {
-                    if (sonarUsed || !isMyTurn) return;
+                    if (isSonarDisabled) return;
                     if (opponents?.length === 1) {
                       setWeaponMode({
                         weapon: 'sonar',
@@ -249,11 +251,11 @@ export function SeaBattleBoards({
                       });
                     }
                   }}
-                  disabled={sonarUsed || !isMyTurn}
+                  disabled={isSonarDisabled}
                   style={{
                     ...buttonBase,
-                    opacity: sonarUsed || !isMyTurn ? 0.35 : 1,
-                    cursor: sonarUsed || !isMyTurn ? 'not-allowed' : 'pointer',
+                    opacity: isSonarDisabled ? 0.35 : 1,
+                    cursor: isSonarDisabled ? 'not-allowed' : 'pointer',
                     color:
                       weaponMode?.weapon === 'sonar' ? '#06b6d4' : '#e0e0e0',
                     borderTop: `1px solid ${weaponMode?.weapon === 'sonar' ? '#06b6d4' : 'rgba(6,182,212,0.3)'}`,
@@ -275,7 +277,7 @@ export function SeaBattleBoards({
                   <button
                     type="button"
                     onClick={() => {
-                      if (radarUsed || !isMyTurn) return;
+                      if (isRadarDisabled) return;
                       if (opponents?.length === 1) {
                         setWeaponMode({
                           weapon: 'radar',
@@ -290,12 +292,12 @@ export function SeaBattleBoards({
                         });
                       }
                     }}
-                    disabled={radarUsed || !isMyTurn}
+                    disabled={isRadarDisabled}
                     style={{
                       ...buttonBase,
-                      opacity: radarUsed || !isMyTurn ? 0.35 : 1,
+                      opacity: isRadarDisabled ? 0.35 : 1,
                       cursor:
-                        radarUsed || !isMyTurn ? 'not-allowed' : 'pointer',
+                        isRadarDisabled ? 'not-allowed' : 'pointer',
                       color:
                         weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
@@ -315,7 +317,7 @@ export function SeaBattleBoards({
                   <button
                     type="button"
                     onClick={() => {
-                      if (radarUsed || !isMyTurn) return;
+                      if (isRadarDisabled) return;
                       const targetId = opponents?.[0]?.playerId;
                       if (!targetId) return;
                       setWeaponMode({
@@ -325,13 +327,13 @@ export function SeaBattleBoards({
                           weaponMode?.radarAxis === 'col' ? 'row' : 'col',
                       });
                     }}
-                    disabled={radarUsed || !isMyTurn}
+                    disabled={isRadarDisabled}
                     style={{
                       ...buttonBase,
                       padding: '8px 10px',
-                      opacity: radarUsed || !isMyTurn ? 0.35 : 1,
+                      opacity: isRadarDisabled ? 0.35 : 1,
                       cursor:
-                        radarUsed || !isMyTurn ? 'not-allowed' : 'pointer',
+                        isRadarDisabled ? 'not-allowed' : 'pointer',
                       color:
                         weaponMode?.weapon === 'radar' ? '#c084fc' : '#a0a0a0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,

--- a/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss
+++ b/apps/web/src/widgets/SeaBattleGame/ui/styles/animations.scss
@@ -612,3 +612,12 @@
 .sb-cell.sb-cell-pending .sb-missile {
   animation: sb-missile-fly 1s cubic-bezier(0.45, 0, 0.9, 0.55) 0.3s both;
 }
+
+@keyframes sb-scanwave-pulse {
+  0% {
+    box-shadow: 0 0 8px 2px rgba(251, 191, 36, 0.6);
+  }
+  100% {
+    box-shadow: 0 0 16px 6px rgba(251, 191, 36, 1);
+  }
+}

--- a/packages/ui/src/components/Chat/ChatMessage.tsx
+++ b/packages/ui/src/components/Chat/ChatMessage.tsx
@@ -138,6 +138,32 @@ const MessageBubble = styled(YStack, {
   } as const,
 });
 
+const NAME_STYLE = { fontSize: 11, lineHeight: '16px' } as const;
+
+function SenderName({
+  name,
+  color,
+  nameStyle,
+}: {
+  name: string;
+  color?: string;
+  nameStyle?: React.CSSProperties;
+}) {
+  return (
+    <Typography
+      uiSize="xs"
+      weight="600"
+      {...(color ? { color } : { alpha: 'medium' })}
+      letterSpacing={0.5}
+      textTransform="uppercase"
+      numberOfLines={1}
+      style={{ ...NAME_STYLE, ...nameStyle }}
+    >
+      {name}
+    </Typography>
+  );
+}
+
 export const ChatMessage = memo(function ChatMessage({
   content,
   contentNode,
@@ -212,17 +238,11 @@ export const ChatMessage = memo(function ChatMessage({
                 )}
               </MessageBubble>
             )}
-            <Typography
-              uiSize="xs"
-              weight="600"
-              {...(senderColor ? { color: senderColor } : { alpha: 'medium' })}
-              letterSpacing={0.5}
-              textTransform="uppercase"
-              numberOfLines={1}
-              style={{ fontSize: 11, lineHeight: '16px', ...senderNameStyle }}
-            >
-              {senderName}
-            </Typography>
+            <SenderName
+              name={senderName}
+              color={senderColor}
+              nameStyle={senderNameStyle}
+            />
           </YStack>
         </XStack>
       )}

--- a/packages/ui/src/components/Chat/ChatMessage.tsx
+++ b/packages/ui/src/components/Chat/ChatMessage.tsx
@@ -41,12 +41,13 @@ const MessageGroup = styled(ThemeableStack, {
   flexDirection: 'column',
   gap: '$1',
   maxWidth: '85%',
+  minWidth: 0,
   
   variants: {
     isOwn: {
       true: {
-        alignItems: 'flex-end',
-        alignSelf: 'flex-end',
+        alignItems: 'flex-start',
+        alignSelf: 'flex-start',
       },
       false: {
         alignItems: 'flex-start',
@@ -80,6 +81,8 @@ type MessageGroupProps = GetProps<typeof MessageGroup>;
 const MessageBubble = styled(YStack, {
   paddingHorizontal: '$4',
   paddingVertical: '$2.5',
+  flexShrink: 1,
+  minWidth: 0,
   
   hoverStyle: {
     scale: 1.01,
@@ -154,8 +157,8 @@ export const ChatMessage = memo(function ChatMessage({
       type={type}
       enterStyle={{ opacity: 0, scale: 0.9, y: 15 }}
     >
-      {!isOwn && !isSystem && senderName && (
-        <XStack ai="center" gap="$2" mb="$1" px="$2">
+      {(isOwn || !isOwn) && !isSystem && senderName && (
+        <XStack ai="center" gap="$2" width="100%" flexShrink={1}>
           {senderAvatar ?? (
             <>
               <Avatar name={senderName} size="sm" src={avatarUrl} />
@@ -182,88 +185,69 @@ export const ChatMessage = memo(function ChatMessage({
           >
             {senderName}
           </Typography>
-        </XStack>
-      )}
-      {isOwn && !isSystem && senderName && (
-        <XStack ai="center" gap="$2" mb="$1" px="$2" alignSelf="flex-end">
-          <Typography
-            uiSize="xs"
-            weight="600"
-            {...(senderColor ? { color: senderColor } : { alpha: 'medium' })}
-            {...(senderNameStyle ? { style: senderNameStyle } : {})}
-            letterSpacing={0.5}
-            textTransform="uppercase"
-          >
-            {senderName}
-          </Typography>
-          {senderAvatar ?? (
-            <>
-              {badgeUrl ? (
-                <View width={16} height={16}>
-                  <img
-                    src={badgeUrl}
-                    alt=""
-                    width={16}
-                    height={16}
-                    style={{ objectFit: 'contain' }}
-                  />
-                </View>
-              ) : null}
-              <Avatar name={senderName} size="sm" src={avatarUrl} />
-            </>
-          )}
-        </XStack>
-      )}
-      <MessageBubble isOwn={isOwn} type={type} data-testid="chat-message">
-        <Typography
-          uiSize={isSystem ? 'xs' : 'sm'}
-          color={isOwn && !isSystem ? 'white' : '$color'}
-          textAlign={isSystem ? 'center' : 'left'}
-          fontStyle={isSystem ? 'italic' : 'normal'}
-        >
-          {isSystem && senderName && !isEncrypted ? (
-            <>
+          <MessageBubble isOwn={isOwn} type={type} data-testid="chat-message" flex={1} style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
+            <Typography
+              uiSize="sm"
+              color={isOwn ? 'white' : '$color'}
+              textAlign="left"
+            >
+              {isEncrypted ? '[Encrypted Message]' : (contentNode ?? content)}
+            </Typography>
+            {timestamp && (
               <Typography
                 uiSize="xs"
-                weight="700"
-                fontStyle="normal"
-                {...(senderColor ? { color: senderColor } : {})}
+                alpha="low"
+                color={isOwn ? 'white' : '$color'}
+                mt="$1"
+                opacity={0.7}
               >
-                {senderName}
+                {timestamp}
               </Typography>
-              {targetName ? (
-                <>
-                  {' → '}
-                  <Typography
-                    uiSize="xs"
-                    weight="700"
-                    fontStyle="normal"
-                    {...(targetColor ? { color: targetColor } : {})}
-                  >
-                    {targetName}
-                  </Typography>
-                </>
-              ) : null}
-              {contentNode ? <> {contentNode}</> : ` ${content}`}
-            </>
-          ) : isEncrypted ? (
-            '[Encrypted Message]'
-          ) : (
-            (contentNode ?? content)
-          )}
-        </Typography>
-        {timestamp && !isSystem && (
+            )}
+          </MessageBubble>
+        </XStack>
+      )}
+      {isSystem && (
+        <MessageBubble isOwn={isOwn} type={type} data-testid="chat-message">
           <Typography
             uiSize="xs"
-            alpha="low"
             color={isOwn ? 'white' : '$color'}
-            mt="$1"
-            opacity={0.7}
+            textAlign="center"
+            fontStyle="italic"
           >
-            {timestamp}
+            {senderName && !isEncrypted ? (
+              <>
+                <Typography
+                  uiSize="xs"
+                  weight="700"
+                  fontStyle="normal"
+                  {...(senderColor ? { color: senderColor } : {})}
+                >
+                  {senderName}
+                </Typography>
+                {targetName ? (
+                  <>
+                    {' → '}
+                    <Typography
+                      uiSize="xs"
+                      weight="700"
+                      fontStyle="normal"
+                      {...(targetColor ? { color: targetColor } : {})}
+                    >
+                      {targetName}
+                    </Typography>
+                  </>
+                ) : null}
+                {contentNode ? <> {contentNode}</> : ` ${content}`}
+              </>
+            ) : isEncrypted ? (
+              '[Encrypted Message]'
+            ) : (
+              (contentNode ?? content)
+            )}
           </Typography>
-        )}
-      </MessageBubble>
+        </MessageBubble>
+      )}
     </MessageGroup>
   );
 });

--- a/packages/ui/src/components/Chat/ChatMessage.tsx
+++ b/packages/ui/src/components/Chat/ChatMessage.tsx
@@ -9,6 +9,8 @@ export type ChatMessageProps = {
    * precedence over `content` for system/action rows. Used to inject
    * inline colored spans (e.g. HIT/MISS/SUNK keywords). */
   contentNode?: React.ReactNode;
+  /** When set, renders an emoji instead of the text bubble. */
+  emoji?: string;
   senderName?: string;
   senderColor?: string;
   /**
@@ -39,15 +41,16 @@ export type ChatMessageProps = {
 const MessageGroup = styled(ThemeableStack, {
   name: 'MessageGroup',
   flexDirection: 'column',
-  gap: '$1',
+  gap: '$0.5',
   maxWidth: '85%',
   minWidth: 0,
+  paddingVertical: '$1',
   
   variants: {
     isOwn: {
       true: {
         alignItems: 'flex-start',
-        alignSelf: 'flex-start',
+        alignSelf: 'flex-end',
       },
       false: {
         alignItems: 'flex-start',
@@ -83,6 +86,7 @@ const MessageBubble = styled(YStack, {
   paddingVertical: '$2.5',
   flexShrink: 1,
   minWidth: 0,
+  alignSelf: 'flex-start',
   
   hoverStyle: {
     scale: 1.01,
@@ -91,6 +95,7 @@ const MessageBubble = styled(YStack, {
   variants: {
     isOwn: {
       true: {
+        alignSelf: 'flex-end',
         borderRadius: '$4',
         borderBottomRightRadius: '$1',
         background: 'linear-gradient(135deg, $primaryGradientStart 0%, $primaryGradientEnd 100%)',
@@ -147,6 +152,7 @@ export const ChatMessage = memo(function ChatMessage({
   badgeUrl,
   senderAvatar,
   isEncrypted,
+  emoji,
   type = 'message',
 }: ChatMessageProps) {
   const isSystem = type === 'system' || type === 'action';
@@ -157,10 +163,16 @@ export const ChatMessage = memo(function ChatMessage({
       type={type}
       enterStyle={{ opacity: 0, scale: 0.9, y: 15 }}
     >
-      {(isOwn || !isOwn) && !isSystem && senderName && (
-        <XStack ai="center" gap="$2" width="100%" flexShrink={1}>
+      {!isSystem && senderName && (
+        <XStack
+          ai="flex-end"
+          gap="$2"
+          width="100%"
+          flexShrink={1}
+          {...(isOwn ? { jc: 'flex-end' } : {})}
+        >
           {senderAvatar ?? (
-            <>
+            <View flexShrink={0}>
               <Avatar name={senderName} size="sm" src={avatarUrl} />
               {badgeUrl ? (
                 <View width={16} height={16}>
@@ -173,38 +185,45 @@ export const ChatMessage = memo(function ChatMessage({
                   />
                 </View>
               ) : null}
-            </>
+            </View>
           )}
-          <Typography
-            uiSize="xs"
-            weight="600"
-            {...(senderColor ? { color: senderColor } : { alpha: 'medium' })}
-            {...(senderNameStyle ? { style: senderNameStyle } : {})}
-            letterSpacing={0.5}
-            textTransform="uppercase"
-          >
-            {senderName}
-          </Typography>
-          <MessageBubble isOwn={isOwn} type={type} data-testid="chat-message" flex={1} style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>
-            <Typography
-              uiSize="sm"
-              color={isOwn ? 'white' : '$color'}
-              textAlign="left"
-            >
-              {isEncrypted ? '[Encrypted Message]' : (contentNode ?? content)}
-            </Typography>
-            {timestamp && (
-              <Typography
-                uiSize="xs"
-                alpha="low"
-                color={isOwn ? 'white' : '$color'}
-                mt="$1"
-                opacity={0.7}
-              >
-                {timestamp}
-              </Typography>
+          <YStack flex={1} minWidth={0} gap="$1">
+            {emoji ? (
+              <span style={{ fontSize: 36, lineHeight: 1 }}>{emoji}</span>
+            ) : (
+              <MessageBubble isOwn={isOwn} type={type} data-testid="chat-message" style={{ wordBreak: 'break-word', overflowWrap: 'anywhere', width: '100%' }}>
+                <Typography
+                  uiSize="sm"
+                  color={isOwn ? 'white' : '$color'}
+                  textAlign="left"
+                >
+                  {isEncrypted ? '[Encrypted Message]' : (contentNode ?? content)}
+                </Typography>
+                {timestamp && (
+                  <Typography
+                    uiSize="xs"
+                    alpha="low"
+                    color={isOwn ? 'white' : '$color'}
+                    mt="$1"
+                    opacity={0.7}
+                  >
+                    {timestamp}
+                  </Typography>
+                )}
+              </MessageBubble>
             )}
-          </MessageBubble>
+            <Typography
+              uiSize="xs"
+              weight="600"
+              {...(senderColor ? { color: senderColor } : { alpha: 'medium' })}
+              letterSpacing={0.5}
+              textTransform="uppercase"
+              numberOfLines={1}
+              style={{ fontSize: 11, lineHeight: '16px', ...senderNameStyle }}
+            >
+              {senderName}
+            </Typography>
+          </YStack>
         </XStack>
       )}
       {isSystem && (


### PR DESCRIPTION
## What
- Enable authenticated watchers/spectators to send messages in game chat
- Show watcher avatars and name colors in game chat messages
- Fix backend error propagation in game chat history note handlers

## Why
- Watchers could not send chat messages — backend rejected with 'No session found' or 'Player not found'
- Watcher messages showed plain monogram avatar instead of their equipped cosmetics
- History note gateways used `handleError()` which re-throws as `WsException`, causing double-logging in `onAny` handler

## Changes

### Backend
- **`game-sessions.service.ts`**: Add `pushChatLog()` method to write chat entries directly to OCI session state (bypasses engine player validation)
- **`sea-battle.service.ts`**: Simplify `postHistoryNote()` to always use `pushChatLog()` — all authenticated users (players and watchers) can now chat
- **`game-history.service.ts`**: Skip gracefully when no session exists for authenticated users (lobby state)
- **`sea-battle.gateway.ts`, `critical.gateway.ts`, `texas-holdem.gateway.ts`**: Replace `handleError()` with `logger.warn()` in history note catch blocks to prevent error propagation

### Frontend
- **`GamePageLayout.tsx`**: `resolveEquipped` falls back to session store cosmetics when user isn't in `room.members` (watchers)
- Pass `isAuthenticated`/`isPlayer` props to `GameChat` for send permission gating