### PR TITLE
feat(seo): add GeoIP redirection and sitemap/rich schema optimization (ARC-890)

### DIFF
--- a/apps/web/src/app/[locale]/games/chess/twitter-image.tsx
+++ b/apps/web/src/app/[locale]/games/chess/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from './opengraph-image';

--- a/apps/web/src/app/[locale]/tournaments/page.tsx
+++ b/apps/web/src/app/[locale]/tournaments/page.tsx
@@ -7,6 +7,8 @@ import { DEFAULT_LOCALE, isLocale, type Locale } from '@/shared/i18n';
 import { getTranslations } from '@/shared/i18n/server';
 import { JsonLd } from '@/shared/ui/JsonLd';
 import TournamentsClient from './TournamentsClient';
+import { fetchPublicTournaments } from '@/features/tournaments/api';
+import { getServerAccessToken } from '@/entities/session/api/serverTokens';
 
 export async function generateMetadata({
   params,
@@ -30,15 +32,37 @@ export default async function TournamentsPage({
 }) {
   const { locale: rawLocale } = await params;
   const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
-  const messages = await getTranslations(locale);
+  const [messages, accessToken] = await Promise.all([
+    getTranslations(locale),
+    getServerAccessToken(),
+  ]);
   const routes = buildRoutes(locale);
+
+  let items: Array<{
+    name: string;
+    url: string;
+    description?: string;
+    itemType?: string;
+  }> = [];
+
+  try {
+    const res = await fetchPublicTournaments({ locale, accessToken });
+    items = (res.items ?? []).map((t) => ({
+      name: t.name,
+      url: `${routes.tournaments}#${t.id}`,
+      description: t.description || t.prizeDescription || undefined,
+      itemType: 'SportsEvent',
+    }));
+  } catch {
+    // Fail-safe fallbacks
+  }
 
   const collectionPage = buildCollectionPageJsonLd({
     locale,
     pageUrl: routes.tournaments,
     name: messages.seo?.tournaments?.title ?? 'Tournaments',
     description: messages.seo?.tournaments?.description,
-    items: [],
+    items,
   });
   const breadcrumb = buildBreadcrumbJsonLd({
     locale,

--- a/apps/web/src/app/[locale]/twitter-image.tsx
+++ b/apps/web/src/app/[locale]/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from './opengraph-image';

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -152,6 +152,18 @@ export default async function RootLayout({
             <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_CDN_URL} />
           </>
         )}
+        {process.env.NEXT_PUBLIC_API_BASE_URL && (
+          <>
+            <link
+              rel="preconnect"
+              href={process.env.NEXT_PUBLIC_API_BASE_URL}
+            />
+            <link
+              rel="dns-prefetch"
+              href={process.env.NEXT_PUBLIC_API_BASE_URL}
+            />
+          </>
+        )}
         <JsonLd data={jsonLd} />
       </head>
       <body className={fontClassName}>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -36,6 +36,9 @@ type RouteKey =
   | 'glimwormLanding'
   | 'ticTacToeLanding'
   | 'cascadeLanding'
+  | 'chessLanding'
+  | 'checkersLanding'
+  | 'catDashLanding'
   | 'shop';
 
 // Last-meaningful-content-change per page. Update by hand when the
@@ -73,6 +76,9 @@ const PAGE_LAST_MODIFIED: Record<RouteKey, string> = {
   glimwormLanding: '2026-05-21',
   ticTacToeLanding: '2026-05-21',
   cascadeLanding: '2026-05-21',
+  chessLanding: '2026-05-21',
+  checkersLanding: '2026-05-21',
+  catDashLanding: '2026-05-21',
   shop: '2026-05-21',
 };
 
@@ -105,6 +111,9 @@ const GAME_LANDING_KEYS: RouteKey[] = [
   'glimwormLanding',
   'ticTacToeLanding',
   'cascadeLanding',
+  'chessLanding',
+  'checkersLanding',
+  'catDashLanding',
 ];
 
 const ROUTE_KEYS: RouteKey[] = (Object.keys(PAGE_LAST_MODIFIED) as RouteKey[])
@@ -164,6 +173,9 @@ const PAGE_PRIORITY: Record<RouteKey, number> = {
   glimwormLanding: 0.9,
   ticTacToeLanding: 0.9,
   cascadeLanding: 0.9,
+  chessLanding: 0.9,
+  checkersLanding: 0.9,
+  catDashLanding: 0.9,
   leaderboards: 0.7,
   tournaments: 0.7,
   rewards: 0.7,

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -123,6 +123,75 @@ function handleVercelFeedbackPreflight(req: NextRequest): NextResponse | null {
   return response;
 }
 
+function getLocaleFromCountry(countryCode?: string | null): Locale | null {
+  if (!countryCode) return null;
+  const code = countryCode.toUpperCase();
+  if (
+    [
+      'ES',
+      'MX',
+      'AR',
+      'CO',
+      'PE',
+      'VE',
+      'CL',
+      'EC',
+      'GT',
+      'CU',
+      'BO',
+      'DO',
+      'HN',
+      'PY',
+      'SV',
+      'NI',
+      'CR',
+      'PA',
+      'UY',
+      'GQ',
+    ].includes(code)
+  ) {
+    return 'es';
+  }
+  if (
+    [
+      'FR',
+      'CA',
+      'MC',
+      'CD',
+      'CG',
+      'CI',
+      'SN',
+      'MG',
+      'CM',
+      'ML',
+      'NE',
+      'TG',
+      'BJ',
+      'BI',
+      'DJ',
+      'RW',
+      'GQ',
+      'KM',
+      'LU',
+      'CH',
+      'BE',
+    ].includes(code)
+  ) {
+    return 'fr';
+  }
+  if (code === 'BY') {
+    return 'by';
+  }
+  if (
+    ['RU', 'UA', 'KZ', 'UZ', 'KG', 'TJ', 'TM', 'MD', 'AM', 'AZ', 'GE'].includes(
+      code,
+    )
+  ) {
+    return 'ru';
+  }
+  return null;
+}
+
 export function proxy(req: NextRequest) {
   const { pathname, search } = req.nextUrl;
 
@@ -166,7 +235,7 @@ export function proxy(req: NextRequest) {
   }
 
   // Case 2: URL has no locale prefix. Pick locale via cookie -> Accept-
-  // Language -> default, then map the (possibly English) first segment
+  // Language -> GeoIP -> default, then map the (possibly English) first segment
   // to the localized slug for that locale in one redirect.
   const cookieLocale = req.cookies.get('app-language')?.value;
   const headerLocale = req.headers
@@ -175,9 +244,14 @@ export function proxy(req: NextRequest) {
     ?.split('-')[0]
     ?.toLowerCase();
 
+  const ipCountry =
+    req.headers.get('x-vercel-ip-country') ?? req.headers.get('cf-ipcountry');
+  const ipLocale = getLocaleFromCountry(ipCountry);
+
   const locale =
     pickSupported(cookieLocale) ??
     pickSupported(headerLocale) ??
+    ipLocale ??
     DEFAULT_LOCALE;
 
   const url = req.nextUrl.clone();


### PR DESCRIPTION
### What
Implements advanced GEO & SEO optimizations for the Arcadeum platform.

### Why
Boosts search engine index coverage, improves page speed and resource hints, dynamically exposes real-time tournaments markup, and redirects international users accurately via GeoIP headers.

### Changes
* **GeoIP Redirection:** Detect country headers to direct users to localized paths.
* **Tournaments SSR Schema:** Dynamic population of tournaments collection markup.
* **Resource Hints:** Added preconnect tags for .
* **Sitemap Integrations:** Added chess, checkers, and cat-dash to sitemap.
* **Social Preview Cards:** Added missing twitter-image fallbacks for root and chess.