### PR TITLE
feat(shorts-factory): Telegram approval flow + stability fixes

### DIFF
--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -215,6 +215,9 @@ jobs:
             echo "==> Installing dependencies..."
             pnpm install --frozen-lockfile 2>/dev/null || pnpm install
 
+            echo "==> Installing Playwright browsers..."
+            npx playwright install chromium --with-deps 2>/dev/null || npx playwright install chromium
+
             echo "==> Ensuring shorts-factory wrapper script exists..."
             if [ ! -f /opt/arcadeum/scripts/shorts-factory-random.sh ]; then
               sudo tee /opt/arcadeum/scripts/shorts-factory-random.sh > /dev/null <<'WRAPPER'

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -218,6 +218,9 @@ jobs:
             echo "==> Installing Playwright browsers..."
             npx playwright install chromium --with-deps 2>/dev/null || npx playwright install chromium
 
+            echo "==> Creating directories..."
+            mkdir -p raw_captures output pending
+
             echo "==> Ensuring shorts-factory wrapper script exists..."
             if [ ! -f /opt/arcadeum/scripts/shorts-factory-random.sh ]; then
               sudo tee /opt/arcadeum/scripts/shorts-factory-random.sh > /dev/null <<'WRAPPER'

--- a/apps/tg-bot/.env.example
+++ b/apps/tg-bot/.env.example
@@ -2,6 +2,9 @@
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-chat-id-or-channel-id
 
+# Shorts Factory Approval
+SHORTS_FACTORY_ADMIN_CHAT_ID=your-admin-chat-id
+
 # Solana
 SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 SOLANA_WS_URL=wss://api.mainnet-beta.solana.com

--- a/apps/tg-bot/.env.example
+++ b/apps/tg-bot/.env.example
@@ -2,8 +2,8 @@
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_CHAT_ID=your-chat-id-or-channel-id
 
-# Shorts Factory Approval
-SHORTS_FACTORY_ADMIN_CHAT_ID=your-admin-chat-id
+# Shorts Factory Approval (falls back to TELEGRAM_DM_CHAT_ID if not set)
+SHORTS_FACTORY_ADMIN_CHAT_ID=
 
 # Solana
 SOLANA_RPC_URL=https://api.mainnet-beta.solana.com

--- a/apps/tg-bot/src/app.module.ts
+++ b/apps/tg-bot/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { PumpFunModule } from './pumpfun/pumpfun.module';
 import { TelegramModule } from './telegram/telegram.module';
 import { HealthMonitorModule } from './health-monitor/health-monitor.module';
+import { ShortsFactoryModule } from './shorts-factory/shorts-factory.module';
 import { HealthController } from './health.controller';
 
 @Module({
@@ -11,6 +12,7 @@ import { HealthController } from './health.controller';
     PumpFunModule,
     TelegramModule,
     HealthMonitorModule,
+    ShortsFactoryModule,
   ],
   controllers: [HealthController],
 })

--- a/apps/tg-bot/src/shorts-factory/shorts-factory.controller.ts
+++ b/apps/tg-bot/src/shorts-factory/shorts-factory.controller.ts
@@ -8,6 +8,8 @@ import {
   HttpStatus,
   Logger,
 } from '@nestjs/common';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   ShortsFactoryService,
   type PendingVideo,
@@ -37,13 +39,14 @@ export class ShortsFactoryController {
 
   @Get('status/:id')
   getStatus(@Param('id') id: string) {
-    const fs = require('fs');
-    const path = require('path');
-    const filePath = path.join(this.shortsFactory.getPendingDir(), `${id}.json`);
+    const filePath = path.join(
+      this.shortsFactory.getPendingDir(),
+      `${id}.json`,
+    );
 
     try {
       const data = fs.readFileSync(filePath, 'utf-8');
-      return JSON.parse(data);
+      return JSON.parse(data) as { status: string };
     } catch {
       return { status: 'not_found' };
     }

--- a/apps/tg-bot/src/shorts-factory/shorts-factory.controller.ts
+++ b/apps/tg-bot/src/shorts-factory/shorts-factory.controller.ts
@@ -1,0 +1,68 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import {
+  ShortsFactoryService,
+  type PendingVideo,
+} from './shorts-factory.service';
+
+@Controller('shorts-factory')
+export class ShortsFactoryController {
+  private readonly logger = new Logger(ShortsFactoryController.name);
+
+  constructor(private readonly shortsFactory: ShortsFactoryService) {}
+
+  @Post('pending')
+  @HttpCode(HttpStatus.CREATED)
+  async createPending(
+    @Body() body: PendingVideo,
+  ): Promise<{ success: boolean; messageId?: number; pendingDir: string }> {
+    this.logger.log(`Received pending video: ${body.id}`);
+
+    const messageId = await this.shortsFactory.notifyAdmin(body);
+
+    return {
+      success: true,
+      messageId,
+      pendingDir: this.shortsFactory.getPendingDir(),
+    };
+  }
+
+  @Get('status/:id')
+  getStatus(@Param('id') id: string) {
+    const fs = require('fs');
+    const path = require('path');
+    const filePath = path.join(this.shortsFactory.getPendingDir(), `${id}.json`);
+
+    try {
+      const data = fs.readFileSync(filePath, 'utf-8');
+      return JSON.parse(data);
+    } catch {
+      return { status: 'not_found' };
+    }
+  }
+
+  @Post('result')
+  @HttpCode(HttpStatus.OK)
+  async postResult(
+    @Body()
+    body: {
+      id: string;
+      status: 'posted' | 'failed';
+      result: { success: boolean; message: string; platforms?: string[] };
+    },
+  ) {
+    this.logger.log(`Received result for video ${body.id}: ${body.status}`);
+
+    await this.shortsFactory.sendResultMessage(body.result);
+
+    return { success: true };
+  }
+}

--- a/apps/tg-bot/src/shorts-factory/shorts-factory.module.ts
+++ b/apps/tg-bot/src/shorts-factory/shorts-factory.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ShortsFactoryService } from './shorts-factory.service';
+import { ShortsFactoryController } from './shorts-factory.controller';
+import { TelegramModule } from '../telegram/telegram.module';
+
+@Module({
+  imports: [TelegramModule],
+  controllers: [ShortsFactoryController],
+  providers: [ShortsFactoryService],
+  exports: [ShortsFactoryService],
+})
+export class ShortsFactoryModule {}

--- a/apps/tg-bot/src/shorts-factory/shorts-factory.service.ts
+++ b/apps/tg-bot/src/shorts-factory/shorts-factory.service.ts
@@ -29,7 +29,9 @@ export class ShortsFactoryService {
     private readonly telegram: TelegramService,
   ) {
     this.adminChatId =
-      this.config.get<string>('SHORTS_FACTORY_ADMIN_CHAT_ID') ?? '';
+      this.config.get<string>('SHORTS_FACTORY_ADMIN_CHAT_ID') ??
+      this.config.get<string>('TELEGRAM_DM_CHAT_ID') ??
+      '';
     this.pendingDir =
       this.config.get<string>('SHORTS_FACTORY_PENDING_DIR') ??
       '/opt/arcadeum/pending';

--- a/apps/tg-bot/src/shorts-factory/shorts-factory.service.ts
+++ b/apps/tg-bot/src/shorts-factory/shorts-factory.service.ts
@@ -1,0 +1,147 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InlineKeyboard } from 'grammy';
+import { TelegramService } from '../telegram/telegram.service';
+
+export interface PendingVideo {
+  id: string;
+  videoPath: string;
+  caption: string;
+  scenario: string;
+  status: 'pending' | 'approved' | 'regenerated' | 'posted' | 'failed';
+  createdAt: string;
+  messageId?: number;
+  result?: {
+    success: boolean;
+    message: string;
+    platforms?: string[];
+  };
+}
+
+@Injectable()
+export class ShortsFactoryService {
+  private readonly logger = new Logger(ShortsFactoryService.name);
+  private readonly adminChatId: string;
+  private readonly pendingDir: string;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly telegram: TelegramService,
+  ) {
+    this.adminChatId =
+      this.config.get<string>('SHORTS_FACTORY_ADMIN_CHAT_ID') ?? '';
+    this.pendingDir =
+      this.config.get<string>('SHORTS_FACTORY_PENDING_DIR') ??
+      '/opt/arcadeum/pending';
+  }
+
+  getPendingDir(): string {
+    return this.pendingDir;
+  }
+
+  async notifyAdmin(pending: PendingVideo): Promise<number | undefined> {
+    if (!this.adminChatId) {
+      this.logger.warn('SHORTS_FACTORY_ADMIN_CHAT_ID not set, skipping admin notification');
+      return undefined;
+    }
+
+    const keyboard = new InlineKeyboard()
+      .text('✅ Confirm', `sf_confirm:${pending.id}`)
+      .text('🔄 Regenerate', `sf_regenerate:${pending.id}`);
+
+    const message =
+      `🎬 <b>New Short Ready for Review</b>\n\n` +
+      `<b>Scenario:</b> ${pending.scenario}\n` +
+      `<b>Caption:</b> ${pending.caption}\n` +
+      `<b>Created:</b> ${new Date(pending.createdAt).toLocaleString()}\n\n` +
+      `Video will be auto-posted in <b>3 hours</b> if no action taken.`;
+
+    try {
+      const bot = this.telegram.getBot();
+      const result = await bot.api.sendMessage(this.adminChatId, message, {
+        parse_mode: 'HTML',
+        reply_markup: keyboard,
+      });
+      this.logger.log(`Sent approval request for video ${pending.id}`);
+      return result.message_id;
+    } catch (err) {
+      this.logger.error(`Failed to send admin notification: ${err}`);
+      return undefined;
+    }
+  }
+
+  async editMessageStatus(
+    messageId: number,
+    status: string,
+    details?: string,
+  ): Promise<void> {
+    if (!this.adminChatId) return;
+
+    const statusEmoji =
+      status === 'approved'
+        ? '✅'
+        : status === 'regenerated'
+          ? '🔄'
+          : status === 'posted'
+            ? '🚀'
+            : status === 'failed'
+              ? '❌'
+              : '⏳';
+
+    const text =
+      `${statusEmoji} <b>Short ${status.charAt(0).toUpperCase() + status.slice(1)}</b>\n\n` +
+      (details ?? '');
+
+    try {
+      const bot = this.telegram.getBot();
+      await bot.api.editMessageText(this.adminChatId, messageId, text, {
+        parse_mode: 'HTML',
+      });
+    } catch (err) {
+      this.logger.error(`Failed to edit message: ${err}`);
+    }
+  }
+
+  async sendResultMessage(result: {
+    success: boolean;
+    message: string;
+    platforms?: string[];
+  }): Promise<void> {
+    if (!this.adminChatId) return;
+
+    const emoji = result.success ? '✅' : '❌';
+    const text =
+      `${emoji} <b>Post ${result.success ? 'Succeeded' : 'Failed'}</b>\n\n` +
+      `${result.message}` +
+      (result.platforms?.length
+        ? `\n\n<b>Platforms:</b> ${result.platforms.join(', ')}`
+        : '');
+
+    try {
+      const bot = this.telegram.getBot();
+      await bot.api.sendMessage(this.adminChatId, text, {
+        parse_mode: 'HTML',
+      });
+    } catch (err) {
+      this.logger.error(`Failed to send result message: ${err}`);
+    }
+  }
+
+  async handleCallbackQuery(
+    action: string,
+    videoId: string,
+    callbackQueryId: string,
+  ): Promise<void> {
+    const bot = this.telegram.getBot();
+
+    if (action === 'sf_confirm') {
+      await bot.api.answerCallbackQuery(callbackQueryId, {
+        text: '✅ Video approved for posting',
+      });
+    } else if (action === 'sf_regenerate') {
+      await bot.api.answerCallbackQuery(callbackQueryId, {
+        text: '🔄 Video will be regenerated',
+      });
+    }
+  }
+}

--- a/apps/tg-bot/src/telegram/telegram.service.spec.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.spec.ts
@@ -6,11 +6,13 @@ jest.mock('grammy', () => {
   const mockStart = jest.fn();
   const mockStop = jest.fn();
   const mockCommand = jest.fn();
+  const mockOn = jest.fn();
 
   return {
     Bot: jest.fn().mockImplementation(() => ({
       api: { sendMessage: mockSendMessage },
       command: mockCommand,
+      on: mockOn,
       start: mockStart,
       stop: mockStop,
     })),
@@ -18,6 +20,7 @@ jest.mock('grammy', () => {
     __mockStart: mockStart,
     __mockStop: mockStop,
     __mockCommand: mockCommand,
+    __mockOn: mockOn,
   };
 });
 

--- a/apps/tg-bot/src/telegram/telegram.service.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Bot, type Context } from 'grammy';
+import type { PendingVideo } from '../shorts-factory/shorts-factory.service';
 
 interface TransactionData {
   type: 'buy' | 'sell';
@@ -142,10 +143,62 @@ export class TelegramService implements OnModuleInit, OnModuleDestroy {
             '/ca — Contract address & links\n' +
             '/chart — Price chart links\n' +
             '/holders — Holder distribution\n' +
+            '/shorts — Shorts factory status\n' +
             '/help — Show this message',
           { parse_mode: 'HTML' },
         ),
     );
+
+    this.bot.on('callback_query:data', async (ctx) => {
+      const data = ctx.callbackQuery.data;
+      if (data.startsWith('sf_')) {
+        const [action, videoId] = data.split(':');
+        const fs = require('fs');
+        const path = require('path');
+        const pendingDir =
+          process.env.SHORTS_FACTORY_PENDING_DIR ?? '/opt/arcadeum/pending';
+        const filePath = path.join(pendingDir, `${videoId}.json`);
+
+        try {
+          const raw = fs.readFileSync(filePath, 'utf-8');
+          const pending: PendingVideo = JSON.parse(raw);
+
+          if (action === 'sf_confirm' && pending.status === 'pending') {
+            pending.status = 'approved';
+            fs.writeFileSync(filePath, JSON.stringify(pending, null, 2));
+            await ctx.answerCallbackQuery({ text: '✅ Video approved' });
+            await ctx.editMessageText(
+              `✅ <b>Short Approved</b>\n\n` +
+                `<b>Scenario:</b> ${pending.scenario}\n` +
+                `<b>Caption:</b> ${pending.caption}\n` +
+                `<b>Approved at:</b> ${new Date().toLocaleString()}`,
+              { parse_mode: 'HTML' },
+            );
+          } else if (action === 'sf_regenerate' && pending.status === 'pending') {
+            pending.status = 'regenerated';
+            fs.writeFileSync(filePath, JSON.stringify(pending, null, 2));
+            await ctx.answerCallbackQuery({ text: '🔄 Video will be regenerated' });
+            await ctx.editMessageText(
+              `🔄 <b>Short Regeneration Requested</b>\n\n` +
+                `<b>Scenario:</b> ${pending.scenario}\n` +
+                `<b>Requested at:</b> ${new Date().toLocaleString()}`,
+              { parse_mode: 'HTML' },
+            );
+          } else {
+            await ctx.answerCallbackQuery({
+              text: '⚠️ Already processed',
+              show_alert: true,
+            });
+          }
+        } catch (err) {
+          this.logger.error(`Callback query error: ${err}`);
+          await ctx.answerCallbackQuery({
+            text: '❌ Error processing request',
+            show_alert: true,
+          });
+        }
+      }
+    });
 
     void this.bot.start({
       onStart: () => this.logger.log('Bot polling started'),
@@ -176,6 +229,10 @@ export class TelegramService implements OnModuleInit, OnModuleDestroy {
       `<a href="https://solscan.io/tx/${tx.signature}">Solscan</a> | <a href="https://pump.fun/coin/${this.mintAddress}">PumpFun</a>`;
 
     await this.sendMessage(message);
+  }
+
+  getBot(): Bot {
+    return this.bot;
   }
 
   async sendAlert(text: string): Promise<void> {

--- a/apps/tg-bot/src/telegram/telegram.service.ts
+++ b/apps/tg-bot/src/telegram/telegram.service.ts
@@ -5,6 +5,8 @@ import {
   OnModuleDestroy,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Bot, type Context } from 'grammy';
 import type { PendingVideo } from '../shorts-factory/shorts-factory.service';
 
@@ -153,15 +155,13 @@ export class TelegramService implements OnModuleInit, OnModuleDestroy {
       const data = ctx.callbackQuery.data;
       if (data.startsWith('sf_')) {
         const [action, videoId] = data.split(':');
-        const fs = require('fs');
-        const path = require('path');
         const pendingDir =
           process.env.SHORTS_FACTORY_PENDING_DIR ?? '/opt/arcadeum/pending';
         const filePath = path.join(pendingDir, `${videoId}.json`);
 
         try {
           const raw = fs.readFileSync(filePath, 'utf-8');
-          const pending: PendingVideo = JSON.parse(raw);
+          const pending = JSON.parse(raw) as PendingVideo;
 
           if (action === 'sf_confirm' && pending.status === 'pending') {
             pending.status = 'approved';
@@ -174,10 +174,15 @@ export class TelegramService implements OnModuleInit, OnModuleDestroy {
                 `<b>Approved at:</b> ${new Date().toLocaleString()}`,
               { parse_mode: 'HTML' },
             );
-          } else if (action === 'sf_regenerate' && pending.status === 'pending') {
+          } else if (
+            action === 'sf_regenerate' &&
+            pending.status === 'pending'
+          ) {
             pending.status = 'regenerated';
             fs.writeFileSync(filePath, JSON.stringify(pending, null, 2));
-            await ctx.answerCallbackQuery({ text: '🔄 Video will be regenerated' });
+            await ctx.answerCallbackQuery({
+              text: '🔄 Video will be regenerated',
+            });
             await ctx.editMessageText(
               `🔄 <b>Short Regeneration Requested</b>\n\n` +
                 `<b>Scenario:</b> ${pending.scenario}\n` +

--- a/scripts/deploy-shorts-factory.sh
+++ b/scripts/deploy-shorts-factory.sh
@@ -18,6 +18,7 @@ npx playwright install-deps chromium
 echo "==> Creating directories..."
 mkdir -p raw_captures
 mkdir -p output
+mkdir -p pending
 
 echo "==> Deploy complete!"
 echo ""

--- a/scripts/shorts-factory/factory.js
+++ b/scripts/shorts-factory/factory.js
@@ -1134,9 +1134,7 @@ async function publishToSocials(videoPath, caption) {
         ],
         settings: {
           __type: 'instagram',
-          post_type: 'reel',
-          is_trial_reel: false,
-          collaborators: [],
+          post_type: 'post',
         },
       }),
     });

--- a/scripts/shorts-factory/factory.js
+++ b/scripts/shorts-factory/factory.js
@@ -18,7 +18,14 @@
 
 const { chromium } = require('playwright');
 const { spawn } = require('child_process');
-const { readdir, unlink, mkdir, stat, readFile } = require('fs/promises');
+const {
+  readdir,
+  unlink,
+  mkdir,
+  stat,
+  readFile,
+  writeFile,
+} = require('fs/promises');
 const path = require('path');
 const axios = require('axios');
 const FormData = require('form-data');
@@ -41,6 +48,7 @@ const CONFIG = {
   // Directories
   rawCapturesDir: path.join(__dirname, '..', '..', 'raw_captures'),
   outputDir: path.join(__dirname, '..', '..', 'output'),
+  pendingDir: path.join(__dirname, '..', '..', 'pending'),
 
   // Video settings
   videoDuration: { min: 5, max: 10 }, // seconds (randomized)
@@ -55,7 +63,152 @@ const CONFIG = {
   postizIntegrationId: process.env.POSTIZ_YOUTUBE_INTEGRATION_ID || '',
   postizInstagramId: process.env.POSTIZ_INSTAGRAM_INTEGRATION_ID || '',
   postizTiktokId: process.env.POSTIZ_TIKTOK_INTEGRATION_ID || '',
+
+  // Telegram Bot API
+  tgBotUrl: process.env.TG_BOT_URL || 'http://localhost:4001',
+
+  // Approval settings
+  approvalTimeoutMs: 3 * 60 * 60 * 1000, // 3 hours
+  pollIntervalMs: 30 * 1000, // 30 seconds
+  enableApproval: process.env.SHORTS_FACTORY_APPROVAL === 'true',
 };
+
+// ============================================================================
+// APPROVAL FLOW
+// ============================================================================
+
+/**
+ * Generates a unique ID for pending videos
+ */
+function generateId() {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+}
+
+/**
+ * Ensures the pending directory exists
+ */
+async function ensurePendingDir() {
+  await mkdir(CONFIG.pendingDir, { recursive: true });
+}
+
+/**
+ * Saves video to pending directory and notifies Telegram bot
+ */
+async function requestApproval(videoPath, caption, scenario) {
+  if (!CONFIG.enableApproval) {
+    log('info', 'Approval flow disabled, posting directly');
+    return { approved: true, autoApproved: false, pendingId: null };
+  }
+
+  await ensurePendingDir();
+  const id = generateId();
+
+  const pending = {
+    id,
+    videoPath,
+    caption,
+    scenario,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  };
+
+  // Save pending metadata
+  const metadataPath = path.join(CONFIG.pendingDir, `${id}.json`);
+  await writeFile(metadataPath, JSON.stringify(pending, null, 2));
+  log('info', `Saved pending video metadata: ${metadataPath}`);
+
+  // Notify Telegram bot
+  try {
+    const response = await axios.post(
+      `${CONFIG.tgBotUrl}/shorts-factory/pending`,
+      pending,
+      { timeout: 10000 },
+    );
+    log('info', 'Notified Telegram bot for approval', {
+      messageId: response.data.messageId,
+    });
+    pending.messageId = response.data.messageId;
+    await writeFile(metadataPath, JSON.stringify(pending, null, 2));
+  } catch (err) {
+    log('error', 'Failed to notify Telegram bot', { error: err.message });
+    // Continue without approval if bot is unavailable
+    return { approved: true, autoApproved: true, pendingId: id };
+  }
+
+  // Poll for approval
+  const pollResult = await pollForApproval(id, metadataPath);
+  return { ...pollResult, pendingId: id };
+}
+
+/**
+ * Polls the pending metadata file for status changes
+ */
+async function pollForApproval(id, metadataPath) {
+  const startTime = Date.now();
+  log(
+    'info',
+    `Polling for approval (timeout: ${CONFIG.approvalTimeoutMs / 1000 / 60}min)...`,
+  );
+
+  while (Date.now() - startTime < CONFIG.approvalTimeoutMs) {
+    await new Promise((r) => setTimeout(r, CONFIG.pollIntervalMs));
+
+    try {
+      const raw = await readFile(metadataPath, 'utf-8');
+      const pending = JSON.parse(raw);
+
+      if (pending.status === 'approved') {
+        log('info', 'Video approved by admin');
+        return { approved: true, autoApproved: false };
+      }
+
+      if (pending.status === 'regenerated') {
+        log('info', 'Video regeneration requested by admin');
+        return { approved: false, regenerated: true };
+      }
+
+      const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(1);
+      log('info', `Still pending... (${elapsed}min elapsed)`);
+    } catch (err) {
+      log('error', 'Error reading pending metadata', { error: err.message });
+    }
+  }
+
+  // Auto-approve after timeout
+  log('info', 'Approval timeout reached, auto-approving');
+  try {
+    const raw = await readFile(metadataPath, 'utf-8');
+    const pending = JSON.parse(raw);
+    pending.status = 'approved';
+    await writeFile(metadataPath, JSON.stringify(pending, null, 2));
+  } catch (err) {
+    log('error', 'Failed to auto-approve', { error: err.message });
+  }
+
+  return { approved: true, autoApproved: true };
+}
+
+/**
+ * Reports the posting result to Telegram bot
+ */
+async function reportResult(id, success, message, platforms) {
+  if (!CONFIG.enableApproval) return;
+
+  try {
+    await axios.post(
+      `${CONFIG.tgBotUrl}/shorts-factory/result`,
+      {
+        id,
+        status: success ? 'posted' : 'failed',
+        result: { success, message, platforms },
+      },
+      { timeout: 10000 },
+    );
+    log('info', 'Reported result to Telegram bot');
+  } catch (err) {
+    log('error', 'Failed to report result', { error: err.message });
+  }
+}
 
 // ============================================================================
 // CAPTIONS POOL
@@ -885,6 +1038,7 @@ async function captureBrowsing() {
       videoPath: latestVideo,
       duration: finalDuration,
       caption: scenario.caption,
+      scenario: scenario.name,
     };
   } catch (error) {
     log('error', 'Failed to capture browsing', {
@@ -1260,6 +1414,7 @@ async function publishToSocials(videoPath, caption) {
   return {
     success: successes.length > 0,
     message: `Published to ${successes.map((r) => r.platform).join(', ') || 'none'}`,
+    platforms: successes.map((r) => r.platform),
     results,
   };
 }
@@ -1274,6 +1429,24 @@ async function publishToSocials(videoPath, caption) {
 async function cleanup() {
   log('info', 'Cleaning up temporary files...');
   await cleanDirectory(CONFIG.rawCapturesDir);
+
+  // Clean old pending files (older than 24 hours)
+  try {
+    await mkdir(CONFIG.pendingDir, { recursive: true });
+    const files = await readdir(CONFIG.pendingDir);
+    const now = Date.now();
+    for (const file of files) {
+      const filePath = path.join(CONFIG.pendingDir, file);
+      const fileStat = await stat(filePath);
+      if (now - fileStat.mtimeMs > 24 * 60 * 60 * 1000) {
+        await unlink(filePath);
+        log('info', `Cleaned old pending file: ${file}`);
+      }
+    }
+  } catch (err) {
+    log('error', 'Error cleaning pending directory', { error: err.message });
+  }
+
   log('info', 'Cleanup complete');
 }
 
@@ -1290,6 +1463,7 @@ async function main() {
 
   let rawVideoPath = null;
   let outputVideoPath = null;
+  let pendingId = null;
 
   try {
     // Step 1: Capture browsing video
@@ -1306,13 +1480,34 @@ async function main() {
     outputVideoPath = await processVideo(rawVideoPath, captureResult.duration);
     log('info', `Processed video saved at: ${outputVideoPath}`);
 
-    // Step 3: Prepare for social media posting
-    log('info', 'Step 3: Preparing social media post...');
+    // Step 3: Request approval (if enabled)
     const caption = captureResult.caption || randomElement(CAPTIONS);
+    const scenario = captureResult.scenario || 'unknown';
     log('info', `Selected caption: "${caption}"`);
-    await publishToSocials(outputVideoPath, caption);
 
-    // Step 4: Cleanup temporary files
+    const approval = await requestApproval(outputVideoPath, caption, scenario);
+
+    if (approval.approved) {
+      // Step 4: Post to social media
+      log('info', 'Step 3: Publishing to social platforms...');
+      const result = await publishToSocials(outputVideoPath, caption);
+
+      // Report result if we have a pending ID
+      if (approval.pendingId) {
+        await reportResult(
+          approval.pendingId,
+          result.success,
+          result.message,
+          result.platforms,
+        );
+      }
+    } else if (approval.regenerated) {
+      log('info', 'Regeneration requested, restarting...');
+      await cleanup();
+      return main(); // Recursive call to regenerate
+    }
+
+    // Step 5: Cleanup temporary files
     log('info', 'Step 4: Cleaning up...');
     await cleanup();
 
@@ -1330,6 +1525,11 @@ async function main() {
       error: error.message,
       stack: error.stack,
     });
+
+    // Report failure
+    if (pendingId) {
+      await reportResult(pendingId, false, error.message);
+    }
 
     // Attempt cleanup even on failure
     await cleanup().catch(() => {});

--- a/scripts/shorts-factory/setup-factory.sh
+++ b/scripts/shorts-factory/setup-factory.sh
@@ -42,6 +42,7 @@ echo "==> Creating directories..."
 cd "$(dirname "$0")/../.."
 mkdir -p raw_captures
 mkdir -p output
+mkdir -p pending
 mkdir -p logs
 
 # Create .env file if it doesn't exist
@@ -53,6 +54,8 @@ POSTIZ_API_KEY=SET_ME
 POSTIZ_YOUTUBE_INTEGRATION_ID=SET_ME
 POSTIZ_INSTAGRAM_INTEGRATION_ID=
 POSTIZ_TIKTOK_INTEGRATION_ID=
+TG_BOT_URL=http://localhost:4001
+SHORTS_FACTORY_APPROVAL=false
 ENVEOF
   echo "Created .env file — edit it and fill in POSTIZ_API_KEY and platform integration IDs"
   echo "Get API key from: https://postiz.arcadeum.games -> Settings -> API Keys"


### PR DESCRIPTION
## What
Add Telegram bot approval flow for shorts factory videos and fix stability issues.

## Why
Shorts factory was broken due to missing Playwright, crashed Redis, and wrong Instagram post type. Additionally, there was no way to review videos before they're posted to social media.

## Changes

### Stability fixes
- `.github/workflows/deploy-oci.yml`: Add Playwright chromium install step to prevent browser binary mismatch
- `scripts/shorts-factory/factory.js`: Change Instagram post_type from `reel` to `post`

### Telegram approval flow (new feature)
- `apps/tg-bot/src/shorts-factory/`: New module with controller, service, and module
  - `POST /shorts-factory/pending` — receive pending video from factory
  - `GET /shorts-factory/status/:id` — poll for approval status
  - `POST /shorts-factory/result` — receive posting result
- `apps/tg-bot/src/telegram/telegram.service.ts`: Add callback query handler for approve/regenerate buttons
- `scripts/shorts-factory/factory.js`: Add approval flow (save to pending/, notify admin, poll for status, auto-confirm after 3h)

### How it works
1. Factory generates video → saves to `pending/` → notifies admin via Telegram
2. Admin sees video with ✅ Confirm / 🔄 Regenerate buttons
3. Admin clicks button → status updated in pending JSON file
4. Factory polls file every 30s → posts on approve, regenerates on regenerate
5. Auto-confirms after 3 hours if admin ignores
6. Shows success/failure messages in Telegram after posting

### Configuration
- `SHORTS_FACTORY_APPROVAL=true` — enable approval flow (disabled by default)
- `SHORTS_FACTORY_ADMIN_CHAT_ID` — admin chat ID for approval messages
- `TG_BOT_URL` — tg-bot URL for factory to call (default: http://localhost:4001)

### Server-side fixes (applied manually)
- Installed Playwright Chromium on OCI server
- Recreated missing `shorts-factory-random.sh` wrapper script
- Added `restart: always` to postiz-redis in docker-compose.yaml
- Updated Instagram integration ID in `.env`