### PR TITLE
fix(web): use anonymous ID for unauthenticated players in quick match

### DIFF
--- a/apps/web/src/entities/session/model/useSessionTokens.ts
+++ b/apps/web/src/entities/session/model/useSessionTokens.ts
@@ -63,10 +63,10 @@ export function useSessionTokens(): SessionTokensValue {
   }, [snapshot.accessTokenExpiresAt, storeRefreshTokens]);
 
   const userId = useMemo(() => {
-    if (snapshot.userId) return snapshot.userId;
+    if (snapshot.userId && snapshot.accessToken) return snapshot.userId;
     if (typeof window === 'undefined') return null;
     return localStorage.getItem('arcadeum_anon_id');
-  }, [snapshot.userId]);
+  }, [snapshot.userId, snapshot.accessToken]);
 
   const finalSnapshot = useMemo(
     () => ({


### PR DESCRIPTION
## What

Fix anonymous players being unable to start Quick Match vs AI due to a stale user ID mismatch.

## Why

When a user's session expires or they log out, the Zustand session store retains the userId from their previous login (the partialize function strips tokens but keeps userId). The useSessionTokens() hook returned this stale ID instead of falling back to the anonymous ID from localStorage, causing all WebSocket events to use a mismatched identity.

The room was created via HTTP API with the correct anon_xxxxx host, but the room page used the old account ID (68f0ac13c9a00d01db50b4dd) for all socket events, resulting in:

- Encryption key withheld -- the stale ID does not start with anon_
- Room is full -- the stale ID is not a participant of the room
- Only the host can update room options -- the stale ID does not match the room hostId

## Changes

- apps/web/src/entities/session/model/useSessionTokens.ts: Only return snapshot.userId when the user is actually authenticated (snapshot.accessToken is set). Otherwise fall back to the anonymous ID from localStorage. This ensures anonymous players always use their correct anon_xxxxx identity for all WebSocket events.
