### PR TITLE
feat(header): add settings gear icon for unauthenticated desktop users

### DIFF
--- a/apps/web/src/widgets/header/ui/HeaderInteractive.tsx
+++ b/apps/web/src/widgets/header/ui/HeaderInteractive.tsx
@@ -30,6 +30,24 @@ const MusicIcon = ({ size = 20 }: { size?: number }) => (
     <circle cx="18" cy="16" r="3" />
   </svg>
 );
+
+const GearIcon = ({ size = 20 }: { size?: number }) => (
+  <span className="gear-icon-wrapper">
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  </span>
+);
 import { MobileLoginIndicator } from '@arcadeum/ui/components/MobileLoginIndicator/MobileLoginIndicator';
 import ProfileMenu from '@/widgets/header/ui/ProfileMenu';
 import dynamic from 'next/dynamic';
@@ -205,6 +223,27 @@ export function HeaderInteractive() {
 
             {!isAuthenticated && (
               <DesktopOnly>
+                <Link
+                  href={routes.settings}
+                  aria-label={t('navigation.settingsTab')}
+                  style={{ textDecoration: 'none', display: 'inline-flex' }}
+                  data-testid="desktop-settings-button"
+                >
+                  <Button
+                    variant="icon"
+                    size="md"
+                    aria-label={t('navigation.settingsTab')}
+                    tabIndex={-1}
+                    hoverStyle={{
+                      y: -2,
+                      transform: 'scale(1.1)',
+                      backgroundColor: 'rgba(255, 255, 255, 0.15)',
+                      borderColor: 'rgba(255, 255, 255, 0.25)',
+                    }}
+                  >
+                    <GearIcon size={20} />
+                  </Button>
+                </Link>
                 <LinkButton
                   variant="primary"
                   size="sm"

--- a/apps/web/src/widgets/header/ui/header-stable.scss
+++ b/apps/web/src/widgets/header/ui/header-stable.scss
@@ -116,6 +116,15 @@
   color: #ffffff;
 }
 
+.gear-icon-wrapper {
+  display: inline-flex;
+  transition: transform 0.4s ease;
+}
+
+.gear-icon-wrapper:hover {
+  transform: rotate(90deg);
+}
+
 .header-inner .mobile-menu-container {
   display: none;
 }


### PR DESCRIPTION
## What
- Added a gear icon button in the desktop header for unauthenticated users, linking to the settings page
- The gear icon rotates 90° on hover with a smooth 0.4s ease transition

## Why
Unauthenticated users had no way to access the settings page on desktop. Settings was only accessible via the ProfileMenu dropdown (authenticated users only) or the mobile hamburger menu. Guests need access to settings for appearance, language, and gameplay preferences.

## Changes
- `apps/web/src/widgets/header/ui/HeaderInteractive.tsx` — Added local `GearIcon` component (proper gear SVG) and a settings icon button in the `!isAuthenticated` block, next to the Login button
- `apps/web/src/widgets/header/ui/header-stable.scss` — Added `.gear-icon-wrapper` styles with hover rotation