### PR TITLE
fix(web): wrap PWA feature text in Text component to fix console error

### DIFF
--- a/apps/web/src/features/pwa/InstallPWAModalContent.tsx
+++ b/apps/web/src/features/pwa/InstallPWAModalContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { XStack, Paragraph } from 'tamagui';
+import { XStack, Paragraph, Text } from 'tamagui';
 import {
   Avatar,
   Modal,
@@ -60,11 +60,11 @@ export function InstallPWAModalContent() {
           <PWAFeaturesList>
             <PWAFeatureItem>
               <PWAFeatureIcon>⚡</PWAFeatureIcon>
-              {t('pwa.install.features.fast')}
+              <Text>{t('pwa.install.features.fast')}</Text>
             </PWAFeatureItem>
             <PWAFeatureItem>
               <PWAFeatureIcon>🔔</PWAFeatureIcon>
-              {t('pwa.install.features.notifications')}
+              <Text>{t('pwa.install.features.notifications')}</Text>
             </PWAFeatureItem>
           </PWAFeaturesList>
 


### PR DESCRIPTION
## What
- Wrap raw text nodes inside `PWAFeatureItem` with `<Text>` component to fix React/Tamagui console error

## Why
`PWAFeatureItem` is a `styled(XStack)` (flex container) which does not accept raw text nodes as direct children. The translated strings from `t('pwa.install.features.fast')` and `t('pwa.install.features.notifications')` were being passed as bare text nodes, causing repeated console errors on every page load.

## Changes
- `apps/web/src/features/pwa/InstallPWAModalContent.tsx`: Import `Text` from tamagui and wrap feature text translations in `<Text>` tags