### PR TITLE
fix(games): fix checkers multi-step validation and board orientation

### DIFF
--- a/apps/be/src/games/engines/checkers/checkers.engine.spec.ts
+++ b/apps/be/src/games/engines/checkers/checkers.engine.spec.ts
@@ -173,6 +173,31 @@ describe('CheckersEngine', () => {
       expect(result.state!.board[1][4]!.playerId).toBe('a');
     });
 
+    it('allows a multi-jump chain with promotion and continues as king in russian variant', () => {
+      const state = engine.initializeState(['a', 'b'], {
+        options: {
+          ruleVariant: 'russian',
+          forcedCaptures: true,
+          variant: 'classic',
+          backwardCaptures: false,
+        },
+      });
+      clearBoard(state);
+      state.board[2][1] = { playerId: 'a', type: 'man' };
+      state.board[1][2] = { playerId: 'b', type: 'man' };
+      state.board[1][4] = { playerId: 'b', type: 'man' };
+
+      const result = doMove(
+        state,
+        'a',
+        multiCapture([s(2, 1, 0, 3, 1, 2), s(0, 3, 2, 5, 1, 4)]),
+      );
+      expect(result.success).toBe(true);
+      expect(result.state!.board[2][5]!.type).toBe('king');
+      expect(result.state!.board[1][2]).toBeNull();
+      expect(result.state!.board[1][4]).toBeNull();
+    });
+
     it('rejects multi-jump with disconnected steps', () => {
       const state = engine.initializeState(['a', 'b']);
       clearBoard(state);

--- a/apps/be/src/games/engines/checkers/checkers.utils.ts
+++ b/apps/be/src/games/engines/checkers/checkers.utils.ts
@@ -397,28 +397,25 @@ export function applyMove(
   if (steps.length === 0) return newBoard;
 
   const firstStep = steps[0];
-  const piece = newBoard[firstStep.fromRow][firstStep.fromCol];
+  let piece = newBoard[firstStep.fromRow][firstStep.fromCol];
   if (!piece) return newBoard;
+
+  newBoard[firstStep.fromRow][firstStep.fromCol] = null;
+
+  const size = newBoard.length;
+  const promotionRow = playerColor === 'light' ? 0 : size - 1;
 
   for (const step of steps) {
     if (step.capturedRow !== undefined && step.capturedCol !== undefined) {
       newBoard[step.capturedRow][step.capturedCol] = null;
     }
-  }
-
-  const lastStep = steps[steps.length - 1];
-  const movingPiece = { ...piece };
-
-  if (movingPiece.type === 'man') {
-    const size = newBoard.length;
-    const promotionRow = playerColor === 'light' ? 0 : size - 1;
-    if (lastStep.toRow === promotionRow) {
-      movingPiece.type = 'king';
+    if (piece.type === 'man' && step.toRow === promotionRow) {
+      piece = { ...piece, type: 'king' };
     }
   }
 
-  newBoard[firstStep.fromRow][firstStep.fromCol] = null;
-  newBoard[lastStep.toRow][lastStep.toCol] = movingPiece;
+  const lastStep = steps[steps.length - 1];
+  newBoard[lastStep.toRow][lastStep.toCol] = piece;
 
   return newBoard;
 }

--- a/apps/be/src/games/engines/checkers/checkers.validators.ts
+++ b/apps/be/src/games/engines/checkers/checkers.validators.ts
@@ -117,7 +117,7 @@ export function validateMovePiece(
       return { ok: false, error: `Invalid step ${i + 1}` };
     }
 
-    currentBoard = applyMove(currentBoard, [validStep]);
+    currentBoard = applyMove(currentBoard, [validStep], playerColor);
   }
 
   if (isCaptureChain) {

--- a/apps/web/src/widgets/CheckersGame/lib/checkersClientLogic.ts
+++ b/apps/web/src/widgets/CheckersGame/lib/checkersClientLogic.ts
@@ -187,27 +187,24 @@ export function applyMoveToBoard(board: Board, steps: MoveStep[]): Board {
   if (steps.length === 0) return newBoard;
 
   const firstStep = steps[0];
-  const piece = newBoard[firstStep.fromRow][firstStep.fromCol];
+  let piece = newBoard[firstStep.fromRow][firstStep.fromCol];
   if (!piece) return newBoard;
+
+  newBoard[firstStep.fromRow][firstStep.fromCol] = null;
+
+  const size = newBoard.length;
 
   for (const step of steps) {
     if (step.capturedRow !== undefined && step.capturedCol !== undefined) {
       newBoard[step.capturedRow][step.capturedCol] = null;
     }
-  }
-
-  const lastStep = steps[steps.length - 1];
-  const movingPiece = { ...piece };
-
-  if (movingPiece.type === 'man') {
-    const size = newBoard.length;
-    if (lastStep.toRow === 0 || lastStep.toRow === size - 1) {
-      movingPiece.type = 'king';
+    if (piece.type === 'man' && (step.toRow === 0 || step.toRow === size - 1)) {
+      piece = { ...piece, type: 'king' };
     }
   }
 
-  newBoard[firstStep.fromRow][firstStep.fromCol] = null;
-  newBoard[lastStep.toRow][lastStep.toCol] = movingPiece;
+  const lastStep = steps[steps.length - 1];
+  newBoard[lastStep.toRow][lastStep.toCol] = piece;
 
   return newBoard;
 }

--- a/apps/web/src/widgets/CheckersGame/ui/CheckersBoard.tsx
+++ b/apps/web/src/widgets/CheckersGame/ui/CheckersBoard.tsx
@@ -13,6 +13,7 @@ interface CheckersBoardProps {
   disabled: boolean;
   ariaLabel: string;
   onCellClick: (row: number, col: number) => void;
+  isFlipped?: boolean;
 }
 
 export function CheckersBoard({
@@ -23,6 +24,7 @@ export function CheckersBoard({
   disabled,
   ariaLabel,
   onCellClick,
+  isFlipped = false,
 }: CheckersBoardProps) {
   const theme = useCheckersTheme();
   const boardSize = board.length;
@@ -42,6 +44,16 @@ export function CheckersBoard({
     return map;
   }, [players]);
 
+  const rows = useMemo(() => {
+    const arr = Array.from({ length: boardSize }, (_, i) => i);
+    return isFlipped ? arr.reverse() : arr;
+  }, [boardSize, isFlipped]);
+
+  const cols = useMemo(() => {
+    const arr = Array.from({ length: boardSize }, (_, i) => i);
+    return isFlipped ? arr.reverse() : arr;
+  }, [boardSize, isFlipped]);
+
   return (
     <YStack
       width="100%"
@@ -57,9 +69,9 @@ export function CheckersBoard({
       aria-label={ariaLabel}
       data-testid="checkers-board"
     >
-      {Array.from({ length: boardSize }).map((_, row) => (
+      {rows.map((row) => (
         <YStack key={row} flexDirection="row" flex={1} role="row">
-          {Array.from({ length: boardSize }).map((_, col) => {
+          {cols.map((col) => {
             const isDarkSquare = (row + col) % 2 === 1;
             const piece = board[row][col];
             const isSelected =

--- a/apps/web/src/widgets/CheckersGame/ui/Game.tsx
+++ b/apps/web/src/widgets/CheckersGame/ui/Game.tsx
@@ -166,6 +166,16 @@ function CheckersGameImpl({
   const [optimisticBoard, setOptimisticBoard] = useState<Board | null>(null);
   const [lastServerBoard, setLastServerBoard] = useState<Board | null>(null);
 
+  const playerColor = useMemo(
+    () =>
+      currentUserId && snapshot
+        ? getPlayerColor(snapshot.players, currentUserId)
+        : null,
+    [snapshot, currentUserId],
+  );
+
+  const isFlipped = playerColor === 'dark';
+
   const displayBoard = optimisticBoard ?? snapshot?.board ?? null;
 
   // Clear optimistic board when server state changes
@@ -329,6 +339,7 @@ function CheckersGameImpl({
             disabled={!myTurn || isGameOver}
             ariaLabel={`Checkers ${displayBoard.length}×${displayBoard.length} board`}
             onCellClick={handleCellClick}
+            isFlipped={isFlipped}
           />
         </>
       ) : null}


### PR DESCRIPTION
## What
Fixes checkers multi-step validation issues on the backend and introduces board orientation flipping for checkers players on the frontend.

## Why
1. Checkers multi-jump/multi-step moves failed validation when a man got promoted to king in the middle of a multi-jump because the backend validator did not pass `playerColor` to the intermediate `applyMove` simulation, nor did `applyMove` evaluate promotion step-by-step.
2. Aligning checkers with chess by ensuring the active player's side of the board is always positioned at the bottom of the screen.

## Changes
- **Backend**:
  - Passed `playerColor` in `validateMovePiece` ([checkers.validators.ts](file:///Users/anatoliyaliaksandrau/js/arcadeum_claude_2/apps/be/src/games/engines/checkers/checkers.validators.ts)) to correctly simulate intermediate piece promotions.
  - Refactored `applyMove` ([checkers.utils.ts](file:///Users/anatoliyaliaksandrau/js/arcadeum_claude_2/apps/be/src/games/engines/checkers/checkers.utils.ts)) to evaluate promotion at each individual step of a move path.
  - Added a unit test validating intermediate promotion multi-jumps ([checkers.engine.spec.ts](file:///Users/anatoliyaliaksandrau/js/arcadeum_claude_2/apps/be/src/games/engines/checkers/checkers.engine.spec.ts)).
- **Frontend**:
  - Refactored `applyMoveToBoard` ([checkersClientLogic.ts](file:///Users/anatoliyaliaksandrau/js/arcadeum_claude_2/apps/web/src/widgets/CheckersGame/lib/checkersClientLogic.ts)) to evaluate promotion at each step.
  - Added `isFlipped` logic in `Game.tsx` ([Game.tsx](file:///Users/anatoliyaliaksandrau/js/arcadeum_claude_2/apps/web/src/widgets/CheckersGame/ui/Game.tsx)) for `'dark'` player color.
  - Inverted row and column rendering in `CheckersBoard` when `isFlipped` is active ([CheckersBoard.tsx](file:///Users/anatoliyaliaksandrau/js/arcadeum_claude_2/apps/web/src/widgets/CheckersGame/ui/CheckersBoard.tsx)).
