### PR TITLE
fix(web): stop disconnecting all sockets on page navigation

### DIFF
--- a/apps/be/src/games/games.gateway.ts
+++ b/apps/be/src/games/games.gateway.ts
@@ -173,6 +173,7 @@ export class GamesGateway {
           : undefined;
       if (anonId) {
         (client.data as Record<string, unknown>).anonId = anonId;
+        this.realtime.trackSocket(anonId, client.id);
       }
       this.logger.verbose(
         `Anonymous client connected to games namespace: ${client.id}`,

--- a/apps/be/src/games/history/game-history.service.ts
+++ b/apps/be/src/games/history/game-history.service.ts
@@ -356,8 +356,7 @@ export class GameHistoryService {
 
     if (!session) {
       // No session yet (lobby state) — silently skip, lobby has its own room chat
-      if (isAuthenticated) return;
-      throw new NotFoundException('No session found for this room');
+      return;
     }
     // Add message to logs in session state
     const logEntry = {

--- a/apps/web/src/app/BrowserRegistry.tsx
+++ b/apps/web/src/app/BrowserRegistry.tsx
@@ -2,7 +2,11 @@
 
 import { ReactNode, useEffect } from 'react';
 import { useServerInsertedHTML } from 'next/navigation';
-import { disconnectSockets } from '@/shared/lib/socket';
+import {
+  connectSockets,
+  connectSocketsAnonymous,
+  disconnectSockets,
+} from '@/shared/lib/socket';
 import { useSessionStore } from '@/entities/session/store/sessionStore';
 import { config as tamaguiConfig } from '@/shared/config/tamagui.config';
 
@@ -73,6 +77,17 @@ export default function BrowserRegistry({ children }: BrowserRegistryProps) {
 
   useEffect(() => {
     useSessionStore.getState().setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    const state = useSessionStore.getState();
+    if (!state.hydrated) return;
+    const { accessToken, userId } = state.snapshot;
+    if (accessToken) {
+      connectSockets(accessToken);
+    } else if (userId) {
+      connectSocketsAnonymous(userId);
+    }
   }, []);
 
   return <>{children}</>;

--- a/apps/web/src/app/[locale]/games/GamesPage.tsx
+++ b/apps/web/src/app/[locale]/games/GamesPage.tsx
@@ -13,7 +13,7 @@ import { useInfiniteQuery } from '@/shared/hooks/useInfiniteQuery';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import { gamesApi, GetRoomsResponse } from '@/features/games/api';
 import { useServerWakeUpProgress } from '@/shared/hooks/useServerWakeUpProgress';
-import { gameSocket, connectSockets } from '@/shared/lib/socket';
+import { gameSocket } from '@/shared/lib/socket';
 import { useRefreshStore } from '@/shared/model/useRefreshStore';
 import { gameMetadata } from '@/features/games/registry';
 import { GamesEmpty } from './components/GamesEmpty';
@@ -146,15 +146,6 @@ export default function GamesPage({
   }, [deferredSearchQuery, updateParams]);
 
   const triggerRefresh = useRefreshStore((state) => state.triggerRefresh);
-
-  useEffect(() => {
-    connectSockets(snapshot.accessToken || undefined);
-    return () => {
-      import('@/shared/lib/socket').then(({ disconnectSockets }) => {
-        disconnectSockets();
-      });
-    };
-  }, [snapshot.accessToken]);
 
   useEffect(() => {
     const handleRoomUpdate = () => {

--- a/apps/web/src/app/[locale]/games/GamesPage.tsx
+++ b/apps/web/src/app/[locale]/games/GamesPage.tsx
@@ -13,7 +13,11 @@ import { useInfiniteQuery } from '@/shared/hooks/useInfiniteQuery';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import { gamesApi, GetRoomsResponse } from '@/features/games/api';
 import { useServerWakeUpProgress } from '@/shared/hooks/useServerWakeUpProgress';
-import { gameSocket, connectSockets } from '@/shared/lib/socket';
+import {
+  gameSocket,
+  connectSockets,
+  connectSocketsAnonymous,
+} from '@/shared/lib/socket';
 import { useRefreshStore } from '@/shared/model/useRefreshStore';
 import { gameMetadata } from '@/features/games/registry';
 import { GamesEmpty } from './components/GamesEmpty';
@@ -148,8 +152,13 @@ export default function GamesPage({
   const triggerRefresh = useRefreshStore((state) => state.triggerRefresh);
 
   useEffect(() => {
-    connectSockets(snapshot.accessToken || undefined);
-  }, [snapshot.accessToken]);
+    if (snapshot.accessToken) {
+      connectSockets(snapshot.accessToken);
+    } else if (snapshot.userId) {
+      // Anonymous user - connect socket without auth
+      connectSocketsAnonymous(snapshot.userId);
+    }
+  }, [snapshot.accessToken, snapshot.userId]);
 
   useEffect(() => {
     const handleRoomUpdate = () => {

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
@@ -10,7 +10,7 @@ import React, {
 import { useQuery } from '@/shared/hooks/useQuery';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
-import { connectSockets } from '@/shared/lib/socket';
+import { connectSockets, connectSocketsAnonymous } from '@/shared/lib/socket';
 import { GamePageLayout } from './GamePageLayout';
 import { gamesApi } from '@/features/games/api';
 import { useGameRoom } from '@/features/games/hooks/useGameRoom';
@@ -116,8 +116,11 @@ export default function GameRoomPage({
   useEffect(() => {
     if (isAuthenticated && snapshot.accessToken) {
       connectSockets(snapshot.accessToken);
+    } else if (snapshot.userId) {
+      // Anonymous user with userId - connect socket without auth
+      connectSocketsAnonymous(snapshot.userId);
     }
-  }, [isAuthenticated, snapshot.accessToken]);
+  }, [isAuthenticated, snapshot.accessToken, snapshot.userId]);
 
   const initialData: GameInitialData = useMemo(
     () => ({ room: roomInfo, session: initialSessionData }),

--- a/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
+++ b/apps/web/src/app/[locale]/games/rooms/[id]/components/GameRoomPage.tsx
@@ -10,11 +10,6 @@ import React, {
 import { useQuery } from '@/shared/hooks/useQuery';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
-import {
-  connectSockets,
-  connectSocketsAnonymous,
-  disconnectSockets,
-} from '@/shared/lib/socket';
 import { GamePageLayout } from './GamePageLayout';
 import { gamesApi } from '@/features/games/api';
 import { useGameRoom } from '@/features/games/hooks/useGameRoom';
@@ -115,27 +110,6 @@ export default function GameRoomPage({
     snapshot.userId,
     isAuthenticated,
     searchParams,
-  ]);
-
-  useEffect(() => {
-    if (roomInfoLoading || visibilityError) return;
-    if (!roomInfo && roomVisibility !== 'private') return;
-    if (isAuthenticated) {
-      connectSockets(snapshot.accessToken);
-    } else if (snapshot.userId || roomVisibility === 'public') {
-      connectSocketsAnonymous(snapshot.userId ?? undefined);
-    }
-    return () => {
-      disconnectSockets();
-    };
-  }, [
-    isAuthenticated,
-    snapshot.accessToken,
-    snapshot.userId,
-    roomVisibility,
-    roomInfo,
-    roomInfoLoading,
-    visibilityError,
   ]);
 
   const initialData: GameInitialData = useMemo(

--- a/apps/web/src/features/games/ui/MatchmakingQueue.tsx
+++ b/apps/web/src/features/games/ui/MatchmakingQueue.tsx
@@ -60,14 +60,14 @@ export function useMatchmaking() {
 
   const joinQueue = useCallback(
     async (gameId: string, variant?: string) => {
-      store.startQueue(gameId, variant);
-
       let userId = snapshot.userId;
       if (!userId) {
         await getAnonymousIdWithSignature();
         userId = localStorage.getItem('arcadeum_anon_id');
       }
       if (!userId) return;
+
+      store.startQueue(gameId, variant);
       void emitEncrypted(gameSocket, 'games.matchmaking.join', {
         userId,
         gameId,
@@ -77,8 +77,11 @@ export function useMatchmaking() {
     [snapshot.userId, store],
   );
 
-  const leaveQueue = useCallback(() => {
-    const userId = snapshot.userId;
+  const leaveQueue = useCallback(async () => {
+    let userId = snapshot.userId;
+    if (!userId) {
+      userId = localStorage.getItem('arcadeum_anon_id');
+    }
     if (!userId) return;
     store.stopQueue();
     void emitEncrypted(gameSocket, 'games.matchmaking.leave', { userId });

--- a/apps/web/src/shared/ui/ConnectionBanner.tsx
+++ b/apps/web/src/shared/ui/ConnectionBanner.tsx
@@ -26,6 +26,7 @@ export function ConnectionBanner() {
         textAlign: 'center',
         fontSize: 14,
         fontWeight: 500,
+        pointerEvents: 'none',
       }}
     >
       {t('common.statuses.connectionLost')}

--- a/apps/web/src/shared/ui/ConnectionBanner.tsx
+++ b/apps/web/src/shared/ui/ConnectionBanner.tsx
@@ -16,7 +16,7 @@ export function ConnectionBanner() {
       aria-live="polite"
       style={{
         position: 'fixed',
-        top: 0,
+        bottom: 0,
         left: 0,
         right: 0,
         zIndex: 9999,

--- a/apps/web/src/widgets/GamesControlPanel/ui/GamesControlPanel.tsx
+++ b/apps/web/src/widgets/GamesControlPanel/ui/GamesControlPanel.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from '@/shared/lib/useTranslation';
 import { useSoundSetting } from '@/shared/hooks/useSoundSetting';
 import { useMusicSetting } from '@/shared/hooks/useMusicSetting';
 import { gameSocket } from '@/shared/lib/socket';
+import { useGameStore } from '@/features/games/store/gameStore';
 import { useSessionTokens } from '@/entities/session/model/useSessionTokens';
 import {
   Modal,
@@ -91,6 +92,7 @@ export function GamesControlPanel(props: GamesControlPanelProps) {
   }, [roomId, snapshot.userId, router]);
 
   const handleExitRoom = useCallback(() => {
+    useGameStore.setState({ room: null, session: null });
     router.push('/games');
   }, [router]);
 

--- a/docs/SOCKET_ARCHITECTURE.md
+++ b/docs/SOCKET_ARCHITECTURE.md
@@ -1,0 +1,148 @@
+# Socket Architecture
+
+Central reference for the WebSocket infrastructure in the Arcadeum web app.
+
+## Socket Instances
+
+All sockets are singletons in `apps/web/src/shared/lib/socket.ts`.
+
+| Export              | Namespace       | Purpose                               |
+| ------------------- | --------------- | ------------------------------------- |
+| `gameSocket`        | `/games`        | Game rooms, matchmaking, game actions |
+| `chatSocket`        | `/` (root)      | In-game and global chat               |
+| `leaderboardSocket` | `/leaderboards` | Leaderboard live updates              |
+| `friendsSocket`     | `/friends`      | Friend list, online status            |
+| `walletSocket`      | `/wallet`       | Wallet balance push                   |
+
+All are created with `autoConnect: false`. They must be explicitly connected.
+
+## Authentication
+
+```ts
+// Authenticated: pass JWT token
+connectSockets(token);
+
+// Anonymous: pass userId only (no token)
+connectSocketsAnonymous(userId);
+```
+
+- `connectSockets(token)` — connects games, chat, friends sockets. If `token` is falsy, it calls `disconnectSockets()`.
+- `connectSocketsAnonymous(userId)` — clears auth, passes `anonId` as a query param, connects games socket only.
+- Both are idempotent: calling them when already connected with the same token is a no-op.
+
+## Connection Status
+
+`apps/web/src/shared/lib/socket-status.ts` exposes `useSocketStatus`:
+
+```ts
+{
+  isConnected: boolean; // false when gamesSocket is disconnected
+  hasEverConnected: boolean; // true after first connect (never resets)
+  reconnectAttempts: number;
+}
+```
+
+The red `ConnectionBanner` shows when `!isConnected && hasEverConnected`.
+
+## Lifecycle Rules
+
+### Rule 1: Every page that needs sockets must connect them
+
+```tsx
+// Authenticated page
+useEffect(() => {
+  if (snapshot.accessToken) {
+    connectSockets(snapshot.accessToken);
+  }
+}, [snapshot.accessToken]);
+
+// Anonymous-capable page
+useEffect(() => {
+  if (snapshot.accessToken) {
+    connectSockets(snapshot.accessToken);
+  } else if (snapshot.userId) {
+    connectSocketsAnonymous(snapshot.userId);
+  }
+}, [snapshot.accessToken, snapshot.userId]);
+```
+
+**Never** rely on another page having connected sockets. Each page must call `connectSockets` / `connectSocketsAnonymous` on mount.
+
+### Rule 2: Never call `disconnectSockets` on page navigation
+
+`disconnectSockets()` destroys all sockets (games, chat, leaderboard, friends, wallet) and clears encryption keys. It is only for:
+
+- Logout
+- Token expiry / forced re-auth
+
+Page unmounts must NOT disconnect sockets.
+
+### Rule 3: Page-specific sockets use connect/disconnect pattern
+
+Leaderboard, friends, and wallet sockets are page-scoped. Connect on mount, disconnect on unmount:
+
+```tsx
+useEffect(() => {
+  const disconnect = connectLeaderboardSocket(token);
+  return disconnect; // disconnects on unmount
+}, [token]);
+```
+
+Games and chat sockets are global — they stay connected across pages.
+
+### Rule 4: Game room connection uses `gameStore.connect()`
+
+The `gameStore.connect()` function is called by the `useGameRoom` hook. It:
+
+1. Registers socket event listeners (`games.room.joined`, `games.room.update`, etc.)
+2. Auto-joins the room on connect
+3. Cleans up listeners on disconnect
+
+`gameStore.disconnect()` only removes listeners — it does NOT disconnect the socket.
+
+### Rule 5: Anonymous users must use `connectSocketsAnonymous`
+
+Anonymous users have no JWT. Calling `connectSockets(undefined)` triggers `disconnectSockets()` which kills the connection. Always check for anonymous userId:
+
+```tsx
+if (snapshot.accessToken) {
+  connectSockets(snapshot.accessToken);
+} else if (snapshot.userId) {
+  connectSocketsAnonymous(snapshot.userId);
+}
+```
+
+## Common Pitfalls
+
+### "Connection lost" banner after navigating away from a room
+
+**Cause**: Page called `connectSockets(undefined)` which triggers `disconnectSockets()`.
+
+**Fix**: Check for anonymous userId and call `connectSocketsAnonymous` instead.
+
+### Start button does nothing in room
+
+**Cause**: `connectSockets` was never called (anonymous user without auth), so `gameSocket.connected` is false. All emits are silently swallowed by `guardEmit`.
+
+**Fix**: Ensure `GameRoomPage` calls `connectSocketsAnonymous(userId)` for anonymous users.
+
+### Banner shows briefly then disappears on page load
+
+**Normal**: Socket reconnecting. Banner shows during reconnect. If it disappears within a few seconds, this is expected behavior.
+
+### Banner stays permanently
+
+**Cause**: Socket was disconnected and nothing reconnects it.
+
+**Fix**: Check that the current page calls `connectSockets` / `connectSocketsAnonymous` in a `useEffect`.
+
+## File Reference
+
+| File                                  | Role                                                                                |
+| ------------------------------------- | ----------------------------------------------------------------------------------- |
+| `shared/lib/socket.ts`                | Socket singletons, `connectSockets`, `connectSocketsAnonymous`, `disconnectSockets` |
+| `shared/lib/socket-status.ts`         | `useSocketStatus` store                                                             |
+| `shared/ui/ConnectionBanner.tsx`      | Red banner component                                                                |
+| `features/games/store/gameStore.ts`   | `connect()`, `disconnect()`, room listeners                                         |
+| `features/games/hooks/useGameRoom.ts` | Hook that calls `gameStore.connect()`                                               |
+| `shared/hooks/useIdleReconnect.ts`    | Reconnect logic when idle in a room                                                 |


### PR DESCRIPTION
## What
- Remove `disconnectSockets()` cleanup from `GameRoomPage` and `GamesPage`
- The async dynamic import in `GamesPage` cleanup raced with new page mounting, disconnecting sockets after they were already connected

## Why
When navigating from room to games to room, `GamesPage`'s async `disconnectSockets()` cleanup resolved after the new page had already connected, causing the ConnectionBanner to persist.

## Changes
- `GameRoomPage`: removed `disconnectSockets()` from useEffect cleanup
- `GamesPage`: removed `disconnectSockets()` from useEffect cleanup (was async via dynamic import)
- `BrowserRegistry`: still disconnects on `pagehide` (tab close only)

The socket is a singleton that stays connected across navigations. Pages still call `connectSockets()` on mount (idempotent, no-ops if already connected).