### PR TITLE
demo: fix sea battle weapons

### DIFF
--- a/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.config.ts
@@ -46,7 +46,7 @@ export function validateSeaBattleConfig(
     if (
       typeof revealAllDuration !== 'number' ||
       revealAllDuration < 1 ||
-      revealAllDuration > 3
+      revealAllDuration > 5
     ) {
       return false;
     }

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.special-weapons.spec.ts
@@ -47,7 +47,7 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       const s = battleState({ sonar: true });
       const result = engine.executeAction(s, 'useSonar', ctx('a'), {
         targetPlayerId: 'b',
-        row: 2,
+        row: 1,
         col: 2,
       });
 
@@ -55,15 +55,15 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       expect(result.state!.lastSonar).toBeDefined();
       expect(result.state!.lastSonar!.attackerId).toBe('a');
       expect(result.state!.lastSonar!.targetId).toBe('b');
-      expect(result.state!.lastSonar!.centerRow).toBe(2);
+      expect(result.state!.lastSonar!.centerRow).toBe(1);
       expect(result.state!.lastSonar!.centerCol).toBe(2);
-      // radius = Math.floor(10 / 3) = 3 → 7×7 area around (2,2), clamped to 6×6
-      expect(result.state!.lastSonar!.radius).toBe(3);
+      // side = 3 → radius = 1 → 3×3 area around (1,2)
+      expect(result.state!.lastSonar!.radius).toBe(1);
       const cells = result.state!.lastSonar!.cells;
-      expect(cells.length).toBe(36);
-      expect(cells).toContainEqual({ row: 0, col: 0, state: CELL_STATE.SHIP });
+      expect(cells.length).toBe(9);
       expect(cells).toContainEqual({ row: 0, col: 1, state: CELL_STATE.SHIP });
-      expect(cells).toContainEqual({ row: 2, col: 2, state: CELL_STATE.EMPTY });
+      expect(cells).toContainEqual({ row: 0, col: 2, state: CELL_STATE.SHIP });
+      expect(cells).toContainEqual({ row: 1, col: 2, state: CELL_STATE.EMPTY });
     });
 
     it('only reveals cells within radius', () => {
@@ -75,9 +75,9 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       });
 
       expect(result.success).toBe(true);
-      // radius = 3 → 7×7 area around (0,9): rows 0-3, cols 6-9 (clamped)
+      // side = 3 → radius = 1 → 3×3 area around (0,9): rows 0-1, cols 8-9 (clamped)
       const cells = result.state!.lastSonar!.cells;
-      expect(cells.length).toBe(16); // 4 rows × 4 cols (clamped at right edge)
+      expect(cells.length).toBe(4); // 2 rows × 2 cols (clamped at edges)
       expect(cells).toContainEqual({ row: 0, col: 9, state: CELL_STATE.EMPTY });
     });
 
@@ -219,14 +219,12 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       expect(result.state!.lastRadar!.targetId).toBe('b');
       expect(result.state!.lastRadar!.row).toBe(1);
       expect(result.state!.lastRadar!.col).toBeUndefined();
-      // halfWidth = Math.floor(10 / 7) = 1 → rows 0, 1, 2
-      expect(result.state!.lastRadar!.halfWidth).toBe(1);
+      // lines = 1 → halfWidth = 0 → just row 1
+      expect(result.state!.lastRadar!.halfWidth).toBe(0);
 
       const cells = result.state!.lastRadar!.cells;
-      expect(cells.length).toBe(30); // 3 rows × 10 cols
-      expect(cells).toContainEqual({ row: 0, col: 0, state: CELL_STATE.SHIP });
+      expect(cells.length).toBe(10); // 1 row × 10 cols
       expect(cells).toContainEqual({ row: 1, col: 0, state: CELL_STATE.EMPTY });
-      expect(cells).toContainEqual({ row: 2, col: 0, state: CELL_STATE.EMPTY });
     });
 
     it('scans a column band and reveals cell states', () => {
@@ -239,14 +237,12 @@ describe('SeaBattleEngine — special weapons (sonar & radar)', () => {
       expect(result.success).toBe(true);
       expect(result.state!.lastRadar!.col).toBe(2);
       expect(result.state!.lastRadar!.row).toBeUndefined();
-      // halfWidth = Math.floor(10 / 7) = 1 → cols 1, 2, 3
-      expect(result.state!.lastRadar!.halfWidth).toBe(1);
+      // lines = 1 → halfWidth = 0 → just col 2
+      expect(result.state!.lastRadar!.halfWidth).toBe(0);
 
       const cells = result.state!.lastRadar!.cells;
-      expect(cells.length).toBe(30); // 3 cols × 10 rows
-      expect(cells).toContainEqual({ row: 0, col: 1, state: CELL_STATE.SHIP });
+      expect(cells.length).toBe(10); // 1 col × 10 rows
       expect(cells).toContainEqual({ row: 0, col: 2, state: CELL_STATE.SHIP });
-      expect(cells).toContainEqual({ row: 0, col: 3, state: CELL_STATE.SHIP });
     });
 
     it('marks radar as used for the player', () => {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.engine.ts
@@ -212,10 +212,13 @@ export class SeaBattleEngine extends BaseGameEngine<SeaBattleState> {
       case 'resetPlacement':
         return runResetPlacement(newState, player);
       case 'attack':
+        delete newState.lastScanWave;
         return executeAttack(newState, player, payload as AttackPayload);
       case 'useSonar':
+        delete newState.lastScanWave;
         return executeSonar(newState, player, payload as SonarPayload);
       case 'useRadar':
+        delete newState.lastScanWave;
         return executeRadar(newState, player, payload as RadarPayload);
       case 'chat':
         return this.executeChat(newState, player, payload as ChatPayload);

--- a/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.special-weapons.ts
@@ -7,12 +7,16 @@ import {
 } from './sea-battle.types';
 import { GameActionResult } from '../base/game-engine.interface';
 
-function getSonarRadius(gridSize: number): number {
-  return Math.floor(gridSize / 3);
+function getSonarSide(gridSize: number): number {
+  if (gridSize <= 10) return 3;
+  if (gridSize <= 15) return 5;
+  return 7;
 }
 
-function getRadarHalfWidth(gridSize: number): number {
-  return Math.floor(gridSize / 7);
+function getRadarLines(gridSize: number): number {
+  if (gridSize <= 10) return 1;
+  if (gridSize <= 15) return 3;
+  return 5;
 }
 
 export function executeSonar(
@@ -36,11 +40,16 @@ export function executeSonar(
   const centerCol = payload.col!;
 
   const gSize = state.gridSize ?? BOARD_SIZE;
-  const radius = getSonarRadius(gSize);
+  const side = getSonarSide(gSize);
   const cells: { row: number; col: number; state: CellState }[] = [];
 
-  for (let r = centerRow - radius; r <= centerRow + radius; r++) {
-    for (let c = centerCol - radius; c <= centerCol + radius; c++) {
+  const rStart = centerRow - Math.floor((side - 1) / 2);
+  const rEnd = rStart + side - 1;
+  const cStart = centerCol - Math.floor((side - 1) / 2);
+  const cEnd = cStart + side - 1;
+
+  for (let r = rStart; r <= rEnd; r++) {
+    for (let c = cStart; c <= cEnd; c++) {
       if (r >= 0 && r < gSize && c >= 0 && c < gSize) {
         cells.push({ row: r, col: c, state: target.board[r][c] });
       }
@@ -52,7 +61,7 @@ export function executeSonar(
     targetId: target.playerId,
     centerRow,
     centerCol,
-    radius,
+    radius: Math.floor((side - 1) / 2),
     cells,
   };
 
@@ -88,7 +97,8 @@ export function executeRadar(
   state.specialWeaponUsage[player.playerId].radarUsed = true;
 
   const gSize = state.gridSize ?? BOARD_SIZE;
-  const halfWidth = getRadarHalfWidth(gSize);
+  const lines = getRadarLines(gSize);
+  const halfWidth = Math.floor(lines / 2);
   const cells: { row: number; col: number; state: CellState }[] = [];
 
   if (payload.row !== undefined) {

--- a/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
+++ b/apps/be/src/games/engines/sea-battle/sea-battle.utils.ts
@@ -133,10 +133,26 @@ export function sanitizeSeaBattleState(
     return true;
   });
 
-  if (sanitized.lastSonar && sanitized.lastSonar.attackerId !== playerId) {
+  const isTeammateOf = (otherId: string): boolean => {
+    if (!viewerTeamId) return false;
+    const otherTeam = sanitized.teams?.find((t) =>
+      t.playerIds.includes(otherId),
+    );
+    return otherTeam?.id === viewerTeamId;
+  };
+
+  if (
+    sanitized.lastSonar &&
+    sanitized.lastSonar.attackerId !== playerId &&
+    !isTeammateOf(sanitized.lastSonar.attackerId)
+  ) {
     delete sanitized.lastSonar;
   }
-  if (sanitized.lastRadar && sanitized.lastRadar.attackerId !== playerId) {
+  if (
+    sanitized.lastRadar &&
+    sanitized.lastRadar.attackerId !== playerId &&
+    !isTeammateOf(sanitized.lastRadar.attackerId)
+  ) {
     delete sanitized.lastRadar;
   }
 

--- a/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/AttackBoard/index.tsx
@@ -117,29 +117,31 @@ export const AttackBoard = memo(function AttackBoard({
   const effectiveLastSonar = snapshot?.lastSonar ?? cachedLastSonar;
   const effectiveLastRadar = snapshot?.lastRadar ?? cachedLastRadar;
 
-  // Scan wave: show all ships for a limited duration when battle starts
+  // Scan wave: show all ships for a limited duration when battle starts (once only)
+  const SW_KEY = 'sb-scanwave-shown';
   const [scanWaveActive, setScanWaveActive] = useState(false);
   const scanWaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    const sw = snapshot?.lastScanWave;
-    if (!sw || snapshot?.phase !== 'battle') return;
-
-    // Defer state update to avoid synchronous cascading renders
-    const raf = requestAnimationFrame(() => setScanWaveActive(true));
-    if (scanWaveTimerRef.current) clearTimeout(scanWaveTimerRef.current);
-    scanWaveTimerRef.current = setTimeout(() => {
-      setScanWaveActive(false);
-      scanWaveTimerRef.current = null;
-    }, sw.duration * 1000);
-
-    return () => {
-      cancelAnimationFrame(raf);
+    if (snapshot?.phase === 'lobby' || snapshot?.phase === 'placement') {
+      sessionStorage.removeItem(SW_KEY);
       if (scanWaveTimerRef.current) {
         clearTimeout(scanWaveTimerRef.current);
         scanWaveTimerRef.current = null;
       }
-    };
+      setTimeout(() => setScanWaveActive(false), 0);
+      return;
+    }
+    const sw = snapshot?.lastScanWave;
+    if (!sw || snapshot?.phase !== 'battle') return;
+    if (sessionStorage.getItem(SW_KEY)) return;
+
+    sessionStorage.setItem(SW_KEY, '1');
+    setTimeout(() => setScanWaveActive(true), 0);
+    scanWaveTimerRef.current = setTimeout(() => {
+      setScanWaveActive(false);
+      scanWaveTimerRef.current = null;
+    }, sw.duration * 1000);
   }, [snapshot?.lastScanWave, snapshot?.phase]);
 
   const sonarHighlightSet = (() => {

--- a/apps/web/src/widgets/SeaBattleGame/ui/HouseRulesPanel.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/HouseRulesPanel.tsx
@@ -207,11 +207,18 @@ export function HouseRulesPanel({
         </label>
 
         {sw?.revealAll && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingLeft: 24 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              paddingLeft: 24,
+            }}
+          >
             <Text fontSize={12} opacity={0.6}>
               Duration:
             </Text>
-            {[1, 2, 3].map((sec) => {
+            {[1, 2, 3, 4, 5].map((sec) => {
               const currentDuration =
                 (gameOptions.revealAllDuration as number) ?? 1;
               return (

--- a/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
+++ b/apps/web/src/widgets/SeaBattleGame/ui/SeaBattleBoards.tsx
@@ -124,15 +124,17 @@ export function SeaBattleBoards({
     setHoveredCell(null);
   }, []);
 
-  // Compute preview cells for sonar (area scales with grid size, matching backend getSonarRadius)
+  // Compute preview cells for sonar (area scales with grid size, matching backend getSonarSide)
   const sonarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'sonar' || !hoveredCell) return null;
-    const radius = Math.floor(gridSize / 3);
+    const side = gridSize <= 10 ? 3 : gridSize <= 15 ? 5 : 7;
     const cells = new Set<string>();
-    for (let dr = -radius; dr <= radius; dr++) {
-      for (let dc = -radius; dc <= radius; dc++) {
-        const r = hoveredCell.row + dr;
-        const c = hoveredCell.col + dc;
+    const rStart = hoveredCell.row - Math.floor((side - 1) / 2);
+    const rEnd = rStart + side - 1;
+    const cStart = hoveredCell.col - Math.floor((side - 1) / 2);
+    const cEnd = cStart + side - 1;
+    for (let r = rStart; r <= rEnd; r++) {
+      for (let c = cStart; c <= cEnd; c++) {
         if (r >= 0 && r < gridSize && c >= 0 && c < gridSize) {
           cells.add(`${weaponMode.targetPlayerId}-${r}-${c}`);
         }
@@ -141,10 +143,11 @@ export function SeaBattleBoards({
     return cells;
   })();
 
-  // Compute preview cells for radar (band of rows/columns, matching backend getRadarHalfWidth)
+  // Compute preview cells for radar (band of rows/columns, matching backend getRadarLines)
   const radarPreviewCells = (() => {
     if (weaponMode?.weapon !== 'radar' || !hoveredCell) return null;
-    const halfWidth = Math.floor(gridSize / 7);
+    const lines = gridSize <= 10 ? 1 : gridSize <= 15 ? 3 : 5;
+    const halfWidth = Math.floor(lines / 2);
     const cells = new Set<string>();
     const axis = weaponMode.radarAxis ?? 'row';
     if (axis === 'row') {
@@ -306,8 +309,7 @@ export function SeaBattleBoards({
                     style={{
                       ...buttonBase,
                       opacity: isRadarDisabled ? 0.35 : 1,
-                      cursor:
-                        isRadarDisabled ? 'not-allowed' : 'pointer',
+                      cursor: isRadarDisabled ? 'not-allowed' : 'pointer',
                       color:
                         weaponMode?.weapon === 'radar' ? '#a855f7' : '#e0e0e0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,
@@ -342,8 +344,7 @@ export function SeaBattleBoards({
                       ...buttonBase,
                       padding: '8px 10px',
                       opacity: isRadarDisabled ? 0.35 : 1,
-                      cursor:
-                        isRadarDisabled ? 'not-allowed' : 'pointer',
+                      cursor: isRadarDisabled ? 'not-allowed' : 'pointer',
                       color:
                         weaponMode?.weapon === 'radar' ? '#c084fc' : '#a0a0a0',
                       borderTop: `1px solid ${weaponMode?.weapon === 'radar' ? '#a855f7' : 'rgba(168,85,247,0.3)'}`,


### PR DESCRIPTION
## What
Fixes sea battle special weapons: scan wave, sonar, radar sizing, and teammate visibility.

## Why
- Scan wave was showing before every turn instead of once at game start
- Scan wave was re-showing after page refresh
- Sonar and radar areas were too large for bigger field sizes
- Teammates couldn't see each other's weapon usage

## Changes
### Scan Wave
- Backend deletes `lastScanWave` from state on first battle action (attack/sonar/radar)
- Frontend uses `sessionStorage` to prevent re-show after page refresh
- Duration options expanded from 1-3s to 1-5s (config + UI)

### Sonar (by grid size)
| Grid | Before | After |
|------|--------|-------|
| 10   | 7×7    | 3×3   |
| 15   | 11×11  | 5×5   |
| 20   | 13×13  | 7×7   |

### Radar (by grid size)
| Grid | Before | After |
|------|--------|-------|
| 10   | 3 lines | 1 line |
| 15   | 5 lines | 3 lines |
| 20   | 5 lines | 5 lines |

### Weapon Visibility
- Sonar/radar results now visible to teammates (same team)
- Opponents cannot see weapon usage data (unchanged)